### PR TITLE
Edison Scientific deep-research integration via edison-client SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Edison Scientific (FutureHouse) Platform API key.
+# Used by scripts/research_media_edison.py + `just research-media-edison*`.
+# Sign up at https://platform.edisonscientific.com/ and create a key.
+#
+# The SDK natively reads EDISON_PLATFORM_API_KEY; EDISON_API_KEY is
+# honored as a legacy alias.
+EDISON_PLATFORM_API_KEY=
+
+# Optional: FutureHouse Falcon key for the legacy
+# scripts/research_media.py + deep-research-client paths. Not used by
+# the Edison-direct script.
+# FUTUREHOUSE_API_KEY=

--- a/data/import_tracking/reports/quality_analysis.md
+++ b/data/import_tracking/reports/quality_analysis.md
@@ -1,22 +1,22 @@
 # CultureMech Media Quality Analysis Report
 
 **Generated**: /Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CultureMech
-**Total Recipes Analyzed**: 500
-**Average Completeness Score**: 35.7/100
+**Total Recipes Analyzed**: 15,827
+**Average Completeness Score**: 62.6/100
 
 ## Quality Distribution
 
-- 🔴 **Critical** (< 50): 500 recipes (100.0%)
-- 🟡 **Needs Work** (50-69): 0 recipes (0.0%)
-- 🟢 **Good** (70-89): 0 recipes (0.0%)
+- 🔴 **Critical** (< 50): 540 recipes (3.4%)
+- 🟡 **Needs Work** (50-69): 9,134 recipes (57.7%)
+- 🟢 **Good** (70-89): 6,153 recipes (38.9%)
 - ⭐ **Excellent** (≥ 90): 0 recipes (0.0%)
 
 ## Common Issues
 
-- **Unmapped ingredients**: 9,690 occurrences
-- **Missing pH**: 510 occurrences
-- **Missing description**: 500 occurrences
-- **Missing/unmapped organisms**: 500 occurrences
+- **Unmapped ingredients**: 186,146 occurrences
+- **Missing pH**: 16,406 occurrences
+- **Missing/unmapped organisms**: 15,827 occurrences
+- **Missing description**: 15,139 occurrences
 
 ## Top Priority Recipes for Edison Review
 

--- a/data/import_tracking/reports/quality_analysis.md
+++ b/data/import_tracking/reports/quality_analysis.md
@@ -1,6 +1,6 @@
 # CultureMech Media Quality Analysis Report
 
-**Generated**: /Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CultureMech
+**Source dir**: `data/normalized_yaml`
 **Total Recipes Analyzed**: 15,827
 **Average Completeness Score**: 62.6/100
 

--- a/project.justfile
+++ b/project.justfile
@@ -55,6 +55,29 @@ research-providers:
 research-provider provider:
     uv run --extra dev python scripts/research_media.py --provider {{provider}} --provider-info
 
+# Edison Scientific deep research via the `edison-client` SDK. Default
+# job is LITERATURE (PaperQA3). Pass `--job literature-high` etc. via
+# *args. Requires EDISON_PLATFORM_API_KEY (or EDISON_API_KEY) in env
+# or .env. See scripts/research_media_edison.py for details.
+[group('Research')]
+research-media-edison target *args="":
+    uv run --extra dev python scripts/research_media_edison.py \
+      --target {{target}} \
+      --template {{templates_dir}}/media_growth_research.md \
+      --out-dir {{research_dir}}/media \
+      {{args}}
+
+# Batch variant: walk a edison_batch.json priority list and research
+# the first N recipes. Default --limit is unset (run all 100); always
+# pass `--limit 5` (or similar) on first runs to bound credit spend.
+[group('Research')]
+research-media-edison-batch batch *args="":
+    uv run --extra dev python scripts/research_media_edison.py \
+      --batch {{batch}} \
+      --template {{templates_dir}}/media_growth_research.md \
+      --out-dir {{research_dir}}/media \
+      {{args}}
+
 [group('Data')]
 fetch-mediadive-raw:
     #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.5.0",
     "deep-research-client[cyberian]>=0.2.4; python_version >= '3.12'",
+    # Used by scripts/research_media_edison.py — both arrive transitively
+    # via deep-research-client today, but declare them explicitly so
+    # fresh `uv run --extra dev ...` doesn't break if those transitives
+    # ever drop out.
+    "edison-client>=0.11.0; python_version >= '3.12'",
+    "python-dotenv>=1.0.0",
 ]
 koza = [
     "koza>=0.6.0",

--- a/scripts/analyze_media_quality.py
+++ b/scripts/analyze_media_quality.py
@@ -168,7 +168,8 @@ def analyze_directory(yaml_dir: Path) -> List[Dict[str, Any]]:
     return results
 
 
-def generate_report(results: List[Dict[str, Any]], output_file: Path, top_n: int = None):
+def generate_report(results: List[Dict[str, Any]], output_file: Path, top_n: int = None,
+                    yaml_dir: Path = None):
     """Generate prioritized report for Edison review."""
 
     if top_n:
@@ -203,7 +204,16 @@ def generate_report(results: List[Dict[str, Any]], output_file: Path, top_n: int
     # Write report
     with open(output_file, 'w') as f:
         f.write("# CultureMech Media Quality Analysis Report\n\n")
-        f.write(f"**Generated**: {Path.cwd()}\n")
+        # Report header shows the source dir as a repo-relative path —
+        # the previous `Path.cwd()` leaked the developer's absolute home
+        # path into a committed report (Copilot caught this on PR #33).
+        if yaml_dir is not None:
+            try:
+                anchor = output_file.resolve().parents[2]  # walk up reports/ → import_tracking/ → data/
+                source_label = str(yaml_dir.resolve().relative_to(anchor.parent))
+            except (ValueError, IndexError):
+                source_label = str(yaml_dir)
+            f.write(f"**Source dir**: `{source_label}`\n")
         f.write(f"**Total Recipes Analyzed**: {total_recipes:,}\n")
         f.write(f"**Average Completeness Score**: {avg_score:.1f}/100\n\n")
 
@@ -335,7 +345,7 @@ def main():
 
     # Generate report
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    generate_report(results, args.output, args.top_n)
+    generate_report(results, args.output, args.top_n, yaml_dir=args.yaml_dir)
 
     # Generate Edison batch file
     args.edison_batch.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/research_media_edison.py
+++ b/scripts/research_media_edison.py
@@ -17,10 +17,12 @@ Auth: reads ``EDISON_PLATFORM_API_KEY`` (SDK-native) or ``EDISON_API_KEY``
 (legacy alias from research_media.py) from environment. A repo-root
 ``.env`` is auto-loaded via python-dotenv.
 
-Outputs land under ``research/media/{slug}-edison-{job}.md`` (matching
-the existing DRC naming convention used by research_media.py). A
-sibling ``{slug}-edison-{job}-meta.yaml`` captures task_id, cost,
-status, and the prompt that was sent — useful for audit and re-runs.
+Outputs land under ``research/media/{slug}-edison-{job}.md``
+(``slug`` = YAML file stem to match research_media.py's DRC naming,
+``job`` = lowercase-hyphenated job name, e.g. ``literature-high``). A
+sibling ``{slug}-edison-{job}-meta.yaml`` captures the rendered query
+text, task_id, total_cost, status, template_path, and template_vars —
+sufficient for audit and re-runs.
 
 Usage::
 
@@ -34,7 +36,9 @@ Usage::
     # different job
     python scripts/research_media_edison.py --target lb_broth --job literature-high
 
-    # dry-run prints the rendered query without spending credits
+    # dry-run skips the API call but still writes the meta yaml
+    # (including the full rendered query) so you can inspect the
+    # prompt that would have been sent without spending credits.
     python scripts/research_media_edison.py --target lb_broth --dry-run
 """
 from __future__ import annotations
@@ -119,12 +123,35 @@ class _DefaultEmpty(dict):
 
 
 def slug_for(media_path: Path) -> str:
-    """Stable filename slug for output naming."""
-    doc = rm.load_media(media_path)
-    cid = str(doc.get("id") or "")
-    if ":" in cid:
-        return cid.split(":", 1)[1]
+    """Stable filename slug for output naming.
+
+    Uses the YAML file stem (e.g. ``luria_bertani_lb_medium``) — human-
+    readable and consistent with research_media.py's DRC outputs.
+    The CultureMech CURIE ID is captured separately in the meta file.
+    """
     return media_path.stem
+
+
+def _short_job(job) -> str:
+    """CLI-friendly filename suffix for a JobNames enum member.
+
+    ``JobNames.LITERATURE_HIGH`` -> ``literature-high`` (hyphens, not
+    underscores, to match the ``--job literature-high`` CLI alias).
+    """
+    return job.name.lower().replace("_", "-")
+
+
+def _display_path(path: Path) -> str:
+    """Show ``path`` relative to the repo when possible; else absolute.
+
+    ``Path.relative_to`` raises ValueError when the target is outside
+    REPO_ROOT (e.g. user passes ``--out-dir /tmp/research``); fall
+    back to absolute string for display rather than crashing.
+    """
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
 
 
 def run_one(
@@ -140,13 +167,34 @@ def run_one(
 
     query, variables = render_query(media_path, template_path)
     slug = slug_for(media_path)
-    job_short = job.name.lower()
+    job_short = _short_job(job)
     md_path = out_dir / f"{slug}-edison-{job_short}.md"
     meta_path = out_dir / f"{slug}-edison-{job_short}-meta.yaml"
 
+    def _safe_rel(p: Path) -> str:
+        return str(p.relative_to(REPO_ROOT)) if str(p).startswith(str(REPO_ROOT)) else str(p)
+
     if dry_run:
-        print(f"[DRY RUN] {media_path.relative_to(REPO_ROOT)} -> {md_path.relative_to(REPO_ROOT)}")
-        print(f"          job={job.name} query_chars={len(query)}")
+        # In dry-run we still write the meta + query alongside the
+        # planned md_path so callers can audit prompts without burning
+        # credits. The meta is the source of truth for "the prompt that
+        # was sent" referenced in the module docstring.
+        out_dir.mkdir(parents=True, exist_ok=True)
+        meta = {
+            "slug": slug,
+            "media_path": _safe_rel(media_path),
+            "media_id": str(rm.load_media(media_path).get("id") or ""),
+            "job": job.name,
+            "job_id": job.value,
+            "status": "dry-run",
+            "template_path": _safe_rel(template_path),
+            "template_vars": variables,
+            "query_chars": len(query),
+            "query": query,
+        }
+        meta_path.write_text(yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100))
+        print(f"[DRY RUN] {_display_path(media_path)} -> {_display_path(md_path)}")
+        print(f"          job={job.name} query_chars={len(query)} meta={_display_path(meta_path)}")
         return {"slug": slug, "status": "dry-run", "cost": 0.0}
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -163,7 +211,8 @@ def run_one(
 
     meta = {
         "slug": slug,
-        "media_path": str(media_path.relative_to(REPO_ROOT)),
+        "media_path": _safe_rel(media_path),
+        "media_id": str(rm.load_media(media_path).get("id") or ""),
         "job": job.name,
         "job_id": job.value,
         "task_id": str(getattr(response, "task_id", None) or ""),
@@ -172,11 +221,13 @@ def run_one(
         "total_cost": total_cost,
         "total_queries": getattr(response, "total_queries", None),
         "has_successful_answer": getattr(response, "has_successful_answer", None),
+        "template_path": _safe_rel(template_path),
         "template_vars": variables,
         "query_chars": len(query),
+        "query": query,
     }
     meta_path.write_text(yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100))
-    print(f"    -> {md_path.relative_to(REPO_ROOT)}  cost={total_cost}")
+    print(f"    -> {_display_path(md_path)}  cost={total_cost}")
     return {"slug": slug, "status": meta["status"], "cost": total_cost or 0.0}
 
 

--- a/scripts/research_media_edison.py
+++ b/scripts/research_media_edison.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Run Edison Scientific deep research against CultureMech media records.
+
+Uses the `edison-client` SDK directly. The companion `research_media.py`
+wraps `deep-research-client`, but as of DRC 0.2.4 only `cyberian` and
+`openai` are registered providers — Edison/PaperQA is not exposed
+there, so we drive the SDK directly.
+
+The default job is LITERATURE (== `job-futurehouse-paperqa3`), the
+PaperQA agent — the best fit for "what organisms grow on this medium,
+what is its pH, what are its CHEBI mappings"-type questions. Use
+``--job literature-high`` for the deeper variant (more reads, higher
+cost), ``--job precedent`` for first-mention search, ``--job phoenix``
+for synthesis.
+
+Auth: reads ``EDISON_PLATFORM_API_KEY`` (SDK-native) or ``EDISON_API_KEY``
+(legacy alias from research_media.py) from environment. A repo-root
+``.env`` is auto-loaded via python-dotenv.
+
+Outputs land under ``research/media/{slug}-edison-{job}.md`` (matching
+the existing DRC naming convention used by research_media.py). A
+sibling ``{slug}-edison-{job}-meta.yaml`` captures task_id, cost,
+status, and the prompt that was sent — useful for audit and re-runs.
+
+Usage::
+
+    # single record
+    python scripts/research_media_edison.py --target dehalospirillum_medium
+
+    # batch from the existing priority list
+    python scripts/research_media_edison.py \\
+        --batch data/import_tracking/reports/edison_batch.json --limit 5
+
+    # different job
+    python scripts/research_media_edison.py --target lb_broth --job literature-high
+
+    # dry-run prints the rendered query without spending credits
+    python scripts/research_media_edison.py --target lb_broth --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import research_media as rm  # noqa: E402  -- reuse template_vars + resolve
+
+DEFAULT_TEMPLATE = REPO_ROOT / "templates" / "media_growth_research.md"
+DEFAULT_OUT_DIR = REPO_ROOT / "research" / "media"
+
+
+_JOB_ALIASES: dict[str, str] = {
+    "literature": "LITERATURE",
+    "paperqa": "LITERATURE",
+    "literature-high": "LITERATURE_HIGH",
+    "literature_high": "LITERATURE_HIGH",
+    "paperqa-high": "LITERATURE_HIGH",
+    "precedent": "PRECEDENT",
+    "phoenix": "PHOENIX",
+}
+
+
+def resolve_job(name: str):
+    """Map a user-friendly --job alias to the edison_client JobNames enum."""
+    from edison_client import JobNames
+
+    key = _JOB_ALIASES.get(name.lower())
+    if key is None:
+        raise SystemExit(
+            f"Unknown --job '{name}'. Choose one of: "
+            + ", ".join(sorted(_JOB_ALIASES))
+        )
+    return getattr(JobNames, key)
+
+
+def load_api_key() -> str:
+    """Pick up the Edison key from env (with the legacy alias).
+
+    The SDK natively reads ``EDISON_PLATFORM_API_KEY``; older code in
+    this repo set ``EDISON_API_KEY``. Honor both.
+    """
+    load_dotenv(REPO_ROOT / ".env")
+    key = os.environ.get("EDISON_PLATFORM_API_KEY") or os.environ.get("EDISON_API_KEY")
+    if not key:
+        raise SystemExit(
+            "EDISON_PLATFORM_API_KEY (or EDISON_API_KEY) is not set. "
+            "Add it to .env at the repo root, or `export EDISON_PLATFORM_API_KEY=...` "
+            "in your shell."
+        )
+    return key
+
+
+def render_query(media_path: Path, template_path: Path) -> tuple[str, dict[str, str]]:
+    """Render the deep-research template for a single recipe.
+
+    Returns ``(query_text, template_vars)`` so callers can stamp the
+    variables into the meta file alongside the rendered query.
+    """
+    doc = rm.load_media(media_path)
+    variables = rm.template_vars(doc, media_path)
+    template = template_path.read_text()
+    return template.format_map(_DefaultEmpty(variables)), variables
+
+
+class _DefaultEmpty(dict):
+    """``str.format_map`` helper: leave unknown placeholders blank instead of KeyError."""
+
+    def __missing__(self, key):  # noqa: ANN001
+        return ""
+
+
+def slug_for(media_path: Path) -> str:
+    """Stable filename slug for output naming."""
+    doc = rm.load_media(media_path)
+    cid = str(doc.get("id") or "")
+    if ":" in cid:
+        return cid.split(":", 1)[1]
+    return media_path.stem
+
+
+def run_one(
+    client,
+    media_path: Path,
+    job,
+    template_path: Path,
+    out_dir: Path,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Submit one task; write results to out_dir; return a stats dict."""
+    from edison_client import TaskRequest
+
+    query, variables = render_query(media_path, template_path)
+    slug = slug_for(media_path)
+    job_short = job.name.lower()
+    md_path = out_dir / f"{slug}-edison-{job_short}.md"
+    meta_path = out_dir / f"{slug}-edison-{job_short}-meta.yaml"
+
+    if dry_run:
+        print(f"[DRY RUN] {media_path.relative_to(REPO_ROOT)} -> {md_path.relative_to(REPO_ROOT)}")
+        print(f"          job={job.name} query_chars={len(query)}")
+        return {"slug": slug, "status": "dry-run", "cost": 0.0}
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    task = TaskRequest(name=job, query=query)
+    print(f"  + submitting {slug} ({job.name})...", flush=True)
+    [response] = client.run_tasks_until_done(task, progress_bar=False)
+
+    # PaperQA-family responses carry the answer + cost; other jobs may not.
+    formatted_answer = getattr(response, "formatted_answer", None)
+    answer = getattr(response, "answer", None)
+    total_cost = getattr(response, "total_cost", None)
+    body = formatted_answer or answer or "(no answer field on this job's response type)"
+    md_path.write_text(body)
+
+    meta = {
+        "slug": slug,
+        "media_path": str(media_path.relative_to(REPO_ROOT)),
+        "job": job.name,
+        "job_id": job.value,
+        "task_id": str(getattr(response, "task_id", None) or ""),
+        "status": getattr(response, "status", None),
+        "submitted_at": datetime.now(timezone.utc).isoformat(),
+        "total_cost": total_cost,
+        "total_queries": getattr(response, "total_queries", None),
+        "has_successful_answer": getattr(response, "has_successful_answer", None),
+        "template_vars": variables,
+        "query_chars": len(query),
+    }
+    meta_path.write_text(yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100))
+    print(f"    -> {md_path.relative_to(REPO_ROOT)}  cost={total_cost}")
+    return {"slug": slug, "status": meta["status"], "cost": total_cost or 0.0}
+
+
+def load_batch_targets(batch_path: Path) -> list[list[str]]:
+    """Return candidate identifiers per entry from a edison_batch.json file.
+
+    Each entry carries both ``recipe_name`` (slug) and ``file_path``
+    (relative to ``data/normalized_yaml/``). The batch file dates from
+    before the snake_case rename, so ``file_path`` often points at a
+    legacy filename; ``recipe_name`` (slug) is what survives. Return
+    ALL candidates per entry so callers can fall through on first miss.
+    """
+    data = json.loads(batch_path.read_text())
+    if not isinstance(data, list):
+        raise SystemExit(f"--batch expects a JSON list of records: {batch_path}")
+    out: list[list[str]] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        candidates = [
+            entry.get("recipe_name"),
+            entry.get("file_path"),
+        ]
+        candidates = [c for c in candidates if c]
+        if candidates:
+            out.append(candidates)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--target", help="Media YAML path, slug, ID, name, or original name.")
+    src.add_argument("--batch", type=Path, help="Path to edison_batch.json (or similar list).")
+    ap.add_argument("--job", default="literature",
+                    help="literature (paperqa3, default) | literature-high | precedent | phoenix")
+    ap.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
+    ap.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    ap.add_argument("--limit", type=int, default=None,
+                    help="When using --batch, cap the number of recipes to research.")
+    ap.add_argument("--start", type=int, default=0,
+                    help="When using --batch, skip this many entries before submitting.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Render queries + print plan; do NOT call the API.")
+    args = ap.parse_args(argv)
+
+    job = resolve_job(args.job)
+
+    targets: list[Path]
+    if args.target:
+        targets = [rm.resolve_media_file(args.target)]
+    else:
+        candidate_lists = load_batch_targets(args.batch)
+        candidate_lists = candidate_lists[args.start:]
+        if args.limit is not None:
+            candidate_lists = candidate_lists[: args.limit]
+        targets = []
+        unresolved: list[str] = []
+        media_dir = REPO_ROOT / "data" / "normalized_yaml"
+        for candidates in candidate_lists:
+            resolved: Path | None = None
+            # Prefer a verbatim `data/normalized_yaml/<candidate>` lookup
+            # for candidates that look like relative paths (have a "/"
+            # or end with ".yaml"). resolve_media_file doesn't apply
+            # this prefix and slug-only fallback hits multi-match
+            # ValueErrors when the slug is shared across several files
+            # (e.g., "dehalospirillum_medium" appears in TOGO/KOMODO/
+            # JCM variants of the same canonical recipe).
+            for name in candidates:
+                if "/" in name or name.endswith(".yaml"):
+                    p = media_dir / name
+                    if p.is_file():
+                        resolved = p.resolve()
+                        break
+            if resolved is None:
+                for name in candidates:
+                    try:
+                        resolved = rm.resolve_media_file(name)
+                        break
+                    except (FileNotFoundError, ValueError):
+                        continue
+            if resolved is None:
+                unresolved.append(" / ".join(candidates))
+            else:
+                targets.append(resolved)
+        if unresolved:
+            print(f"Note: skipped {len(unresolved)} unresolvable batch entries:",
+                  file=sys.stderr)
+            for u in unresolved[:5]:
+                print(f"  - {u}", file=sys.stderr)
+            if len(unresolved) > 5:
+                print(f"  - ... {len(unresolved) - 5} more", file=sys.stderr)
+
+    if not targets:
+        print("No targets to research.", file=sys.stderr)
+        return 2
+
+    print(f"Edison job:    {job.name} ({job.value})")
+    print(f"Template:      {args.template.relative_to(REPO_ROOT)}")
+    print(f"Output dir:    {args.out_dir.relative_to(REPO_ROOT)}")
+    print(f"Recipes:       {len(targets)}")
+    if args.dry_run:
+        print("Mode:          DRY RUN (no API calls, no credits spent)")
+    print()
+
+    client = None
+    if not args.dry_run:
+        api_key = load_api_key()
+        from edison_client import EdisonClient
+        client = EdisonClient(api_key=api_key)
+
+    results: list[dict[str, Any]] = []
+    try:
+        for media_path in targets:
+            results.append(
+                run_one(client, media_path, job, args.template, args.out_dir, args.dry_run)
+            )
+    finally:
+        if client is not None:
+            client.close()
+
+    if not args.dry_run:
+        total_cost = sum(r["cost"] or 0.0 for r in results)
+        print()
+        print(f"Done. {len(results)} recipes researched. Total reported cost: {total_cost:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_research_media_edison.py
+++ b/tests/test_research_media_edison.py
@@ -1,0 +1,124 @@
+"""Tests for scripts/research_media_edison.py batch resolution + slug helpers.
+
+Focus is the resolution logic that bridges the priority-list JSON
+(``recipe_name`` + ``file_path``) to actual YAML paths under
+``data/normalized_yaml/``. The corpus drifts as files are renamed
+(snake_case migration, orphan-page cleanups), so the resolver has
+to:
+
+1. prefer ``data/normalized_yaml/<file_path>`` verbatim when the
+   candidate looks like a relative path;
+2. fall back to slug-style matching when the path-style lookup
+   misses;
+3. skip entries that resolve to nothing (without crashing the run).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load_module():
+    """Load research_media_edison.py without going through the package
+    (the script lives in scripts/, not under src/)."""
+    path = REPO_ROOT / "scripts" / "research_media_edison.py"
+    spec = importlib.util.spec_from_file_location("research_media_edison", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["research_media_edison"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rme():
+    return _load_module()
+
+
+def _make_recipe(category_dir: Path, name: str, recipe_id: str = "CultureMech:099999") -> Path:
+    """Drop a minimal MediaRecipe YAML under tmp data dir."""
+    category_dir.mkdir(parents=True, exist_ok=True)
+    path = category_dir / f"{name}.yaml"
+    path.write_text(
+        f"id: {recipe_id}\n"
+        f"name: {name}\n"
+        "category: bacterial\n"
+        "physical_state: LIQUID\n"
+        "medium_type: COMPLEX\n"
+    )
+    return path
+
+
+def test_load_batch_targets_returns_candidate_lists(rme, tmp_path):
+    batch = tmp_path / "edison_batch.json"
+    batch.write_text(json.dumps([
+        {"recipe_name": "alpha_medium",
+         "file_path": "bacterial/ALPHA_MEDIUM.yaml"},
+        {"recipe_name": "beta_medium"},                              # no file_path
+        {"file_path": "bacterial/GAMMA_MEDIUM.yaml"},                # no recipe_name
+        {},                                                          # empty entry, skipped
+    ]))
+    candidates = rme.load_batch_targets(batch)
+    # 3 of 4 entries yield at least one candidate.
+    assert len(candidates) == 3
+    # Order within each candidate list: recipe_name first, file_path second.
+    assert candidates[0] == ["alpha_medium", "bacterial/ALPHA_MEDIUM.yaml"]
+    assert candidates[1] == ["beta_medium"]
+    assert candidates[2] == ["bacterial/GAMMA_MEDIUM.yaml"]
+
+
+def test_load_batch_targets_rejects_non_list(rme, tmp_path):
+    batch = tmp_path / "bad.json"
+    batch.write_text(json.dumps({"not": "a list"}))
+    with pytest.raises(SystemExit):
+        rme.load_batch_targets(batch)
+
+
+def test_short_job_uses_hyphens(rme):
+    """CLI alias and filename suffix should match: literature-high, not _high."""
+    from edison_client import JobNames
+
+    assert rme._short_job(JobNames.LITERATURE) == "literature"
+    assert rme._short_job(JobNames.LITERATURE_HIGH) == "literature-high"
+    assert rme._short_job(JobNames.PHOENIX) == "phoenix"
+
+
+def test_slug_for_uses_yaml_stem(rme, tmp_path):
+    """Output filename should be human-readable (stem), not the numeric CURIE local part.
+
+    Output paths from research_media.py's DRC variant use the stem;
+    keep parity so users can sort/find research outputs by recipe name.
+    """
+    recipe = _make_recipe(tmp_path / "data" / "normalized_yaml" / "bacterial",
+                          "luria_bertani_lb_medium",
+                          recipe_id="CultureMech:009674")
+    assert rme.slug_for(recipe) == "luria_bertani_lb_medium"
+
+
+def test_display_path_safe_when_outside_repo(rme, tmp_path):
+    """`Path.relative_to(REPO_ROOT)` raises when path is outside; the
+    display helper must fall through to an absolute string instead."""
+    outside = tmp_path / "elsewhere" / "out.md"
+    out = rme._display_path(outside)
+    # Either the absolute path or something relative — never raises.
+    assert str(outside) in out or outside.name in out
+
+
+def test_resolve_job_known_aliases(rme):
+    from edison_client import JobNames
+
+    assert rme.resolve_job("literature") is JobNames.LITERATURE
+    assert rme.resolve_job("paperqa") is JobNames.LITERATURE
+    assert rme.resolve_job("literature-high") is JobNames.LITERATURE_HIGH
+    assert rme.resolve_job("paperqa-high") is JobNames.LITERATURE_HIGH
+
+
+def test_resolve_job_unknown_raises(rme):
+    with pytest.raises(SystemExit, match="Unknown --job"):
+        rme.resolve_job("not-a-real-job")

--- a/uv.lock
+++ b/uv.lock
@@ -930,9 +930,11 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "deep-research-client", extra = ["cyberian"], marker = "python_full_version >= '3.12'" },
+    { name = "edison-client", marker = "python_full_version >= '3.12'" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "python-dotenv" },
     { name = "ruff" },
 ]
 koza = [
@@ -947,6 +949,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "deep-research-client", extras = ["cyberian"], marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.2.4" },
+    { name = "edison-client", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=0.11.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "koza", marker = "extra == 'koza'", specifier = ">=0.6.0" },
     { name = "linkml", specifier = ">=1.7.0" },
@@ -961,6 +964,7 @@ requires-dist = [
     { name = "pypdf2", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "requests", specifier = ">=2.31.0" },


### PR DESCRIPTION
## Summary
Wires a programmatic path to FutureHouse / Edison Scientific deep research over CultureMech media records.

The existing `scripts/research_media.py` wraps `deep-research-client`, but DRC 0.2.4 registers only `openai` and `cyberian` as providers — Edison / PaperQA isn't accessible through it. The `edison-client` SDK is already in `pyproject` deps; this PR invokes it directly.

## New file: `scripts/research_media_edison.py`
- **Single recipe**: `python scripts/research_media_edison.py --target <slug|id|path>`
- **Batch**: `python scripts/research_media_edison.py --batch data/import_tracking/reports/edison_batch.json --limit 5`
- `--job literature` (paperqa3, default) | `literature-high` | `precedent` | `phoenix`. Aliases `paperqa`, `paperqa-high`.
- `--dry-run` renders the query and prints the plan without an API call (no credits).
- `--start` / `--limit` cap or skip into a batch list.
- Auth: `EDISON_PLATFORM_API_KEY` (SDK-native) or legacy `EDISON_API_KEY`; auto-loads repo-root `.env` via python-dotenv.
- Reuses `research_media.py`'s `template_vars` / `load_media` / `resolve_media_file` so the rendered query matches the existing DRC workflow.
- Outputs: `research/media/{slug}-edison-{job}.md` + sibling `-meta.yaml` (task_id, total_cost, status, template_vars).

## Batch resolution fix
The 100-recipe `edison_batch.json` priority list was failing to resolve because `research_media.py`'s `resolve_media_file`:
- treats string `file_path`s as CWD-relative (not `data/normalized_yaml/`-relative), and
- raises on multi-match slugs (e.g. `dehalospirillum_medium` exists in 5 importer-flavor variants).

The Edison batch resolver tries `data/normalized_yaml/<file_path>` verbatim first — unambiguous — then falls back to slug matching. Resolvability is **100% (5/5)** in the smoke dry-run.

## Justfile targets
- `just research-media-edison <target> [*args]`
- `just research-media-edison-batch <batch.json> [*args]` (always pass `--limit N` on first runs)

## Also
- `.env.example` added (gitignored — `.env` already is).
- `data/import_tracking/reports/edison_batch.json` regenerated against current corpus via `analyze_media_quality.py` (the March-vintage file pre-dated the snake_case + orphan-page cleanups; few entries still resolved).

## Out of scope here
Live API smoke test deferred until user confirms `.env` has the new LBL key (2.6k credits).

## Test plan
- [x] Dry-run single recipe (`--target luria_bertani_lb_medium`)
- [x] Dry-run batch (`--limit 5`) — 5/5 resolve cleanly
- [x] `just --list` shows both new targets in the Research group
- [ ] Live test deferred (key rotation)
- [x] `just validate-strict` clean (no schema/data touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)