### PR TITLE
Audit follow-ons (code): PhRange class + 5 helper adoptions

### DIFF
--- a/reports/pipeline_writers_audit.tsv
+++ b/reports/pipeline_writers_audit.tsv
@@ -5,7 +5,7 @@ scripts/aggregate_unmapped_ingredients.py	yes	no	no	no	yes
 scripts/analyze_metal_concentrations.py	yes	no	no	no	no
 scripts/apply_edison_results.py	yes	yes	yes	no	no
 scripts/apply_growth_evidence.py	yes	yes	no	no	yes
-scripts/apply_media_variant_links.py	yes	no	no	no	yes
+scripts/apply_media_variant_links.py	yes	yes	no	no	yes
 scripts/assign_culturemech_ids.py	yes	yes	yes	no	yes
 scripts/assign_taxonomy.py	yes	no	yes	no	no
 scripts/audit_writers.py	yes	yes	yes	yes	no
@@ -17,7 +17,7 @@ scripts/cleanup_residual_errors.py	yes	yes	yes	no	no
 scripts/compare_fingerprints.py	yes	no	no	no	no
 scripts/create_recipe_from_input.py	yes	yes	yes	no	no
 scripts/enrich_genome_ids.py	yes	no	no	no	yes
-scripts/enrich_solutions_with_chebi.py	yes	no	yes	no	no
+scripts/enrich_solutions_with_chebi.py	yes	yes	yes	no	no
 scripts/enrich_with_chebi.py	yes	yes	yes	no	yes
 scripts/enrich_with_kg_microbe_matches.py	yes	yes	yes	no	no
 scripts/fetch_pubmed_abstracts.py	yes	no	yes	no	yes
@@ -62,10 +62,10 @@ src/culturemech/import/togo_importer.py	yes	yes	no	no	yes
 src/culturemech/import/utex_importer.py	yes	yes	no	no	yes
 src/culturemech/enrich/backfill_pipeline.py	yes	yes	yes	no	no
 src/culturemech/enrich/dsmz_resolver.py	yes	yes	yes	no	no
-src/culturemech/enrich/fix_unnamed_and_physical_state.py	yes	no	yes	no	no
+src/culturemech/enrich/fix_unnamed_and_physical_state.py	yes	yes	yes	no	no
 src/culturemech/enrich/hierarchy_enricher.py	yes	yes	yes	no	no
 src/culturemech/enrich/mediaingredientmech_linker.py	yes	yes	yes	no	no
-src/culturemech/enrich/normalize_enums.py	yes	no	yes	no	no
+src/culturemech/enrich/normalize_enums.py	yes	yes	yes	no	no
 src/culturemech/enrich/preparation_steps_extractor.py	yes	yes	yes	no	no
 src/culturemech/enrich/role_importer.py	yes	yes	yes	no	no
-src/culturemech/merge/merge_recipes.py	yes	no	yes	no	yes
+src/culturemech/merge/merge_recipes.py	yes	yes	yes	no	yes

--- a/scripts/apply_media_variant_links.py
+++ b/scripts/apply_media_variant_links.py
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover - exercised only outside the uv env
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "apply_media_variant_links.py"
 ACTION = "APPLIED_VARIANT_LINKS"

--- a/scripts/apply_media_variant_links.py
+++ b/scripts/apply_media_variant_links.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,11 @@ except ImportError:  # pragma: no cover - exercised only outside the uv env
     RuamelYAML = None
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
+
+CURATOR = "apply_media_variant_links.py"
+ACTION = "APPLIED_VARIANT_LINKS"
 DEFAULT_PROPOSALS = REPO_ROOT / "reports" / "media_variant_link_proposals.tsv"
 REPORTS_DIR = REPO_ROOT / "reports"
 DRY_RUN_JSON = REPORTS_DIR / "media_variant_link_apply_plan.json"
@@ -228,6 +234,12 @@ def plan_links(rows: list[dict[str, str]], args: argparse.Namespace) -> list[dic
 
     if args.apply:
         for rel_path in sorted(dirty):
+            record_curation_event(
+                recipes[rel_path],
+                curator=CURATOR,
+                action=ACTION,
+                notes=f"applied variant-link plan ({rel_path})",
+            )
             write_yaml(REPO_ROOT / rel_path, recipes[rel_path])
 
     return plans

--- a/scripts/cleanup_residual_errors.py
+++ b/scripts/cleanup_residual_errors.py
@@ -34,7 +34,7 @@ from typing import Any
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "cleanup_residual_errors.py"
 ACTION = "CLEANUP_RESIDUAL_ERRORS"

--- a/scripts/enrich_solutions_with_chebi.py
+++ b/scripts/enrich_solutions_with_chebi.py
@@ -25,6 +25,10 @@ import yaml
 from tqdm import tqdm
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
+
+CURATOR = "enrich_solutions_with_chebi.py"
+ACTION = "ENRICHED_SOLUTIONS_WITH_CHEBI"
 
 
 def load_compound_mapping(mapping_path: Path) -> dict:
@@ -101,6 +105,13 @@ def enrich_solution_yaml(
             num_enriched += 1
 
     # Save enriched YAML
+    if num_enriched > 0:
+        record_curation_event(
+            data,
+            curator=CURATOR,
+            action=ACTION,
+            notes=f"added chebi_term to {num_enriched}/{num_total} composition entries",
+        )
     if not dry_run and num_enriched > 0:
         with open(yaml_path, 'w') as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/scripts/enrich_solutions_with_chebi.py
+++ b/scripts/enrich_solutions_with_chebi.py
@@ -25,7 +25,7 @@ import yaml
 from tqdm import tqdm
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "enrich_solutions_with_chebi.py"
 ACTION = "ENRICHED_SOLUTIONS_WITH_CHEBI"

--- a/scripts/fix_schema_inconsistencies.py
+++ b/scripts/fix_schema_inconsistencies.py
@@ -13,7 +13,7 @@ from typing import Dict, List
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 from culturemech.validation import (  # noqa: E402
     ValidationFailedError,
     write_validated_recipe,

--- a/scripts/migrate_data_quality_flags.py
+++ b/scripts/migrate_data_quality_flags.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_data_quality_flags.py"
 ACTION = "MIGRATED_DATA_QUALITY_FLAGS"

--- a/scripts/migrate_legacy_fields.py
+++ b/scripts/migrate_legacy_fields.py
@@ -30,7 +30,7 @@ from typing import Any
 import yaml
 
 from culturemech.preparation_actions import infer_prep_action
-from culturemech.curate import record_curation_event
+from culturemech.curate.curation_event import record_curation_event
 
 CURATOR = "migrate_legacy_fields.py"
 ACTION = "MIGRATED_LEGACY_FIELDS"

--- a/scripts/migrate_ontology_term_rename.py
+++ b/scripts/migrate_ontology_term_rename.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_ontology_term_rename.py"
 ACTION = "MIGRATED_ONTOLOGY_TERM_RENAME"

--- a/scripts/migrate_ph_range.py
+++ b/scripts/migrate_ph_range.py
@@ -30,15 +30,18 @@ from typing import Any
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_ph_range.py"
 ACTION = "MIGRATED_PH_RANGE"
 DEFAULT_ROOT = "data/normalized_yaml"
 
-# Match optional leading text + "<num>" or "<num> - <num>" + optional trailing text.
+# Match "<num>" or "<num> <sep> <num>" with `sep` ∈ { hyphen-minus, en/em dash,
+# the word "to" }. Earlier versions used a character class `[-–to]+` which
+# accidentally matched any combination of t/o/- characters (e.g. "7tt8" would
+# parse as 7..8) — Copilot caught that on PR #23.
 _RANGE_PATTERN = re.compile(
-    r"(?P<low>\d+(?:\.\d+)?)\s*(?:[-–to]+\s*(?P<high>\d+(?:\.\d+)?))?"
+    r"(?P<low>\d+(?:\.\d+)?)\s*(?:(?:-|–|—|\bto\b)\s*(?P<high>\d+(?:\.\d+)?))?"
 )
 
 

--- a/scripts/migrate_ph_range.py
+++ b/scripts/migrate_ph_range.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Migrate `MediaRecipe.ph_range` from a free-text string to the
+structured `PhRange` class introduced for G33 (audit follow-on).
+
+Parsing rules (best-effort; preserves the original whenever a clean
+parse isn't possible):
+
+  "6.8-7.2"             -> {min: 6.8, max: 7.2}
+  "7"                   -> {min: 7.0, max: 7.0}
+  "6.5 - 7.0"           -> {min: 6.5, max: 7.0}
+  "approximately 7.4"   -> {min: 7.4, max: 7.4, notes: "approximately 7.4"}
+  "alkaline 9-10"       -> {min: 9.0, max: 10.0, notes: "alkaline 9-10"}
+  "varies by species"   -> {notes: "varies by species"}
+
+Each migrated file gets a CurationEvent via the G10 helper.
+Re-runs are no-ops (ph_range value is a dict after the first migration).
+
+Usage:
+    python scripts/migrate_ph_range.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from culturemech.curate import record_curation_event  # noqa: E402
+
+CURATOR = "migrate_ph_range.py"
+ACTION = "MIGRATED_PH_RANGE"
+DEFAULT_ROOT = "data/normalized_yaml"
+
+# Match optional leading text + "<num>" or "<num> - <num>" + optional trailing text.
+_RANGE_PATTERN = re.compile(
+    r"(?P<low>\d+(?:\.\d+)?)\s*(?:[-–to]+\s*(?P<high>\d+(?:\.\d+)?))?"
+)
+
+
+def parse_ph_range(text: str) -> dict[str, Any]:
+    """Parse a free-text pH-range string into a PhRange-shaped dict."""
+    m = _RANGE_PATTERN.search(text)
+    if not m:
+        return {"notes": text}
+    low = float(m.group("low"))
+    high = float(m.group("high")) if m.group("high") else low
+    # If the captured substring is not the whole string (e.g. has prefix /
+    # suffix like "alkaline 9-10" or "approximately 7.4"), keep the original
+    # text in notes so the qualifier isn't lost.
+    captured = m.group(0)
+    out: dict[str, Any] = {"min": low, "max": high}
+    if captured.strip() != text.strip():
+        out["notes"] = text
+    return out
+
+
+def migrate_one(path: Path, dry_run: bool) -> bool:
+    try:
+        with path.open() as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    ph = data.get("ph_range")
+    if not isinstance(ph, str):
+        return False
+    parsed = parse_ph_range(ph)
+    data["ph_range"] = parsed
+    record_curation_event(
+        data,
+        curator=CURATOR,
+        action=ACTION,
+        notes=f"ph_range {ph!r} -> {parsed!r}",
+    )
+    if not dry_run:
+        with path.open("w") as f:
+            yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=80)
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", default=DEFAULT_ROOT)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    paths = sorted(Path(args.root).rglob("*.yaml"))
+    n = 0
+    for p in paths:
+        if migrate_one(p, args.dry_run):
+            n += 1
+    mode = "[DRY RUN] " if args.dry_run else ""
+    print(f"{mode}scanned: {len(paths)}, migrated: {n}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_preparation_steps.py
+++ b/scripts/migrate_preparation_steps.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from culturemech.curate import record_curation_event  # noqa: E402
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
 
 CURATOR = "migrate_preparation_steps.py"
 ACTION = "MIGRATED_PREPARATION_STEPS"

--- a/src/culturemech/enrich/fix_unnamed_and_physical_state.py
+++ b/src/culturemech/enrich/fix_unnamed_and_physical_state.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import yaml
 import re
 
-from culturemech.curate import record_curation_event
+from culturemech.curate.curation_event import record_curation_event
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/culturemech/enrich/fix_unnamed_and_physical_state.py
+++ b/src/culturemech/enrich/fix_unnamed_and_physical_state.py
@@ -11,8 +11,13 @@ from pathlib import Path
 import yaml
 import re
 
+from culturemech.curate import record_curation_event
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+CURATOR = "fix_unnamed_and_physical_state.py"
+ACTION = "FIXED_UNNAMED_AND_PHYSICAL_STATE"
 
 
 class MediaFixer:
@@ -140,6 +145,14 @@ class MediaFixer:
                 logger.info(f"{'[DRY RUN] ' if self.dry_run else ''}Modified {yaml_path.name}")
                 for change in changes:
                     logger.info(f"  - {change}")
+
+                record_curation_event(
+                    data,
+                    curator=CURATOR,
+                    action=ACTION,
+                    notes=f"fixed {len(changes)} field(s)",
+                    changes="; ".join(changes)[:500],
+                )
 
                 if not self.dry_run:
                     # Write back to file

--- a/src/culturemech/enrich/normalize_enums.py
+++ b/src/culturemech/enrich/normalize_enums.py
@@ -15,8 +15,13 @@ from typing import Dict, Any, Optional
 import yaml
 import re
 
+from culturemech.curate import record_curation_event
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+CURATOR = "normalize_enums.py"
+ACTION = "NORMALIZED_ENUMS"
 
 
 class EnumNormalizer:
@@ -260,6 +265,14 @@ class EnumNormalizer:
                 logger.info(f"{'[DRY RUN] ' if self.dry_run else ''}Modified {yaml_path.name}")
                 for change in changes:
                     logger.info(f"  - {change}")
+
+                record_curation_event(
+                    data,
+                    curator=CURATOR,
+                    action=ACTION,
+                    notes=f"normalized {len(changes)} enum value(s)",
+                    changes="; ".join(changes)[:500],
+                )
 
                 if not self.dry_run:
                     # Write back to file, preserving formatting as much as possible

--- a/src/culturemech/enrich/normalize_enums.py
+++ b/src/culturemech/enrich/normalize_enums.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Optional
 import yaml
 import re
 
-from culturemech.curate import record_curation_event
+from culturemech.curate.curation_event import record_curation_event
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/culturemech/merge/merge_recipes.py
+++ b/src/culturemech/merge/merge_recipes.py
@@ -26,12 +26,16 @@ from pathlib import Path
 
 import yaml
 
+from culturemech.curate import record_curation_event
 from culturemech.enrich.hierarchy_importer import MediaIngredientMechHierarchyImporter
 from culturemech.merge.fingerprint import RecipeFingerprinter
 from culturemech.merge.hierarchy_fingerprint import HierarchyAwareFingerprinter
 from culturemech.merge.matcher import RecipeMatcher
 from culturemech.merge.merge_rules import MergeRuleEngine
 from culturemech.merge.merger import RecipeMerger
+
+CURATOR = "merge_recipes.py"
+ACTION = "MERGED_RECIPES"
 
 
 def find_all_recipes(normalized_dir: Path) -> list[Path]:
@@ -422,6 +426,16 @@ Examples:
             # Generate output filename (use canonical name)
             filename = merged_recipe['name'].replace('/', '_').replace(' ', '_') + '.yaml'
             output_path = args.output_dir / filename
+
+            # Record provenance for the merge so the audit trail captures
+            # how this canonical record was produced.
+            record_curation_event(
+                merged_recipe,
+                curator=CURATOR,
+                action=ACTION,
+                notes=f"merged {len(paths)} source recipe(s) on fingerprint {fp}",
+                source=", ".join(p.name for p in paths)[:500],
+            )
 
             # Write merged recipe
             with open(output_path, 'w', encoding='utf-8') as f:

--- a/src/culturemech/merge/merge_recipes.py
+++ b/src/culturemech/merge/merge_recipes.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import yaml
 
-from culturemech.curate import record_curation_event
+from culturemech.curate.curation_event import record_curation_event
 from culturemech.enrich.hierarchy_importer import MediaIngredientMechHierarchyImporter
 from culturemech.merge.fingerprint import RecipeFingerprinter
 from culturemech.merge.hierarchy_fingerprint import HierarchyAwareFingerprinter

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -255,8 +255,9 @@ classes:
         range: float
 
       ph_range:
-        description: Acceptable pH range (e.g., "6.8-7.2")
-        range: string
+        description: Acceptable pH range. Structured as PhRange (min/max floats; notes for unparseable values).
+        range: PhRange
+        inlined: true
 
       # Algae-specific culture conditions
       light_intensity:
@@ -1337,6 +1338,24 @@ classes:
         description: Temperature unit
         range: TemperatureUnitEnum
         required: true
+
+  PhRange:
+    description: >-
+      Acceptable pH range for a medium. Use `min` and `max` (floats) for
+      parseable ranges; `notes` preserves the original free-text whenever
+      a value can't be parsed cleanly (avoids data loss during migration).
+    attributes:
+      min:
+        description: Lower bound of the acceptable pH range (inclusive).
+        range: float
+      max:
+        description: Upper bound of the acceptable pH range (inclusive).
+        range: float
+      notes:
+        description: >-
+          Free-text qualifier or the original unparseable value
+          (e.g. "varies by species", "alkaline 9-10 for halophiles").
+        range: string
 
   PreparationStep:
     description: A step in medium preparation

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-05-19T20:18:42
+# Generation date: 2026-05-19T22:59:07
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -197,7 +197,7 @@ class MediaRecipe(YAMLRoot):
     source_environment: Optional[Union[Union[dict, "SourceEnvironmentDescriptor"], list[Union[dict, "SourceEnvironmentDescriptor"]]]] = empty_list()
     organism_culture_type: Optional[Union[str, "OrganismCultureTypeEnum"]] = None
     ph_value: Optional[float] = None
-    ph_range: Optional[str] = None
+    ph_range: Optional[Union[dict, "PhRange"]] = None
     light_intensity: Optional[str] = None
     light_cycle: Optional[str] = None
     light_quality: Optional[str] = None
@@ -312,8 +312,8 @@ class MediaRecipe(YAMLRoot):
         if self.ph_value is not None and not isinstance(self.ph_value, float):
             self.ph_value = float(self.ph_value)
 
-        if self.ph_range is not None and not isinstance(self.ph_range, str):
-            self.ph_range = str(self.ph_range)
+        if self.ph_range is not None and not isinstance(self.ph_range, PhRange):
+            self.ph_range = PhRange(**as_dict(self.ph_range))
 
         if self.light_intensity is not None and not isinstance(self.light_intensity, str):
             self.light_intensity = str(self.light_intensity)
@@ -1389,6 +1389,36 @@ class TemperatureValue(YAMLRoot):
             self.MissingRequiredField("unit")
         if not isinstance(self.unit, TemperatureUnitEnum):
             self.unit = TemperatureUnitEnum(self.unit)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class PhRange(YAMLRoot):
+    """
+    Acceptable pH range for a medium. Use `min` and `max` (floats) for parseable ranges; `notes` preserves the
+    original free-text whenever a value can't be parsed cleanly (avoids data loss during migration).
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = CULTUREMECH["PhRange"]
+    class_class_curie: ClassVar[str] = "culturemech:PhRange"
+    class_name: ClassVar[str] = "PhRange"
+    class_model_uri: ClassVar[URIRef] = CULTUREMECH.PhRange
+
+    min: Optional[float] = None
+    max: Optional[float] = None
+    notes: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.min is not None and not isinstance(self.min, float):
+            self.min = float(self.min)
+
+        if self.max is not None and not isinstance(self.max, float):
+            self.max = float(self.max)
+
+        if self.notes is not None and not isinstance(self.notes, str):
+            self.notes = str(self.notes)
 
         super().__post_init__(**kwargs)
 
@@ -3257,7 +3287,7 @@ slots.mediaRecipe__ph_value = Slot(uri=CULTUREMECH.ph_value, name="mediaRecipe__
                    model_uri=CULTUREMECH.mediaRecipe__ph_value, domain=None, range=Optional[float])
 
 slots.mediaRecipe__ph_range = Slot(uri=CULTUREMECH.ph_range, name="mediaRecipe__ph_range", curie=CULTUREMECH.curie('ph_range'),
-                   model_uri=CULTUREMECH.mediaRecipe__ph_range, domain=None, range=Optional[str])
+                   model_uri=CULTUREMECH.mediaRecipe__ph_range, domain=None, range=Optional[Union[dict, PhRange]])
 
 slots.mediaRecipe__light_intensity = Slot(uri=CULTUREMECH.light_intensity, name="mediaRecipe__light_intensity", curie=CULTUREMECH.curie('light_intensity'),
                    model_uri=CULTUREMECH.mediaRecipe__light_intensity, domain=None, range=Optional[str])
@@ -3765,6 +3795,15 @@ slots.temperatureValue__value = Slot(uri=CULTUREMECH.value, name="temperatureVal
 
 slots.temperatureValue__unit = Slot(uri=CULTUREMECH.unit, name="temperatureValue__unit", curie=CULTUREMECH.curie('unit'),
                    model_uri=CULTUREMECH.temperatureValue__unit, domain=None, range=Union[str, "TemperatureUnitEnum"])
+
+slots.phRange__min = Slot(uri=CULTUREMECH.min, name="phRange__min", curie=CULTUREMECH.curie('min'),
+                   model_uri=CULTUREMECH.phRange__min, domain=None, range=Optional[float])
+
+slots.phRange__max = Slot(uri=CULTUREMECH.max, name="phRange__max", curie=CULTUREMECH.curie('max'),
+                   model_uri=CULTUREMECH.phRange__max, domain=None, range=Optional[float])
+
+slots.phRange__notes = Slot(uri=CULTUREMECH.notes, name="phRange__notes", curie=CULTUREMECH.curie('notes'),
+                   model_uri=CULTUREMECH.phRange__notes, domain=None, range=Optional[str])
 
 slots.preparationStep__step_number = Slot(uri=CULTUREMECH.step_number, name="preparationStep__step_number", curie=CULTUREMECH.curie('step_number'),
                    model_uri=CULTUREMECH.preparationStep__step_number, domain=None, range=int)


### PR DESCRIPTION
## Summary

Code-only half of the audit-cleanup follow-ons. Two tracks:

1. **PhRange structured class** — replaces the free-text `MediaRecipe.ph_range` slot with a typed `PhRange { min: float, max: float, notes: string }`. `scripts/migrate_ph_range.py` parses the existing 967 free-text values into structured form; the data half is in the follow-up PR.
2. **Helper adoption** — refactors 5 high-volume historical writers to call `record_curation_event()` (the G10 helper from PR #22). Writer audit now shows 45/70 writers append `curation_history` (was 40/70).

## What's in this PR (9 files)

**Schema** (`src/culturemech/schema/culturemech.yaml` + regenerated `culturemech_dataclasses.py`)
- New `PhRange` class: `min`, `max` (floats); `notes` (string, free-text fallback for unparseable values).
- `MediaRecipe.ph_range` slot retyped from `range: string` to `range: PhRange`, inlined.

**Migration script** (idempotent, `--dry-run`, appends `CurationEvent`)
- `scripts/migrate_ph_range.py` — best-effort regex parse:
  - `"6.8-7.2"` → `{min: 6.8, max: 7.2}`
  - `"7"` → `{min: 7.0, max: 7.0}`
  - `"approximately 7.4"` → `{min: 7.4, max: 7.4, notes: "approximately 7.4"}`
  - `"varies by species"` → `{notes: "varies by species"}`

**Helper adoption** — 5 high-volume historical writers now record `CurationEvent` via the G10 helper:

| Script | Action label |
|---|---|
| `src/culturemech/merge/merge_recipes.py` | `MERGED_RECIPES` (source field lists original recipe files) |
| `scripts/apply_media_variant_links.py` | `APPLIED_VARIANT_LINKS` (fires once per affected file) |
| `src/culturemech/enrich/normalize_enums.py` | `NORMALIZED_ENUMS` (changes field records normalizations) |
| `src/culturemech/enrich/fix_unnamed_and_physical_state.py` | `FIXED_UNNAMED_AND_PHYSICAL_STATE` |
| `scripts/enrich_solutions_with_chebi.py` | `ENRICHED_SOLUTIONS_WITH_CHEBI` |

## What's *not* in this PR

- The 967-record ph_range string→dict data migration. Follow-up PR (`audit-followups-data`, base = this branch) applies it.
- Adoption of `write_validated_recipe` (G09) in additional writers — left as further follow-up. Only `fix_schema_inconsistencies.py` adopted it so far (PR #22).
- Structured classes for `temperature_range` / `salinity` / `light_cycle`. Each has only a single placeholder value across the whole corpus (241/67/241 records of the same algae catch-all); structuring them is busywork with no real data to migrate. Documented in the commit message.

## Test plan

- [ ] `just validate-strict` on this branch alone still validates 0-errors for records that don't currently have ph_range (which is the entire corpus minus 967 records — the existing 967 string-shape records will fail validation against the new PhRange range until the data PR merges).
- [ ] After both PRs merge: full-corpus validate-strict returns 0 ERROR rows (verified locally on the combined branch).
- [ ] `uv run python scripts/migrate_ph_range.py --dry-run` reports `migrated: 967` against current main (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)