### PR TITLE
Hotfix: YAML parse error from PR #9 whitespace fix

### DIFF
--- a/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
+++ b/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: DAS Vitamin Cocktail'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/1_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/1_F_2_Medium.yaml
@@ -53,8 +53,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
+++ b/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
@@ -38,8 +38,7 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Supplemented Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
+++ b/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Natural sea-salt'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/5_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/5_F_2_Medium.yaml
@@ -53,8 +53,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
@@ -43,8 +43,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Modified Bold 3N Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Allen_Medium.yaml
+++ b/data/normalized_yaml/algae/Allen_Medium.yaml
@@ -53,8 +53,7 @@ ingredients:
   notes: 'Original amount: Citric Acid•H2O(Fisher A 104)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
@@ -64,8 +64,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Erdschreiber''s Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
@@ -58,8 +58,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Bold_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_3N_Medium.yaml
@@ -53,8 +53,7 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
@@ -58,8 +58,7 @@ ingredients:
   notes: 'Original amount: Bold Trace Stock'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Botryococcus_Medium.yaml
+++ b/data/normalized_yaml/algae/Botryococcus_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Bristol_Medium.yaml
+++ b/data/normalized_yaml/algae/Bristol_Medium.yaml
@@ -39,8 +39,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized

--- a/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Modified COMBO Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Cyanidium_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanidium_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/DYIII_Medium.yaml
+++ b/data/normalized_yaml/algae/DYIII_Medium.yaml
@@ -68,8 +68,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/DYV_Medium.yaml
+++ b/data/normalized_yaml/algae/DYV_Medium.yaml
@@ -73,8 +73,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
@@ -33,8 +33,7 @@ ingredients:
   notes: 'Original amount: DAS Vitamin Cocktail'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Desmid_Medium.yaml
+++ b/data/normalized_yaml/algae/Desmid_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: KNO3(Baker 3190)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Enrichment Solution for Seawater Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Euglena_Medium.yaml
+++ b/data/normalized_yaml/algae/Euglena_Medium.yaml
@@ -33,8 +33,7 @@ ingredients:
   notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/F_2_Medium.yaml
@@ -44,8 +44,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized

--- a/data/normalized_yaml/algae/HEPES_Medium.yaml
+++ b/data/normalized_yaml/algae/HEPES_Medium.yaml
@@ -48,8 +48,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/J_Medium.yaml
+++ b/data/normalized_yaml/algae/J_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: G9 Trace Metals for J medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/LDM_Medium.yaml
+++ b/data/normalized_yaml/algae/LDM_Medium.yaml
@@ -63,8 +63,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Malt_Medium.yaml
+++ b/data/normalized_yaml/algae/Malt_Medium.yaml
@@ -13,8 +13,7 @@ ingredients:
   notes: 'Original amount: Malt extract(Sigma M-0383)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Sterile dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
@@ -73,8 +73,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
@@ -63,8 +63,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: F/2 Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
@@ -68,8 +68,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
@@ -48,8 +48,7 @@ ingredients:
   notes: 'Original amount: Barley grains autoclaved'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/N_20_Medium.yaml
+++ b/data/normalized_yaml/algae/N_20_Medium.yaml
@@ -63,8 +63,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Ochromonas_Medium.yaml
+++ b/data/normalized_yaml/algae/Ochromonas_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Liver extract infusion'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/P49_Medium.yaml
+++ b/data/normalized_yaml/algae/P49_Medium.yaml
@@ -68,8 +68,7 @@ ingredients:
   notes: 'Original amount: Thiamine Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Polytomella_Medium.yaml
+++ b/data/normalized_yaml/algae/Polytomella_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Sodium acetate(Fisher BP 333)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Porphryridium_Medium.yaml
+++ b/data/normalized_yaml/algae/Porphryridium_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Tryptone(Sigma T 9410)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Proteose_Medium.yaml
+++ b/data/normalized_yaml/algae/Proteose_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Proteose Peptone(BD 211684)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
+++ b/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
@@ -58,8 +58,7 @@ ingredients:
   notes: 'Original amount: KH2PO4(Sigma P 0662)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
+++ b/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Spirulina_Medium.yaml
+++ b/data/normalized_yaml/algae/Spirulina_Medium.yaml
@@ -19,8 +19,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized

--- a/data/normalized_yaml/algae/TAP_Medium.yaml
+++ b/data/normalized_yaml/algae/TAP_Medium.yaml
@@ -29,8 +29,7 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized

--- a/data/normalized_yaml/algae/Trebouxia_Medium.yaml
+++ b/data/normalized_yaml/algae/Trebouxia_Medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Glucose(BACTO-dextrose or Sigma D 9634)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Volvocacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvocacean_Medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Euglena Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Volvox_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvox_Medium.yaml
@@ -48,8 +48,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/WC+_Medium.yaml
+++ b/data/normalized_yaml/algae/WC+_Medium.yaml
@@ -68,8 +68,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/WC_Medium.yaml
+++ b/data/normalized_yaml/algae/WC_Medium.yaml
@@ -63,8 +63,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/Waris_Medium.yaml
+++ b/data/normalized_yaml/algae/Waris_Medium.yaml
@@ -33,8 +33,7 @@ ingredients:
   notes: 'Original amount: P-IV Metal Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/a_medium.yaml
+++ b/data/normalized_yaml/algae/a_medium.yaml
@@ -59,8 +59,7 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/bg_11_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_medium.yaml
@@ -59,8 +59,7 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/bg_11_n_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_n_medium.yaml
@@ -54,8 +54,7 @@ ingredients:
     3946)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/bristol_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bristol_nacl_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NaCl(Fisher S271-500)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/chus_medium.yaml
+++ b/data/normalized_yaml/algae/chus_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NaHCO3(Fisher S 233)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
+++ b/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Sphagnum extract'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/erdschreibers_medium.yaml
@@ -38,8 +38,7 @@ ingredients:
   notes: 'Original amount: Vitamin B12'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/f_2_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/f_2_nh4_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/mes_volvox_medium.yaml
+++ b/data/normalized_yaml/algae/mes_volvox_medium.yaml
@@ -53,8 +53,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
+++ b/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: F/2 Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
+++ b/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: Sodium Metasilicate'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/soil_seawater_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Pasteurized Seawater'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/soilwater_gr_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_medium.yaml
@@ -23,8 +23,7 @@ ingredients:
   notes: 'Original amount: dH2O'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: NH4MgPO4(Sigma 529354)'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
+++ b/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
@@ -38,8 +38,7 @@ ingredients:
   notes: 'Original amount: Euglena Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
+++ b/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
@@ -28,8 +28,7 @@ ingredients:
   notes: 'Original amount: Biotin Vitamin Solution'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.

--- a/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
+++ b/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
@@ -18,8 +18,7 @@ ingredients:
   notes: 'Original amount: Soilwater: GR+ Medium'
 preparation_steps:
 - step_number: 1
-  instruction: Important Notes To Consider: The quality of water, including natural
-    seawater, is important.
+  instruction: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
 - step_number: 2
   instruction: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
     water, Milli-Q water (Millipore Corp.), etc.


### PR DESCRIPTION
## Summary
- PR #9 ("Normalize whitespace in preparation_steps...") inserted a space after `Notes To Consider:` in 92 YAMLs. The new `: ` inside an unquoted YAML scalar makes the parser interpret it as a mapping separator → 99 files now fail to load with `mapping values are not allowed here`.
- This hotfix wraps the affected `description` / `instruction` scalars in single quotes so the literal `:` survives. Multi-line plain-scalar continuations collapse into the single-quoted string.
- Net effect: same human-visible text + same whitespace improvement from #9, but the YAML actually parses.

## Test plan
- [x] `yaml.safe_load` on every YAML under `data/normalized_yaml/`: 99 broken → 0 broken
- [ ] `just gen-pages` runs without exceptions (verified locally; pages regenerate cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)