### PR TITLE
Backport audit-machinery fixes from MediaIngredientMech PR #32

### DIFF
--- a/scripts/audit_writers.py
+++ b/scripts/audit_writers.py
@@ -33,7 +33,6 @@ import re
 import sys
 from pathlib import Path
 
-ROOT = Path(".").resolve()
 SEARCH_DIRS = [
     Path("scripts"),
     Path("src/culturemech/import"),

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -34,10 +34,11 @@ from linkml.validator import Validator
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity
 
-SCHEMA_PATH = Path("src/culturemech/schema/culturemech.yaml")
-OAK_CONFIG_PATH = Path("conf/oak_config.yaml")
-DEFAULT_ROOTS = [Path(f"data/normalized_yaml/{sub}") for sub in
-                 ("algae", "bacterial", "fungal", "archaea", "specialized")]
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = _REPO_ROOT / "src" / "culturemech" / "schema" / "culturemech.yaml"
+OAK_CONFIG_PATH = _REPO_ROOT / "conf" / "oak_config.yaml"
+DEFAULT_ROOTS = [_REPO_ROOT / "data" / "normalized_yaml" / sub
+                 for sub in ("algae", "bacterial", "fungal", "archaea", "specialized")]
 
 
 _SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")

--- a/src/culturemech/validation/write_validated.py
+++ b/src/culturemech/validation/write_validated.py
@@ -123,12 +123,16 @@ def write_validated_recipe(
     errors = validate_recipe(recipe, target_class=target_class, schema_path=schema_path)
     if errors:
         raise ValidationFailedError(path, errors)
+    # Match the existing repo convention for yaml emission so re-running
+    # this helper over an existing file produces a byte-identical diff
+    # instead of churning block / flow style.
     opts = {
+        "default_flow_style": False,
         "sort_keys": False,
         "allow_unicode": True,
         "width": 80,
         **(yaml_kwargs or {}),
     }
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w") as f:
+    with path.open("w", encoding="utf-8") as f:
         yaml.safe_dump(recipe, f, **opts)

--- a/src/culturemech/validation/write_validated.py
+++ b/src/culturemech/validation/write_validated.py
@@ -36,7 +36,7 @@ from linkml.validator import Validator
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity, ValidationResult
 
-DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schema" / "culturemech.yaml"
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "culturemech.yaml"
 
 _VALIDATORS: dict[Path, Validator] = {}
 _VALIDATOR_LOCK = Lock()

--- a/src/culturemech/validation/write_validated.py
+++ b/src/culturemech/validation/write_validated.py
@@ -36,7 +36,7 @@ from linkml.validator import Validator
 from linkml.validator.plugins import JsonschemaValidationPlugin
 from linkml.validator.report import Severity, ValidationResult
 
-DEFAULT_SCHEMA_PATH = Path("src/culturemech/schema/culturemech.yaml")
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schema" / "culturemech.yaml"
 
 _VALIDATORS: dict[Path, Validator] = {}
 _VALIDATOR_LOCK = Lock()


### PR DESCRIPTION
## Summary

Three small but real bugs surfaced by Copilot on the recent [MIM port of the audit machinery](https://github.com/CultureBotAI/MediaIngredientMech/pull/32). All apply equally to CultureMech (this repo is the source of the same code), so backporting now keeps the four-repo family in sync.

| File | Fix | Impact |
|---|---|---|
| \`scripts/validate_strict.py\` | \`SCHEMA_PATH\` / \`OAK_CONFIG_PATH\` / \`DEFAULT_ROOTS\` resolved relative to \`__file__\` | A non-repo-root invocation previously failed silently (no schema found → 0 files / 0 errors → exit 0). Now works from any cwd. |
| \`src/culturemech/validation/write_validated.py\` | Add \`default_flow_style=False\` + \`encoding="utf-8"\` to default yaml.safe_dump opts | Roundtripping a recipe through \`write_validated_recipe\` no longer churns block / flow style. Matches the convention used by every other yaml writer in this repo. |
| \`scripts/audit_writers.py\` | Drop unused \`ROOT\` global | Ruff F841 hygiene. |

No semantic change to the validation policy or the audit categories.

## Test plan

- [x] All three files \`ast.parse\` cleanly.
- [x] \`uv run python scripts/validate_strict.py --sample 5\` → 0 errors as before.
- [x] cwd-independence: invoking with absolute path from \`/tmp\` now finds the schema and validates 3 files cleanly (previous behavior was a silent exit 2 / no files found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)