### PR TITLE
Backfill source_environment from CommunityMech ENVO data (closes #2)

### DIFF
--- a/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
+++ b/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
@@ -235,11 +235,9 @@ source_environment:
 - preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
-    label: laboratory environment
 - preferred_term: freshwater environment
   term:
     id: ENVO:01000306
-    label: freshwater environment
   notes: 'Natural algae-bacteria association from freshwater habitat, maintained in
     laboratory culture to study nitrogen stress responses and mutualistic interactions.
     The consortium demonstrates stable co-occurrence and metabolic cooperation under

--- a/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
+++ b/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
@@ -51,6 +51,11 @@ curation_history:
   curator: migrate_legacy_fields.py
   action: MIGRATED_LEGACY_FIELDS
   notes: category->lowercase=1
+- timestamp: '2026-05-24T04:38:33.182473+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=2 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 references:
 - reference: CCAP:TAP
 - reference: https://www.ccap.ac.uk/wp-content/uploads/MR_TAP.pdf
@@ -226,3 +231,18 @@ target_organisms:
     snippet: Chlorella vulgaris and bacteria of the genus Delftia
     explanation: The source studied Chlorella vulgaris UTEX 395 growth in TAP medium
       and compared algal growth with and without Delftia sp. co-culture.
+source_environment:
+- preferred_term: laboratory bioreactor
+  term:
+    id: ENVO:01001405
+    label: laboratory environment
+- preferred_term: freshwater environment
+  term:
+    id: ENVO:01000306
+    label: freshwater environment
+  notes: 'Natural algae-bacteria association from freshwater habitat, maintained in
+    laboratory culture to study nitrogen stress responses and mutualistic interactions.
+    The consortium demonstrates stable co-occurrence and metabolic cooperation under
+    nutrient limitation.
+
+    '

--- a/data/normalized_yaml/algae/f_2.yaml
+++ b/data/normalized_yaml/algae/f_2.yaml
@@ -257,7 +257,6 @@ source_environment:
 - preferred_term: marine environment
   term:
     id: ENVO:00002149
-    label: marine environment
   notes: 'Synthetic community assembled in laboratory culture to model diatom-bacteria
     interactions in marine phytoplankton. Members were isolated from marine environments
     and maintained under controlled conditions to study dynamic relationships between

--- a/data/normalized_yaml/algae/f_2.yaml
+++ b/data/normalized_yaml/algae/f_2.yaml
@@ -49,6 +49,11 @@ curation_history:
   action: MIGRATED_LEGACY_FIELDS
   notes: curation_history.date->timestamp=2; references.reference_id->reference=2;
     category->lowercase=1
+- timestamp: '2026-05-24T04:38:33.196459+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 references:
 - reference: CCAP:f2
 - reference: https://www.ccap.ac.uk/wp-content/uploads/MR_f2.pdf
@@ -248,3 +253,14 @@ data_quality_flags:
 - ingredients_curated
 - curation_method:automated_expert_mapping
 original_name: f/2
+source_environment:
+- preferred_term: marine environment
+  term:
+    id: ENVO:00002149
+    label: marine environment
+  notes: 'Synthetic community assembled in laboratory culture to model diatom-bacteria
+    interactions in marine phytoplankton. Members were isolated from marine environments
+    and maintained under controlled conditions to study dynamic relationships between
+    the diatom and associated bacteria.
+
+    '

--- a/data/normalized_yaml/bacterial/9k_medium.yaml
+++ b/data/normalized_yaml/bacterial/9k_medium.yaml
@@ -119,7 +119,6 @@ source_environment:
 - preferred_term: mine tailing
   term:
     id: ENVO:00000072
-    label: mine tailing
   notes: 'Industrial copper sulfide ore heap leach operation. Crushed low-grade ore
     is piled in heaps and irrigated with acidic solution (pH 1.5-2.5) containing the
     microbial consortium. The heaps provide a heterogeneous environment with spatial
@@ -133,7 +132,6 @@ source_environment:
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
-    label: acid mine drainage
   notes: 'Extremely acidic (pH <2), metal-rich environments including natural acid
     mine drainage and industrial biomining operations. The consortium thrives on pyrite
     (FeS₂) and chalcopyrite (CuFeS₂) surfaces where ferrous iron concentrations are

--- a/data/normalized_yaml/bacterial/9k_medium.yaml
+++ b/data/normalized_yaml/bacterial/9k_medium.yaml
@@ -110,3 +110,36 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "9K MEDIUM" to "9k_medium" for consistent matching
+- timestamp: '2026-05-24T04:38:33.227537+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=2 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: mine tailing
+  term:
+    id: ENVO:00000072
+    label: mine tailing
+  notes: 'Industrial copper sulfide ore heap leach operation. Crushed low-grade ore
+    is piled in heaps and irrigated with acidic solution (pH 1.5-2.5) containing the
+    microbial consortium. The heaps provide a heterogeneous environment with spatial
+    gradients in pH (1.67-2.5), Fe²⁺/Fe³⁺ ratios, oxygen availability, temperature,
+    and copper concentration. Heap age ranges from fresh ore (<100 days) to aged ore
+    (>250 days), with microbial succession reflecting changing chemical conditions.
+    The engineered environment promotes iron and sulfur oxidation to generate sulfuric
+    acid and ferric iron for mineral dissolution.
+
+    '
+- preferred_term: acid mine drainage
+  term:
+    id: ENVO:00002186
+    label: acid mine drainage
+  notes: 'Extremely acidic (pH <2), metal-rich environments including natural acid
+    mine drainage and industrial biomining operations. The consortium thrives on pyrite
+    (FeS₂) and chalcopyrite (CuFeS₂) surfaces where ferrous iron concentrations are
+    high. Environments are aerobic to microaerobic, with temperatures ranging from
+    30-50°C. High concentrations of dissolved metals (Fe, Cu, Zn) and sulfate are
+    characteristic. The extreme acidity and metal content exclude most organisms,
+    creating niches for specialized acidophiles.
+
+    '

--- a/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
+++ b/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
@@ -92,3 +92,21 @@ curation_history:
   notes: Normalized name from "Nitrogen-Free Medium for Leptospirillum ferrodiazotrophum"
     to "nitrogen_free_medium_for_leptospirillum_ferrodiazotrophum" for consistent
     matching
+- timestamp: '2026-05-24T04:38:33.284210+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: acid mine drainage
+  term:
+    id: ENVO:00002186
+    label: acid mine drainage
+  notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
+    interface of underground AMD streams and pools within the Richmond Mine. The mine
+    contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,
+    generating sulfuric acid and solubilizing metals. Temperatures range from 30-50°C
+    at sampling sites and exceed 56°C deeper in the mine. Metal concentrations reach
+    decagrams per liter, creating one of Earth''s most extreme habitats.
+
+    '

--- a/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
+++ b/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
@@ -101,7 +101,6 @@ source_environment:
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
-    label: acid mine drainage
   notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
     interface of underground AMD streams and pools within the Richmond Mine. The mine
     contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,

--- a/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
+++ b/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
@@ -101,4 +101,3 @@ source_environment:
 - preferred_term: compost
   term:
     id: ENVO:00002170
-    label: compost

--- a/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
+++ b/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
@@ -92,3 +92,13 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PCS-FP medium for thermophilic cellulose degradation"
     to "pcs_fp_medium_for_thermophilic_cellulose_degradation" for consistent matching
+- timestamp: '2026-05-24T04:38:33.299025+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: compost
+  term:
+    id: ENVO:00002170
+    label: compost

--- a/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
+++ b/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
@@ -67,16 +67,24 @@ curation_history:
 - timestamp: '2026-03-17T19:46:27.033553+00:00'
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
-  notes: Normalized name from "Luria-Bertani (LB) medium" to
-    "luria_bertani_lb_medium" for consistent matching
+  notes: Normalized name from "Luria-Bertani (LB) medium" to "luria_bertani_lb_medium"
+    for consistent matching
+- timestamp: '2026-05-24T04:38:33.256049+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 parent_media:
   path: data/normalized_yaml/bacterial/TOGO_M2897_LB_medium.yaml
   relationship: SALINITY_VARIANT
   id: CultureMech:009433
   name: lb_medium
-  notes: Reviewed TOGO LB/Luria-Bertani LB pair; records differ only in NaCl
-    concentration.
+  notes: Reviewed TOGO LB/Luria-Bertani LB pair; records differ only in NaCl concentration.
 variant_relationship: SALINITY_VARIANT
 variant_modifications:
-- NaCl increased from 0.5 g/L to 10 g/L while the TOGO LB formulation remains
-  unchanged.
+- NaCl increased from 0.5 g/L to 10 g/L while the TOGO LB formulation remains unchanged.
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
+++ b/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
@@ -87,4 +87,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/bacterial/mannitol_agar.yaml
+++ b/data/normalized_yaml/bacterial/mannitol_agar.yaml
@@ -73,4 +73,14 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "MANNITOL AGAR" to "mannitol_agar" for consistent matching
+- timestamp: '2026-05-24T04:38:33.221911+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 kg_microbe_match: mediadive.medium:J598
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/mannitol_agar.yaml
+++ b/data/normalized_yaml/bacterial/mannitol_agar.yaml
@@ -83,4 +83,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/bacterial/mineral_medium.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium.yaml
@@ -165,9 +165,53 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''5.5-6'' -> {''min'': 5.5, ''max'': 6.0}'
+- timestamp: '2026-05-24T04:38:33.207592+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=4 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_1007_MINERAL_MEDIUM.yaml
   relationship: SOURCE_DUPLICATE
   id: CultureMech:003510
   name: mineral_medium
   notes: Same source medium number and matching ingredient/concentration signature.
+source_environment:
+- preferred_term: sulfate-free anaerobic environment
+  term:
+    id: ENVO:01001405
+    label: laboratory bioreactor
+  notes: 'Grown in continuous culture on lactate without sulfate under strict anaerobic
+    conditions. In the absence of sulfate, D. vulgaris cannot use its typical respiratory
+    pathway and must rely on syntrophic partnership with a H2-consuming organism.
+    The system demonstrates obligate dependence on interspecies hydrogen transfer
+    for energy conservation.
+
+    '
+- preferred_term: soil
+  term:
+    id: ENVO:00001998
+    label: soil
+- preferred_term: acid mine drainage
+  term:
+    id: ENVO:00002186
+    label: acid mine drainage
+  notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
+    interface of underground AMD streams and pools within the Richmond Mine. The mine
+    contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,
+    generating sulfuric acid and solubilizing metals. Temperatures range from 30-50°C
+    at sampling sites and exceed 56°C deeper in the mine. Metal concentrations reach
+    decagrams per liter, creating one of Earth''s most extreme habitats.
+
+    '
+- preferred_term: anaerobic environment
+  term:
+    id: ENVO:00002229
+    label: anaerobic environment
+  notes: 'Isolated from anaerobic granular sludge. Grown as syntrophic coculture under
+    strict anaerobic conditions. S. fumaroxidans oxidizes propionate syntrophically
+    in co-culture with the hydrogen- and formate-utilizing M. hungatei. The consortium
+    operates via interspecies electron transfer through both H2 and formate as electron
+    carriers.
+
+    '

--- a/data/normalized_yaml/bacterial/mineral_medium.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium.yaml
@@ -180,7 +180,6 @@ source_environment:
 - preferred_term: sulfate-free anaerobic environment
   term:
     id: ENVO:01001405
-    label: laboratory bioreactor
   notes: 'Grown in continuous culture on lactate without sulfate under strict anaerobic
     conditions. In the absence of sulfate, D. vulgaris cannot use its typical respiratory
     pathway and must rely on syntrophic partnership with a H2-consuming organism.
@@ -191,11 +190,9 @@ source_environment:
 - preferred_term: soil
   term:
     id: ENVO:00001998
-    label: soil
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
-    label: acid mine drainage
   notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
     interface of underground AMD streams and pools within the Richmond Mine. The mine
     contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,
@@ -207,7 +204,6 @@ source_environment:
 - preferred_term: anaerobic environment
   term:
     id: ENVO:00002229
-    label: anaerobic environment
   notes: 'Isolated from anaerobic granular sludge. Grown as syntrophic coculture under
     strict anaerobic conditions. S. fumaroxidans oxidizes propionate syntrophically
     in co-culture with the hydrogen- and formate-utilizing M. hungatei. The consortium

--- a/data/normalized_yaml/bacterial/r2a_agar.yaml
+++ b/data/normalized_yaml/bacterial/r2a_agar.yaml
@@ -121,10 +121,20 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "R2A AGAR" to "r2a_agar" for consistent matching
+- timestamp: '2026-05-24T04:38:33.216229+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 variant_children:
 - path: data/normalized_yaml/bacterial/5_x_r2a_agar.yaml
   relationship: CONCENTRATION_VARIANT
   id: CultureMech:002271
   name: 5_x_r2a_agar
-  notes: 5 x R2A Agar increases all parsed R2A nutrient and salt components
-    five-fold while agar remains 15 g/L.
+  notes: 5 x R2A Agar increases all parsed R2A nutrient and salt components five-fold
+    while agar remains 15 g/L.
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/r2a_agar.yaml
+++ b/data/normalized_yaml/bacterial/r2a_agar.yaml
@@ -137,4 +137,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
@@ -25,13 +25,12 @@ ingredients:
     value: '17.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: Pancreatic enzymatic digest of casein providing amino acids and
-    peptides; Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar (TSA)
-    commercial product
+  notes: Pancreatic enzymatic digest of casein providing amino acids and peptides;
+    Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar (TSA) commercial product
   synonyms:
   - synonym_text: tryptone
     synonym_type: EXACT
@@ -47,13 +46,12 @@ ingredients:
     value: '3.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: Peptic digest of soybean meal providing additional peptides and
-    carbohydrates; Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar
-    (TSA) commercial product
+  notes: Peptic digest of soybean meal providing additional peptides and carbohydrates;
+    Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar (TSA) commercial product
   synonyms:
   - synonym_text: soytone
     synonym_type: EXACT
@@ -69,12 +67,12 @@ ingredients:
     value: '2.5'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: Carbon/energy source; Constituent of Tryptic Soy Broth (TSB) / Tryptic
-    Soy Agar (TSA) commercial product
+  notes: Carbon/energy source; Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy
+    Agar (TSA) commercial product
   synonyms:
   - synonym_text: dextrose
     synonym_type: EXACT
@@ -88,12 +86,12 @@ ingredients:
     value: '5.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: Maintains osmotic equilibrium; Constituent of Tryptic Soy Broth (TSB) /
-    Tryptic Soy Agar (TSA) commercial product
+  notes: Maintains osmotic equilibrium; Constituent of Tryptic Soy Broth (TSB) / Tryptic
+    Soy Agar (TSA) commercial product
   synonyms:
   - synonym_text: NaCl
     synonym_type: EXACT
@@ -107,12 +105,12 @@ ingredients:
     value: '2.5'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: pH buffer; Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar
-    (TSA) commercial product
+  notes: pH buffer; Constituent of Tryptic Soy Broth (TSB) / Tryptic Soy Agar (TSA)
+    commercial product
   synonyms:
   - synonym_text: K2HPO4
     synonym_type: EXACT
@@ -128,12 +126,12 @@ ingredients:
     value: '15.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth
-      (TSB) / Tryptic Soy Agar (TSA)
+    supplier_name: Multiple suppliers (BD, Sigma, Neogen) Tryptic Soy Broth (TSB)
+      / Tryptic Soy Agar (TSA)
     catalog_number: Multiple (22092 Sigma, 211825 BD)
     product_url: https://en.wikipedia.org/wiki/Tryptic_soy_broth
-  notes: Solidifying agent (for TSA only, not in TSB); Constituent of Tryptic
-    Soy Broth (TSB) / Tryptic Soy Agar (TSA) commercial product
+  notes: Solidifying agent (for TSA only, not in TSB); Constituent of Tryptic Soy
+    Broth (TSB) / Tryptic Soy Agar (TSA) commercial product
 media_term:
   preferred_term: TOGO Medium M1669
   term:
@@ -180,8 +178,13 @@ curation_history:
 - timestamp: '2026-03-17T19:46:13.287649+00:00'
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
-  notes: Normalized name from "Tryptic Soy Agar" to "tryptic_soy_agar" for
-    consistent matching
+  notes: Normalized name from "Tryptic Soy Agar" to "tryptic_soy_agar" for consistent
+    matching
+- timestamp: '2026-05-24T04:38:33.249105+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 parent_media:
   path: data/normalized_yaml/bacterial/TOGO_M66_Trypticase_Soy_Agar.yaml
   relationship: SOURCE_DUPLICATE
@@ -189,5 +192,10 @@ parent_media:
   name: trypticase_soy_agar
 variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
-- Same ingredient and concentration signature; review as possible duplicate
-  source record.
+- Same ingredient and concentration signature; review as possible duplicate source
+  record.
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
@@ -198,4 +198,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
@@ -254,4 +254,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
@@ -163,30 +163,30 @@ references:
   title: Production of amylase by Arthrobacter psychrolactophilus
   authors: Smith, M. R.; Zahnley, J. C.
   year: 2005
-  notes: Reports growth of Arthrobacter psychrolactophilus ATCC 700733 in TSB
-    without dextrose supplemented with soluble starch or maltose.
+  notes: Reports growth of Arthrobacter psychrolactophilus ATCC 700733 in TSB without
+    dextrose supplemented with soluble starch or maltose.
 - reference: BacDive:7598
   title: Arthrobacter psychrolactophilus B7 strain record
   authors: BacDive / DSMZ
   year: 2026
-  notes: Strain record linking B7 to ATCC 700733, DSM 15612, JCM 12399, CIP
-    107481, NCBITaxon:92442, and genome assembly GCA_003219795.
+  notes: Strain record linking B7 to ATCC 700733, DSM 15612, JCM 12399, CIP 107481,
+    NCBITaxon:92442, and genome assembly GCA_003219795.
 variants:
 - name: tsb_without_dextrose_plus_starch_or_maltose
-  description: Tryptic Soy Broth without dextrose, supplemented with soluble
-    starch or maltose as the fermentable substrate.
+  description: Tryptic Soy Broth without dextrose, supplemented with soluble starch
+    or maltose as the fermentable substrate.
   modifications:
   - Omit dextrose/glucose from the parent Tryptic Soy Broth formulation.
   - Add 0.5% or 1.0% (w/v) soluble starch or maltose.
-  purpose: Growth and extracellular amylase production by Arthrobacter
-    psychrolactophilus ATCC 700733 at 22 degrees C.
+  purpose: Growth and extracellular amylase production by Arthrobacter psychrolactophilus
+    ATCC 700733 at 22 degrees C.
   evidence:
   - reference: PMID:15931519
     supports: SUPPORT
     snippet: tryptic soy broth without dextrose (TSBWD) containing 0.5% or 1.0%
-    explanation: Smith and Zahnley report the study-specific TSBWD variant and
-      the starch/maltose supplement levels used for Arthrobacter
-      psychrolactophilus ATCC 700733 growth.
+    explanation: Smith and Zahnley report the study-specific TSBWD variant and the
+      starch/maltose supplement levels used for Arthrobacter psychrolactophilus ATCC
+      700733 growth.
 target_organisms:
 - preferred_term: Arthrobacter psychrolactophilus
   term:
@@ -197,33 +197,33 @@ target_organisms:
   strain: B7; ATCC 700733; DSM 15612; JCM 12399; CIP 107481
   growth_metrics:
   - temperature_celsius: 22.0
-    measurement_conditions: Source reports a 1.5-2.3 h doubling-time range in
-      TSB without dextrose containing 0.5% or 1.0% soluble starch or maltose.
+    measurement_conditions: Source reports a 1.5-2.3 h doubling-time range in TSB
+      without dextrose containing 0.5% or 1.0% soluble starch or maltose.
     evidence:
     - reference: PMID:15931519
       supports: SUPPORT
       snippet: grew with a doubling time of 1.5-2.3 h (22 degrees C)
-      explanation: The PubMed-indexed abstract explicitly reports growth and a
-        doubling-time range for Arthrobacter psychrolactophilus ATCC 700733 in
-        the TSBWD starch/maltose variant.
+      explanation: The PubMed-indexed abstract explicitly reports growth and a doubling-time
+        range for Arthrobacter psychrolactophilus ATCC 700733 in the TSBWD starch/maltose
+        variant.
     is_max_attainment: false
   evidence:
   - reference: PMID:15931519
     supports: SUPPORT
-    explanation: The study names Arthrobacter psychrolactophilus ATCC 700733 and
-      reports positive growth in the TSBWD starch/maltose formulation.
+    explanation: The study names Arthrobacter psychrolactophilus ATCC 700733 and reports
+      positive growth in the TSBWD starch/maltose formulation.
   - reference: BacDive:7598
     supports: SUPPORT
-    explanation: BacDive identifies B7 as the type strain corresponding to ATCC
-      700733, DSM 15612, JCM 12399, and CIP 107481, with NCBI taxon 92442 and
-      genome assembly GCA_003219795.
+    explanation: BacDive identifies B7 as the type strain corresponding to ATCC 700733,
+      DSM 15612, JCM 12399, and CIP 107481, with NCBI taxon 92442 and genome assembly
+      GCA_003219795.
 curation_history:
 - timestamp: '2026-05-11T00:00:00Z'
   curator: culturemech-agentic-curation
   action: Added literature-backed TSBWD growth variant
   notes: Modeled Arthrobacter psychrolactophilus ATCC 700733 growth evidence from
-    PMID:15931519 as a Tryptic Soy Broth variant because the source omits
-    dextrose and adds soluble starch or maltose.
+    PMID:15931519 as a Tryptic Soy Broth variant because the source omits dextrose
+    and adds soluble starch or maltose.
 - timestamp: '2026-01-27T06:35:58.102455Z'
   curator: togo-import
   action: Imported from TOGO Medium
@@ -245,3 +245,13 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Tryptic Soy Broth" to "tryptic_soy_broth" for consistent
     matching
+- timestamp: '2026-05-24T04:38:33.238120+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
@@ -141,3 +141,19 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Glycerol Fermentation Medium for DIET Coculture" to
     "glycerol_fermentation_medium_for_diet_coculture" for consistent matching
+- timestamp: '2026-05-24T04:38:33.263218+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: laboratory culture
+  term:
+    id: ENVO:01001405
+    label: laboratory culture
+  notes: 'Laboratory synthetic coculture developed to optimize glycerol fermentation
+    toward 1,3-propanediol production. Cultured under strict anaerobic conditions
+    using Hungate techniques at 35°C with N2 gas phase. DIET occurs through physical
+    cell-to-cell contact mediated by conductive nanowires produced by G. sulfurreducens.
+
+    '

--- a/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
@@ -150,7 +150,6 @@ source_environment:
 - preferred_term: laboratory culture
   term:
     id: ENVO:01001405
-    label: laboratory culture
   notes: 'Laboratory synthetic coculture developed to optimize glycerol fermentation
     toward 1,3-propanediol production. Cultured under strict anaerobic conditions
     using Hungate techniques at 35°C with N2 gas phase. DIET occurs through physical

--- a/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
+++ b/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
@@ -80,4 +80,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
+++ b/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
@@ -70,4 +70,14 @@ curation_history:
   curator: cleanup_residual_errors.py
   action: CLEANUP_RESIDUAL_ERRORS
   notes: R04_fill_missing_explanation=1
+- timestamp: '2026-05-24T04:38:33.269053+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
 kg_microbe_match: mediadive.medium:263
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
@@ -102,7 +102,6 @@ source_environment:
 - preferred_term: sediment
   term:
     id: ENVO:00002007
-    label: sediment
   notes: 'Isolated from anaerobic sediments and biofilms. DIET is an important process
     in anaerobic soils and sediments generating methane. Cocultures form aggregates
     under strict anaerobic conditions, with direct cell-to-cell electron transfer

--- a/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
@@ -93,3 +93,19 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Modified DSM 120 Medium for DIET Coculture" to "modified_dsm_120_medium_for_diet_coculture"
     for consistent matching
+- timestamp: '2026-05-24T04:38:33.274031+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: sediment
+  term:
+    id: ENVO:00002007
+    label: sediment
+  notes: 'Isolated from anaerobic sediments and biofilms. DIET is an important process
+    in anaerobic soils and sediments generating methane. Cocultures form aggregates
+    under strict anaerobic conditions, with direct cell-to-cell electron transfer
+    mediated by conductive pili.
+
+    '

--- a/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
@@ -85,7 +85,6 @@ source_environment:
 - preferred_term: sediment
   term:
     id: ENVO:00002007
-    label: sediment
   notes: 'Isolated from anaerobic sediments. DIET is an important process in anaerobic
     soils and sediments generating methane. Cocultures form conductive aggregates
     under strict anaerobic conditions, with direct cell-to-cell electron transfer

--- a/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
@@ -76,3 +76,19 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Modified Freshwater Medium for DIET Coculture" to "modified_freshwater_medium_for_diet_coculture"
     for consistent matching
+- timestamp: '2026-05-24T04:38:33.279095+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: sediment
+  term:
+    id: ENVO:00002007
+    label: sediment
+  notes: 'Isolated from anaerobic sediments. DIET is an important process in anaerobic
+    soils and sediments generating methane. Cocultures form conductive aggregates
+    under strict anaerobic conditions, with direct cell-to-cell electron transfer
+    mediated by conductive pili and aggregate structures.
+
+    '

--- a/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
+++ b/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
@@ -88,4 +88,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
+++ b/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
@@ -79,3 +79,13 @@ curation_history:
   curator: cleanup_residual_errors.py
   action: CLEANUP_RESIDUAL_ERRORS
   notes: R04_fill_missing_explanation=1
+- timestamp: '2026-05-24T04:38:33.294104+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
+++ b/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
@@ -88,4 +88,3 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
-    label: rhizosphere

--- a/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
+++ b/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
@@ -79,3 +79,13 @@ curation_history:
   curator: cleanup_residual_errors.py
   action: CLEANUP_RESIDUAL_ERRORS
   notes: R04_fill_missing_explanation=1
+- timestamp: '2026-05-24T04:38:33.289545+00:00'
+  curator: backfill_source_environment.py
+  action: BACKFILLED_SOURCE_ENVIRONMENT
+  notes: added=1 env(s) from CommunityMech
+  source: CommunityMech (environment_term + culturemech_id linkage)
+source_environment:
+- preferred_term: rhizosphere
+  term:
+    id: ENVO:00005801
+    label: rhizosphere

--- a/scripts/backfill_source_environment.py
+++ b/scripts/backfill_source_environment.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Backfill `source_environment` on CultureMech recipes from CommunityMech.
+
+Closes issue #2: every CommunityMech community/isolate YAML that carries
+both an `environment_term` (ENVO-grounded) AND a `culturemech_id`
+reference is a curator-vetted assertion that the linked CultureMech
+recipe targets that environment. Walk those, dedupe by ENVO id per
+recipe, and append `SourceEnvironmentDescriptor` entries to the recipe's
+`source_environment` list (the schema slot landed in commit dbe26e8ce
+but no records populated it).
+
+CommunityMech is assumed to live at a sibling path:
+    ../CommunityMech/CommunityMech
+
+Tests + examples are excluded (they contain synthetic CultureMech IDs
+that don't exist in this corpus).
+
+Each touched recipe gets a CurationEvent via the G10 helper. Re-runs
+are idempotent — existing source_environment entries with matching ENVO
+ids are skipped.
+
+Usage:
+    python scripts/backfill_source_environment.py [--dry-run]
+                                                  [--communitymech-root PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
+
+CURATOR = "backfill_source_environment.py"
+ACTION = "BACKFILLED_SOURCE_ENVIRONMENT"
+DEFAULT_COMMUNITYMECH = REPO_ROOT.parent / "CommunityMech" / "CommunityMech"
+DEFAULT_DATA_ROOT = REPO_ROOT / "data" / "normalized_yaml"
+SKIP_PREFIXES = ("tests/", "examples/")
+
+
+def collect_env_links(cm_root: Path) -> dict[str, list[dict[str, Any]]]:
+    """Walk CommunityMech YAMLs and return {culturemech_id: [env, ...]}.
+
+    Deduped by (culturemech_id, envo_term_id); first observation wins
+    for preferred_term / notes when multiple communities point to the
+    same recipe with the same ENVO id.
+    """
+    by_recipe: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+    for path in sorted(cm_root.rglob("*.yaml")):
+        rel = str(path.relative_to(cm_root))
+        if any(rel.startswith(p) for p in SKIP_PREFIXES):
+            continue
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            continue
+        if not isinstance(doc, dict):
+            continue
+        env = doc.get("environment_term")
+        if not isinstance(env, dict):
+            continue
+        cm_ids: set[str] = set()
+        _collect_culturemech_ids(doc, cm_ids)
+        if not cm_ids:
+            continue
+        envo_id = ((env.get("term") or {}).get("id") or "").strip()
+        # Build a SourceEnvironmentDescriptor-shaped dict.
+        # ENVO id missing? Still keep it (envo is recommended, not required).
+        descriptor: dict[str, Any] = {
+            "preferred_term": env.get("preferred_term") or "",
+        }
+        term_section = env.get("term")
+        if isinstance(term_section, dict):
+            descriptor["term"] = {k: term_section[k] for k in ("id", "label")
+                                  if term_section.get(k)}
+        if env.get("notes"):
+            descriptor["notes"] = env["notes"]
+        dedup_key = envo_id or descriptor["preferred_term"] or rel
+        for cmid in cm_ids:
+            if dedup_key not in by_recipe[cmid]:
+                by_recipe[cmid][dedup_key] = descriptor
+    return {k: list(v.values()) for k, v in by_recipe.items()}
+
+
+def _collect_culturemech_ids(node: Any, sink: set[str]) -> None:
+    if isinstance(node, dict):
+        cmid = node.get("culturemech_id")
+        if isinstance(cmid, str) and cmid.startswith("CultureMech:"):
+            sink.add(cmid)
+        for v in node.values():
+            _collect_culturemech_ids(v, sink)
+    elif isinstance(node, list):
+        for v in node:
+            _collect_culturemech_ids(v, sink)
+
+
+def index_recipes_by_id(data_root: Path) -> dict[str, Path]:
+    """Index CultureMech recipes by id field."""
+    out: dict[str, Path] = {}
+    for path in data_root.rglob("*.yaml"):
+        try:
+            with path.open() as f:
+                # Cheap scan: id is always on the first ~10 lines.
+                for _ in range(20):
+                    line = f.readline()
+                    if not line:
+                        break
+                    if line.startswith("id: CultureMech:"):
+                        rid = line.split(":", 1)[1].strip()
+                        out[f"CultureMech:{rid.split(':', 1)[1] if ':' in rid else rid}"] = path
+                        break
+        except OSError:
+            continue
+    return out
+
+
+def merge_into_recipe(
+    recipe: dict[str, Any],
+    new_envs: list[dict[str, Any]],
+) -> int:
+    """Append new SourceEnvironmentDescriptor entries; skip if same ENVO
+    id (or same preferred_term when no ENVO) already present.
+
+    Returns the count of newly-added entries.
+    """
+    existing = recipe.setdefault("source_environment", [])
+    existing_keys: set[str] = set()
+    for entry in existing:
+        if not isinstance(entry, dict):
+            continue
+        envo_id = ((entry.get("term") or {}).get("id") or "").strip()
+        existing_keys.add(envo_id or entry.get("preferred_term") or "")
+    added = 0
+    for env in new_envs:
+        envo_id = ((env.get("term") or {}).get("id") or "").strip()
+        key = envo_id or env.get("preferred_term") or ""
+        if key in existing_keys:
+            continue
+        existing.append(env)
+        existing_keys.add(key)
+        added += 1
+    return added
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--communitymech-root", type=Path, default=DEFAULT_COMMUNITYMECH)
+    ap.add_argument("--data-root", type=Path, default=DEFAULT_DATA_ROOT)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if not args.communitymech_root.is_dir():
+        print(f"CommunityMech root not found: {args.communitymech_root}",
+              file=sys.stderr)
+        return 2
+
+    print(f"Scanning {args.communitymech_root} for environment_term + culturemech_id links...",
+          file=sys.stderr)
+    links = collect_env_links(args.communitymech_root)
+    print(f"  -> {sum(len(v) for v in links.values())} env entries "
+          f"across {len(links)} CultureMech recipes", file=sys.stderr)
+
+    print(f"Indexing recipes under {args.data_root}...", file=sys.stderr)
+    recipe_index = index_recipes_by_id(args.data_root)
+    print(f"  -> indexed {len(recipe_index)} recipes", file=sys.stderr)
+
+    missing: list[str] = []
+    touched = 0
+    total_added = 0
+    for cmid, envs in sorted(links.items()):
+        path = recipe_index.get(cmid)
+        if path is None:
+            missing.append(cmid)
+            continue
+        with path.open() as f:
+            recipe = yaml.safe_load(f)
+        if not isinstance(recipe, dict):
+            continue
+        added = merge_into_recipe(recipe, envs)
+        if added == 0:
+            continue
+        record_curation_event(
+            recipe,
+            curator=CURATOR,
+            action=ACTION,
+            notes=f"added={added} env(s) from CommunityMech",
+            source="CommunityMech (environment_term + culturemech_id linkage)",
+            skip_if_recent=True,
+        )
+        touched += 1
+        total_added += added
+        rel = path.relative_to(REPO_ROOT)
+        print(f"  + {cmid}: added {added} env(s) -> {rel}", file=sys.stderr)
+        if not args.dry_run:
+            with path.open("w") as f:
+                yaml.safe_dump(recipe, f, sort_keys=False, allow_unicode=True,
+                               width=80)
+
+    mode = "[DRY RUN] " if args.dry_run else ""
+    print(file=sys.stderr)
+    print(f"{mode}Recipes touched: {touched}", file=sys.stderr)
+    print(f"{mode}Env entries added: {total_added}", file=sys.stderr)
+    if missing:
+        print(f"{mode}Skipped {len(missing)} CultureMech IDs not in corpus: "
+              f"{', '.join(missing[:5])}{'...' if len(missing) > 5 else ''}",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_source_environment.py
+++ b/scripts/backfill_source_environment.py
@@ -58,8 +58,13 @@ def collect_env_links(cm_root: Path) -> dict[str, list[dict[str, Any]]]:
         if any(rel.startswith(p) for p in SKIP_PREFIXES):
             continue
         try:
-            doc = yaml.safe_load(path.read_text())
-        except yaml.YAMLError:
+            # path.read_text() can raise OSError on permission/disk errors
+            # and UnicodeDecodeError on non-UTF-8 content — both should
+            # skip the file rather than crash a multi-thousand-file scan
+            # (Copilot caught this on PR #28).
+            text = path.read_text(encoding="utf-8")
+            doc = yaml.safe_load(text)
+        except (OSError, UnicodeDecodeError, yaml.YAMLError):
             continue
         if not isinstance(doc, dict):
             continue
@@ -70,19 +75,33 @@ def collect_env_links(cm_root: Path) -> dict[str, list[dict[str, Any]]]:
         _collect_culturemech_ids(doc, cm_ids)
         if not cm_ids:
             continue
-        envo_id = ((env.get("term") or {}).get("id") or "").strip()
-        # Build a SourceEnvironmentDescriptor-shaped dict.
-        # ENVO id missing? Still keep it (envo is recommended, not required).
-        descriptor: dict[str, Any] = {
-            "preferred_term": env.get("preferred_term") or "",
-        }
         term_section = env.get("term")
+        envo_id = ""
+        envo_label = ""
         if isinstance(term_section, dict):
-            descriptor["term"] = {k: term_section[k] for k in ("id", "label")
-                                  if term_section.get(k)}
+            envo_id = (term_section.get("id") or "").strip()
+            envo_label = (term_section.get("label") or "").strip()
+        # Build a SourceEnvironmentDescriptor-shaped dict. Fall back to
+        # the ENVO label or id when CommunityMech omitted preferred_term
+        # — empty strings make for hard-to-use entries and break dedup
+        # (Copilot caught this on PR #28).
+        preferred_term = env.get("preferred_term") or envo_label or envo_id
+        if not preferred_term:
+            # No identifying info at all; skip rather than emit an empty
+            # descriptor.
+            continue
+        descriptor: dict[str, Any] = {"preferred_term": preferred_term}
+        # Only emit term.id (not term.label): the same ENVO CURIE has
+        # been observed with different labels across CommunityMech
+        # curators (e.g., ENVO:01001405 → "laboratory bioreactor" vs
+        # "laboratory culture" vs "laboratory environment"), and Term.label
+        # is intended to be the *canonical* ontology label. Downstream
+        # consumers should resolve the label from ENVO directly.
+        if envo_id:
+            descriptor["term"] = {"id": envo_id}
         if env.get("notes"):
             descriptor["notes"] = env["notes"]
-        dedup_key = envo_id or descriptor["preferred_term"] or rel
+        dedup_key = envo_id or preferred_term
         for cmid in cm_ids:
             if dedup_key not in by_recipe[cmid]:
                 by_recipe[cmid][dedup_key] = descriptor
@@ -124,13 +143,47 @@ def index_recipes_by_id(data_root: Path) -> dict[str, Path]:
 def merge_into_recipe(
     recipe: dict[str, Any],
     new_envs: list[dict[str, Any]],
-) -> int:
+) -> tuple[int, int]:
     """Append new SourceEnvironmentDescriptor entries; skip if same ENVO
     id (or same preferred_term when no ENVO) already present.
 
-    Returns the count of newly-added entries.
+    Also strips stale `term.label` values from any existing entry that
+    appears to have come from a previous backfill — this script no
+    longer propagates labels from CommunityMech (see collect_env_links)
+    and re-running should normalize earlier writes.
+
+    Source slot may be missing, a single dict (LinkML dataclasses accept
+    one-or-many for multivalued slots), or a list. Normalize to a list
+    in place before processing — Copilot caught the dict-shape edge on
+    PR #28.
+
+    Returns ``(added, normalized)`` — count of newly-appended entries
+    and count of existing entries whose stale label was stripped.
     """
-    existing = recipe.setdefault("source_environment", [])
+    raw = recipe.get("source_environment")
+    if raw is None:
+        existing: list[dict[str, Any]] = []
+        recipe["source_environment"] = existing
+    elif isinstance(raw, list):
+        existing = raw
+    elif isinstance(raw, dict):
+        existing = [raw]
+        recipe["source_environment"] = existing
+    else:
+        # Unrecognized shape — overwrite to a clean list rather than
+        # silently corrupting the recipe.
+        existing = []
+        recipe["source_environment"] = existing
+
+    normalized = 0
+    for entry in existing:
+        if not isinstance(entry, dict):
+            continue
+        term = entry.get("term")
+        if isinstance(term, dict) and "label" in term:
+            del term["label"]
+            normalized += 1
+
     existing_keys: set[str] = set()
     for entry in existing:
         if not isinstance(entry, dict):
@@ -146,7 +199,7 @@ def merge_into_recipe(
         existing.append(env)
         existing_keys.add(key)
         added += 1
-    return added
+    return added, normalized
 
 
 def main() -> int:
@@ -183,21 +236,27 @@ def main() -> int:
             recipe = yaml.safe_load(f)
         if not isinstance(recipe, dict):
             continue
-        added = merge_into_recipe(recipe, envs)
-        if added == 0:
+        added, normalized = merge_into_recipe(recipe, envs)
+        if added == 0 and normalized == 0:
             continue
-        record_curation_event(
-            recipe,
-            curator=CURATOR,
-            action=ACTION,
-            notes=f"added={added} env(s) from CommunityMech",
-            source="CommunityMech (environment_term + culturemech_id linkage)",
-            skip_if_recent=True,
-        )
+        if added > 0:
+            record_curation_event(
+                recipe,
+                curator=CURATOR,
+                action=ACTION,
+                notes=f"added={added} env(s) from CommunityMech",
+                source="CommunityMech (environment_term + culturemech_id linkage)",
+                skip_if_recent=True,
+            )
         touched += 1
         total_added += added
         rel = path.relative_to(REPO_ROOT)
-        print(f"  + {cmid}: added {added} env(s) -> {rel}", file=sys.stderr)
+        marks = []
+        if added:
+            marks.append(f"added {added} env(s)")
+        if normalized:
+            marks.append(f"stripped {normalized} stale label(s)")
+        print(f"  + {cmid}: {', '.join(marks)} -> {rel}", file=sys.stderr)
         if not args.dry_run:
             with path.open("w") as f:
                 yaml.safe_dump(recipe, f, sort_keys=False, allow_unicode=True,


### PR DESCRIPTION
## Summary
Issue #2 added the `SourceEnvironmentDescriptor` schema + `source_environment` slot (commit `dbe26e8ce`) but no recipes populated it. This PR ships `scripts/backfill_source_environment.py` and applies it: 17 recipes get 22 ENVO-grounded environment entries pulled directly from CommunityMech's curated `environment_term` data.

## Method
The script walks `../CommunityMech` (excluding `tests/` and `examples/`) for community YAMLs that carry **both** `environment_term` (ENVO-grounded) and a `culturemech_id` back-reference. Each such pair is a curator-vetted assertion that the linked recipe targets that environment, so it's safe to populate `source_environment` directly. Dedup is by `(recipe_id, envo_id)`; some recipes are touched by multiple communities at different environments (e.g., `CultureMech:000423` gets 4 entries: anaerobic digester / soil / acid mine drainage / sulfate-free anaerobic).

Each touched recipe carries a `CurationEvent` via `record_curation_event()` for provenance. Script is idempotent — re-runs add nothing because the dedup guard catches existing entries.

## Out of scope
Inferring `source_environment` for the remaining 15,810 recipes from recipe metadata (names, applications, descriptions) is an NLP/keyword-mining enrichment problem — separate future work.

## Validation
`just validate-strict`: **0 ERROR rows across 15,827 records** (unchanged).

## Test plan
- [x] Dry-run reports 17 recipes / 22 env entries to add
- [x] Apply produces matching numbers
- [x] Re-run after apply touches 0 recipes (idempotent)
- [x] `just validate-strict` clean
- [x] Sample record shows correctly structured `source_environment:` list

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)