### PR TITLE
Normalize whitespace in preparation_steps descriptions/instructions

### DIFF
--- a/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
+++ b/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: DAS Vitamin Cocktail'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/1_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/1_F_2_Medium.yaml
@@ -53,14 +53,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -68,7 +68,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
+++ b/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
@@ -38,14 +38,14 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -53,7 +53,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Supplemented Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
+++ b/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Natural sea-salt'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/5_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/5_F_2_Medium.yaml
@@ -53,14 +53,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -68,7 +68,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
@@ -43,14 +43,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -58,7 +58,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Modified Bold 3N Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Allen_Medium.yaml
+++ b/data/normalized_yaml/algae/Allen_Medium.yaml
@@ -53,14 +53,14 @@ ingredients:
   notes: 'Original amount: Citric Acid•H2O(Fisher A 104)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -68,7 +68,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
@@ -64,7 +64,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider:The quality of water, including natural
+  description: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   action: MIX
@@ -73,7 +73,7 @@ preparation_steps:
 - step_number: 3
   action: MIX
   description: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   action: MIX
@@ -83,7 +83,7 @@ preparation_steps:
   action: MIX
   description: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   action: ADJUST_PH
   description: In most cases, if pH adjustment is required, this occurs before sterilization.

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
@@ -58,14 +58,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -73,7 +73,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Bold_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_3N_Medium.yaml
@@ -53,14 +53,14 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -68,7 +68,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
@@ -58,14 +58,14 @@ ingredients:
   notes: 'Original amount: Bold Trace Stock'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -73,7 +73,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Botryococcus_Medium.yaml
+++ b/data/normalized_yaml/algae/Botryococcus_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Bristol_Medium.yaml
+++ b/data/normalized_yaml/algae/Bristol_Medium.yaml
@@ -39,7 +39,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider:The quality of water, including natural
+  description: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   action: MIX
@@ -48,7 +48,7 @@ preparation_steps:
 - step_number: 3
   action: MIX
   description: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   action: MIX
@@ -58,7 +58,7 @@ preparation_steps:
   action: MIX
   description: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   action: ADJUST_PH
   description: In most cases, if pH adjustment is required, this occurs before sterilization.

--- a/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Modified COMBO Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Cyanidium_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanidium_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/DYIII_Medium.yaml
+++ b/data/normalized_yaml/algae/DYIII_Medium.yaml
@@ -68,14 +68,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -83,7 +83,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/DYV_Medium.yaml
+++ b/data/normalized_yaml/algae/DYV_Medium.yaml
@@ -73,14 +73,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -88,7 +88,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
@@ -33,14 +33,14 @@ ingredients:
   notes: 'Original amount: DAS Vitamin Cocktail'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -48,7 +48,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Desmid_Medium.yaml
+++ b/data/normalized_yaml/algae/Desmid_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: KNO3(Baker 3190)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Euglena_Medium.yaml
+++ b/data/normalized_yaml/algae/Euglena_Medium.yaml
@@ -33,14 +33,14 @@ ingredients:
   notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -48,7 +48,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/F_2_Medium.yaml
@@ -44,7 +44,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider:The quality of water, including natural
+  description: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   action: MIX
@@ -53,7 +53,7 @@ preparation_steps:
 - step_number: 3
   action: MIX
   description: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   action: MIX
@@ -63,7 +63,7 @@ preparation_steps:
   action: MIX
   description: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   action: ADJUST_PH
   description: In most cases, if pH adjustment is required, this occurs before sterilization.

--- a/data/normalized_yaml/algae/HEPES_Medium.yaml
+++ b/data/normalized_yaml/algae/HEPES_Medium.yaml
@@ -48,14 +48,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -63,7 +63,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/J_Medium.yaml
+++ b/data/normalized_yaml/algae/J_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: G9 Trace Metals for J medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/LDM_Medium.yaml
+++ b/data/normalized_yaml/algae/LDM_Medium.yaml
@@ -63,14 +63,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -78,7 +78,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Malt_Medium.yaml
+++ b/data/normalized_yaml/algae/Malt_Medium.yaml
@@ -13,14 +13,14 @@ ingredients:
   notes: 'Original amount: Malt extract(Sigma M-0383)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -28,7 +28,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
@@ -73,14 +73,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -88,7 +88,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
@@ -63,14 +63,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -78,7 +78,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: F/2 Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
@@ -68,14 +68,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -83,7 +83,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
@@ -48,14 +48,14 @@ ingredients:
   notes: 'Original amount: Barley grains autoclaved'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -63,7 +63,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/N_20_Medium.yaml
+++ b/data/normalized_yaml/algae/N_20_Medium.yaml
@@ -63,14 +63,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -78,7 +78,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Ochromonas_Medium.yaml
+++ b/data/normalized_yaml/algae/Ochromonas_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Liver extract infusion'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/P49_Medium.yaml
+++ b/data/normalized_yaml/algae/P49_Medium.yaml
@@ -68,14 +68,14 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -83,7 +83,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Polytomella_Medium.yaml
+++ b/data/normalized_yaml/algae/Polytomella_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Sodium acetate(Fisher BP 333)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Porphryridium_Medium.yaml
+++ b/data/normalized_yaml/algae/Porphryridium_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Tryptone(Sigma T 9410)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Proteose_Medium.yaml
+++ b/data/normalized_yaml/algae/Proteose_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Proteose Peptone(BD 211684)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
+++ b/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
@@ -58,14 +58,14 @@ ingredients:
   notes: 'Original amount: KH2PO4(Sigma P 0662)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -73,7 +73,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
+++ b/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Spirulina_Medium.yaml
+++ b/data/normalized_yaml/algae/Spirulina_Medium.yaml
@@ -19,7 +19,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider:The quality of water, including natural
+  description: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   action: MIX
@@ -28,7 +28,7 @@ preparation_steps:
 - step_number: 3
   action: MIX
   description: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   action: MIX
@@ -38,7 +38,7 @@ preparation_steps:
   action: MIX
   description: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   action: ADJUST_PH
   description: In most cases, if pH adjustment is required, this occurs before sterilization.

--- a/data/normalized_yaml/algae/TAP_Medium.yaml
+++ b/data/normalized_yaml/algae/TAP_Medium.yaml
@@ -29,7 +29,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider:The quality of water, including natural
+  description: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   action: MIX
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 3
   action: MIX
   description: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   action: MIX
@@ -48,7 +48,7 @@ preparation_steps:
   action: MIX
   description: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   action: ADJUST_PH
   description: In most cases, if pH adjustment is required, this occurs before sterilization.

--- a/data/normalized_yaml/algae/Trebouxia_Medium.yaml
+++ b/data/normalized_yaml/algae/Trebouxia_Medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Glucose(BACTO-dextrose or Sigma D 9634)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Volvocacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvocacean_Medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Euglena Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Volvox_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvox_Medium.yaml
@@ -48,14 +48,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -63,7 +63,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/WC+_Medium.yaml
+++ b/data/normalized_yaml/algae/WC+_Medium.yaml
@@ -68,14 +68,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -83,7 +83,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/WC_Medium.yaml
+++ b/data/normalized_yaml/algae/WC_Medium.yaml
@@ -63,14 +63,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -78,7 +78,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/Waris_Medium.yaml
+++ b/data/normalized_yaml/algae/Waris_Medium.yaml
@@ -33,14 +33,14 @@ ingredients:
   notes: 'Original amount: P-IV Metal Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -48,7 +48,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/a_medium.yaml
+++ b/data/normalized_yaml/algae/a_medium.yaml
@@ -59,14 +59,14 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -74,7 +74,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/bg_11_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_medium.yaml
@@ -59,14 +59,14 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -74,7 +74,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/bg_11_n_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_n_medium.yaml
@@ -54,14 +54,14 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -69,7 +69,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/bristol_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bristol_nacl_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/chus_medium.yaml
+++ b/data/normalized_yaml/algae/chus_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NaHCO3(Fisher S 233)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
+++ b/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Sphagnum extract'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/erdschreibers_medium.yaml
@@ -38,14 +38,14 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -53,7 +53,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/f_2_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/f_2_nh4_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/mes_volvox_medium.yaml
+++ b/data/normalized_yaml/algae/mes_volvox_medium.yaml
@@ -53,14 +53,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -68,7 +68,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
+++ b/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: F/2 Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
+++ b/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: Sodium Metasilicate'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/soil_seawater_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/soilwater_gr_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_medium.yaml
@@ -23,14 +23,14 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -38,7 +38,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
+++ b/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
@@ -38,14 +38,14 @@ ingredients:
   notes: 'Original amount: Euglena Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -53,7 +53,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
+++ b/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
@@ -28,14 +28,14 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -43,7 +43,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
+++ b/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
@@ -18,14 +18,14 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider:The quality of water, including natural
+  instruction: Important Notes To Consider: The quality of water, including natural
     seawater, is important.
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.
 - step_number: 3
   instruction: Natural seawater and natural freshwater should be obtained from a non-polluted
-    source.When dissolving chemicals, wait for the first component to dissolve before
+    source. When dissolving chemicals, wait for the first component to dissolve before
     adding the second.
 - step_number: 4
   instruction: Stirring, and sometimes the addition of heat, is often required to
@@ -33,7 +33,7 @@ preparation_steps:
 - step_number: 5
   instruction: Preparation of stock solutions for frequently made algal culture media
     make preparing media convenient but also necessary to avoid errors from weighing
-    very tiny amounts.Attention should be given to the pH of the final medium.
+    very tiny amounts. Attention should be given to the pH of the final medium.
 - step_number: 6
   instruction: In most cases, if pH adjustment is required, this occurs before sterilization.
 - step_number: 7

--- a/data/normalized_yaml/bacterial/mq116_medium.yaml
+++ b/data/normalized_yaml/bacterial/mq116_medium.yaml
@@ -221,7 +221,7 @@ preparation_steps:
   action: AUTOCLAVE
   description: Mix components thoroughly and adjust pH to 7.0. Distribute the medium
     into culture vessels (e.g., 20 ml medium in 60 ml serum bottle) under a N2 gas
-    atmosphere, seal with butyl rubber stoppers and autoclave.After cooling, aseptically
+    atmosphere, seal with butyl rubber stoppers and autoclave. After cooling, aseptically
     and anaerobically add per liter the following solutions (autoclaved and stored
     under N2)
 - step_number: 2


### PR DESCRIPTION
## Summary
- Copilot review of #7 flagged missing spaces after colons/periods in prep-steps text (e.g. `Notes To Consider:The quality of water...`, `non-polluted source.When dissolving chemicals`). The whitespace defects came from upstream source documents.
- Fixes 283 occurrences across 100 YAMLs:
  - 92 × `Notes To Consider:([A-Z])` → `Notes To Consider: \1`
  - 191 × `([a-z].)([A-Z])` → `\1 \2` (sentence boundary), block-scoped to `preparation_steps[*].description` / `instruction` to avoid touching CURIE/decimal patterns elsewhere.

## Test plan
- [x] `git diff --stat` confirms only single-character insertions in `preparation_steps` continuations.
- [x] No CURIE, decimal, ontology-id, or non-prep field touched.
- [ ] Pages refresh on next `just gen-pages` will reflect the fix on the public site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)