### PR TITLE
Audit cleanup follow-ups: 9 backlog items (G09-G14, G16, G18, G20)

### DIFF
--- a/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
+++ b/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
@@ -93,16 +93,16 @@ variants:
   modifications:
   - Use magnetosome-deficient strain B17316 derived from M. gryphiswaldense MSR-1.
   - Add Cr(VI) at 10 mg/L.
-  purpose: Capture strain-modification and chromium-stress growth evidence under
-    the parent Magnetospirillum gryphiswaldense Medium record.
+  purpose: Capture strain-modification and chromium-stress growth evidence under the
+    parent Magnetospirillum gryphiswaldense Medium record.
   evidence:
   - reference: PMID:37088211
     supports: SUPPORT
     snippet: The addition of 10 mg L-1 Cr(VI) significantly inhibited cell growth,
       but the magnetosome-deficient strain, B17316, showed an average specific growth
       rate of 0.062 h-1 at the same dosage.
-    explanation: Literature evidence supports a Cr(VI)-stress variant for
-      magnetosome-deficient Magnetospirillum gryphiswaldense strain B17316.
+    explanation: Literature evidence supports a Cr(VI)-stress variant for magnetosome-deficient
+      Magnetospirillum gryphiswaldense strain B17316.
 curation_history:
 - timestamp: '2026-01-26T17:53:17.212107Z'
   curator: mediadive-import
@@ -133,6 +133,10 @@ curation_history:
   curator: literature_review_apply
   action: ADDED_GROWTH_EVIDENCE
   notes: organisms_added=1 metrics_added=1 genomes_added=0
+- timestamp: '2026-05-20T02:54:07.099061+00:00'
+  curator: migrate_ontology_term_rename.py
+  action: MIGRATED_ONTOLOGY_TERM_RENAME
+  notes: ontology_term->ontology_id for 2 entry/entries
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: MAGNETOSPIRILLUM GRYPHISWALDENSE
@@ -144,7 +148,7 @@ target_organisms:
   - modification_type: KNOCKOUT
     target: magnetosome operon
     description: magnetosome-deficient strain B17316
-    ontology_term: NCIT:C120956
+    ontology_id: NCIT:C120956
   growth_metrics:
   - growth_rate_per_hour: 0.062
     evidence:
@@ -162,4 +166,4 @@ target_organisms:
       target: chromium hexavalent
       level: 10.0
       level_unit: mg/L
-      ontology_term: CHEBI:53456
+      ontology_id: CHEBI:53456

--- a/project.justfile
+++ b/project.justfile
@@ -752,6 +752,23 @@ validate-strict *args:
     #!/usr/bin/env bash
     uv run python scripts/validate_strict.py {{args}}
 
+# Scan-only collision check for CultureMech:NNNNNN IDs. Exits non-zero if any
+# cross-file duplicates are detected. Use as a pre-commit / CI safety net.
+[group('QC')]
+assign-ids-check:
+    #!/usr/bin/env bash
+    uv run python scripts/assign_culturemech_ids.py --check
+
+# Mint CultureMech:NNNNNN IDs for any YAML records missing one. Refuses to run
+# if cross-file collisions exist among existing IDs (run `assign-ids-check`
+# first to surface them).
+#     just assign-ids --dry-run   # rehearse only
+#     just assign-ids             # apply
+[group('QC')]
+assign-ids *args:
+    #!/usr/bin/env bash
+    uv run python scripts/assign_culturemech_ids.py {{args}}
+
 # ================================================================
 # VALIDATION AND FIXING (Track 3)
 # ================================================================

--- a/reports/instance_validation_failures.tsv
+++ b/reports/instance_validation_failures.tsv
@@ -1,1 +1,1 @@
-file	category	detail	path	message
+file	layer	category	detail	path	message

--- a/reports/pipeline_writers_audit.tsv
+++ b/reports/pipeline_writers_audit.tsv
@@ -6,13 +6,14 @@ scripts/analyze_metal_concentrations.py	yes	no	no	no	no
 scripts/apply_edison_results.py	yes	yes	yes	no	no
 scripts/apply_growth_evidence.py	yes	yes	no	no	yes
 scripts/apply_media_variant_links.py	yes	no	no	no	yes
-scripts/assign_culturemech_ids.py	yes	yes	yes	no	no
+scripts/assign_culturemech_ids.py	yes	yes	yes	no	yes
 scripts/assign_taxonomy.py	yes	no	yes	no	no
 scripts/audit_writers.py	yes	yes	yes	yes	no
 scripts/build_media_content_review_manifest.py	yes	no	no	no	yes
 scripts/build_media_growth_review_manifest.py	yes	no	no	no	no
 scripts/cleanup_media_quality.py	yes	yes	no	no	no
 scripts/cleanup_recipe_ingredients.py	yes	no	yes	no	yes
+scripts/cleanup_residual_errors.py	yes	yes	yes	no	no
 scripts/compare_fingerprints.py	yes	no	no	no	no
 scripts/create_recipe_from_input.py	yes	yes	yes	no	no
 scripts/enrich_genome_ids.py	yes	no	no	no	yes
@@ -20,7 +21,7 @@ scripts/enrich_solutions_with_chebi.py	yes	no	yes	no	no
 scripts/enrich_with_chebi.py	yes	yes	yes	no	yes
 scripts/enrich_with_kg_microbe_matches.py	yes	yes	yes	no	no
 scripts/fetch_pubmed_abstracts.py	yes	no	yes	no	yes
-scripts/fix_schema_inconsistencies.py	yes	no	yes	no	no
+scripts/fix_schema_inconsistencies.py	yes	yes	yes	yes	no
 scripts/fix_validation_errors.py	yes	no	yes	yes	yes
 scripts/generate_sssom_mappings.py	yes	no	no	no	yes
 scripts/import_from_communitymech.py	yes	yes	yes	no	no
@@ -28,7 +29,11 @@ scripts/import_from_culturebotht.py	yes	yes	yes	no	no
 scripts/import_mediadive_solutions.py	yes	no	yes	no	no
 scripts/infer_ph_values.py	yes	yes	yes	no	no
 scripts/infer_sterilization_method.py	yes	yes	yes	no	no
+scripts/migrate_data_quality_flags.py	yes	yes	yes	no	no
 scripts/migrate_growth_metrics_v2.py	yes	no	no	no	no
+scripts/migrate_legacy_fields.py	yes	yes	yes	no	no
+scripts/migrate_ontology_term_rename.py	yes	yes	yes	no	no
+scripts/migrate_preparation_steps.py	yes	yes	yes	no	no
 scripts/migrate_solutions_from_ingredients.py	yes	yes	yes	no	no
 scripts/monitor_merges.py	yes	no	no	no	no
 scripts/normalize_media_names_to_snake_case.py	yes	yes	yes	no	no

--- a/scripts/assign_culturemech_ids.py
+++ b/scripts/assign_culturemech_ids.py
@@ -39,6 +39,9 @@ class CultureMechIDAssigner:
             'errors': []
         }
         self.id_registry = {}  # Maps CultureMech ID → file path
+        # Maps CultureMech ID → list of file paths (only populated when >1).
+        # Used by --check to detect cross-file ID collisions.
+        self.duplicates: Dict[str, List[str]] = defaultdict(list)
 
     def format_id(self, id_number: int) -> str:
         """Format ID as CultureMech:NNNNNN."""
@@ -82,7 +85,14 @@ class CultureMechIDAssigner:
                     if id_num:
                         self.stats['files_with_id'] += 1
                         highest_id = max(highest_id, id_num)
-                        self.id_registry[existing_id] = str(yaml_path)
+                        if existing_id in self.id_registry:
+                            # Cross-file duplicate. Remember both sides.
+                            entry = self.duplicates[existing_id]
+                            if not entry:
+                                entry.append(self.id_registry[existing_id])
+                            entry.append(str(yaml_path))
+                        else:
+                            self.id_registry[existing_id] = str(yaml_path)
 
             except Exception as e:
                 self.stats['errors'].append(f"Error scanning {yaml_path.name}: {e}")
@@ -264,6 +274,12 @@ def main():
         action='store_true',
         help='Dry run mode - no files will be modified'
     )
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Scan-only: detect cross-file ID collisions and exit non-zero if any found. '
+             'No files modified. Use this as a pre-commit / CI gate.'
+    )
 
     args = parser.parse_args()
 
@@ -284,6 +300,19 @@ def main():
 
     # Step 1: Scan for existing IDs
     highest_existing = assigner.scan_existing_ids(args.input_dir)
+
+    # Collision detection — applies in --check mode and is also a pre-flight
+    # check before any new assignment runs.
+    if assigner.duplicates:
+        print(f"\n❌ {len(assigner.duplicates)} duplicate CultureMech ID(s) detected:")
+        for id_str, paths in sorted(assigner.duplicates.items()):
+            print(f"  {id_str}: {len(paths)} files")
+            for p in paths:
+                print(f"    - {p}")
+        return 2
+    if args.check:
+        print("\n✓ No duplicate IDs detected.")
+        return 0
 
     # Step 2: Set starting ID to next available
     if highest_existing > 0:

--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -49,6 +49,7 @@ _VALIDATE_BEFORE_WRITE = re.compile(
     r"|RecipeValidator"
     r"|validate_recipe\("
     r"|validator\.validate\("
+    r"|write_validated_recipe\("  # G09 helper from culturemech.validation
 )
 
 
@@ -63,6 +64,9 @@ def script_paths() -> list[Path]:
 
 def looks_like_yaml_writer(text: str) -> bool:
     if "yaml.safe_dump(" in text or "yaml.dump(" in text:
+        return True
+    # write_validated_recipe is the G09 helper that wraps yaml.safe_dump.
+    if "write_validated_recipe(" in text:
         return True
     # `.write_text(` only counts if combined with a yaml hint nearby.
     if ".write_text(" in text and _WRITE_YAML_HINT.search(text):

--- a/scripts/cleanup_residual_errors.py
+++ b/scripts/cleanup_residual_errors.py
@@ -27,12 +27,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import datetime
 import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
 
 CURATOR = "cleanup_residual_errors.py"
 ACTION = "CLEANUP_RESIDUAL_ERRORS"
@@ -44,10 +46,6 @@ UNIT_CONVERSIONS = {
     "G_PER_100ML": ("G_PER_L", 10.0),
     "ML_PER_40ML": ("PERCENT_V_V", 2.5),
 }
-
-
-def now_iso() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def _to_float(value: Any) -> float | None:
@@ -171,13 +169,7 @@ def migrate_one(path: Path, dry_run: bool) -> dict[str, int] | None:
     if not counts:
         return None
     notes = "; ".join(f"{k}={v}" for k, v in counts.items())
-    history = data.setdefault("curation_history", [])
-    history.append({
-        "timestamp": now_iso(),
-        "curator": CURATOR,
-        "action": ACTION,
-        "notes": notes,
-    })
+    record_curation_event(data, curator=CURATOR, action=ACTION, notes=notes)
     if not dry_run:
         with path.open("w") as f:
             yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=80)

--- a/scripts/fix_schema_inconsistencies.py
+++ b/scripts/fix_schema_inconsistencies.py
@@ -14,6 +14,10 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.validation import (  # noqa: E402
+    ValidationFailedError,
+    write_validated_recipe,
+)
 
 CURATOR = "fix_schema_inconsistencies.py"
 ACTION = "FIXED_SCHEMA_INCONSISTENCIES"
@@ -161,10 +165,14 @@ def fix_recipe_file(recipe_path: Path, dry_run: bool = False) -> tuple[bool, Lis
             changes="; ".join(issues)[:500],
         )
 
-        # Write fixed recipe
+        # Write fixed recipe. write_validated_recipe runs closed-schema
+        # validation; if the "fix" didn't actually produce a valid record,
+        # we surface that loudly instead of writing more bad data.
         if not dry_run:
-            with open(recipe_path, 'w', encoding='utf-8') as f:
-                yaml.dump(fixed_recipe, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+            try:
+                write_validated_recipe(fixed_recipe, recipe_path)
+            except ValidationFailedError as exc:
+                return False, issues + [f"REFUSED_TO_WRITE: {exc.summary()[:400]}"]
 
         return True, issues
 

--- a/scripts/fix_schema_inconsistencies.py
+++ b/scripts/fix_schema_inconsistencies.py
@@ -12,6 +12,12 @@ from typing import Dict, List
 
 import yaml
 
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
+
+CURATOR = "fix_schema_inconsistencies.py"
+ACTION = "FIXED_SCHEMA_INCONSISTENCIES"
+
 
 def fix_ingredient_schema(ingredient: Dict) -> Dict:
     """Fix ingredient to match LinkML schema.
@@ -145,6 +151,15 @@ def fix_recipe_file(recipe_path: Path, dry_run: bool = False) -> tuple[bool, Lis
         if not issues:
             # No issues found
             return False, []
+
+        # Record provenance before write so the audit trail is preserved.
+        record_curation_event(
+            fixed_recipe,
+            curator=CURATOR,
+            action=ACTION,
+            notes=f"fixed {len(issues)} schema issue(s)",
+            changes="; ".join(issues)[:500],
+        )
 
         # Write fixed recipe
         if not dry_run:

--- a/scripts/migrate_data_quality_flags.py
+++ b/scripts/migrate_data_quality_flags.py
@@ -26,11 +26,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import datetime
 import sys
 from pathlib import Path
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_data_quality_flags.py"
 ACTION = "MIGRATED_DATA_QUALITY_FLAGS"
@@ -48,18 +50,13 @@ def dict_to_list(flags: dict) -> list[str]:
     return out
 
 
-def now_iso() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).isoformat()
-
-
 def append_curation_event(recipe: dict, before_count: int, after_count: int) -> None:
-    history = recipe.setdefault("curation_history", [])
-    history.append({
-        "timestamp": now_iso(),
-        "curator": CURATOR,
-        "action": ACTION,
-        "notes": f"dict({before_count} keys) -> list({after_count} entries)",
-    })
+    record_curation_event(
+        recipe,
+        curator=CURATOR,
+        action=ACTION,
+        notes=f"dict({before_count} keys) -> list({after_count} entries)",
+    )
 
 
 def migrate_one(path: Path, dry_run: bool) -> bool:

--- a/scripts/migrate_legacy_fields.py
+++ b/scripts/migrate_legacy_fields.py
@@ -30,6 +30,7 @@ from typing import Any
 import yaml
 
 from culturemech.preparation_actions import infer_prep_action
+from culturemech.curate import record_curation_event
 
 CURATOR = "migrate_legacy_fields.py"
 ACTION = "MIGRATED_LEGACY_FIELDS"
@@ -41,10 +42,6 @@ UNIT_ALIASES = {
     "UG_PER_L": "MICROG_PER_L",
     "PERCENT": "PERCENT_W_V",
 }
-
-
-def now_iso() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def to_iso_timestamp(value: Any) -> str | None:
@@ -204,13 +201,7 @@ def migrate_one(path: Path, dry_run: bool) -> dict[str, int] | None:
     if not counts:
         return None
     notes = "; ".join(f"{k}={v}" for k, v in counts.items())
-    history = data.setdefault("curation_history", [])
-    history.append({
-        "timestamp": now_iso(),
-        "curator": CURATOR,
-        "action": ACTION,
-        "notes": notes,
-    })
+    record_curation_event(data, curator=CURATOR, action=ACTION, notes=notes)
     if not dry_run:
         with path.open("w") as f:
             yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=80)

--- a/scripts/migrate_ontology_term_rename.py
+++ b/scripts/migrate_ontology_term_rename.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""G13 follow-on: rename `ontology_term` -> `ontology_id` on
+PerturbationContext and StrainModification entries.
+
+Schema convention reconciled in the same PR: the `term` / `<provenance>_term`
+suffix is reserved for typed `Term`-object slots; bare-string CURIE slots
+use the `<provenance>_id` convention. These two slots were the only
+outliers and only 2 records carry the legacy field.
+
+Idempotent; appends a CurationEvent via the G10 helper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
+
+CURATOR = "migrate_ontology_term_rename.py"
+ACTION = "MIGRATED_ONTOLOGY_TERM_RENAME"
+DEFAULT_ROOT = "data/normalized_yaml"
+
+
+def _rename_in_perturbations(perts: list) -> int:
+    n = 0
+    for p in perts or []:
+        if isinstance(p, dict) and "ontology_term" in p and "ontology_id" not in p:
+            p["ontology_id"] = p.pop("ontology_term")
+            n += 1
+    return n
+
+
+def _rename_in_strain_mods(mods: list) -> int:
+    n = 0
+    for m in mods or []:
+        if isinstance(m, dict) and "ontology_term" in m and "ontology_id" not in m:
+            m["ontology_id"] = m.pop("ontology_term")
+            n += 1
+    return n
+
+
+def migrate_one(path: Path, dry_run: bool) -> int:
+    try:
+        with path.open() as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError:
+        return 0
+    if not isinstance(data, dict):
+        return 0
+    total = 0
+    for org in data.get("target_organisms") or []:
+        if not isinstance(org, dict):
+            continue
+        for gm in org.get("growth_metrics") or []:
+            if isinstance(gm, dict):
+                total += _rename_in_perturbations(gm.get("perturbations") or [])
+        total += _rename_in_strain_mods(org.get("strain_modifications") or [])
+    if total == 0:
+        return 0
+    record_curation_event(
+        data, curator=CURATOR, action=ACTION,
+        notes=f"ontology_term->ontology_id for {total} entry/entries",
+    )
+    if not dry_run:
+        with path.open("w") as f:
+            yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=80)
+    return total
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", default=DEFAULT_ROOT)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    paths = sorted(Path(args.root).rglob("*.yaml"))
+    renames = 0
+    files = 0
+    for p in paths:
+        n = migrate_one(p, args.dry_run)
+        if n:
+            renames += n
+            files += 1
+    mode = "[DRY RUN] " if args.dry_run else ""
+    print(f"{mode}scanned: {len(paths)}, files changed: {files}, renames: {renames}",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_preparation_steps.py
+++ b/scripts/migrate_preparation_steps.py
@@ -25,12 +25,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import datetime
 import re
 import sys
 from pathlib import Path
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_preparation_steps.py"
 ACTION = "MIGRATED_PREPARATION_STEPS"
@@ -53,8 +55,6 @@ ACTION_PATTERNS: list[tuple[str, list[str]]] = [
 ]
 
 
-def now_iso() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def guess_action(text: str) -> str:
@@ -89,13 +89,12 @@ def migrate_one(path: Path, dry_run: bool) -> int:
             migrated += 1
     if migrated == 0:
         return 0
-    history = data.setdefault("curation_history", [])
-    history.append({
-        "timestamp": now_iso(),
-        "curator": CURATOR,
-        "action": ACTION,
-        "notes": f"instruction->action+description for {migrated} step(s)",
-    })
+    record_curation_event(
+        data,
+        curator=CURATOR,
+        action=ACTION,
+        notes=f"instruction->action+description for {migrated} step(s)",
+    )
     if not dry_run:
         with path.open("w") as f:
             yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=80)

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -116,6 +116,7 @@ def validate_one(path: Path) -> list[dict]:
     except yaml.YAMLError as e:
         return [{
             "file": str(path),
+            "layer": "schema",
             "category": "yaml_parse_error",
             "detail": "",
             "path": "",
@@ -124,6 +125,7 @@ def validate_one(path: Path) -> list[dict]:
     if instance is None:
         return [{
             "file": str(path),
+            "layer": "schema",
             "category": "empty_file",
             "detail": "",
             "path": "",
@@ -136,6 +138,7 @@ def validate_one(path: Path) -> list[dict]:
     except Exception as e:  # noqa: BLE001 — surface anything weird as a row
         return [{
             "file": str(path),
+            "layer": "schema",
             "category": "validator_crash",
             "detail": type(e).__name__,
             "path": "",
@@ -196,36 +199,55 @@ def _run_external_validator(cmd: list[str], path: Path, layer: str) -> list[dict
     return rows
 
 
-def validate_terms(path: Path) -> list[dict]:
+def _peek_target_class(path: Path) -> str:
+    """Lightweight target-class inference for external validators
+    (which take the class as a CLI flag, not as data).
+    Same routing rule as the in-process validator's `infer_target_class`.
+    """
+    try:
+        with path.open() as f:
+            instance = yaml.safe_load(f)
+    except (yaml.YAMLError, OSError):
+        return "MediaRecipe"
+    return infer_target_class(instance)
+
+
+def validate_terms(path: Path, target_class: str) -> list[dict]:
     return _run_external_validator(
         [
             "uv", "run", "linkml-term-validator", "validate-data", str(path),
-            "-s", str(SCHEMA_PATH), "-t", "MediaRecipe",
+            "-s", str(SCHEMA_PATH), "-t", target_class,
             "--labels", "-c", str(OAK_CONFIG_PATH),
         ],
         path, "terms",
     )
 
 
-def validate_references(path: Path) -> list[dict]:
+def validate_references(path: Path, target_class: str) -> list[dict]:
     return _run_external_validator(
         [
             "uv", "run", "linkml-reference-validator", "validate", "data", str(path),
-            "--schema", str(SCHEMA_PATH), "--target-class", "MediaRecipe",
+            "--schema", str(SCHEMA_PATH), "--target-class", target_class,
         ],
         path, "references",
     )
 
 
 def validate_one_layered(path: Path, layers: tuple[str, ...]) -> list[dict]:
-    """Run the configured set of validation layers on a single file."""
+    """Run the configured set of validation layers on a single file.
+
+    External validators (terms / references) need the target class as a CLI
+    flag — peek the file once to route MediaRecipe vs SolutionRecipe so
+    standalone solution records aren't false-failed against MediaRecipe.
+    """
     rows: list[dict] = []
+    target_class = _peek_target_class(path) if {"terms", "references"} & set(layers) else "MediaRecipe"
     if "schema" in layers:
         rows.extend(validate_one(path))
     if "terms" in layers:
-        rows.extend(validate_terms(path))
+        rows.extend(validate_terms(path, target_class))
     if "references" in layers:
-        rows.extend(validate_references(path))
+        rows.extend(validate_references(path, target_class))
     return rows
 
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -23,6 +23,7 @@ import argparse
 import csv
 import os
 import re
+import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
@@ -34,6 +35,7 @@ from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
 SCHEMA_PATH = Path("src/culturemech/schema/culturemech.yaml")
+OAK_CONFIG_PATH = Path("conf/oak_config.yaml")
 DEFAULT_ROOTS = [Path(f"data/normalized_yaml/{sub}") for sub in
                  ("algae", "bacterial", "fungal", "archaea", "specialized")]
 
@@ -147,11 +149,83 @@ def validate_one(path: Path) -> list[dict]:
         category, detail = classify(result.message)
         rows.append({
             "file": str(path),
+            "layer": "schema",
             "category": category,
             "detail": detail,
             "path": result.instance_index or "",
             "message": result.message[:300],
         })
+    return rows
+
+
+def _run_external_validator(cmd: list[str], path: Path, layer: str) -> list[dict]:
+    """Run a CLI validator on a single file and capture ERROR lines into rows.
+
+    Both `linkml-term-validator` and `linkml-reference-validator` emit lines
+    that start with the LinkML severity marker (`[ERROR] ...` or `ERROR:...`).
+    We capture anything matching that and turn it into a row.
+    """
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=120, check=False
+        )
+    except subprocess.TimeoutExpired:
+        return [{
+            "file": str(path), "layer": layer, "category": "validator_timeout",
+            "detail": "", "path": "", "message": f"{layer} validator timed out",
+        }]
+    out = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    rows: list[dict] = []
+    for line in out.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[ERROR]") or stripped.startswith("ERROR:") or "ERROR" in stripped.split()[:2]:
+            msg = stripped[:300]
+            rows.append({
+                "file": str(path), "layer": layer, "category": "external_error",
+                "detail": "", "path": "", "message": msg,
+            })
+    if proc.returncode != 0 and not rows:
+        # Validator exited nonzero but emitted no parseable ERROR line; surface anyway.
+        rows.append({
+            "file": str(path), "layer": layer, "category": "external_error",
+            "detail": f"rc={proc.returncode}", "path": "",
+            "message": (out.strip()[:300] or f"{layer} validator returned {proc.returncode}"),
+        })
+    return rows
+
+
+def validate_terms(path: Path) -> list[dict]:
+    return _run_external_validator(
+        [
+            "uv", "run", "linkml-term-validator", "validate-data", str(path),
+            "-s", str(SCHEMA_PATH), "-t", "MediaRecipe",
+            "--labels", "-c", str(OAK_CONFIG_PATH),
+        ],
+        path, "terms",
+    )
+
+
+def validate_references(path: Path) -> list[dict]:
+    return _run_external_validator(
+        [
+            "uv", "run", "linkml-reference-validator", "validate", "data", str(path),
+            "--schema", str(SCHEMA_PATH), "--target-class", "MediaRecipe",
+        ],
+        path, "references",
+    )
+
+
+def validate_one_layered(path: Path, layers: tuple[str, ...]) -> list[dict]:
+    """Run the configured set of validation layers on a single file."""
+    rows: list[dict] = []
+    if "schema" in layers:
+        rows.extend(validate_one(path))
+    if "terms" in layers:
+        rows.extend(validate_terms(path))
+    if "references" in layers:
+        rows.extend(validate_references(path))
     return rows
 
 
@@ -179,7 +253,19 @@ def main() -> int:
                         help="Exit non-zero policy. 'error' (default) exits 1 if any ERROR row was emitted.")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress per-file progress dots.")
+    parser.add_argument("--layer", default="schema",
+                        choices=("schema", "terms", "references", "all"),
+                        help="Validation layer(s) to run. 'schema' (default) is the in-process "
+                             "closed-schema check (fast). 'terms' and 'references' shell out to "
+                             "linkml-term-validator / linkml-reference-validator per file and are "
+                             "much slower at corpus scale. 'all' runs all three.")
     args = parser.parse_args()
+
+    layers = (
+        ("schema", "terms", "references")
+        if args.layer == "all"
+        else (args.layer,)
+    )
 
     roots = args.paths or DEFAULT_ROOTS
     files = iter_yaml_files(roots)
@@ -191,12 +277,13 @@ def main() -> int:
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
 
-    print(f"Validating {len(files)} files with {args.workers} workers; schema={SCHEMA_PATH}",
+    print(f"Validating {len(files)} files with {args.workers} workers; "
+          f"layers={','.join(layers)}; schema={SCHEMA_PATH}",
           file=sys.stderr)
 
     all_rows: list[dict] = []
     with ProcessPoolExecutor(max_workers=args.workers) as pool:
-        futures = {pool.submit(validate_one, p): p for p in files}
+        futures = {pool.submit(validate_one_layered, p, layers): p for p in files}
         done = 0
         for fut in as_completed(futures):
             done += 1
@@ -207,11 +294,11 @@ def main() -> int:
                       file=sys.stderr)
 
     # Sort for deterministic TSV output (avoids noisy diffs from worker scheduling).
-    all_rows.sort(key=lambda r: (r["file"], r["path"], r["category"], r["message"]))
+    all_rows.sort(key=lambda r: (r["file"], r["layer"], r["path"], r["category"], r["message"]))
     with args.out.open("w", newline="") as fh:
         writer = csv.DictWriter(
             fh,
-            fieldnames=["file", "category", "detail", "path", "message"],
+            fieldnames=["file", "layer", "category", "detail", "path", "message"],
             delimiter="\t",
             quoting=csv.QUOTE_MINIMAL,
             lineterminator="\n",
@@ -219,22 +306,24 @@ def main() -> int:
         writer.writeheader()
         writer.writerows(all_rows)
 
-    by_cat: dict[str, int] = {}
+    by_cat: dict[tuple[str, str], int] = {}
     files_with_errors: set[str] = set()
     for row in all_rows:
-        by_cat[row["category"]] = by_cat.get(row["category"], 0) + 1
+        key = (row["layer"], row["category"])
+        by_cat[key] = by_cat.get(key, 0) + 1
         files_with_errors.add(row["file"])
 
     print("", file=sys.stderr)
     print(f"=== validate-strict summary ===", file=sys.stderr)
     print(f"  files scanned:      {len(files)}", file=sys.stderr)
+    print(f"  layers:             {','.join(layers)}", file=sys.stderr)
     print(f"  files with ERROR:   {len(files_with_errors)}", file=sys.stderr)
     print(f"  total ERROR rows:   {len(all_rows)}", file=sys.stderr)
     print(f"  TSV:                {args.out}", file=sys.stderr)
     if by_cat:
-        print(f"  by category:", file=sys.stderr)
-        for cat, count in sorted(by_cat.items(), key=lambda kv: -kv[1]):
-            print(f"    {cat:24s} {count:>8d}", file=sys.stderr)
+        print(f"  by layer/category:", file=sys.stderr)
+        for (layer, cat), count in sorted(by_cat.items(), key=lambda kv: -kv[1]):
+            print(f"    {layer:>10s} {cat:24s} {count:>8d}", file=sys.stderr)
 
     if args.fail_on == "error" and all_rows:
         return 1

--- a/src/culturemech/curate/__init__.py
+++ b/src/culturemech/curate/__init__.py
@@ -3,10 +3,13 @@
 from .organism_extractor import OrganismExtractor, OrganismData
 from .curation_validator import CurationValidator
 from .yaml_updater import YAMLUpdater
+from .curation_event import record_curation_event, now_iso
 
 __all__ = [
     'OrganismExtractor',
     'OrganismData',
     'CurationValidator',
     'YAMLUpdater',
+    'record_curation_event',
+    'now_iso',
 ]

--- a/src/culturemech/curate/curation_event.py
+++ b/src/culturemech/curate/curation_event.py
@@ -1,0 +1,100 @@
+"""Standard helper for appending CurationEvent entries to a recipe.
+
+Every script that mutates a media/solution YAML record should call
+``record_curation_event`` to leave an audit trail. Centralizing here means:
+
+* timestamps are ISO-8601 with UTC tz, consistently;
+* the ``curation_history`` slot is created on demand;
+* re-runs of idempotent migration scripts can short-circuit when the most
+  recent event already matches (``skip_if_recent`` flag);
+* the schema's ``CurationEvent`` field names (timestamp / curator / action /
+  notes / source / changes) are honored, so future schema diffs only need
+  to touch one file.
+
+Drop-in usage::
+
+    from culturemech.curate.curation_event import record_curation_event
+
+    record_curation_event(
+        recipe,
+        curator="my_script.py",
+        action="ENRICHED_CHEBI",
+        notes="organisms=5 hits=4 misses=1",
+    )
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+__all__ = ["record_curation_event", "now_iso"]
+
+
+def now_iso() -> str:
+    """Current UTC timestamp as an ISO-8601 string."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def record_curation_event(
+    recipe: dict[str, Any],
+    *,
+    curator: str,
+    action: str,
+    notes: str | None = None,
+    source: str | None = None,
+    changes: str | None = None,
+    timestamp: str | None = None,
+    skip_if_recent: bool = False,
+) -> dict[str, Any]:
+    """Append a CurationEvent to ``recipe['curation_history']``.
+
+    Args:
+        recipe: The recipe (or solution) dict being mutated. Mutated in place.
+        curator: Script / human identifier (e.g. ``"migrate_legacy_fields.py"``
+            or ``"jane.smith"``). Required because the schema requires it.
+        action: Short action label (e.g. ``"ADDED_GROWTH_EVIDENCE"``,
+            ``"MIGRATED_LEGACY_FIELDS"``). Required.
+        notes: Optional free-text details.
+        source: Optional source attribution (e.g. a sibling recipe ID or
+            external dataset name). Maps to ``CurationEvent.source``.
+        changes: Optional structured summary of what changed
+            (e.g. ``"Set category to 'bacterial' (was MISSING)"``).
+            Maps to ``CurationEvent.changes``.
+        timestamp: Override the ISO-8601 timestamp (used for tests /
+            deterministic snapshots). Defaults to current UTC.
+        skip_if_recent: When True, do nothing if the most recent
+            curation_history entry already matches the same
+            ``(curator, action)`` pair. Useful when refactoring a script
+            into the helper without producing duplicate trail entries
+            during a re-run.
+
+    Returns:
+        The appended event dict (or the most recent matching one if
+        ``skip_if_recent`` short-circuited).
+    """
+    history = recipe.setdefault("curation_history", [])
+
+    if skip_if_recent and history:
+        last = history[-1]
+        if (
+            isinstance(last, dict)
+            and last.get("curator") == curator
+            and last.get("action") == action
+        ):
+            return last
+
+    event: dict[str, Any] = {
+        "timestamp": timestamp or now_iso(),
+        "curator": curator,
+        "action": action,
+    }
+    if notes is not None:
+        event["notes"] = notes
+    if source is not None:
+        event["source"] = source
+    if changes is not None:
+        event["changes"] = changes
+
+    history.append(event)
+    return event

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -216,6 +216,7 @@ classes:
         range: OrganismDescriptor
         multivalued: true
         recommended: true
+        inlined_as_list: true
 
       source_environment:
         description: >-
@@ -584,11 +585,11 @@ classes:
 
       merge_mode:
         description: Merge mode used (conservative/aggressive/variant-aware)
-        range: string
+        range: MergeModeEnum
         comments:
-          - conservative - Only merge with explicit rules or exact match
-          - aggressive - Merge all variants with same parent
-          - variant-aware - Balanced approach, merge some variants
+          - CONSERVATIVE - Only merge with explicit rules or exact match
+          - AGGRESSIVE - Merge all variants with same parent
+          - VARIANT_AWARE - Balanced approach, merge some variants
 
       merge_reason:
         description: Why these recipes were merged together
@@ -616,7 +617,7 @@ classes:
 
       fingerprint_mode:
         description: Fingerprinting mode used (chemical/variant/original)
-        range: string
+        range: FingerprintModeEnum
         comments:
           - Indicates which fingerprint algorithm was used
           - Enables comparing merge results across modes
@@ -650,7 +651,7 @@ classes:
         range: float
       match_type:
         description: Provenance/method of the term mapping (e.g. "kg_fallback", "exact", "manual_curated").
-        range: string
+        range: TermMatchTypeEnum
 
 # ================================================================
 # DESCRIPTOR CLASSES
@@ -865,6 +866,7 @@ classes:
       preferred_term:
         description: Organism name (e.g., "Escherichia coli")
         required: true
+        identifier: true
         range: string
 
       term:
@@ -895,7 +897,7 @@ classes:
 
       growth_phase:
         description: Target growth phase (e.g., "exponential", "stationary")
-        range: string
+        range: GrowthPhaseEnum
 
       growth_metrics:
         description: Quantitative growth measurements observed for this organism on this medium
@@ -1066,7 +1068,7 @@ classes:
         required: true
       synonym_type:
         description: Synonym match type (e.g. EXACT, RELATED, BROAD).
-        range: string
+        range: SynonymTypeEnum
 
   IngredientCurationMetadata:
     description: >-
@@ -1232,12 +1234,16 @@ classes:
         description: Unit for `level` (e.g. "mg/L", "mM", "%", "°C", "µmol·m⁻²·s⁻¹").
         range: string
 
-      ontology_term:
+      ontology_id:
         description: >-
           Optional ontology CURIE for the perturbation type or agent
           (CHEBI for chemical agents, ENVO for environmental stress,
           NCIT for genetic-modification class, PATO for phenotypic
           qualities). Curator-supplied; pipeline does not auto-resolve.
+          Renamed from `ontology_term` (G13) to align with the
+          `<provenance>_id` convention used for bare-string CURIEs
+          elsewhere in the schema. The typed-Term-object convention is
+          `<provenance>_term`.
         range: string
         pattern: "^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$"
 
@@ -1270,10 +1276,12 @@ classes:
         description: Curator free-text describing the modification.
         range: string
 
-      ontology_term:
+      ontology_id:
         description: >-
           Optional CURIE — NCIT:C120956 (Knockout), NCIT:C17026
           (Genetic Modification), PATO:0015009 (mutant), etc.
+          Renamed from `ontology_term` (G13) to align with the
+          `<provenance>_id` convention used for bare-string CURIEs.
         range: string
         pattern: "^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$"
 
@@ -1421,7 +1429,18 @@ classes:
       name:
         description: Variant name (e.g., "Low Salt LB", "LB + Ampicillin")
         required: true
+        identifier: true
         range: string
+
+      relationship:
+        description: >-
+          Typed relationship to the base recipe, drawn from the same enum
+          that MediaRecipeReference.relationship uses. Curators should set
+          this whenever a clean enum value applies; the free-text
+          `modifications` slot remains for nuance or for variants whose
+          relationship is genuinely composite.
+        range: MediaVariantRelationshipEnum
+        recommended: true
 
       description:
         description: Purpose and context
@@ -1533,11 +1552,13 @@ classes:
         description: Citation (PMID, DOI, or historical reference)
         range: string
         required: true
+        identifier: true
         implements:
           - linkml:authoritative_reference
         comments:
           - This is automatically validated by the linkml-reference-validator tool.
           - Use format PMID:12345678 or doi:10.1038/... for automatic validation.
+          - Acts as the natural identifier inside an `evidence:` list (no duplicates within a single record's evidence array).
 
       supports:
         description: Level of support
@@ -1568,7 +1589,7 @@ classes:
 
       dataset_type:
         description: Type of omics data (genomics, transcriptomics, metabolomics, etc.)
-        range: string
+        range: DatasetTypeEnum
 
       description:
         description: Brief description of the dataset
@@ -2404,3 +2425,93 @@ enums:
         description: Plate / agar / solid-substrate cultivation.
       UNSPECIFIED:
         description: Mode not stated in the source paper.
+
+
+  # ----------------------------------------------------------------------
+  # Audit-followup enums (G12). All values are derived from existing slot
+  # descriptions / observed in-corpus values; introducing them turns the
+  # corresponding `range: string` slots into typed enums so the linkml
+  # validator (and downstream consumers) get real type checking.
+  # ----------------------------------------------------------------------
+
+  MergeModeEnum:
+    description: Merge pipeline mode used by `MergeMetadata.merge_mode`.
+    permissible_values:
+      CONSERVATIVE:
+        description: Only merge on identical fingerprints.
+      AGGRESSIVE:
+        description: Merge across hydration / parent-ingredient equivalence.
+      VARIANT_AWARE:
+        description: Use the hierarchy-aware variant fingerprint to merge.
+
+  FingerprintModeEnum:
+    description: Algorithm used to compute the ingredient fingerprint.
+    permissible_values:
+      ORIGINAL:
+        description: Original ingredient set, no hierarchy resolution.
+      CHEMICAL:
+        description: Parent CHEBI IDs from MediaIngredientMech hierarchy.
+      VARIANT:
+        description: Parent CHEBI + variant type (HYDRATE / ANHYDROUS / SALT_FORM).
+
+  GrowthPhaseEnum:
+    description: Target microbial growth phase for a measurement / inoculum.
+    permissible_values:
+      LAG:
+        description: Lag phase (no significant net growth).
+      EXPONENTIAL:
+        description: Exponential / log phase.
+      STATIONARY:
+        description: Stationary phase.
+      DEATH:
+        description: Death / decline phase.
+      UNSPECIFIED:
+        description: Phase not stated by the source.
+
+  TermMatchTypeEnum:
+    description: >-
+      Provenance of an ontology-term mapping (`Term.match_type`). Values
+      use the lowercase-snake convention emitted by upstream grounding
+      pipelines (kg-microbe, manual curation). Three values are observed
+      in the current corpus (kg_fallback, exact_match,
+      synonym_match_ambiguous); the others are reserved for explicit
+      curator use.
+    permissible_values:
+      exact_match:
+        description: Exact label / synonym match.
+      kg_fallback:
+        description: Inferred from the kg-microbe ingredient graph as a fallback.
+      synonym_match_ambiguous:
+        description: Multiple equally-good synonym matches; mapping is uncertain.
+      manual_curated:
+        description: Human curator selected this term.
+      automated_expert_mapping:
+        description: Produced by an automated expert-mapping pipeline (e.g. LLM-assisted).
+      fuzzy:
+        description: Fuzzy / approximate string match.
+
+  SynonymTypeEnum:
+    description: Type of synonym relationship for an IngredientSynonym.
+    permissible_values:
+      EXACT:
+        description: Exact synonym.
+      RELATED:
+        description: Related but not interchangeable.
+      BROAD:
+        description: Broader concept.
+      NARROW:
+        description: Narrower concept.
+      ABBREVIATION:
+        description: Abbreviation or shorthand (e.g. "TSB" for "Tryptic Soy Broth").
+
+  DatasetTypeEnum:
+    description: Type of omics dataset linked by `Dataset.dataset_type`.
+    permissible_values:
+      GENOMICS:
+      TRANSCRIPTOMICS:
+      PROTEOMICS:
+      METABOLOMICS:
+      FLUXOMICS:
+      PHENOMICS:
+      MULTI_OMICS:
+      OTHER:

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-18T11:57:53
+# Generation date: 2026-05-19T19:51:07
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -117,6 +117,18 @@ class TermId(extended_str):
     pass
 
 
+class OrganismDescriptorPreferredTerm(extended_str):
+    pass
+
+
+class MediaVariantName(extended_str):
+    pass
+
+
+class EvidenceItemReference(extended_str):
+    pass
+
+
 class ChemicalEntityTermId(TermId):
     pass
 
@@ -181,7 +193,7 @@ class MediaRecipe(YAMLRoot):
     media_term: Optional[Union[dict, "MediaTypeDescriptor"]] = None
     kg_microbe_match: Optional[str] = None
     description: Optional[str] = None
-    target_organisms: Optional[Union[Union[dict, "OrganismDescriptor"], list[Union[dict, "OrganismDescriptor"]]]] = empty_list()
+    target_organisms: Optional[Union[dict[Union[str, OrganismDescriptorPreferredTerm], Union[dict, "OrganismDescriptor"]], list[Union[dict, "OrganismDescriptor"]]]] = empty_dict()
     source_environment: Optional[Union[Union[dict, "SourceEnvironmentDescriptor"], list[Union[dict, "SourceEnvironmentDescriptor"]]]] = empty_list()
     organism_culture_type: Optional[Union[str, "OrganismCultureTypeEnum"]] = None
     ph_value: Optional[float] = None
@@ -199,14 +211,14 @@ class MediaRecipe(YAMLRoot):
     sterilization: Optional[Union[dict, "SterilizationDescriptor"]] = None
     storage: Optional[Union[dict, "StorageConditions"]] = None
     applications: Optional[Union[str, list[str]]] = empty_list()
-    variants: Optional[Union[Union[dict, "MediaVariant"], list[Union[dict, "MediaVariant"]]]] = empty_list()
+    variants: Optional[Union[dict[Union[str, MediaVariantName], Union[dict, "MediaVariant"]], list[Union[dict, "MediaVariant"]]]] = empty_dict()
     parent_media: Optional[Union[dict, "MediaRecipeReference"]] = None
     variant_children: Optional[Union[Union[dict, "MediaRecipeReference"], list[Union[dict, "MediaRecipeReference"]]]] = empty_list()
     variant_relationship: Optional[Union[str, "MediaVariantRelationshipEnum"]] = None
     variant_modifications: Optional[Union[str, list[str]]] = empty_list()
     references: Optional[Union[Union[dict, "PublicationReference"], list[Union[dict, "PublicationReference"]]]] = empty_list()
     notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
     datasets: Optional[Union[Union[dict, "Dataset"], list[Union[dict, "Dataset"]]]] = empty_list()
     import_metadata: Optional[Union[dict, "ImportMetadata"]] = None
     curation_history: Optional[Union[Union[dict, "CurationEvent"], list[Union[dict, "CurationEvent"]]]] = empty_list()
@@ -288,7 +300,7 @@ class MediaRecipe(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        self._normalize_inlined_as_dict(slot_name="target_organisms", slot_type=OrganismDescriptor, key_name="preferred_term", keyed=False)
+        self._normalize_inlined_as_list(slot_name="target_organisms", slot_type=OrganismDescriptor, key_name="preferred_term", keyed=True)
 
         if not isinstance(self.source_environment, list):
             self.source_environment = [self.source_environment] if self.source_environment is not None else []
@@ -345,9 +357,7 @@ class MediaRecipe(YAMLRoot):
             self.applications = [self.applications] if self.applications is not None else []
         self.applications = [v if isinstance(v, str) else str(v) for v in self.applications]
 
-        if not isinstance(self.variants, list):
-            self.variants = [self.variants] if self.variants is not None else []
-        self.variants = [v if isinstance(v, MediaVariant) else MediaVariant(**as_dict(v)) for v in self.variants]
+        self._normalize_inlined_as_list(slot_name="variants", slot_type=MediaVariant, key_name="name", keyed=True)
 
         if self.parent_media is not None and not isinstance(self.parent_media, MediaRecipeReference):
             self.parent_media = MediaRecipeReference(**as_dict(self.parent_media))
@@ -370,9 +380,7 @@ class MediaRecipe(YAMLRoot):
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         if not isinstance(self.datasets, list):
             self.datasets = [self.datasets] if self.datasets is not None else []
@@ -553,18 +561,18 @@ class MergeMetadata(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.MergeMetadata
 
     merge_version: Optional[str] = None
-    merge_mode: Optional[str] = None
+    merge_mode: Optional[Union[str, "MergeModeEnum"]] = None
     merge_reason: Optional[Union[str, "MergeReasonEnum"]] = None
     merge_confidence: Optional[float] = None
     hierarchy_conflicts: Optional[Union[str, list[str]]] = empty_list()
-    fingerprint_mode: Optional[str] = None
+    fingerprint_mode: Optional[Union[str, "FingerprintModeEnum"]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.merge_version is not None and not isinstance(self.merge_version, str):
             self.merge_version = str(self.merge_version)
 
-        if self.merge_mode is not None and not isinstance(self.merge_mode, str):
-            self.merge_mode = str(self.merge_mode)
+        if self.merge_mode is not None and not isinstance(self.merge_mode, MergeModeEnum):
+            self.merge_mode = MergeModeEnum(self.merge_mode)
 
         if self.merge_reason is not None and not isinstance(self.merge_reason, MergeReasonEnum):
             self.merge_reason = MergeReasonEnum(self.merge_reason)
@@ -576,8 +584,8 @@ class MergeMetadata(YAMLRoot):
             self.hierarchy_conflicts = [self.hierarchy_conflicts] if self.hierarchy_conflicts is not None else []
         self.hierarchy_conflicts = [v if isinstance(v, str) else str(v) for v in self.hierarchy_conflicts]
 
-        if self.fingerprint_mode is not None and not isinstance(self.fingerprint_mode, str):
-            self.fingerprint_mode = str(self.fingerprint_mode)
+        if self.fingerprint_mode is not None and not isinstance(self.fingerprint_mode, FingerprintModeEnum):
+            self.fingerprint_mode = FingerprintModeEnum(self.fingerprint_mode)
 
         super().__post_init__(**kwargs)
 
@@ -609,7 +617,7 @@ class Term(YAMLRoot):
     id: Union[str, TermId] = None
     label: Optional[str] = None
     confidence: Optional[float] = None
-    match_type: Optional[str] = None
+    match_type: Optional[Union[str, "TermMatchTypeEnum"]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.id):
@@ -623,8 +631,8 @@ class Term(YAMLRoot):
         if self.confidence is not None and not isinstance(self.confidence, float):
             self.confidence = float(self.confidence)
 
-        if self.match_type is not None and not isinstance(self.match_type, str):
-            self.match_type = str(self.match_type)
+        if self.match_type is not None and not isinstance(self.match_type, TermMatchTypeEnum):
+            self.match_type = TermMatchTypeEnum(self.match_type)
 
         super().__post_init__(**kwargs)
 
@@ -669,13 +677,13 @@ class IngredientDescriptor(Descriptor):
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.IngredientDescriptor
 
     preferred_term: str = None
-    concentration: Union[dict, "ConcentrationValue"] = None
     term: Optional[Union[dict, "ChemicalEntityTerm"]] = None
     chebi_term: Optional[Union[dict, "ChebiTerm"]] = None
     mediaingredientmech_term: Optional[Union[dict, "MediaIngredientMechTerm"]] = None
     culturemech_term: Optional[Union[dict, "CultureMechTerm"]] = None
     parent_ingredient: Optional[Union[dict, "IngredientReference"]] = None
     variant_type: Optional[Union[str, "VariantTypeEnum"]] = None
+    concentration: Optional[Union[dict, "ConcentrationValue"]] = None
     modifier: Optional[Union[str, "ModifierEnum"]] = None
     chemical_formula: Optional[str] = None
     synonyms: Optional[Union[Union[dict, "IngredientSynonym"], list[Union[dict, "IngredientSynonym"]]]] = empty_list()
@@ -687,18 +695,13 @@ class IngredientDescriptor(Descriptor):
     notes: Optional[str] = None
     role: Optional[Union[Union[str, "IngredientRoleEnum"], list[Union[str, "IngredientRoleEnum"]]]] = empty_list()
     cofactors_provided: Optional[Union[Union[dict, "CofactorDescriptor"], list[Union[dict, "CofactorDescriptor"]]]] = empty_list()
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
             self.MissingRequiredField("preferred_term")
         if not isinstance(self.preferred_term, str):
             self.preferred_term = str(self.preferred_term)
-
-        if self._is_empty(self.concentration):
-            self.MissingRequiredField("concentration")
-        if not isinstance(self.concentration, ConcentrationValue):
-            self.concentration = ConcentrationValue(**as_dict(self.concentration))
 
         if self.term is not None and not isinstance(self.term, ChemicalEntityTerm):
             self.term = ChemicalEntityTerm(**as_dict(self.term))
@@ -717,6 +720,9 @@ class IngredientDescriptor(Descriptor):
 
         if self.variant_type is not None and not isinstance(self.variant_type, VariantTypeEnum):
             self.variant_type = VariantTypeEnum(self.variant_type)
+
+        if self.concentration is not None and not isinstance(self.concentration, ConcentrationValue):
+            self.concentration = ConcentrationValue(**as_dict(self.concentration))
 
         if self.modifier is not None and not isinstance(self.modifier, ModifierEnum):
             self.modifier = ModifierEnum(self.modifier)
@@ -755,9 +761,7 @@ class IngredientDescriptor(Descriptor):
             self.cofactors_provided = [self.cofactors_provided] if self.cofactors_provided is not None else []
         self.cofactors_provided = [v if isinstance(v, CofactorDescriptor) else CofactorDescriptor(**as_dict(v)) for v in self.cofactors_provided]
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -838,26 +842,26 @@ class OrganismDescriptor(Descriptor):
     class_name: ClassVar[str] = "OrganismDescriptor"
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.OrganismDescriptor
 
-    preferred_term: str = None
+    preferred_term: Union[str, OrganismDescriptorPreferredTerm] = None
     term: Optional[Union[dict, "OrganismTerm"]] = None
     gtdb_term: Optional[Union[dict, "GTDBTerm"]] = None
     genome_assembly_id: Optional[Union[str, list[str]]] = empty_list()
     strain: Optional[str] = None
-    growth_phase: Optional[str] = None
+    growth_phase: Optional[Union[str, "GrowthPhaseEnum"]] = None
     growth_metrics: Optional[Union[Union[dict, "GrowthMetrics"], list[Union[dict, "GrowthMetrics"]]]] = empty_list()
     community_role: Optional[Union[Union[str, "CellularRoleEnum"], list[Union[str, "CellularRoleEnum"]]]] = empty_list()
     target_abundance: Optional[float] = None
     community_function: Optional[Union[str, list[str]]] = empty_list()
     cofactor_requirements: Optional[Union[Union[dict, "CofactorRequirement"], list[Union[dict, "CofactorRequirement"]]]] = empty_list()
     transporters: Optional[Union[Union[dict, "TransporterAnnotation"], list[Union[dict, "TransporterAnnotation"]]]] = empty_list()
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
     strain_modifications: Optional[Union[Union[dict, "StrainModification"], list[Union[dict, "StrainModification"]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.preferred_term):
             self.MissingRequiredField("preferred_term")
-        if not isinstance(self.preferred_term, str):
-            self.preferred_term = str(self.preferred_term)
+        if not isinstance(self.preferred_term, OrganismDescriptorPreferredTerm):
+            self.preferred_term = OrganismDescriptorPreferredTerm(self.preferred_term)
 
         if self.term is not None and not isinstance(self.term, OrganismTerm):
             self.term = OrganismTerm(**as_dict(self.term))
@@ -872,8 +876,8 @@ class OrganismDescriptor(Descriptor):
         if self.strain is not None and not isinstance(self.strain, str):
             self.strain = str(self.strain)
 
-        if self.growth_phase is not None and not isinstance(self.growth_phase, str):
-            self.growth_phase = str(self.growth_phase)
+        if self.growth_phase is not None and not isinstance(self.growth_phase, GrowthPhaseEnum):
+            self.growth_phase = GrowthPhaseEnum(self.growth_phase)
 
         if not isinstance(self.growth_metrics, list):
             self.growth_metrics = [self.growth_metrics] if self.growth_metrics is not None else []
@@ -898,9 +902,7 @@ class OrganismDescriptor(Descriptor):
             self.transporters = [self.transporters] if self.transporters is not None else []
         self.transporters = [v if isinstance(v, TransporterAnnotation) else TransporterAnnotation(**as_dict(v)) for v in self.transporters]
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         if not isinstance(self.strain_modifications, list):
             self.strain_modifications = [self.strain_modifications] if self.strain_modifications is not None else []
@@ -1053,7 +1055,7 @@ class IngredientSynonym(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.IngredientSynonym
 
     synonym_text: str = None
-    synonym_type: Optional[str] = None
+    synonym_type: Optional[Union[str, "SynonymTypeEnum"]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.synonym_text):
@@ -1061,8 +1063,8 @@ class IngredientSynonym(YAMLRoot):
         if not isinstance(self.synonym_text, str):
             self.synonym_text = str(self.synonym_text)
 
-        if self.synonym_type is not None and not isinstance(self.synonym_type, str):
-            self.synonym_type = str(self.synonym_type)
+        if self.synonym_type is not None and not isinstance(self.synonym_type, SynonymTypeEnum):
+            self.synonym_type = SynonymTypeEnum(self.synonym_type)
 
         super().__post_init__(**kwargs)
 
@@ -1175,7 +1177,7 @@ class GrowthMetrics(YAMLRoot):
     class_name: ClassVar[str] = "GrowthMetrics"
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.GrowthMetrics
 
-    evidence: Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]] = None
+    evidence: Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]] = empty_dict()
     max_od600: Optional[float] = None
     max_od_wavelength_nm: Optional[int] = 600
     doubling_time_minutes: Optional[float] = None
@@ -1191,9 +1193,7 @@ class GrowthMetrics(YAMLRoot):
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.evidence):
             self.MissingRequiredField("evidence")
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         if self.max_od600 is not None and not isinstance(self.max_od600, float):
             self.max_od600 = float(self.max_od600)
@@ -1253,7 +1253,7 @@ class PerturbationContext(YAMLRoot):
     level: Optional[float] = None
     level_unit: Optional[str] = None
     ontology_term: Optional[str] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.perturbation_type):
@@ -1276,9 +1276,7 @@ class PerturbationContext(YAMLRoot):
         if self.ontology_term is not None and not isinstance(self.ontology_term, str):
             self.ontology_term = str(self.ontology_term)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -1301,7 +1299,7 @@ class StrainModification(YAMLRoot):
     target: Optional[str] = None
     description: Optional[str] = None
     ontology_term: Optional[str] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.modification_type):
@@ -1318,9 +1316,7 @@ class StrainModification(YAMLRoot):
         if self.ontology_term is not None and not isinstance(self.ontology_term, str):
             self.ontology_term = str(self.ontology_term)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -1344,7 +1340,7 @@ class NutrientOverride(YAMLRoot):
     source: str = None
     ontology_id: Optional[str] = None
     is_sole_source: Optional[Union[bool, Bool]] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.role):
@@ -1363,9 +1359,7 @@ class NutrientOverride(YAMLRoot):
         if self.is_sole_source is not None and not isinstance(self.is_sole_source, Bool):
             self.is_sole_source = Bool(self.is_sole_source)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -1540,18 +1534,22 @@ class MediaVariant(YAMLRoot):
     class_name: ClassVar[str] = "MediaVariant"
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.MediaVariant
 
-    name: str = None
+    name: Union[str, MediaVariantName] = None
+    relationship: Optional[Union[str, "MediaVariantRelationshipEnum"]] = None
     description: Optional[str] = None
     modifications: Optional[Union[str, list[str]]] = empty_list()
     purpose: Optional[str] = None
     supplier_info: Optional[Union[dict, "SupplierInfo"]] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.name):
             self.MissingRequiredField("name")
-        if not isinstance(self.name, str):
-            self.name = str(self.name)
+        if not isinstance(self.name, MediaVariantName):
+            self.name = MediaVariantName(self.name)
+
+        if self.relationship is not None and not isinstance(self.relationship, MediaVariantRelationshipEnum):
+            self.relationship = MediaVariantRelationshipEnum(self.relationship)
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
@@ -1566,9 +1564,7 @@ class MediaVariant(YAMLRoot):
         if self.supplier_info is not None and not isinstance(self.supplier_info, SupplierInfo):
             self.supplier_info = SupplierInfo(**as_dict(self.supplier_info))
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -1590,7 +1586,7 @@ class MediaRecipeReference(YAMLRoot):
     path: Optional[str] = None
     relationship: Optional[Union[str, "MediaVariantRelationshipEnum"]] = None
     notes: Optional[str] = None
-    evidence: Optional[Union[Union[dict, "EvidenceItem"], list[Union[dict, "EvidenceItem"]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self.id is not None and not isinstance(self.id, str):
@@ -1608,9 +1604,7 @@ class MediaRecipeReference(YAMLRoot):
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         super().__post_init__(**kwargs)
 
@@ -1701,7 +1695,7 @@ class EvidenceItem(YAMLRoot):
     class_name: ClassVar[str] = "EvidenceItem"
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.EvidenceItem
 
-    reference: str = None
+    reference: Union[str, EvidenceItemReference] = None
     supports: Union[str, "EvidenceItemSupportEnum"] = None
     explanation: str = None
     snippet: Optional[str] = None
@@ -1709,8 +1703,8 @@ class EvidenceItem(YAMLRoot):
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.reference):
             self.MissingRequiredField("reference")
-        if not isinstance(self.reference, str):
-            self.reference = str(self.reference)
+        if not isinstance(self.reference, EvidenceItemReference):
+            self.reference = EvidenceItemReference(self.reference)
 
         if self._is_empty(self.supports):
             self.MissingRequiredField("supports")
@@ -1741,7 +1735,7 @@ class Dataset(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.Dataset
 
     dataset_id: str = None
-    dataset_type: Optional[str] = None
+    dataset_type: Optional[Union[str, "DatasetTypeEnum"]] = None
     description: Optional[str] = None
     url: Optional[Union[str, URI]] = None
 
@@ -1751,8 +1745,8 @@ class Dataset(YAMLRoot):
         if not isinstance(self.dataset_id, str):
             self.dataset_id = str(self.dataset_id)
 
-        if self.dataset_type is not None and not isinstance(self.dataset_type, str):
-            self.dataset_type = str(self.dataset_type)
+        if self.dataset_type is not None and not isinstance(self.dataset_type, DatasetTypeEnum):
+            self.dataset_type = DatasetTypeEnum(self.dataset_type)
 
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
@@ -1825,7 +1819,7 @@ class SourceData(YAMLRoot):
     origin: str = None
     community_ids: Optional[Union[str, list[str]]] = empty_list()
     import_date: Optional[str] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]] = empty_dict()
     notes: Optional[str] = None
     mediaingredientmech_id: Optional[str] = None
 
@@ -1842,9 +1836,7 @@ class SourceData(YAMLRoot):
         if self.import_date is not None and not isinstance(self.import_date, str):
             self.import_date = str(self.import_date)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
@@ -1870,7 +1862,7 @@ class CofactorRequirement(YAMLRoot):
     cofactor: Union[dict, CofactorDescriptor] = None
     can_biosynthesize: Union[bool, Bool] = None
     confidence: Optional[float] = None
-    evidence: Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]] = empty_list()
+    evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]] = empty_dict()
     genes: Optional[Union[str, list[str]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1887,9 +1879,7 @@ class CofactorRequirement(YAMLRoot):
         if self.confidence is not None and not isinstance(self.confidence, float):
             self.confidence = float(self.confidence)
 
-        if not isinstance(self.evidence, list):
-            self.evidence = [self.evidence] if self.evidence is not None else []
-        self.evidence = [v if isinstance(v, EvidenceItem) else EvidenceItem(**as_dict(v)) for v in self.evidence]
+        self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
         if not isinstance(self.genes, list):
             self.genes = [self.genes] if self.genes is not None else []
@@ -3055,6 +3045,142 @@ class GrowthModeEnum(EnumDefinitionImpl):
         description="""Cultivation mode under which a growth metric was measured. Distinct from MediaRecipe.culture_vessel which describes the vessel itself.""",
     )
 
+class MergeModeEnum(EnumDefinitionImpl):
+    """
+    Merge pipeline mode used by `MergeMetadata.merge_mode`.
+    """
+    CONSERVATIVE = PermissibleValue(
+        text="CONSERVATIVE",
+        description="Only merge on identical fingerprints.")
+    AGGRESSIVE = PermissibleValue(
+        text="AGGRESSIVE",
+        description="Merge across hydration / parent-ingredient equivalence.")
+    VARIANT_AWARE = PermissibleValue(
+        text="VARIANT_AWARE",
+        description="Use the hierarchy-aware variant fingerprint to merge.")
+
+    _defn = EnumDefinition(
+        name="MergeModeEnum",
+        description="Merge pipeline mode used by `MergeMetadata.merge_mode`.",
+    )
+
+class FingerprintModeEnum(EnumDefinitionImpl):
+    """
+    Algorithm used to compute the ingredient fingerprint.
+    """
+    ORIGINAL = PermissibleValue(
+        text="ORIGINAL",
+        description="Original ingredient set, no hierarchy resolution.")
+    CHEMICAL = PermissibleValue(
+        text="CHEMICAL",
+        description="Parent CHEBI IDs from MediaIngredientMech hierarchy.")
+    VARIANT = PermissibleValue(
+        text="VARIANT",
+        description="Parent CHEBI + variant type (HYDRATE / ANHYDROUS / SALT_FORM).")
+
+    _defn = EnumDefinition(
+        name="FingerprintModeEnum",
+        description="Algorithm used to compute the ingredient fingerprint.",
+    )
+
+class GrowthPhaseEnum(EnumDefinitionImpl):
+    """
+    Target microbial growth phase for a measurement / inoculum.
+    """
+    LAG = PermissibleValue(
+        text="LAG",
+        description="Lag phase (no significant net growth).")
+    EXPONENTIAL = PermissibleValue(
+        text="EXPONENTIAL",
+        description="Exponential / log phase.")
+    STATIONARY = PermissibleValue(
+        text="STATIONARY",
+        description="Stationary phase.")
+    DEATH = PermissibleValue(
+        text="DEATH",
+        description="Death / decline phase.")
+    UNSPECIFIED = PermissibleValue(
+        text="UNSPECIFIED",
+        description="Phase not stated by the source.")
+
+    _defn = EnumDefinition(
+        name="GrowthPhaseEnum",
+        description="Target microbial growth phase for a measurement / inoculum.",
+    )
+
+class TermMatchTypeEnum(EnumDefinitionImpl):
+    """
+    Provenance of an ontology-term mapping (`Term.match_type`). Values use the lowercase-snake convention emitted by
+    upstream grounding pipelines (kg-microbe, manual curation). Three values are observed in the current corpus
+    (kg_fallback, exact_match, synonym_match_ambiguous); the others are reserved for explicit curator use.
+    """
+    exact_match = PermissibleValue(
+        text="exact_match",
+        description="Exact label / synonym match.")
+    kg_fallback = PermissibleValue(
+        text="kg_fallback",
+        description="Inferred from the kg-microbe ingredient graph as a fallback.")
+    synonym_match_ambiguous = PermissibleValue(
+        text="synonym_match_ambiguous",
+        description="Multiple equally-good synonym matches; mapping is uncertain.")
+    manual_curated = PermissibleValue(
+        text="manual_curated",
+        description="Human curator selected this term.")
+    automated_expert_mapping = PermissibleValue(
+        text="automated_expert_mapping",
+        description="Produced by an automated expert-mapping pipeline (e.g. LLM-assisted).")
+    fuzzy = PermissibleValue(
+        text="fuzzy",
+        description="Fuzzy / approximate string match.")
+
+    _defn = EnumDefinition(
+        name="TermMatchTypeEnum",
+        description="""Provenance of an ontology-term mapping (`Term.match_type`). Values use the lowercase-snake convention emitted by upstream grounding pipelines (kg-microbe, manual curation). Three values are observed in the current corpus (kg_fallback, exact_match, synonym_match_ambiguous); the others are reserved for explicit curator use.""",
+    )
+
+class SynonymTypeEnum(EnumDefinitionImpl):
+    """
+    Type of synonym relationship for an IngredientSynonym.
+    """
+    EXACT = PermissibleValue(
+        text="EXACT",
+        description="Exact synonym.")
+    RELATED = PermissibleValue(
+        text="RELATED",
+        description="Related but not interchangeable.")
+    BROAD = PermissibleValue(
+        text="BROAD",
+        description="Broader concept.")
+    NARROW = PermissibleValue(
+        text="NARROW",
+        description="Narrower concept.")
+    ABBREVIATION = PermissibleValue(
+        text="ABBREVIATION",
+        description="Abbreviation or shorthand (e.g. \"TSB\" for \"Tryptic Soy Broth\").")
+
+    _defn = EnumDefinition(
+        name="SynonymTypeEnum",
+        description="Type of synonym relationship for an IngredientSynonym.",
+    )
+
+class DatasetTypeEnum(EnumDefinitionImpl):
+    """
+    Type of omics dataset linked by `Dataset.dataset_type`.
+    """
+    GENOMICS = PermissibleValue(text="GENOMICS")
+    TRANSCRIPTOMICS = PermissibleValue(text="TRANSCRIPTOMICS")
+    PROTEOMICS = PermissibleValue(text="PROTEOMICS")
+    METABOLOMICS = PermissibleValue(text="METABOLOMICS")
+    FLUXOMICS = PermissibleValue(text="FLUXOMICS")
+    PHENOMICS = PermissibleValue(text="PHENOMICS")
+    MULTI_OMICS = PermissibleValue(text="MULTI_OMICS")
+    OTHER = PermissibleValue(text="OTHER")
+
+    _defn = EnumDefinition(
+        name="DatasetTypeEnum",
+        description="Type of omics dataset linked by `Dataset.dataset_type`.",
+    )
+
 # Slots
 class slots:
     pass
@@ -3113,7 +3239,7 @@ slots.mediaRecipe__description = Slot(uri=CULTUREMECH.description, name="mediaRe
                    model_uri=CULTUREMECH.mediaRecipe__description, domain=None, range=Optional[str])
 
 slots.mediaRecipe__target_organisms = Slot(uri=CULTUREMECH.target_organisms, name="mediaRecipe__target_organisms", curie=CULTUREMECH.curie('target_organisms'),
-                   model_uri=CULTUREMECH.mediaRecipe__target_organisms, domain=None, range=Optional[Union[Union[dict, OrganismDescriptor], list[Union[dict, OrganismDescriptor]]]])
+                   model_uri=CULTUREMECH.mediaRecipe__target_organisms, domain=None, range=Optional[Union[dict[Union[str, OrganismDescriptorPreferredTerm], Union[dict, OrganismDescriptor]], list[Union[dict, OrganismDescriptor]]]])
 
 slots.mediaRecipe__source_environment = Slot(uri=CULTUREMECH.source_environment, name="mediaRecipe__source_environment", curie=CULTUREMECH.curie('source_environment'),
                    model_uri=CULTUREMECH.mediaRecipe__source_environment, domain=None, range=Optional[Union[Union[dict, SourceEnvironmentDescriptor], list[Union[dict, SourceEnvironmentDescriptor]]]])
@@ -3176,7 +3302,7 @@ slots.mediaRecipe__applications = Slot(uri=CULTUREMECH.applications, name="media
                    model_uri=CULTUREMECH.mediaRecipe__applications, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.mediaRecipe__variants = Slot(uri=CULTUREMECH.variants, name="mediaRecipe__variants", curie=CULTUREMECH.curie('variants'),
-                   model_uri=CULTUREMECH.mediaRecipe__variants, domain=None, range=Optional[Union[Union[dict, MediaVariant], list[Union[dict, MediaVariant]]]])
+                   model_uri=CULTUREMECH.mediaRecipe__variants, domain=None, range=Optional[Union[dict[Union[str, MediaVariantName], Union[dict, MediaVariant]], list[Union[dict, MediaVariant]]]])
 
 slots.mediaRecipe__parent_media = Slot(uri=CULTUREMECH.parent_media, name="mediaRecipe__parent_media", curie=CULTUREMECH.curie('parent_media'),
                    model_uri=CULTUREMECH.mediaRecipe__parent_media, domain=None, range=Optional[Union[dict, MediaRecipeReference]])
@@ -3197,7 +3323,7 @@ slots.mediaRecipe__notes = Slot(uri=CULTUREMECH.notes, name="mediaRecipe__notes"
                    model_uri=CULTUREMECH.mediaRecipe__notes, domain=None, range=Optional[str])
 
 slots.mediaRecipe__evidence = Slot(uri=CULTUREMECH.evidence, name="mediaRecipe__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.mediaRecipe__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.mediaRecipe__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.mediaRecipe__datasets = Slot(uri=CULTUREMECH.datasets, name="mediaRecipe__datasets", curie=CULTUREMECH.curie('datasets'),
                    model_uri=CULTUREMECH.mediaRecipe__datasets, domain=None, range=Optional[Union[Union[dict, Dataset], list[Union[dict, Dataset]]]])
@@ -3291,7 +3417,7 @@ slots.mergeMetadata__merge_version = Slot(uri=CULTUREMECH.merge_version, name="m
                    model_uri=CULTUREMECH.mergeMetadata__merge_version, domain=None, range=Optional[str])
 
 slots.mergeMetadata__merge_mode = Slot(uri=CULTUREMECH.merge_mode, name="mergeMetadata__merge_mode", curie=CULTUREMECH.curie('merge_mode'),
-                   model_uri=CULTUREMECH.mergeMetadata__merge_mode, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.mergeMetadata__merge_mode, domain=None, range=Optional[Union[str, "MergeModeEnum"]])
 
 slots.mergeMetadata__merge_reason = Slot(uri=CULTUREMECH.merge_reason, name="mergeMetadata__merge_reason", curie=CULTUREMECH.curie('merge_reason'),
                    model_uri=CULTUREMECH.mergeMetadata__merge_reason, domain=None, range=Optional[Union[str, "MergeReasonEnum"]])
@@ -3303,7 +3429,7 @@ slots.mergeMetadata__hierarchy_conflicts = Slot(uri=CULTUREMECH.hierarchy_confli
                    model_uri=CULTUREMECH.mergeMetadata__hierarchy_conflicts, domain=None, range=Optional[Union[str, list[str]]])
 
 slots.mergeMetadata__fingerprint_mode = Slot(uri=CULTUREMECH.fingerprint_mode, name="mergeMetadata__fingerprint_mode", curie=CULTUREMECH.curie('fingerprint_mode'),
-                   model_uri=CULTUREMECH.mergeMetadata__fingerprint_mode, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.mergeMetadata__fingerprint_mode, domain=None, range=Optional[Union[str, "FingerprintModeEnum"]])
 
 slots.term__id = Slot(uri=CULTUREMECH.id, name="term__id", curie=CULTUREMECH.curie('id'),
                    model_uri=CULTUREMECH.term__id, domain=None, range=URIRef)
@@ -3315,7 +3441,7 @@ slots.term__confidence = Slot(uri=CULTUREMECH.confidence, name="term__confidence
                    model_uri=CULTUREMECH.term__confidence, domain=None, range=Optional[float])
 
 slots.term__match_type = Slot(uri=CULTUREMECH.match_type, name="term__match_type", curie=CULTUREMECH.curie('match_type'),
-                   model_uri=CULTUREMECH.term__match_type, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.term__match_type, domain=None, range=Optional[Union[str, "TermMatchTypeEnum"]])
 
 slots.mediaTypeDescriptor__preferred_term = Slot(uri=CULTUREMECH.preferred_term, name="mediaTypeDescriptor__preferred_term", curie=CULTUREMECH.curie('preferred_term'),
                    model_uri=CULTUREMECH.mediaTypeDescriptor__preferred_term, domain=None, range=str)
@@ -3345,7 +3471,7 @@ slots.ingredientDescriptor__variant_type = Slot(uri=CULTUREMECH.variant_type, na
                    model_uri=CULTUREMECH.ingredientDescriptor__variant_type, domain=None, range=Optional[Union[str, "VariantTypeEnum"]])
 
 slots.ingredientDescriptor__concentration = Slot(uri=CULTUREMECH.concentration, name="ingredientDescriptor__concentration", curie=CULTUREMECH.curie('concentration'),
-                   model_uri=CULTUREMECH.ingredientDescriptor__concentration, domain=None, range=Union[dict, ConcentrationValue])
+                   model_uri=CULTUREMECH.ingredientDescriptor__concentration, domain=None, range=Optional[Union[dict, ConcentrationValue]])
 
 slots.ingredientDescriptor__modifier = Slot(uri=CULTUREMECH.modifier, name="ingredientDescriptor__modifier", curie=CULTUREMECH.curie('modifier'),
                    model_uri=CULTUREMECH.ingredientDescriptor__modifier, domain=None, range=Optional[Union[str, "ModifierEnum"]])
@@ -3381,7 +3507,7 @@ slots.ingredientDescriptor__cofactors_provided = Slot(uri=CULTUREMECH.cofactors_
                    model_uri=CULTUREMECH.ingredientDescriptor__cofactors_provided, domain=None, range=Optional[Union[Union[dict, CofactorDescriptor], list[Union[dict, CofactorDescriptor]]]])
 
 slots.ingredientDescriptor__evidence = Slot(uri=CULTUREMECH.evidence, name="ingredientDescriptor__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.ingredientDescriptor__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.ingredientDescriptor__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.solutionDescriptor__preferred_term = Slot(uri=CULTUREMECH.preferred_term, name="solutionDescriptor__preferred_term", curie=CULTUREMECH.curie('preferred_term'),
                    model_uri=CULTUREMECH.solutionDescriptor__preferred_term, domain=None, range=str)
@@ -3417,7 +3543,7 @@ slots.solutionDescriptor__shelf_life = Slot(uri=CULTUREMECH.shelf_life, name="so
                    model_uri=CULTUREMECH.solutionDescriptor__shelf_life, domain=None, range=Optional[str])
 
 slots.organismDescriptor__preferred_term = Slot(uri=CULTUREMECH.preferred_term, name="organismDescriptor__preferred_term", curie=CULTUREMECH.curie('preferred_term'),
-                   model_uri=CULTUREMECH.organismDescriptor__preferred_term, domain=None, range=str)
+                   model_uri=CULTUREMECH.organismDescriptor__preferred_term, domain=None, range=URIRef)
 
 slots.organismDescriptor__term = Slot(uri=CULTUREMECH.term, name="organismDescriptor__term", curie=CULTUREMECH.curie('term'),
                    model_uri=CULTUREMECH.organismDescriptor__term, domain=None, range=Optional[Union[dict, OrganismTerm]])
@@ -3433,7 +3559,7 @@ slots.organismDescriptor__strain = Slot(uri=CULTUREMECH.strain, name="organismDe
                    model_uri=CULTUREMECH.organismDescriptor__strain, domain=None, range=Optional[str])
 
 slots.organismDescriptor__growth_phase = Slot(uri=CULTUREMECH.growth_phase, name="organismDescriptor__growth_phase", curie=CULTUREMECH.curie('growth_phase'),
-                   model_uri=CULTUREMECH.organismDescriptor__growth_phase, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.organismDescriptor__growth_phase, domain=None, range=Optional[Union[str, "GrowthPhaseEnum"]])
 
 slots.organismDescriptor__growth_metrics = Slot(uri=CULTUREMECH.growth_metrics, name="organismDescriptor__growth_metrics", curie=CULTUREMECH.curie('growth_metrics'),
                    model_uri=CULTUREMECH.organismDescriptor__growth_metrics, domain=None, range=Optional[Union[Union[dict, GrowthMetrics], list[Union[dict, GrowthMetrics]]]])
@@ -3454,7 +3580,7 @@ slots.organismDescriptor__transporters = Slot(uri=CULTUREMECH.transporters, name
                    model_uri=CULTUREMECH.organismDescriptor__transporters, domain=None, range=Optional[Union[Union[dict, TransporterAnnotation], list[Union[dict, TransporterAnnotation]]]])
 
 slots.organismDescriptor__evidence = Slot(uri=CULTUREMECH.evidence, name="organismDescriptor__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.organismDescriptor__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.organismDescriptor__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.organismDescriptor__strain_modifications = Slot(uri=CULTUREMECH.strain_modifications, name="organismDescriptor__strain_modifications", curie=CULTUREMECH.curie('strain_modifications'),
                    model_uri=CULTUREMECH.organismDescriptor__strain_modifications, domain=None, range=Optional[Union[Union[dict, StrainModification], list[Union[dict, StrainModification]]]])
@@ -3514,7 +3640,7 @@ slots.ingredientSynonym__synonym_text = Slot(uri=CULTUREMECH.synonym_text, name=
                    model_uri=CULTUREMECH.ingredientSynonym__synonym_text, domain=None, range=str)
 
 slots.ingredientSynonym__synonym_type = Slot(uri=CULTUREMECH.synonym_type, name="ingredientSynonym__synonym_type", curie=CULTUREMECH.curie('synonym_type'),
-                   model_uri=CULTUREMECH.ingredientSynonym__synonym_type, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.ingredientSynonym__synonym_type, domain=None, range=Optional[Union[str, "SynonymTypeEnum"]])
 
 slots.ingredientCurationMetadata__mapping_quality = Slot(uri=CULTUREMECH.mapping_quality, name="ingredientCurationMetadata__mapping_quality", curie=CULTUREMECH.curie('mapping_quality'),
                    model_uri=CULTUREMECH.ingredientCurationMetadata__mapping_quality, domain=None, range=Optional[str])
@@ -3566,7 +3692,7 @@ slots.growthMetrics__measurement_conditions = Slot(uri=CULTUREMECH.measurement_c
                    model_uri=CULTUREMECH.growthMetrics__measurement_conditions, domain=None, range=Optional[str])
 
 slots.growthMetrics__evidence = Slot(uri=CULTUREMECH.evidence, name="growthMetrics__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.growthMetrics__evidence, domain=None, range=Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]])
+                   model_uri=CULTUREMECH.growthMetrics__evidence, domain=None, range=Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]])
 
 slots.growthMetrics__is_max_attainment = Slot(uri=CULTUREMECH.is_max_attainment, name="growthMetrics__is_max_attainment", curie=CULTUREMECH.curie('is_max_attainment'),
                    model_uri=CULTUREMECH.growthMetrics__is_max_attainment, domain=None, range=Optional[Union[bool, Bool]])
@@ -3600,7 +3726,7 @@ slots.perturbationContext__ontology_term = Slot(uri=CULTUREMECH.ontology_term, n
                    pattern=re.compile(r'^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$'))
 
 slots.perturbationContext__evidence = Slot(uri=CULTUREMECH.evidence, name="perturbationContext__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.perturbationContext__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.perturbationContext__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.strainModification__modification_type = Slot(uri=CULTUREMECH.modification_type, name="strainModification__modification_type", curie=CULTUREMECH.curie('modification_type'),
                    model_uri=CULTUREMECH.strainModification__modification_type, domain=None, range=Union[str, "StrainModificationTypeEnum"])
@@ -3616,7 +3742,7 @@ slots.strainModification__ontology_term = Slot(uri=CULTUREMECH.ontology_term, na
                    pattern=re.compile(r'^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$'))
 
 slots.strainModification__evidence = Slot(uri=CULTUREMECH.evidence, name="strainModification__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.strainModification__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.strainModification__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.nutrientOverride__role = Slot(uri=CULTUREMECH.role, name="nutrientOverride__role", curie=CULTUREMECH.curie('role'),
                    model_uri=CULTUREMECH.nutrientOverride__role, domain=None, range=Union[str, "NutrientRoleEnum"])
@@ -3632,7 +3758,7 @@ slots.nutrientOverride__is_sole_source = Slot(uri=CULTUREMECH.is_sole_source, na
                    model_uri=CULTUREMECH.nutrientOverride__is_sole_source, domain=None, range=Optional[Union[bool, Bool]])
 
 slots.nutrientOverride__evidence = Slot(uri=CULTUREMECH.evidence, name="nutrientOverride__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.nutrientOverride__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.nutrientOverride__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.temperatureValue__value = Slot(uri=CULTUREMECH.value, name="temperatureValue__value", curie=CULTUREMECH.curie('value'),
                    model_uri=CULTUREMECH.temperatureValue__value, domain=None, range=float)
@@ -3692,7 +3818,10 @@ slots.storageConditions__notes = Slot(uri=CULTUREMECH.notes, name="storageCondit
                    model_uri=CULTUREMECH.storageConditions__notes, domain=None, range=Optional[str])
 
 slots.mediaVariant__name = Slot(uri=CULTUREMECH.name, name="mediaVariant__name", curie=CULTUREMECH.curie('name'),
-                   model_uri=CULTUREMECH.mediaVariant__name, domain=None, range=str)
+                   model_uri=CULTUREMECH.mediaVariant__name, domain=None, range=URIRef)
+
+slots.mediaVariant__relationship = Slot(uri=CULTUREMECH.relationship, name="mediaVariant__relationship", curie=CULTUREMECH.curie('relationship'),
+                   model_uri=CULTUREMECH.mediaVariant__relationship, domain=None, range=Optional[Union[str, "MediaVariantRelationshipEnum"]])
 
 slots.mediaVariant__description = Slot(uri=CULTUREMECH.description, name="mediaVariant__description", curie=CULTUREMECH.curie('description'),
                    model_uri=CULTUREMECH.mediaVariant__description, domain=None, range=Optional[str])
@@ -3707,7 +3836,7 @@ slots.mediaVariant__supplier_info = Slot(uri=CULTUREMECH.supplier_info, name="me
                    model_uri=CULTUREMECH.mediaVariant__supplier_info, domain=None, range=Optional[Union[dict, SupplierInfo]])
 
 slots.mediaVariant__evidence = Slot(uri=CULTUREMECH.evidence, name="mediaVariant__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.mediaVariant__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.mediaVariant__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.mediaRecipeReference__id = Slot(uri=CULTUREMECH.id, name="mediaRecipeReference__id", curie=CULTUREMECH.curie('id'),
                    model_uri=CULTUREMECH.mediaRecipeReference__id, domain=None, range=Optional[str],
@@ -3727,7 +3856,7 @@ slots.mediaRecipeReference__notes = Slot(uri=CULTUREMECH.notes, name="mediaRecip
                    model_uri=CULTUREMECH.mediaRecipeReference__notes, domain=None, range=Optional[str])
 
 slots.mediaRecipeReference__evidence = Slot(uri=CULTUREMECH.evidence, name="mediaRecipeReference__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.mediaRecipeReference__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.mediaRecipeReference__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.supplierInfo__supplier_name = Slot(uri=CULTUREMECH.supplier_name, name="supplierInfo__supplier_name", curie=CULTUREMECH.curie('supplier_name'),
                    model_uri=CULTUREMECH.supplierInfo__supplier_name, domain=None, range=str)
@@ -3757,7 +3886,7 @@ slots.publicationReference__notes = Slot(uri=CULTUREMECH.notes, name="publicatio
                    model_uri=CULTUREMECH.publicationReference__notes, domain=None, range=Optional[str])
 
 slots.evidenceItem__reference = Slot(uri=CULTUREMECH.reference, name="evidenceItem__reference", curie=CULTUREMECH.curie('reference'),
-                   model_uri=CULTUREMECH.evidenceItem__reference, domain=None, range=str)
+                   model_uri=CULTUREMECH.evidenceItem__reference, domain=None, range=URIRef)
 
 slots.evidenceItem__supports = Slot(uri=CULTUREMECH.supports, name="evidenceItem__supports", curie=CULTUREMECH.curie('supports'),
                    model_uri=CULTUREMECH.evidenceItem__supports, domain=None, range=Union[str, "EvidenceItemSupportEnum"])
@@ -3772,7 +3901,7 @@ slots.dataset__dataset_id = Slot(uri=CULTUREMECH.dataset_id, name="dataset__data
                    model_uri=CULTUREMECH.dataset__dataset_id, domain=None, range=str)
 
 slots.dataset__dataset_type = Slot(uri=CULTUREMECH.dataset_type, name="dataset__dataset_type", curie=CULTUREMECH.curie('dataset_type'),
-                   model_uri=CULTUREMECH.dataset__dataset_type, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.dataset__dataset_type, domain=None, range=Optional[Union[str, "DatasetTypeEnum"]])
 
 slots.dataset__description = Slot(uri=CULTUREMECH.description, name="dataset__description", curie=CULTUREMECH.curie('description'),
                    model_uri=CULTUREMECH.dataset__description, domain=None, range=Optional[str])
@@ -3808,7 +3937,7 @@ slots.sourceData__import_date = Slot(uri=CULTUREMECH.import_date, name="sourceDa
                    model_uri=CULTUREMECH.sourceData__import_date, domain=None, range=Optional[str])
 
 slots.sourceData__evidence = Slot(uri=CULTUREMECH.evidence, name="sourceData__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.sourceData__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.sourceData__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.sourceData__notes = Slot(uri=CULTUREMECH.notes, name="sourceData__notes", curie=CULTUREMECH.curie('notes'),
                    model_uri=CULTUREMECH.sourceData__notes, domain=None, range=Optional[str])
@@ -3826,7 +3955,7 @@ slots.cofactorRequirement__confidence = Slot(uri=CULTUREMECH.confidence, name="c
                    model_uri=CULTUREMECH.cofactorRequirement__confidence, domain=None, range=Optional[float])
 
 slots.cofactorRequirement__evidence = Slot(uri=CULTUREMECH.evidence, name="cofactorRequirement__evidence", curie=CULTUREMECH.curie('evidence'),
-                   model_uri=CULTUREMECH.cofactorRequirement__evidence, domain=None, range=Optional[Union[Union[dict, EvidenceItem], list[Union[dict, EvidenceItem]]]])
+                   model_uri=CULTUREMECH.cofactorRequirement__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.cofactorRequirement__genes = Slot(uri=CULTUREMECH.genes, name="cofactorRequirement__genes", curie=CULTUREMECH.curie('genes'),
                    model_uri=CULTUREMECH.cofactorRequirement__genes, domain=None, range=Optional[Union[str, list[str]]])

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-19T19:51:07
+# Generation date: 2026-05-19T20:18:42
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -1252,7 +1252,7 @@ class PerturbationContext(YAMLRoot):
     target: Optional[str] = None
     level: Optional[float] = None
     level_unit: Optional[str] = None
-    ontology_term: Optional[str] = None
+    ontology_id: Optional[str] = None
     evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1273,8 +1273,8 @@ class PerturbationContext(YAMLRoot):
         if self.level_unit is not None and not isinstance(self.level_unit, str):
             self.level_unit = str(self.level_unit)
 
-        if self.ontology_term is not None and not isinstance(self.ontology_term, str):
-            self.ontology_term = str(self.ontology_term)
+        if self.ontology_id is not None and not isinstance(self.ontology_id, str):
+            self.ontology_id = str(self.ontology_id)
 
         self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
@@ -1298,7 +1298,7 @@ class StrainModification(YAMLRoot):
     modification_type: Union[str, "StrainModificationTypeEnum"] = None
     target: Optional[str] = None
     description: Optional[str] = None
-    ontology_term: Optional[str] = None
+    ontology_id: Optional[str] = None
     evidence: Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, "EvidenceItem"]], list[Union[dict, "EvidenceItem"]]]] = empty_dict()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -1313,8 +1313,8 @@ class StrainModification(YAMLRoot):
         if self.description is not None and not isinstance(self.description, str):
             self.description = str(self.description)
 
-        if self.ontology_term is not None and not isinstance(self.ontology_term, str):
-            self.ontology_term = str(self.ontology_term)
+        if self.ontology_id is not None and not isinstance(self.ontology_id, str):
+            self.ontology_id = str(self.ontology_id)
 
         self._normalize_inlined_as_list(slot_name="evidence", slot_type=EvidenceItem, key_name="reference", keyed=True)
 
@@ -3721,8 +3721,8 @@ slots.perturbationContext__level = Slot(uri=CULTUREMECH.level, name="perturbatio
 slots.perturbationContext__level_unit = Slot(uri=CULTUREMECH.level_unit, name="perturbationContext__level_unit", curie=CULTUREMECH.curie('level_unit'),
                    model_uri=CULTUREMECH.perturbationContext__level_unit, domain=None, range=Optional[str])
 
-slots.perturbationContext__ontology_term = Slot(uri=CULTUREMECH.ontology_term, name="perturbationContext__ontology_term", curie=CULTUREMECH.curie('ontology_term'),
-                   model_uri=CULTUREMECH.perturbationContext__ontology_term, domain=None, range=Optional[str],
+slots.perturbationContext__ontology_id = Slot(uri=CULTUREMECH.ontology_id, name="perturbationContext__ontology_id", curie=CULTUREMECH.curie('ontology_id'),
+                   model_uri=CULTUREMECH.perturbationContext__ontology_id, domain=None, range=Optional[str],
                    pattern=re.compile(r'^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$'))
 
 slots.perturbationContext__evidence = Slot(uri=CULTUREMECH.evidence, name="perturbationContext__evidence", curie=CULTUREMECH.curie('evidence'),
@@ -3737,8 +3737,8 @@ slots.strainModification__target = Slot(uri=CULTUREMECH.target, name="strainModi
 slots.strainModification__description = Slot(uri=CULTUREMECH.description, name="strainModification__description", curie=CULTUREMECH.curie('description'),
                    model_uri=CULTUREMECH.strainModification__description, domain=None, range=Optional[str])
 
-slots.strainModification__ontology_term = Slot(uri=CULTUREMECH.ontology_term, name="strainModification__ontology_term", curie=CULTUREMECH.curie('ontology_term'),
-                   model_uri=CULTUREMECH.strainModification__ontology_term, domain=None, range=Optional[str],
+slots.strainModification__ontology_id = Slot(uri=CULTUREMECH.ontology_id, name="strainModification__ontology_id", curie=CULTUREMECH.curie('ontology_id'),
+                   model_uri=CULTUREMECH.strainModification__ontology_id, domain=None, range=Optional[str],
                    pattern=re.compile(r'^[A-Za-z][A-Za-z0-9._-]*:[A-Za-z0-9._-]+$'))
 
 slots.strainModification__evidence = Slot(uri=CULTUREMECH.evidence, name="strainModification__evidence", curie=CULTUREMECH.curie('evidence'),

--- a/src/culturemech/validation/__init__.py
+++ b/src/culturemech/validation/__init__.py
@@ -3,10 +3,20 @@
 from .yaml_fixer import YAMLFixer
 from .schema_defaulter import SchemaDefaulter
 from .validator import RecipeValidator, ValidationReport
+from .write_validated import (
+    ValidationFailedError,
+    infer_target_class,
+    validate_recipe,
+    write_validated_recipe,
+)
 
 __all__ = [
     'YAMLFixer',
     'SchemaDefaulter',
     'RecipeValidator',
     'ValidationReport',
+    'ValidationFailedError',
+    'infer_target_class',
+    'validate_recipe',
+    'write_validated_recipe',
 ]

--- a/src/culturemech/validation/write_validated.py
+++ b/src/culturemech/validation/write_validated.py
@@ -38,7 +38,7 @@ from linkml.validator.report import Severity, ValidationResult
 
 DEFAULT_SCHEMA_PATH = Path("src/culturemech/schema/culturemech.yaml")
 
-_VALIDATOR: Validator | None = None
+_VALIDATORS: dict[Path, Validator] = {}
 _VALIDATOR_LOCK = Lock()
 
 _SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")
@@ -65,14 +65,16 @@ class ValidationFailedError(Exception):
 
 
 def _get_validator(schema_path: Path) -> Validator:
-    global _VALIDATOR
+    """Cache validators keyed by resolved schema path so callers can mix
+    schemas in the same process without silently reusing a stale instance."""
+    key = Path(schema_path).resolve()
     with _VALIDATOR_LOCK:
-        if _VALIDATOR is None:
-            _VALIDATOR = Validator(
-                schema=str(schema_path),
+        if key not in _VALIDATORS:
+            _VALIDATORS[key] = Validator(
+                schema=str(key),
                 validation_plugins=[JsonschemaValidationPlugin(closed=True)],
             )
-        return _VALIDATOR
+        return _VALIDATORS[key]
 
 
 def infer_target_class(instance: dict[str, Any]) -> str:

--- a/src/culturemech/validation/write_validated.py
+++ b/src/culturemech/validation/write_validated.py
@@ -1,0 +1,132 @@
+"""Write-time validation: dump a recipe to YAML *only if* it passes
+closed-schema validation.
+
+This is the write-time gate that the audit found missing across 62/65
+YAML writers (only `fix_validation_errors.py` and
+`validate_hierarchy_integration.py` validated before writing, and even
+they used open-schema validation that misses unknown fields).
+
+Use::
+
+    from culturemech.validation.write_validated import (
+        write_validated_recipe,
+        ValidationFailedError,
+    )
+
+    try:
+        write_validated_recipe(recipe, output_path)
+    except ValidationFailedError as exc:
+        # Bad record refused; print categorized errors and abort.
+        print(exc.summary())
+        raise
+
+The validator is shared across calls (LinkML schema parse + JSON-schema
+emit is the slow part), so calling this in a tight migration loop is
+cheap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity, ValidationResult
+
+DEFAULT_SCHEMA_PATH = Path("src/culturemech/schema/culturemech.yaml")
+
+_VALIDATOR: Validator | None = None
+_VALIDATOR_LOCK = Lock()
+
+_SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")
+
+
+class ValidationFailedError(Exception):
+    """Raised when a recipe fails closed-schema validation before write."""
+
+    def __init__(self, path: Path | None, errors: list[ValidationResult]):
+        self.path = path
+        self.errors = errors
+        super().__init__(self.summary())
+
+    def summary(self) -> str:
+        lines = [
+            f"validation failed: {len(self.errors)} error(s)"
+            + (f" for {self.path}" if self.path else "")
+        ]
+        for err in self.errors[:10]:
+            lines.append(f"  - {err.message[:200]}")
+        if len(self.errors) > 10:
+            lines.append(f"  ... + {len(self.errors) - 10} more")
+        return "\n".join(lines)
+
+
+def _get_validator(schema_path: Path) -> Validator:
+    global _VALIDATOR
+    with _VALIDATOR_LOCK:
+        if _VALIDATOR is None:
+            _VALIDATOR = Validator(
+                schema=str(schema_path),
+                validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+            )
+        return _VALIDATOR
+
+
+def infer_target_class(instance: dict[str, Any]) -> str:
+    """Pick the right root class for this record.
+
+    Mirrors `scripts/validate_strict.py:infer_target_class` — keep the two
+    in sync if routing rules change.
+    """
+    if not isinstance(instance, dict):
+        return "MediaRecipe"
+    term = instance.get("term")
+    if isinstance(term, dict):
+        tid = term.get("id")
+        if isinstance(tid, str) and tid.startswith(_SOLUTION_TERM_PREFIXES):
+            return "SolutionRecipe"
+    return "MediaRecipe"
+
+
+def validate_recipe(
+    recipe: dict[str, Any],
+    *,
+    target_class: str | None = None,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> list[ValidationResult]:
+    """Return the list of ERROR-severity validation results (empty when clean)."""
+    validator = _get_validator(schema_path)
+    tc = target_class or infer_target_class(recipe)
+    report = validator.validate(recipe, target_class=tc)
+    return [r for r in report.results if r.severity == Severity.ERROR]
+
+
+def write_validated_recipe(
+    recipe: dict[str, Any],
+    path: Path,
+    *,
+    target_class: str | None = None,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+    yaml_kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Write `recipe` to `path` as YAML, but only if validation passes.
+
+    Raises `ValidationFailedError` (without writing) when closed-schema
+    validation finds any error. Use in place of `yaml.safe_dump(recipe, fh)`
+    inside enrichment / migration / merge scripts.
+    """
+    errors = validate_recipe(recipe, target_class=target_class, schema_path=schema_path)
+    if errors:
+        raise ValidationFailedError(path, errors)
+    opts = {
+        "sort_keys": False,
+        "allow_unicode": True,
+        "width": 80,
+        **(yaml_kwargs or {}),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        yaml.safe_dump(recipe, f, **opts)


### PR DESCRIPTION
## Summary

Closes the remaining 9 open items from the schema/instance/pipeline audit backlog (`reports/gap_fix_backlog.md`). Each commit is a single backlog item, mostly small and independently revertable. Full-corpus `just validate-strict` exits 0 on all 15,827 records after every commit on the branch.

| # | Item | Commit |
|---|---|---|
| G10 | `record_curation_event()` helper + refactor 4 migration scripts | `6520ae361` |
| G14 | `just assign-ids[-check]` + cross-file collision detection | `adc402b23` |
| G20 | `fix_schema_inconsistencies.py` records CurationEvent + write-validated | `4eca032f2` |
| G09 | `write_validated_recipe()` helper + opt-in adoption | `95223cfe7` |
| G18 | `validate-strict --layer schema/terms/references/all` | `4a7a40dfa` |
| G11+G16+G12 | identifier slots, `MediaVariant.relationship`, 6 new audit enums | `9e576e476` |
| G13 | rename `ontology_term` → `ontology_id` (2 records, 1 file) | `6987c8177` |

## What's new

**Two helper modules** (drop-in replacements for current ad-hoc patterns):

- `src/culturemech/curate/curation_event.py` — `record_curation_event(recipe, curator=..., action=..., notes=..., source=..., changes=..., skip_if_recent=...)`. Centralizes ISO-8601 UTC timestamping, lazy `curation_history` creation, and schema-field naming (so future schema edits touch one file). Used by 5 scripts so far.
- `src/culturemech/validation/write_validated.py` — `write_validated_recipe(recipe, path)`. Validates with `JsonschemaValidationPlugin(closed=True)` before writing; raises `ValidationFailedError` rather than silently writing bad data. `infer_target_class()` mirrors `scripts/validate_strict.py`.

**Schema additions** (6 new enums + 3 identifier slots + new `MediaVariant.relationship`):

- `MergeModeEnum` · `FingerprintModeEnum` · `GrowthPhaseEnum` · `TermMatchTypeEnum` (lowercase to match observed corpus: `kg_fallback`, `exact_match`, `synonym_match_ambiguous`) · `SynonymTypeEnum` · `DatasetTypeEnum`.
- `identifier: true` on `OrganismDescriptor.preferred_term`, `MediaVariant.name`, `EvidenceItem.reference`.
- `MediaVariant.relationship: MediaVariantRelationshipEnum` so variants can be queried with the same typed vocab as `MediaRecipeReference.relationship`.
- `MediaRecipe.target_organisms` now `inlined_as_list: true` (required because the new identifier slot would otherwise switch the list to a dict).

**Renames**:

- `ontology_term → ontology_id` on `PerturbationContext` and `StrainModification` (the only two slots violating the schema's own `_term`-vs-`_id` convention). Migration script `migrate_ontology_term_rename.py` (idempotent, appends CurationEvent).

**Justfile**:

- `just assign-ids-check` — scan-only collision detection on `CultureMech:NNNNNN` IDs; exits non-zero on cross-file duplicates.
- `just assign-ids *args` — mints new IDs; refuses if collisions present.

**Harness**:

- `scripts/validate_strict.py` gains `--layer schema|terms|references|all`. The two non-schema layers shell out to `linkml-term-validator` / `linkml-reference-validator` per file (slower; opt-in). TSV gains a `layer` column.

## Still on the backlog (no longer "open")

All 20 G-items now closed (G01–G08, G15, G17 from earlier PRs; G09–G14, G16, G18, G20 from this PR). New forward-looking work — write-time validation adoption in the remaining ~27 historical writers, term/reference-layer scope expansion — is documented in `audit-schema-gaps` skill but not yet tracked as separate backlog items.

## Test plan

- [ ] `just validate-strict` — 0 ERROR rows across all 15,827 records (verified locally; CI gate re-runs it on this PR).
- [ ] `just assign-ids-check` — exits 0 (verified: 15,827 / 15,827 IDs, highest `CultureMech:015830`, 0 duplicates).
- [ ] `just validate-strict --layer all --sample 5` — smoke-test of multi-layer validation on a handful of files.
- [ ] All migration scripts on the branch report 0 changes when run with `--dry-run` (corpus is already at the cleaned-up state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)