### PR TITLE
Extractor: detect perturbation language; backfill 7 rejected PMIDs into perturbation schema

### DIFF
--- a/data/normalized_yaml/bacterial/caulobacter_medium.yaml
+++ b/data/normalized_yaml/bacterial/caulobacter_medium.yaml
@@ -74,3 +74,29 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "CAULOBACTER MEDIUM" to "caulobacter_medium" for consistent
     matching
+- timestamp: '2026-05-04T06:34:23.033204+00:00'
+  curator: literature_review_apply
+  action: ADDED_GROWTH_EVIDENCE
+  notes: organisms_added=1 metrics_added=1 genomes_added=0 strain_mods_added=0
+target_organisms:
+- preferred_term: Caulobacter sp. K31
+  term:
+    id: NCBITaxon:366602
+    label: Caulobacter sp. K31
+  growth_metrics:
+  - doubling_time_minutes: 2400.0
+    evidence:
+    - reference: PMID:25274120
+      supports: SUPPORT
+      snippet: K31 is a novel Caulobacter isolate that has the ability to tolerate
+        copper and chlorophenols, and can grow at 4 ° C with a doubling time of 40
+        h.
+      explanation: 'Auto-applied from literature query: backfill PMID:25274120'
+    is_max_attainment: false
+    growth_mode: BATCH
+    perturbations:
+    - perturbation_type: TEMPERATURE_STRESS
+      descriptor: cold growth at 4°C
+      target: temperature
+      level: 4.0
+      level_unit: °C

--- a/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
+++ b/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
@@ -108,6 +108,37 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "MAGNETOSPIRILLUM GRYPHISWALDENSE MEDIUM" to "magnetospirillum_gryphiswaldense_medium"
     for consistent matching
+- timestamp: '2026-05-04T06:34:23.043058+00:00'
+  curator: literature_review_apply
+  action: ADDED_GROWTH_EVIDENCE
+  notes: organisms_added=1 metrics_added=1 genomes_added=0 strain_mods_added=1
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: MAGNETOSPIRILLUM GRYPHISWALDENSE
+- preferred_term: Magnetospirillum gryphiswaldense
+  term:
+    id: NCBITaxon:55518
+    label: Magnetospirillum gryphiswaldense
+  strain_modifications:
+  - modification_type: KNOCKOUT
+    target: magnetosome operon
+    description: magnetosome-deficient strain B17316
+    ontology_term: NCIT:C120956
+  growth_metrics:
+  - growth_rate_per_hour: 0.062
+    evidence:
+    - reference: PMID:37088211
+      supports: SUPPORT
+      snippet: The addition of 10 mg L-1 Cr(VI) significantly inhibited cell growth,
+        but the magnetosome-deficient strain, B17316, showed an average specific growth
+        rate of 0.062 h-1 at the same dosage.
+      explanation: 'Auto-applied from literature query: backfill PMID:37088211'
+    is_max_attainment: false
+    growth_mode: BATCH
+    perturbations:
+    - perturbation_type: CHEMICAL_STRESS
+      descriptor: Cr(VI) at 10 mg/L
+      target: chromium hexavalent
+      level: 10.0
+      level_unit: mg/L
+      ontology_term: CHEBI:53456

--- a/data/normalized_yaml/bacterial/methanosarcina_medium.yaml
+++ b/data/normalized_yaml/bacterial/methanosarcina_medium.yaml
@@ -389,3 +389,27 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOSARCINA MEDIUM" to "methanosarcina_medium" for
     consistent matching
+- timestamp: '2026-05-04T06:34:23.060619+00:00'
+  curator: literature_review_apply
+  action: ADDED_GROWTH_EVIDENCE
+  notes: organisms_added=1 metrics_added=1 genomes_added=0 strain_mods_added=0
+target_organisms:
+- preferred_term: Methanosarcina acetivorans
+  term:
+    id: NCBITaxon:2214
+    label: Methanosarcina acetivorans
+  growth_metrics:
+  - doubling_time_minutes: 2940.0
+    evidence:
+    - reference: PMID:21097629
+      supports: SUPPORT
+      snippet: M. acetivorans was found to be polyploid during fast growth (t(D) =
+        6 h; 17 genome copies) and oligoploid during slow growth (doubling time =
+        49 h; 3 genome copies).
+      explanation: 'Auto-applied from literature query: backfill PMID:21097629'
+    is_max_attainment: false
+    growth_mode: BATCH
+    perturbations:
+    - perturbation_type: GROWTH_PHASE
+      descriptor: slow-growth phase
+      target: growth phase

--- a/data/normalized_yaml/bacterial/pyrococcus_medium.yaml
+++ b/data/normalized_yaml/bacterial/pyrococcus_medium.yaml
@@ -327,3 +327,31 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PYROCOCCUS MEDIUM" to "pyrococcus_medium" for consistent
     matching
+- timestamp: '2026-05-04T06:34:23.081340+00:00'
+  curator: literature_review_apply
+  action: ADDED_GROWTH_EVIDENCE
+  notes: organisms_added=1 metrics_added=1 genomes_added=0 strain_mods_added=1
+target_organisms:
+- preferred_term: Pyrococcus furiosus
+  term:
+    id: NCBITaxon:2261
+    label: Pyrococcus furiosus
+  strain_modifications:
+  - modification_type: ADAPTATION
+    target: cellulose utilization
+    description: serially adapted for growth on CF11 cellulose
+  growth_metrics:
+  - doubling_time_minutes: 64.0
+    evidence:
+    - reference: PMID:21421788
+      supports: SUPPORT
+      snippet: P. furiosus was serially adapted for growth on CF11 cellulose and H₂
+        production, which is the first reported instance of hyperthermophilic growth
+        on cellulose, with a doubling time of 64 min.
+      explanation: 'Auto-applied from literature query: backfill PMID:21421788'
+    is_max_attainment: false
+    growth_mode: BATCH
+    nutrient_overrides:
+    - role: CARBON_SOURCE
+      source: CF11 cellulose
+      is_sole_source: true

--- a/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
+++ b/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
@@ -203,3 +203,27 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "RHODOBACTER SPHAEROIDES MEDIUM" to "rhodobacter_sphaeroides_medium"
     for consistent matching
+- timestamp: '2026-05-04T06:34:23.096312+00:00'
+  curator: literature_review_apply
+  action: ADDED_GROWTH_EVIDENCE
+  notes: organisms_added=1 metrics_added=1 genomes_added=0 strain_mods_added=0
+target_organisms:
+- preferred_term: Rhodobacter sphaeroides
+  term:
+    id: NCBITaxon:1063
+    label: Rhodobacter sphaeroides
+  growth_metrics:
+  - doubling_time_minutes: 1080.0
+    evidence:
+    - reference: PMID:19826864
+      supports: SUPPORT
+      snippet: Rhodobacter sphaeroides OU5 grows phototrophically with generation
+        doubling time of 18 h on L-phenylalanine when used as sole source of nitrogen.
+      explanation: 'Auto-applied from literature query: backfill PMID:19826864'
+    is_max_attainment: false
+    growth_mode: BATCH
+    nutrient_overrides:
+    - role: NITROGEN_SOURCE
+      source: L-phenylalanine
+      is_sole_source: true
+      ontology_id: CHEBI:17295

--- a/scripts/apply_growth_evidence.py
+++ b/scripts/apply_growth_evidence.py
@@ -82,9 +82,43 @@ def make_evidence_item(pmid: str, snippet: str, query: str | None) -> dict:
     return ev
 
 
+def _merge_strain_modifications(organism: dict, new_mods: list[dict]) -> int:
+    """Merge new StrainModification entries onto the OrganismDescriptor.
+
+    Dedup is by (modification_type, target_lower) — same gene knockout
+    cited from two PMIDs is one logical modification, not two.
+    Returns count of newly added entries.
+    """
+    if not new_mods:
+        return 0
+    existing = organism.setdefault("strain_modifications", [])
+    seen: set[tuple[str, str]] = set()
+    for em in existing:
+        key = ((em.get("modification_type") or ""),
+               (em.get("target") or "").strip().lower())
+        seen.add(key)
+    added = 0
+    for m in new_mods:
+        if not isinstance(m, dict):
+            continue
+        key = ((m.get("modification_type") or ""),
+               (m.get("target") or "").strip().lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        existing.append(dict(m))
+        added += 1
+    return added
+
+
 def apply_candidate(recipe: dict, candidate: dict) -> dict:
     """Mutate recipe in place; return a count dict describing changes."""
-    counts = {"organisms_added": 0, "metrics_added": 0, "genomes_added": 0}
+    counts = {
+        "organisms_added": 0,
+        "metrics_added": 0,
+        "genomes_added": 0,
+        "strain_mods_added": 0,
+    }
     extracted = candidate.get("extracted") or {}
     pmid = candidate.get("pmid") or ""
     snippet = candidate.get("snippet") or ""
@@ -111,11 +145,27 @@ def apply_candidate(recipe: dict, candidate: dict) -> dict:
 
     organism = target_organisms[idx]
 
+    # v2 schema: strain_modifications live on the OrganismDescriptor
+    # (carry across observations). Apply before growth-metrics so the
+    # mods are in place when downstream tooling joins them up.
+    counts["strain_mods_added"] = _merge_strain_modifications(
+        organism, extracted.get("strain_modifications") or [],
+    )
+
     metrics = extracted.get("growth_metrics") or {}
     if metrics:
         gm_entry: dict = dict(metrics)
         if pmid:
             gm_entry["evidence"] = [make_evidence_item(pmid, snippet, query)]
+        # v2 schema: per-observation perturbation context fields.
+        if "is_max_attainment" in extracted:
+            gm_entry["is_max_attainment"] = extracted["is_max_attainment"]
+        if extracted.get("growth_mode"):
+            gm_entry["growth_mode"] = extracted["growth_mode"]
+        if extracted.get("perturbations"):
+            gm_entry["perturbations"] = list(extracted["perturbations"])
+        if extracted.get("nutrient_overrides"):
+            gm_entry["nutrient_overrides"] = list(extracted["nutrient_overrides"])
         # Dedup: skip when an existing growth_metrics entry already
         # cites the same PMID. Keeps `apply-growth --apply` idempotent
         # across re-runs of the same proposal.
@@ -156,7 +206,8 @@ def append_curation_history(recipe: dict, summary: dict) -> None:
         "notes": (
             f"organisms_added={summary['organisms_added']} "
             f"metrics_added={summary['metrics_added']} "
-            f"genomes_added={summary['genomes_added']}"
+            f"genomes_added={summary['genomes_added']} "
+            f"strain_mods_added={summary.get('strain_mods_added', 0)}"
         ),
     })
 
@@ -174,6 +225,7 @@ def process_proposal(proposal_path: Path, apply: bool) -> dict:
         "organisms_added": 0,
         "metrics_added": 0,
         "genomes_added": 0,
+        "strain_mods_added": 0,
         "wrote": False,
     }
     try:
@@ -202,11 +254,12 @@ def process_proposal(proposal_path: Path, apply: bool) -> dict:
     with open(recipe_path) as f:
         recipe = yaml.safe_load(f) or {}
 
-    cum = {"organisms_added": 0, "metrics_added": 0, "genomes_added": 0}
+    cum = {"organisms_added": 0, "metrics_added": 0, "genomes_added": 0,
+           "strain_mods_added": 0}
     for c in high_conf:
         deltas = apply_candidate(recipe, c)
         for k in cum:
-            cum[k] += deltas[k]
+            cum[k] += deltas.get(k, 0)
         summary["applied"] += 1
 
     summary.update(cum)
@@ -244,7 +297,8 @@ def main() -> int:
 
     totals = {"applied": 0, "skipped_no_support": 0,
               "skipped_missing_recipe": 0, "organisms_added": 0,
-              "metrics_added": 0, "genomes_added": 0, "wrote": 0}
+              "metrics_added": 0, "genomes_added": 0,
+              "strain_mods_added": 0, "wrote": 0}
 
     for p in proposals:
         s = process_proposal(p, apply=args.apply)
@@ -252,13 +306,15 @@ def main() -> int:
             f"  {p.name}: applied={s['applied']} "
             f"orgs+={s['organisms_added']} metrics+={s['metrics_added']} "
             f"genomes+={s['genomes_added']} "
+            f"strain_mods+={s.get('strain_mods_added', 0)} "
             f"skipped_no_support={s['skipped_no_support']} "
             f"missing_recipe={s['skipped_missing_recipe']} "
             f"{'(wrote)' if s['wrote'] else ''}"
         )
         for k in ("applied", "skipped_no_support", "skipped_missing_recipe",
-                  "organisms_added", "metrics_added", "genomes_added"):
-            totals[k] += s[k]
+                  "organisms_added", "metrics_added", "genomes_added",
+                  "strain_mods_added"):
+            totals[k] += s.get(k, 0)
         if s["wrote"]:
             totals["wrote"] += 1
 

--- a/scripts/propose_growth_evidence.py
+++ b/scripts/propose_growth_evidence.py
@@ -69,6 +69,133 @@ TD_RE = re.compile(rf"\btd\s*(?:=|:|~|≈)?\s*{NUMERIC_RE}\s*(min(?:utes?)?|h|ho
 GROWTH_RATE_RE = re.compile(rf"(?:growth rate|μ|mu)\s*(?:of|=|:|~|≈)?\s*{NUMERIC_RE}\s*(?:h\^?-?1|/h|hr-1|per hour|h\^\(-1\))", re.IGNORECASE)
 
 
+# ---------------- perturbation / conditional-growth patterns ----------------
+#
+# These regexes drive the v2-schema extraction (PerturbationContext,
+# StrainModification, NutrientOverride, growth_mode, is_max_attainment)
+# added by commit 0a81ef48c. The extractor does NOT auto-resolve
+# ontology CURIEs — the curator supplies those at review time. We only
+# surface descriptors, types, and quantitative levels when extractable.
+
+# StrainModification — knockouts, deletions, insertions, mutants, adapted strains.
+_STRAIN_MOD_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"\b(?P<target>[A-Za-z][\w-]{1,30})\s*[:]{2}\s*Tn\d+\b"),
+     "INSERTION"),
+    (re.compile(r"\b(?P<target>[A-Za-z][\w-]{1,30})\s*[:]{2}knockout\b", re.IGNORECASE),
+     "KNOCKOUT"),
+    (re.compile(r"\bknockout(?:\s+(?:strain|mutant))?\s+(?:of\s+)?(?P<target>[A-Za-z][\w-]{1,30})\b", re.IGNORECASE),
+     "KNOCKOUT"),
+    (re.compile(r"\b(?P<target>[A-Za-z][\w-]{1,30})\s+knockout\b", re.IGNORECASE),
+     "KNOCKOUT"),
+    (re.compile(r"\b(?:Δ|delta)\s*(?P<target>[A-Za-z][\w-]{1,30})\b", re.IGNORECASE),
+     "DELETION"),
+    (re.compile(r"\bdeletion\s+(?:strain|mutant)?\s*(?:of\s+)?(?P<target>[A-Za-z][\w-]{1,30})\b", re.IGNORECASE),
+     "DELETION"),
+    (re.compile(r"\b(?P<target>[A-Za-z][\w-]{1,30})\s+deletion\b", re.IGNORECASE),
+     "DELETION"),
+    (re.compile(r"\b(?P<target>[A-Za-z][\w-]{1,30})-deficient\b", re.IGNORECASE),
+     "KNOCKOUT"),
+    (re.compile(r"\bserially\s+adapted\s+for\s+(?:growth\s+on\s+)?(?P<target>[A-Za-z][\w\-\s]{2,40})\b", re.IGNORECASE),
+     "ADAPTATION"),
+    (re.compile(r"\b(?:experimentally\s+)?adapted\s+(?:for|to)\s+(?:growth\s+on\s+)?(?P<target>[A-Za-z][\w\-\s]{2,40})\b", re.IGNORECASE),
+     "ADAPTATION"),
+    (re.compile(r"\bselected\s+for\s+(?P<target>[A-Za-z][\w\-\s]{2,40})\b", re.IGNORECASE),
+     "SELECTION"),
+    (re.compile(r"\bmutant\s+strain(?:\s+(?:of|in)\s+)?(?P<target>[A-Za-z][\w-]{1,30})?\b", re.IGNORECASE),
+     "POINT_MUTATION"),
+]
+
+# Chemical-stress detection — heavy metals, oxidative agents, antibiotics.
+# Heavy-metal pattern: matches "<agent> ... <level> <unit>" within ~40
+# chars. Levels often appear before the agent ("addition of 10 mg L-1
+# Cr(VI)") so we anchor on either order. Units accept the common
+# formatter variants used in PubMed abstracts: "mg/L", "mg L-1",
+# "mg·L-1", "mM", "µM", etc.
+_LEVEL_UNIT = r"(?P<level>\d+(?:\.\d+)?)\s*(?P<unit>mg\s*[·\s/]?\s*L\s*-?\s*1|mg\s*/\s*L|mg/L|mM|µM|uM|μM|µg/mL|ug/mL|nM|%)"
+_METAL_AGENT = r"(?P<agent>Cr\(VI\)|Cr6\+|Cr\(III\)|Cd\d*\+?|Pb\d*\+?|Hg\d*\+?|As\d*\+?|Ni\d*\+?|Cu\d*\+?|Zn\d*\+?)"
+_HEAVY_METAL_RE = re.compile(
+    rf"{_METAL_AGENT}(?:\s+at\s+|\s+of\s+|\s+\(|\s+){_LEVEL_UNIT}",
+    re.IGNORECASE,
+)
+# Reverse-order ("10 mg L-1 Cr(VI)") — common in chemistry abstracts.
+_HEAVY_METAL_REV_RE = re.compile(
+    rf"{_LEVEL_UNIT}\s+(?:of\s+)?{_METAL_AGENT}",
+    re.IGNORECASE,
+)
+# Even without a numeric level — flag heavy-metal mention.
+_HEAVY_METAL_LITE_RE = re.compile(
+    r"\b(?P<agent>Cr\(VI\)|Cr6\+|Cr\(III\)|Cd2\+|Pb2\+|Hg2\+|As\d+\+|chromate|chromium|cadmium|mercury|arsenic|nickel)\b",
+    re.IGNORECASE,
+)
+_OXIDATIVE_RE = re.compile(
+    r"\b(?P<agent>H2O2|hydrogen\s+peroxide|peroxide|paraquat|menadione|oxidative\s+stress)\b",
+    re.IGNORECASE,
+)
+_ANTIBIOTIC_RE = re.compile(
+    r"\b(?P<agent>ampicillin|kanamycin|tetracycline|chloramphenicol|streptomycin|rifampicin|gentamicin|spectinomycin)"
+    r"(?:\s+at\s+(?P<level>\d+(?:\.\d+)?)\s*(?P<unit>mg/mL|µg/mL|ug/mL|µg·mL-1|mM|µM|uM))?",
+    re.IGNORECASE,
+)
+
+# Temperature-stress — explicit cold-shock / heat-stress / "at N°C" phrasing.
+_TEMP_STRESS_AFFIRMATIVES = (
+    "cold shock", "cold-shock", "cold stress", "cold growth",
+    "heat shock", "heat-shock", "heat stress",
+    "low temperature", "elevated temperature", "temperature shock",
+)
+_TEMP_RE = re.compile(
+    rf"\bat\s+{NUMERIC_RE}\s*(?:°\s*C|degrees?\s*C|°?C)\b",
+    re.IGNORECASE,
+)
+_TEMP_AND_GROWTH_RE = re.compile(
+    rf"\b(?:grow|grew|growth|cultivation|cultivated|incubated)\s+(?:at\s+)?{NUMERIC_RE}\s*(?:°\s*C|degrees?\s*C|°?C)\b",
+    re.IGNORECASE,
+)
+
+# Nutrient overrides — "sole carbon source", "as the only nitrogen source", etc.
+_SOLE_SOURCE_RE = re.compile(
+    r"(?:^|\b)(?P<source>[A-Za-z][\w\-\(\),]{1,40}(?:\s+[\w\-\(\),]{1,40}){0,3})"
+    r"\s+(?:when\s+used\s+)?as\s+(?:the\s+)?(?:sole|only)\s+source\s+of\s+(?P<role>nitrogen|carbon|sulfur|phosphate|phosphorus|electron)\b",
+    re.IGNORECASE,
+)
+_SOLE_SOURCE_ALT_RE = re.compile(
+    r"\b(?:sole|only)\s+(?P<role>nitrogen|carbon|sulfur|phosphate|phosphorus|electron)\s+(?:source|donor|acceptor)\s*[:\-]?\s*(?P<source>[A-Za-z][\w\-\(\),]{1,40}(?:\s+[\w\-\(\),]{1,40}){0,3})",
+    re.IGNORECASE,
+)
+_WITH_SOURCE_RE = re.compile(
+    r"\bwith\s+(?P<source>[A-Za-z][\w\-\(\),]{1,40}(?:\s+[\w\-\(\),]{1,40}){0,2})"
+    r"\s+as\s+(?:the\s+)?(?:sole\s+)?(?P<role>carbon|nitrogen|sulfur|phosphate|phosphorus|electron)\s+source\b",
+    re.IGNORECASE,
+)
+
+# Growth mode — chemostat / fed-batch / biofilm / continuous flow.
+_GROWTH_MODE_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"\bchemostat\b", re.IGNORECASE), "CHEMOSTAT"),
+    (re.compile(r"\bturbidostat\b", re.IGNORECASE), "TURBIDOSTAT"),
+    (re.compile(r"\bfed[\s-]batch\b", re.IGNORECASE), "FED_BATCH"),
+    (re.compile(r"\bcontinuous(?:[\s-]flow)?\s+(?:culture|cultivation)\b", re.IGNORECASE), "CONTINUOUS_FLOW"),
+    (re.compile(r"\bbiofilm\b", re.IGNORECASE), "BIOFILM"),
+    (re.compile(r"\bbatch\s+(?:culture|growth|cultivation)\b", re.IGNORECASE), "BATCH"),
+]
+
+# Max-attainment affirmatives extending the OD-context ones to apply
+# across all metric types. Used for is_max_attainment detection.
+_MAX_ATTAINMENT_AFFIRMATIVES = (
+    "up to", "maximum", "minimum doubling time", "fastest", "shortest",
+    "exponential phase", "exponential growth",
+    "optimum growth", "optimal growth", "highest", "max ",
+)
+_CONDITIONAL_MARKERS = (
+    "during slow growth", "slow-growth",
+    "lag phase", "stress", "deficient", "knockout", "mutant",
+    "adapted", "limited", "limitation",
+    "cold shock", "heat shock", "cold growth",
+    "as sole source", "as the sole source", "as the only source",
+    "as the sole carbon", "as the sole nitrogen",
+    "chemostat", "fed-batch", "biofilm",
+)
+
+
 # ---------------- recipe loading ----------------
 
 def iter_recipes(medium_glob: str | None,
@@ -321,6 +448,292 @@ def find_snippet_for(text: str, needle: str) -> str | None:
     return None
 
 
+# ---------------- v2: perturbation / conditional-growth extraction ----------------
+
+def _normalize_role(raw: str) -> str:
+    r = raw.strip().lower()
+    return {
+        "carbon": "CARBON_SOURCE",
+        "nitrogen": "NITROGEN_SOURCE",
+        "sulfur": "SULFUR_SOURCE",
+        "phosphate": "PHOSPHATE_SOURCE",
+        "phosphorus": "PHOSPHATE_SOURCE",
+        "electron": "ELECTRON_DONOR",
+    }.get(r, "OTHER")
+
+
+def _dedup_dicts(items: list[dict]) -> list[dict]:
+    """Stable dedup of small dicts by their JSON repr (fields are scalar)."""
+    seen: set[str] = set()
+    out: list[dict] = []
+    for d in items:
+        key = json.dumps(d, sort_keys=True, default=str)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(d)
+    return out
+
+
+def extract_strain_modifications(text: str) -> list[dict]:
+    """Return a list of StrainModification candidate dicts."""
+    if not text:
+        return []
+    out: list[dict] = []
+    seen_targets: set[tuple[str, str]] = set()
+    for pat, mod_type in _STRAIN_MOD_PATTERNS:
+        for m in pat.finditer(text):
+            tgt = (m.groupdict().get("target") or "").strip()
+            if not tgt or len(tgt) < 2:
+                continue
+            # Skip very generic words masquerading as targets.
+            if tgt.lower() in {"the", "a", "an", "and", "for", "with", "of", "in",
+                               "strain", "mutant", "growth", "study"}:
+                continue
+            key = (mod_type, tgt.lower())
+            if key in seen_targets:
+                continue
+            seen_targets.add(key)
+            entry: dict = {
+                "modification_type": mod_type,
+                "target": tgt,
+            }
+            if mod_type == "KNOCKOUT":
+                entry["ontology_term"] = "NCIT:C120956"
+            out.append(entry)
+    return out
+
+
+def extract_perturbations(text: str) -> list[dict]:
+    """Return a list of PerturbationContext candidate dicts.
+
+    Detects chemical stress (heavy metals, oxidative agents, antibiotics),
+    temperature stress, and growth-phase markers. Numeric levels and
+    units are extracted when adjacent to the agent name.
+    """
+    if not text:
+        return []
+    out: list[dict] = []
+
+    # Chemical stress — heavy metals (with quantitative level).
+    # Try both orderings: "<agent> at <level> <unit>" and the chemistry-
+    # paper-common reverse "<level> <unit> <agent>".
+    for pat in (_HEAVY_METAL_RE, _HEAVY_METAL_REV_RE):
+        for m in pat.finditer(text):
+            agent = m.group("agent").strip()
+            level = m.group("level")
+            unit = (m.group("unit") or "").strip()
+            # Normalize "mg L-1", "mg·L-1", "mg L 1", "mg/L" → "mg/L"
+            unit_norm = re.sub(r"\s+", "", unit)
+            unit_norm = unit_norm.replace("·", "/").replace("L-1", "/L")
+            unit_norm = unit_norm.replace("L1", "/L")
+            unit_norm = re.sub(r"/+", "/", unit_norm).rstrip("/")
+            if unit_norm.lower() == "mgl":
+                unit_norm = "mg/L"
+            descriptor = f"{agent} at {level} {unit_norm}".strip()
+            entry = {
+                "perturbation_type": "CHEMICAL_STRESS",
+                "descriptor": descriptor,
+                "target": agent,
+            }
+            try:
+                entry["level"] = float(level)
+            except (ValueError, TypeError):
+                pass
+            if unit_norm:
+                entry["level_unit"] = unit_norm
+            out.append(entry)
+
+    # Lite heavy-metal mention (no quantitative level extractable)
+    if not any(p.get("perturbation_type") == "CHEMICAL_STRESS" for p in out):
+        m = _HEAVY_METAL_LITE_RE.search(text)
+        if m:
+            agent = m.group("agent").strip()
+            out.append({
+                "perturbation_type": "CHEMICAL_STRESS",
+                "descriptor": f"{agent} stress",
+                "target": agent,
+            })
+
+    # Oxidative stress
+    for m in _OXIDATIVE_RE.finditer(text):
+        agent = m.group("agent").strip()
+        out.append({
+            "perturbation_type": "OXIDATIVE_STRESS",
+            "descriptor": agent,
+            "target": agent,
+        })
+        break  # one is sufficient
+
+    # Antibiotics — chemical-stress class
+    for m in _ANTIBIOTIC_RE.finditer(text):
+        agent = m.group("agent").strip()
+        entry = {
+            "perturbation_type": "CHEMICAL_STRESS",
+            "descriptor": agent,
+            "target": agent,
+        }
+        level = m.group("level")
+        unit = (m.group("unit") or "").strip() if m.group("unit") else ""
+        if level:
+            try:
+                entry["level"] = float(level)
+            except ValueError:
+                pass
+            if unit:
+                entry["level_unit"] = unit
+        out.append(entry)
+        break
+
+    # Temperature stress — affirmative cold/heat-shock context, OR "at N°C"
+    # paired with a growth/cultivation verb. We flag when:
+    #   (a) an affirmative shock/stress phrase is present, OR
+    #   (b) the abstract reports growth at a low temperature (≤10°C) or
+    #       a high temperature (≥45°C) tied to a growth verb — these
+    #       are non-default for typical mesophilic curated organisms.
+    # Avoids tagging routine "incubated at 37°C" mentions.
+    text_l = text.lower()
+    has_temp_affirmative = any(p in text_l for p in _TEMP_STRESS_AFFIRMATIVES)
+    temp_match = None
+    descriptor_phrase = None
+    if has_temp_affirmative:
+        temp_match = _TEMP_AND_GROWTH_RE.search(text) or _TEMP_RE.search(text)
+        if temp_match:
+            descriptor_phrase = next((p for p in _TEMP_STRESS_AFFIRMATIVES
+                                      if p in text_l), "temperature stress")
+    else:
+        # Implicit cold/heat — growth verb paired with extreme temp.
+        for m in _TEMP_AND_GROWTH_RE.finditer(text):
+            try:
+                t = float(m.group(1))
+            except ValueError:
+                continue
+            if t <= 10.0:
+                temp_match = m
+                descriptor_phrase = f"cold growth at {m.group(1)}°C"
+                break
+            if t >= 45.0:
+                temp_match = m
+                descriptor_phrase = f"thermophilic growth at {m.group(1)}°C"
+                break
+
+    if temp_match is not None and descriptor_phrase is not None:
+        level = temp_match.group(1)
+        entry: dict = {
+            "perturbation_type": "TEMPERATURE_STRESS",
+            "descriptor": descriptor_phrase if "°C" in descriptor_phrase
+                          else f"{descriptor_phrase} at {level}°C",
+            "target": "temperature",
+            "level_unit": "°C",
+        }
+        try:
+            entry["level"] = float(level)
+        except ValueError:
+            pass
+        out.append(entry)
+
+    # Growth-phase — slow-growth / lag-phase markers as conditional context.
+    # We *don't* treat plain "stationary phase" as a perturbation: a
+    # max-OD measurement reported at stationary phase is the standard
+    # max-attainment claim. We only flag explicit slow-growth / lag-phase
+    # qualifiers, which the curator triages have actually rejected as
+    # conditional kinetic claims (PMID:21097629 etc).
+    slow_phrases = (
+        "during slow growth", "slow-growth phase", "slow growth phase",
+        "lag phase",
+    )
+    if any(phrase in text_l for phrase in slow_phrases):
+        descriptor_phrase = next((p for p in slow_phrases if p in text_l),
+                                 "slow growth")
+        out.append({
+            "perturbation_type": "GROWTH_PHASE",
+            "descriptor": descriptor_phrase,
+            "target": "growth phase",
+        })
+
+    return _dedup_dicts(out)
+
+
+def extract_nutrient_overrides(text: str) -> list[dict]:
+    """Return a list of NutrientOverride candidate dicts."""
+    if not text:
+        return []
+    out: list[dict] = []
+    for pat in (_SOLE_SOURCE_RE, _SOLE_SOURCE_ALT_RE, _WITH_SOURCE_RE):
+        for m in pat.finditer(text):
+            role_raw = m.group("role")
+            source = (m.group("source") or "").strip(" ,.;:-")
+            if not source or len(source) < 2:
+                continue
+            # Trim trailing prepositions / articles
+            source = re.sub(
+                r"\s+(when\s+used|when|as|in|for|of|the|a|an)$",
+                "", source, flags=re.IGNORECASE,
+            ).strip(" ,.;:-")
+            # Trim leading prepositions / articles (".on L-phenylalanine")
+            source = re.sub(
+                r"^(?:on|with|in|using|the|a|an)\s+",
+                "", source, flags=re.IGNORECASE,
+            ).strip(" ,.;:-")
+            if not source or len(source) < 2:
+                continue
+            entry = {
+                "role": _normalize_role(role_raw),
+                "source": source,
+                "is_sole_source": True,
+            }
+            out.append(entry)
+    return _dedup_dicts(out)
+
+
+def extract_growth_mode(text: str) -> str | None:
+    """Return a GrowthModeEnum value or None.
+
+    Priority: non-batch modes (CHEMOSTAT, TURBIDOSTAT, FED_BATCH,
+    CONTINUOUS_FLOW, BIOFILM) win over BATCH when both are mentioned —
+    a paper that explicitly contrasts batch vs chemostat is reporting
+    on the more-specific mode.
+    """
+    if not text:
+        return None
+    found_batch = False
+    for pat, mode in _GROWTH_MODE_PATTERNS:
+        if pat.search(text):
+            if mode == "BATCH":
+                found_batch = True
+                continue
+            return mode
+    return "BATCH" if found_batch else None
+
+
+def detect_max_attainment(text: str,
+                          perturbations: list[dict],
+                          strain_mods: list[dict],
+                          nutrient_overrides: list[dict],
+                          growth_mode: str | None) -> bool | None:
+    """Return True/False/None for is_max_attainment.
+
+    Heuristic order (matches the schema-doc's intent):
+      1. If any perturbation/conditional marker is present (perturbations,
+         strain_mods, nutrient_overrides, or non-BATCH growth_mode), the
+         metric is conditional — return False.
+      2. Else if affirmative max-attainment language is present, return True.
+      3. Else None (curator decides).
+    """
+    if perturbations or strain_mods or nutrient_overrides:
+        return False
+    if growth_mode and growth_mode != "BATCH":
+        return False
+    if not text:
+        return None
+    text_l = text.lower()
+    if any(m in text_l for m in _CONDITIONAL_MARKERS):
+        return False
+    if any(p in text_l for p in _MAX_ATTAINMENT_AFFIRMATIVES):
+        return True
+    return None
+
+
 # ---------------- per-recipe proposal ----------------
 
 def propose_for_recipe(recipe: dict, recipe_path: Path,
@@ -363,6 +776,16 @@ def propose_for_recipe(recipe: dict, recipe_path: Path,
             organisms_in_abs = extract_organisms(abstract)
             strains = extract_strains(abstract)
 
+            # v2 schema additions: perturbation / conditional-growth context.
+            strain_modifications = extract_strain_modifications(abstract)
+            perturbations = extract_perturbations(abstract)
+            nutrient_overrides = extract_nutrient_overrides(abstract)
+            growth_mode = extract_growth_mode(abstract)
+            is_max_attainment = detect_max_attainment(
+                abstract, perturbations, strain_modifications,
+                nutrient_overrides, growth_mode,
+            )
+
             if not (metrics or genomes or organisms_in_abs):
                 continue
 
@@ -372,17 +795,31 @@ def propose_for_recipe(recipe: dict, recipe_path: Path,
                 if metric_snippet:
                     break
 
+            extracted: dict = {
+                "organisms": organisms_in_abs,
+                "strains": strains,
+                "genome_assembly_ids": genomes,
+                "growth_metrics": metrics,
+            }
+            # Only emit v2 fields when populated — keeps proposal YAMLs
+            # tidy for non-perturbed papers.
+            if strain_modifications:
+                extracted["strain_modifications"] = strain_modifications
+            if perturbations:
+                extracted["perturbations"] = perturbations
+            if nutrient_overrides:
+                extracted["nutrient_overrides"] = nutrient_overrides
+            if growth_mode is not None:
+                extracted["growth_mode"] = growth_mode
+            if is_max_attainment is not None:
+                extracted["is_max_attainment"] = is_max_attainment
+
             candidates.append({
                 "pmid": pmid,
                 "title": data.get("title", ""),
                 "year": data.get("year", ""),
                 "query": q,
-                "extracted": {
-                    "organisms": organisms_in_abs,
-                    "strains": strains,
-                    "genome_assembly_ids": genomes,
-                    "growth_metrics": metrics,
-                },
+                "extracted": extracted,
                 "snippet": metric_snippet or "",
                 "supports": "REVIEW",
             })


### PR DESCRIPTION
## Summary

Two-part PR landing the curator-workflow follow-ups for schema commit
[`0a81ef48c`](https://github.com/CultureBotAI/CultureMech/commit/0a81ef48c)
(which added `PerturbationContext` / `StrainModification` / `NutrientOverride`
plus `is_max_attainment` and `growth_mode` on `GrowthMetrics`).

### Part A — Extractor extension

`scripts/propose_growth_evidence.py` and `scripts/apply_growth_evidence.py`
now detect and write the v2 schema fields:

- **Strain modifications**: knockout / Δgene / deletion / Tn-insertion /
  *X*-deficient / serially-adapted / selected-for / mutant-strain patterns.
  KNOCKOUT entries auto-tag `NCIT:C120956`.
- **Chemical stress**: heavy metals (`Cr(VI)`, `Cd2+`, `Pb`, `Hg`, `As`, `Ni`,
  `Cu`, `Zn`) in both orderings (`Cr(VI) at 10 mg/L` and `10 mg L-1 Cr(VI)`),
  oxidative agents (`H2O2`, `paraquat`, `peroxide`), and antibiotics. Levels +
  units extracted when adjacent.
- **Temperature stress**: explicit cold/heat-shock language OR an extreme
  temperature (≤10 °C / ≥45 °C) paired with a growth verb. Avoids tagging
  routine `incubated at 37 °C`.
- **Nutrient overrides**: `<src> as sole source of <role>`, `sole <role>
  source: <src>`, and `with <src> as <role> source` patterns. Trims leading
  prepositions ("on", "with") so `L-phenylalanine when used as sole source of
  nitrogen` cleanly yields `{role: NITROGEN_SOURCE, source: L-phenylalanine}`.
- **Growth mode**: `chemostat` / `turbidostat` / `fed-batch` / `continuous-flow`
  / `biofilm` win over `BATCH` when both appear.
- **`is_max_attainment` heuristic**: `False` when any perturbation /
  strain-mod / nutrient-override / non-`BATCH` mode is present, `True` on
  affirmative max-language (`up to`, `fastest`, `exponential phase`), `None`
  otherwise. Plain "stationary phase" alone does NOT flip the flag —
  max-OD measured at stationary phase is the standard max-attainment claim.

### Part B — Backfill of 5 originally-rejected PMIDs

| PMID | Recipe | Metric | Conditional context |
|------|--------|--------|---------------------|
| 37088211 | magnetospirillum_gryphiswaldense_medium | μ = 0.062 h⁻¹ | KNOCKOUT magnetosome operon + CHEMICAL_STRESS Cr(VI) 10 mg/L |
| 21097629 | methanosarcina_medium ¹ | doubling 49 h | GROWTH_PHASE slow-growth |
| 25274120 | caulobacter_medium | doubling 40 h | TEMPERATURE_STRESS 4 °C |
| 21421788 | pyrococcus_medium | doubling 64 min | ADAPTATION cellulose + NUTRIENT_OVERRIDE CF11 cellulose (C-source) |
| 19826864 | rhodobacter_sphaeroides_medium | doubling 18 h | NUTRIENT_OVERRIDE L-phenylalanine (N-source) |

¹ The task spec suggested `methanocaldococcus_jannaschii_medium`, but the
abstract attributes the 49 h doubling time to *M. acetivorans*, not *M.
jannaschii*. Routed to `methanosarcina_medium` (DSMZ 120) accordingly.

### Skipped

**PMID:10792526** (Mtb H37Rv 14.7 h batch + 24 h chemostat) — the paper
develops a Mtb-specific chemically-defined medium that is NOT in the recipe
set. The generic `chemically_defined_medium.yaml` (togomedium.org/medium/M3118)
is unrelated, and 7H9 is explicitly distinguished from the paper's medium.
Skipped per task spec ("if not present, skip with a note") rather than
mis-attaching to a generic recipe.

## Test plan

- [x] Smoke-test extractor on all 6 cached PMID abstracts → every one extracts
      the expected `PerturbationContext` / `StrainModification` /
      `NutrientOverride` / `growth_mode` / `is_max_attainment` values.
- [x] Sanity-check non-perturbation control sentence → returns zero
      perturbations (preserves existing curated rows).
- [x] `apply-growth --proposal-dir workspace/reports/growth_evidence_proposals_backfill --apply`
      → 5 recipes written, 7 v2 fields populated.
- [x] `just validate-growth` → exit 0, 22 OK / 2 MISSING_CACHE (unchanged
      from baseline; cache state is independent of these edits).
- [x] `linkml.validator.Validator` against schema commit `0a81ef48c` → 0
      issues on all 5 backfilled recipes; 0 issues on the 4 pre-existing
      curated recipes (m9, nutrient_broth, bg11, geobacter_sulfurreducens_medium).
- [x] Idempotency: re-running the apply touches 0 records (existing-PMID
      dedup on growth_metrics + (mod_type, target) dedup on
      strain_modifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)