### PR TITLE
Add id↔label correspondence validation (canonical label gate + product checker)

### DIFF
--- a/.claude/skills/id-label-correspondence/skill.md
+++ b/.claude/skills/id-label-correspondence/skill.md
@@ -1,0 +1,85 @@
+---
+name: id-label-correspondence
+description: Validate that every ontology ID carries its correct ontology LABEL across CultureMech recipe YAMLs and SSSOM mapping products. Uses LinkML schema bindings + linkml-term-validator for term.{id,label} (canonical label) and a shared OAK validator for products. Run report-then-enforce; triage drift as wrong-label vs wrong-id.
+category: research
+requires_database: false
+requires_internet: true
+version: 1.0.0
+---
+
+# ID↔Label correspondence (CultureMech)
+
+## The invariant
+
+Every ontology **ID** must carry its **correct ontology label**, everywhere —
+recipe YAML inputs and the SSSOM mapping products. Checking that an ID *exists*
+is not enough; the **label must be the right label for that ID**. A wrong label
+often signals a **wrong ID** (the more serious bug).
+
+Policy (**Hybrid**):
+- **`Term.label`** (under every grounding slot: ingredient `term`/`chebi_term`,
+  organism `term`, environment `term`, cofactor/precursor/substrate terms) must
+  equal the **canonical** OBO label (e.g. `CHEBI:32599` → `magnesium sulfate`).
+  The source/recipe name lives in the sibling `preferred_term`, not in
+  `term.label`.
+- **SSSOM `*_label` columns** accept canonical OR an exact/related synonym.
+
+See `docs/ID_LABEL_CORRESPONDENCE.md` for the cross-repo rationale.
+
+## How it's enforced
+
+**Engine A — LinkML-native (YAML).** The schema marks `Term.label`
+`slot_uri: rdfs:label` and gives every descriptor term slot a range-less
+`binding` (`binds_value_of: id`). `linkml-term-validator validate-data --labels`
+then verifies `term.label` against OAK's canonical label and **fails** on drift.
+
+```bash
+just validate-terms data/normalized_yaml/bacterial/<file>.yaml   # one file
+just validate-terms-all                                          # all recipes
+```
+
+(The 3-layer `just validate <file>` recipe already runs this term layer.)
+
+**Engine B — shared OAK validator (products).**
+`scripts/validate_id_label_correspondence.py` (vendored byte-identical across
+the Mech repos) checks `output/*.sssom.tsv` (`subject_*`/`object_*`) per
+`conf/id_label_targets.yaml`.
+
+```bash
+just validate-products       # enforce (exit 2 on mismatch / unknown id)
+just report-label-drift      # baseline: reports/label_drift.tsv, never fails
+```
+
+## Rollout: report → baseline → enforce
+
+The CI gate is **report-only** first (`label-correspondence.yaml` uploads
+`reports/label_drift.tsv`, non-blocking) — enforcing surfaces existing drift,
+including the many recipe terms with empty `label: ''`.
+
+1. `just report-label-drift` → open `reports/label_drift.tsv`.
+2. **Triage** each row (below).
+3. Once cleared, add `validate-terms-all` + `validate-products` to a blocking
+   CI job (Phase 2).
+
+## Triage: wrong label vs wrong ID
+
+- **Empty/stale label, right ID** → set `term.label` to the canonical OBO label
+  (use `scripts/enrich_sssom_with_ols.py` / OLS to fetch it).
+- **Wrong ID** → the label names a *different* term; fix the **ID**.
+- **`ID_NOT_FOUND`** → obsolete/removed CURIE; re-map (see
+  `scripts/remove_invalid_chebi_ids.py`, `scripts/trace_invalid_chebi_sources.py`).
+
+## Surfaces (`conf/id_label_targets.yaml`)
+
+- `data/normalized_yaml/**/*.yaml` (`term.{id,label}`) — canonical
+- `output/*.sssom.tsv` (`subject_*`/`object_*`) — canonical-or-synonym
+
+Prefixes without an OAK adapter (`mediadive.compound`, `komodo.medium`, `DSMZ`,
+`TOGO`, `ATCC`, `MediaIngredientMech:`, `CultureMech:`, `GTDB`) are reported
+`SKIPPED_NO_ADAPTER`.
+
+## Related
+
+- `conf/oak_config.yaml` (OAK adapter map for the term validator),
+  `scripts/enrich_sssom_with_ols.py` (OLS label fetch),
+  `scripts/remove_invalid_chebi_ids.py`.

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,0 +1,55 @@
+name: label-correspondence
+
+# Phase 1 (report-only): generate the id↔label drift report and upload it as an
+# artifact. Does NOT fail the build — it surfaces existing label drift for
+# triage. Phase 2 will switch to the blocking gates (`just validate-terms-all`
+# + `just validate-products`).
+
+on:
+  pull_request:
+    paths: &trigger_paths
+      - "data/normalized_yaml/**"
+      - "output/**.sssom.tsv"
+      - "src/culturemech/schema/**"
+      - "scripts/validate_id_label_correspondence.py"
+      - "conf/id_label_targets.yaml"
+      - ".github/workflows/label-correspondence.yaml"
+  push:
+    branches: [main]
+    paths: *trigger_paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  label-drift-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      # Cache OAK sqlite ontologies (CHEBI/NCBITaxon/ENVO/NCIT/...) across runs.
+      - name: Cache OAK ontologies
+        uses: actions/cache@v4
+        with:
+          path: ~/.data/oaklib
+          key: oaklib-${{ runner.os }}-v1
+
+      - name: Generate id↔label drift report (non-blocking)
+        run: just report-label-drift
+
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: label-drift-report-${{ github.run_id }}
+          path: reports/label_drift.tsv
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ tmp/
 # Legacy pre-three-tier-migration media directory (kb/media_backup +
 # kb/media_backup_old). Live data lives under data/normalized_yaml/.
 kb/
+
+# linkml-term-validator / OAK label cache
+cache/

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -21,6 +21,11 @@ targets:
     policy: canonical
     pairs:
       - [id, label]
+    # mediaingredientmech_chebi_term.label is intentionally MIM's preferred_term
+    # (not the OBO canonical label), so excluded from the canonical gate to
+    # avoid false MISMATCHes.
+    exclude_keys:
+      - mediaingredientmech_chebi_term
 
   # data products: CHEBI mapping SSSOM exports — canonical OR synonym
   - name: sssom

--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -1,0 +1,33 @@
+# Targets for scripts/validate_id_label_correspondence.py (Engine B).
+# See docs/ID_LABEL_CORRESPONDENCE.md. Prefixes not in `adapters`
+# (mediadive.compound, komodo.medium, DSMZ, TOGO, ATCC, MediaIngredientMech,
+# CultureMech, GTDB, …) are reported SKIPPED_NO_ADAPTER.
+
+adapters:
+  CHEBI: sqlite:obo:chebi
+  NCBITaxon: sqlite:obo:ncbitaxon
+  ENVO: sqlite:obo:envo
+  UBERON: sqlite:obo:uberon
+  NCIT: sqlite:obo:ncit
+  FOODON: sqlite:obo:foodon
+
+synonym_scope: exact_related
+
+targets:
+  # data inputs (recipe YAMLs) — every nested term.{id,label} block — canonical
+  - name: normalized_yaml
+    kind: yaml
+    glob: "data/normalized_yaml/**/*.yaml"
+    policy: canonical
+    pairs:
+      - [id, label]
+
+  # data products: CHEBI mapping SSSOM exports — canonical OR synonym
+  - name: sssom
+    kind: tabular
+    format: tsv
+    glob: "output/*.sssom.tsv"
+    policy: canonical_or_synonym
+    pairs:
+      - [subject_id, subject_label]
+      - [object_id, object_label]

--- a/conf/oak_config.yaml
+++ b/conf/oak_config.yaml
@@ -5,6 +5,9 @@ ontology_adapters:
   # Chemicals - Chemical Entities of Biological Interest
   CHEBI: sqlite:obo:chebi
 
+  # Food materials - Food Ontology (819 recipe files ground ingredients to FOODON)
+  FOODON: sqlite:obo:foodon
+
   # Organisms - NCBI Taxonomy
   NCBITaxon: sqlite:obo:ncbitaxon
 

--- a/docs/ID_LABEL_CORRESPONDENCE.md
+++ b/docs/ID_LABEL_CORRESPONDENCE.md
@@ -1,0 +1,75 @@
+# ID↔Label correspondence
+
+A cross-repo invariant for CultureMech, MIM, and CommunityMech.
+
+## The invariant
+
+> Every ontology **ID** must carry its **correct ontology label**, everywhere it
+> appears — data **inputs**, **intermediates**, and **data products** (mappings,
+> exports, results).
+
+Checking that an ID *exists* in an ontology is **not** sufficient. The label
+asserted next to the ID must be the **right label for that ID**. A wrong label
+is often the visible symptom of a **wrong ID** — the more serious bug.
+
+## Why this was needed
+
+The previous term validation (`linkml-term-validator validate-data --labels`)
+silently passed files with wrong labels, because `--labels` only fires for slots
+that declare a LinkML **`binding`** — and no schema had bindings. Demonstration:
+corrupting `ENVO:00002046`'s label to `ZZZ_not_sludge_wrong` still reported
+"✅ Validation passed". Data products (SSSOM/CSV/KGX) were never label-checked at
+all, since no LinkML tool reads them.
+
+## Policy (Hybrid)
+
+| Surface | Field | Required label |
+|---|---|---|
+| Schema YAML | `*_label` / `term.label` / `ontology_label` | the **canonical** OBO label |
+| Products | SSSOM/CSV `*_label` columns | canonical **or** an exact/related synonym |
+
+The schema `label` field holds the **canonical** ontology label. Human / project
+/ surface names (abbreviations, formulas like `NaCl`, recipe names) live in
+`preferred_term` (or `synonyms` / `notes`), never in the canonical `label` field.
+
+## How it's enforced — two engines
+
+**Engine A — LinkML-native gate (YAML data).** Each schema marks its label slot
+`slot_uri: rdfs:label` and gives the term-bearing slot a **range-less**
+`binding` (`binds_value_of: <id_field>`). A range-less binding triggers
+`linkml-term-validator validate-data --labels` to compare the asserted label to
+OAK's canonical label and **fail** on mismatch — without an enum-membership
+check (which would require expensive per-ontology tree expansion). ID existence
+is covered by Engine B's OAK lookup.
+
+**Engine B — shared OAK validator (products + unified report).**
+`scripts/validate_id_label_correspondence.py` is **vendored byte-identical**
+across the three Mech repos (same convention as `_edison_capture.py`; verify
+with `md5`). It reads `conf/id_label_targets.yaml`, resolves canonical label +
+synonyms from the same OAK sqlite adapters the repos already use, and classifies
+each `(id, label)` pair: `OK_CANONICAL`, `OK_SYNONYM`, `MISMATCH`,
+`ID_NOT_FOUND`, `EMPTY_LABEL`, or `SKIPPED_NO_ADAPTER` (prefix with no adapter,
+e.g. `cas:`, `kgmicrobe.compound:`). It runs in `--report` mode (non-failing
+TSV) or enforce mode (exit 2).
+
+## Rollout: report → baseline → enforce
+
+Enforcement surfaces existing drift, so it lands in three steps:
+
+1. **Report** — `just report-label-drift` writes `reports/label_drift.tsv`; the
+   `label-correspondence` CI workflow runs this **non-blocking**.
+2. **Baseline / triage** — fix each row: stale label → write the canonical
+   label; wrong ID → re-map the ID.
+3. **Enforce** — add `validate-terms-all` + `validate-products` to `qc` and flip
+   the CI workflow to blocking.
+
+## Per-repo recipes
+
+| Repo | Engine A (YAML) | Engine B (products) | Report |
+|---|---|---|---|
+| MIM | `just validate-terms[-all]` | `just validate-products` | `just report-label-drift` |
+| CultureMech | `just validate-terms <file>` | `just validate-products` | `just report-label-drift` |
+| CommunityMech | `just validate-terms[-all]` | `just validate-products` | `just report-label-drift` |
+
+Engine A and Engine B agree on canonical labels for YAML; Engine B additionally
+tolerates synonyms on product surface labels.

--- a/project.justfile
+++ b/project.justfile
@@ -785,6 +785,32 @@ validate-references file:
     uv run linkml-reference-validator validate data {{file}} --schema {{schema_path}} --target-class MediaRecipe
     echo "✓ Reference validation passed"
 
+# id↔label gate (Engine A): the schema now binds every descriptor term slot,
+# so --labels verifies term.label is the CANONICAL ontology label for term.id
+# across all recipe files. Fails (non-zero) on any label drift.
+[group('QC')]
+validate-terms-all:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    rc=0
+    for file in data/normalized_yaml/*/*.yaml; do
+        [ -e "$file" ] || continue
+        uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}} || rc=1
+    done
+    exit $rc
+
+# id↔label gate (Engine B): verify (id,label) pairs in DATA PRODUCTS
+# (output/*.sssom.tsv) correspond to the ontology. Exits 2 on any mismatch.
+[group('QC')]
+validate-products:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+
+# Baseline (non-failing): unified id↔label drift report across recipe YAMLs +
+# SSSOM products to reports/label_drift.tsv. Use before enforcing.
+[group('QC')]
+report-label-drift:
+    uv run python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml --report reports/label_drift.tsv
+
 [group('QC')]
 validate-all:
     #!/usr/bin/env bash

--- a/project.justfile
+++ b/project.justfile
@@ -792,8 +792,10 @@ validate-references file:
 validate-terms-all:
     #!/usr/bin/env bash
     set -uo pipefail
+    shopt -s globstar nullglob
     rc=0
-    for file in data/normalized_yaml/*/*.yaml; do
+    # `**/*.yaml` (recursive, matching Engine B) instead of one-level `*/*.yaml`.
+    for file in data/normalized_yaml/**/*.yaml; do
         [ -e "$file" ] || continue
         uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}} || rc=1
     done

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Validate that every ontology ID carries its correct ontology LABEL.
+
+Shared, schema/config-driven id↔label correspondence checker. Vendored
+**byte-identical** across the Mech repos (CultureMech / MIM / CommunityMech)
+— the same convention as ``scripts/_edison_capture.py``. Verify with
+``md5``; a fix here must be synced to all copies.
+
+Why this exists
+---------------
+``linkml-term-validator validate-data --labels`` only checks that the
+label of an ontology ID matches the ontology — and only for LinkML data
+instances (YAML) whose schema declares a ``binding``. It does NOT cover
+**data products**: SSSOM TSVs, mapping CSVs, KGX node tables, and review
+TSVs all carry (id, label) columns that no LinkML tool reads. This script
+closes that gap and also produces a single cross-surface drift report.
+
+What it checks
+--------------
+For every (id, label) pair in the configured targets it resolves the
+canonical label (and synonyms) from the same OAK sqlite adapters the
+repos already use, and classifies the pair:
+
+    OK_CANONICAL        label == canonical OBO label
+    OK_SYNONYM          label is an accepted synonym (policy-dependent)
+    MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
+    ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
+    EMPTY_LABEL         id present, label blank                             (ERROR)
+    SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
+
+Policy (per target, ``conf/id_label_targets.yaml``)
+    ``canonical``            accept only the canonical OBO label (strict;
+                             mirrors the linkml-term-validator schema gate).
+    ``canonical_or_synonym`` accept canonical OR a synonym within
+                             ``synonym_scope`` (exact | exact_related | all).
+
+Modes
+    ``--report PATH``  write a TSV of every non-OK pair and exit 0 (baseline).
+    (default)          enforce: exit 2 if any ERROR-class pair is found.
+
+Usage::
+
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml
+    python scripts/validate_id_label_correspondence.py -c conf/id_label_targets.yaml \\
+        --report reports/label_drift.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _safe_rel(path: Path) -> str:
+    """``path`` relative to the repo when possible; else its absolute string."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+# Verdict classes that should fail an --enforce run.
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+
+_CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
+_WS_RE = re.compile(r"\s+")
+
+# OAK alias predicates by synonym scope (always includes label + exact).
+_SYNONYM_PREDICATES = {
+    "exact": ["oio:hasExactSynonym"],
+    "exact_related": ["oio:hasExactSynonym", "oio:hasRelatedSynonym"],
+    "all": [
+        "oio:hasExactSynonym",
+        "oio:hasRelatedSynonym",
+        "oio:hasBroadSynonym",
+        "oio:hasNarrowSynonym",
+    ],
+}
+
+
+def normalize(text: str) -> str:
+    """Casefold, strip, collapse internal whitespace — for label comparison."""
+    return _WS_RE.sub(" ", str(text).strip()).casefold()
+
+
+def prefix_of(curie: str) -> str | None:
+    m = _CURIE_RE.match(str(curie).strip())
+    return m.group(1) if m else None
+
+
+class AdapterPool:
+    """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
+
+    The allowlist (``adapters`` map in the config) is the safety boundary:
+    prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
+    ``DSMZ``, …) are never looked up — they are reported as
+    ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+    """
+
+    def __init__(self, adapters: dict[str, str]):
+        self._selectors = adapters
+        self._cache: dict[str, Any] = {}
+
+    def get(self, prefix: str | None):
+        if not prefix or prefix not in self._selectors:
+            return None
+        if prefix not in self._cache:
+            try:
+                from oaklib import get_adapter
+
+                self._cache[prefix] = get_adapter(self._selectors[prefix])
+            except Exception as exc:  # pragma: no cover - environment dependent
+                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
+                self._cache[prefix] = None
+        return self._cache[prefix]
+
+
+def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+    """Return (canonical_label, accepted_normalized_set, id_found).
+
+    ``accepted_normalized_set`` always contains the canonical label; with a
+    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    ``id_found`` is False when the id is absent from the ontology.
+    """
+    try:
+        canonical = adapter.label(curie)
+    except Exception:
+        canonical = None
+    if canonical is None:
+        return None, set(), False
+    accepted = {normalize(canonical)}
+    alias_map: dict[str, list[str]] = {}
+    try:
+        alias_map = adapter.entity_alias_map(curie) or {}
+    except Exception:
+        alias_map = {}
+    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+        for alias in alias_map.get(pred, []) or []:
+            accepted.add(normalize(alias))
+    return canonical, accepted, True
+
+
+def classify(
+    *,
+    curie: str,
+    label: str,
+    adapter: Any,
+    policy: str,
+    scope: str,
+) -> dict[str, Any]:
+    """Classify one (id, label) pair into a verdict dict."""
+    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    base = {"id": curie, "label": label, "canonical": canonical or ""}
+    if not found:
+        return {**base, "verdict": "ID_NOT_FOUND"}
+    if label is None or str(label).strip() == "":
+        return {**base, "verdict": "EMPTY_LABEL"}
+    norm_label = normalize(label)
+    if canonical and norm_label == normalize(canonical):
+        return {**base, "verdict": "OK_CANONICAL"}
+    if policy == "canonical_or_synonym" and norm_label in accepted:
+        return {**base, "verdict": "OK_SYNONYM"}
+    return {**base, "verdict": "MISMATCH"}
+
+
+# -- target readers -------------------------------------------------------
+
+def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+    delim = "," if fmt == "csv" else "\t"
+    with path.open(newline="", encoding="utf-8") as fh:
+        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
+    if not lines:
+        return [], []
+    reader = csv.DictReader(lines, delimiter=delim)
+    return list(reader.fieldnames or []), list(reader)
+
+
+def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) for each configured id/label column pair."""
+    fields, rows = _read_tabular_rows(path, fmt)
+    field_set = set(fields)
+    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
+    for n, row in enumerate(rows, start=2):  # row 1 is the header
+        for id_col, label_col in usable:
+            curie = (row.get(id_col) or "").strip()
+            if not curie:
+                continue
+            label = (row.get(label_col) or "").strip()
+            yield f"row {n} [{id_col}/{label_col}]", curie, label
+
+
+def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+    if isinstance(node, dict):
+        for id_key, label_key in pairs:
+            if id_key in node and label_key in node:
+                curie = node.get(id_key)
+                if isinstance(curie, str) and curie.strip():
+                    label = node.get(label_key)
+                    label = label if isinstance(label, str) else ""
+                    yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
+        for k, v in node.items():
+            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+
+
+def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+    """Yield (locator, id, label) from a YAML doc by recursively finding dicts
+    that carry BOTH an id key and its sibling label key."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception as exc:  # pragma: no cover
+        print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
+        return
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+
+
+# -- driver ---------------------------------------------------------------
+
+def load_config(config_path: Path) -> dict[str, Any]:
+    cfg = yaml.safe_load(config_path.read_text())
+    if not isinstance(cfg, dict):
+        raise SystemExit(f"Config is not a mapping: {config_path}")
+    cfg.setdefault("adapters", {})
+    cfg.setdefault("synonym_scope", "exact_related")
+    cfg.setdefault("targets", [])
+    return cfg
+
+
+def run(config_path: Path, report_path: Path | None) -> int:
+    cfg = load_config(config_path)
+    pool = AdapterPool(cfg["adapters"])
+    default_scope = cfg["synonym_scope"]
+
+    findings: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    for target in cfg["targets"]:
+        name = target.get("name", target.get("glob", "?"))
+        kind = target.get("kind", "tabular")
+        policy = target.get("policy", "canonical_or_synonym")
+        scope = target.get("synonym_scope", default_scope)
+        pairs = target.get("pairs", [])
+        globs = target.get("glob")
+        glob_list = globs if isinstance(globs, list) else [globs]
+        paths: list[Path] = []
+        for g in glob_list:
+            paths.extend(sorted(REPO_ROOT.glob(g)))
+        if not paths:
+            print(f"  - {name}: no files match {glob_list}")
+            continue
+        for path in paths:
+            rel = _safe_rel(path)
+            if kind == "yaml":
+                pairs_iter = iter_yaml(path, pairs)
+            else:
+                pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
+            for locator, curie, label in pairs_iter:
+                prefix = prefix_of(curie)
+                adapter = pool.get(prefix)
+                if adapter is None:
+                    verdict = "SKIPPED_NO_ADAPTER"
+                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                else:
+                    rec = classify(
+                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                    )
+                counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
+                if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
+                    findings.append({
+                        "surface": name,
+                        "file": str(rel),
+                        "locator": locator,
+                        "policy": policy,
+                        **rec,
+                    })
+
+    # Summary
+    print("\nid↔label correspondence summary:")
+    for verdict in (
+        "OK_CANONICAL",
+        "OK_SYNONYM",
+        "MISMATCH",
+        "ID_NOT_FOUND",
+        "EMPTY_LABEL",
+        "SKIPPED_NO_ADAPTER",
+    ):
+        if verdict in counts:
+            print(f"  {verdict:>20}: {counts[verdict]}")
+
+    if report_path is not None:
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with report_path.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.writer(fh, delimiter="\t")
+            w.writerow(
+                ["surface", "file", "locator", "id", "current_label",
+                 "canonical_label", "verdict", "policy"]
+            )
+            for f in findings:
+                w.writerow([
+                    f["surface"], f["file"], f["locator"], f["id"],
+                    f["label"], f["canonical"], f["verdict"], f["policy"],
+                ])
+        print(f"\nWrote {len(findings)} flagged pairs to {_safe_rel(report_path)}")
+        return 0
+
+    errors = [f for f in findings if f["verdict"] in _ERROR_VERDICTS]
+    if errors:
+        print(f"\n❌ {len(errors)} id↔label correspondence error(s):")
+        for f in errors[:50]:
+            print(f"  {f['verdict']}: {f['file']} {f['locator']} "
+                  f"{f['id']} label='{f['label']}' canonical='{f['canonical']}'")
+        if len(errors) > 50:
+            print(f"  ... {len(errors) - 50} more")
+        return 2
+    print("\n✅ All id↔label pairs correspond.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-c", "--config", type=Path, default=REPO_ROOT / "conf" / "id_label_targets.yaml")
+    ap.add_argument("--report", type=Path, default=None,
+                    help="Write a drift TSV here and exit 0 (baseline mode).")
+    args = ap.parse_args(argv)
+    if not args.config.is_file():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        return 2
+    return run(args.config, args.report)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -26,6 +26,7 @@ repos already use, and classifies the pair:
     MISMATCH            label is neither canonical nor an accepted synonym  (ERROR)
     ID_NOT_FOUND        id has an adapter but is absent from the ontology   (ERROR)
     EMPTY_LABEL         id present, label blank                             (ERROR)
+    ADAPTER_ERROR       a CONFIGURED adapter failed to load                 (ERROR)
     SKIPPED_NO_ADAPTER  prefix has no configured OAK adapter (cas:, MIM:, …)
 
 Policy (per target, ``conf/id_label_targets.yaml``)
@@ -67,7 +68,10 @@ def _safe_rel(path: Path) -> str:
 
 
 # Verdict classes that should fail an --enforce run.
-_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL"}
+# ADAPTER_ERROR is fatal: a configured adapter that fails to LOAD must never be
+# silently downgraded to SKIPPED_NO_ADAPTER (which would let an enforce run pass
+# while checking nothing).
+_ERROR_VERDICTS = {"MISMATCH", "ID_NOT_FOUND", "EMPTY_LABEL", "ADAPTER_ERROR"}
 
 _CURIE_RE = re.compile(r"^([A-Za-z][A-Za-z0-9.]*):(.+)$")
 _WS_RE = re.compile(r"\s+")
@@ -95,6 +99,12 @@ def prefix_of(curie: str) -> str | None:
     return m.group(1) if m else None
 
 
+# Sentinel returned by ``AdapterPool.get`` when a CONFIGURED adapter fails to
+# load. Distinct from ``None`` (prefix not configured → legitimate skip) so the
+# caller can raise a fatal ADAPTER_ERROR instead of a benign SKIPPED_NO_ADAPTER.
+LOAD_FAILED = object()
+
+
 class AdapterPool:
     """Lazily loads OAK adapters, but ONLY for prefixes in the allowlist.
 
@@ -102,37 +112,63 @@ class AdapterPool:
     prefixes without an entry (``cas:``, ``MIM:``, ``kgmicrobe.compound:``,
     ``DSMZ``, …) are never looked up — they are reported as
     ``SKIPPED_NO_ADAPTER`` instead of triggering a futile ontology download.
+
+    Prefix matching is case-insensitive: data carries lowercase ``mesh:`` while
+    the allowlist (and OAK's OBO CURIEs) use uppercase ``MESH:``. ``get`` keys
+    on the canonical allowlist case, and callers can rewrite the CURIE prefix
+    via ``canonical_prefix`` so the lookup actually resolves.
+
+    ``get`` returns one of three things:
+
+    * ``None``          — prefix is not in the allowlist (legitimate skip).
+    * ``LOAD_FAILED``   — prefix IS configured but its adapter raised on load.
+    * an OAK adapter    — ready to query.
+
+    The ``LOAD_FAILED`` case is deliberately NOT collapsed into ``None`` so a
+    broken-but-configured adapter surfaces as a fatal verdict rather than
+    silently passing an enforce run.
     """
 
     def __init__(self, adapters: dict[str, str]):
         self._selectors = adapters
+        # Case-insensitive prefix lookup: data carries lowercase `mesh:` while
+        # the allowlist (and OAK's OBO CURIEs) use uppercase `MESH:`. Map any
+        # casing of a data prefix back to its canonical allowlist key.
+        self._canonical: dict[str, str] = {key.casefold(): key for key in adapters}
         self._cache: dict[str, Any] = {}
 
-    def get(self, prefix: str | None):
-        if not prefix or prefix not in self._selectors:
+    def canonical_prefix(self, prefix: str | None) -> str | None:
+        """Return the allowlist key matching ``prefix`` case-insensitively."""
+        if not prefix:
             return None
-        if prefix not in self._cache:
+        return self._canonical.get(prefix.casefold())
+
+    def get(self, prefix: str | None):
+        key = self.canonical_prefix(prefix)
+        if key is None:
+            return None
+        if key not in self._cache:
             try:
                 from oaklib import get_adapter
 
-                self._cache[prefix] = get_adapter(self._selectors[prefix])
+                self._cache[key] = get_adapter(self._selectors[key])
             except Exception as exc:  # pragma: no cover - environment dependent
-                print(f"  ! failed to load adapter for {prefix}: {exc}", file=sys.stderr)
-                self._cache[prefix] = None
-        return self._cache[prefix]
+                print(f"  ! failed to load adapter for {key}: {exc}", file=sys.stderr)
+                self._cache[key] = LOAD_FAILED
+        return self._cache[key]
 
 
 def accepted_labels(
-    adapter: Any, curie: str, scope: str, *, with_synonyms: bool = True
+    adapter: Any, curie: str, scope: str, *, include_synonyms: bool = True
 ) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
-    ``accepted_normalized_set`` always contains the canonical label; with a
-    non-``canonical`` policy the caller widens it via ``scope`` synonyms.
-    When ``with_synonyms`` is False (e.g. a strict ``canonical`` policy) the
-    synonym lookup is skipped entirely — those aliases would never be
-    accepted, so building them is wasted work.
-    ``id_found`` is False when the id is absent from the ontology.
+    ``accepted_normalized_set`` always contains the canonical label; when
+    ``include_synonyms`` is set it is widened via ``scope`` synonyms. Callers
+    using a strict ``canonical`` policy never consult synonyms, so they pass
+    ``include_synonyms=False`` to skip the (potentially expensive)
+    ``entity_alias_map`` lookup entirely. ``id_found`` is False when the id is
+    absent from the ontology.
     """
     try:
         canonical = adapter.label(curie)
@@ -141,7 +177,7 @@ def accepted_labels(
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    if with_synonyms:
+    if include_synonyms:
         alias_map: dict[str, list[str]] = {}
         try:
             alias_map = adapter.entity_alias_map(curie) or {}
@@ -160,10 +196,18 @@ def classify(
     adapter: Any,
     policy: str,
     scope: str,
+    lookup_curie: str | None = None,
 ) -> dict[str, Any]:
-    """Classify one (id, label) pair into a verdict dict."""
+    """Classify one (id, label) pair into a verdict dict.
+
+    ``curie`` is reported verbatim; ``lookup_curie`` (when given) is the
+    case-normalized CURIE actually passed to the adapter so that, e.g., a
+    lowercase ``mesh:`` row resolves against OAK's uppercase ``MESH:`` ids.
+    Synonyms are only built when the policy actually consults them.
+    """
+    include_synonyms = policy != "canonical"
     canonical, accepted, found = accepted_labels(
-        adapter, curie, scope, with_synonyms=(policy != "canonical")
+        adapter, lookup_curie or curie, scope, include_synonyms=include_synonyms
     )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
@@ -183,40 +227,67 @@ def classify(
 def _read_tabular_rows(
     path: Path, fmt: str
 ) -> tuple[list[str], list[dict[str, str]], list[int]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines.
+    """Read a TSV/CSV, skipping ONLY the leading SSSOM ``#`` comment prelude.
 
-    Also returns the true physical (1-based) file line number for each data
-    row, so locators stay accurate even when a ``#`` prelude was stripped.
-    Assumes one physical line per row (true for these SSSOM/TSV/CSV artifacts
-    — no multi-line quoted fields).
+    Returns ``(fieldnames, rows, data_line_numbers)`` where each entry of
+    ``data_line_numbers`` is the TRUE 1-based physical file line where the
+    corresponding data row begins, so locators stay accurate even after the
+    prelude is removed. ``#`` lines that appear *after* the header are NOT
+    stripped (only the contiguous top-of-file prelude is), matching the SSSOM
+    convention where the metadata block precedes the table.
+
+    The physical line numbers come from the original file, so a quoted
+    multiline field could desync ``len(data_line_numbers)`` from ``len(rows)``;
+    the caller falls back to a post-header ordinal in that case.
     """
     delim = "," if fmt == "csv" else "\t"
     with path.open(newline="", encoding="utf-8") as fh:
-        kept = [(n, ln) for n, ln in enumerate(fh, start=1)
-                if not ln.lstrip().startswith("#")]
-    if not kept:
+        raw = list(enumerate(fh, start=1))  # (physical_line_number, text)
+    # Strip only the contiguous prelude of ``#`` lines at the top of the file.
+    start = 0
+    while start < len(raw) and raw[start][1].lstrip().startswith("#"):
+        start += 1
+    body = raw[start:]
+    if not body:
         return [], [], []
-    line_nums = [n for n, _ in kept]
-    lines = [ln for _, ln in kept]
+    lines = [text for _, text in body]
+    # body[0] is the header; data rows begin at the next physical line.
+    data_line_numbers = [phys for phys, _ in body[1:]]
     reader = csv.DictReader(lines, delimiter=delim)
-    rows = list(reader)
-    # kept[0] is the header; data rows start at the next physical line.
-    row_lines = line_nums[1:1 + len(rows)]
-    return list(reader.fieldnames or []), rows, row_lines
+    return list(reader.fieldnames or []), list(reader), data_line_numbers
 
 
 def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) for each configured id/label column pair."""
-    fields, rows, row_lines = _read_tabular_rows(path, fmt)
+    fields, rows, line_numbers = _read_tabular_rows(path, fmt)
     field_set = set(fields)
-    usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    for row, phys_line in zip(rows, row_lines):  # phys_line = true file line
+    # Keep any pair whose id column exists; a missing label column is allowed
+    # so an id present without its label still gets an EMPTY_LABEL verdict
+    # rather than being silently dropped.
+    usable = [(i, l) for (i, l) in pairs if i in field_set]
+    # RISK: a configured pair whose ID column is absent must NOT vanish silently.
+    # Warn loudly when the file has rows but a configured pair can't be applied
+    # at all. (A missing LABEL column alone is fine — it yields EMPTY_LABEL.)
+    if rows:
+        for (i, l) in pairs:
+            if i not in field_set or l not in field_set:
+                missing = [c for c in (i, l) if c not in field_set]
+                print(
+                    f"  ! {_safe_rel(path)}: configured id/label pair "
+                    f"[{i}/{l}] — missing column(s) {missing}; "
+                    f"present columns: {sorted(field_set)}",
+                    file=sys.stderr,
+                )
+    for idx, row in enumerate(rows):
+        # True physical line number when available (a quoted multiline field
+        # could desync the count); else fall back to the post-header ordinal.
+        line_no = line_numbers[idx] if idx < len(line_numbers) else idx + 2
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"line {phys_line} [{id_col}/{label_col}]", curie, label
+            yield f"line {line_no} [{id_col}/{label_col}]", curie, label
 
 
 def _walk_yaml(
@@ -227,7 +298,9 @@ def _walk_yaml(
 ) -> Iterator[tuple[str, str, str]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
-            if id_key in node and label_key in node:
+            # An id present without its sibling label must still be checked
+            # (yields EMPTY_LABEL), so we do NOT require label_key to exist.
+            if id_key in node:
                 curie = node.get(id_key)
                 if isinstance(curie, str) and curie.strip():
                     label = node.get(label_key)
@@ -249,7 +322,7 @@ def iter_yaml(
     path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
 ) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) from a YAML doc by recursively finding dicts
-    that carry BOTH an id key and its sibling label key."""
+    that carry an id key (and, when present, its sibling label key)."""
     try:
         doc = yaml.safe_load(path.read_text())
     except Exception as exc:  # pragma: no cover
@@ -302,11 +375,22 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 prefix = prefix_of(curie)
                 adapter = pool.get(prefix)
                 if adapter is None:
-                    verdict = "SKIPPED_NO_ADAPTER"
-                    rec = {"id": curie, "label": label, "canonical": "", "verdict": verdict}
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "SKIPPED_NO_ADAPTER"}
+                elif adapter is LOAD_FAILED:
+                    rec = {"id": curie, "label": label, "canonical": "",
+                           "verdict": "ADAPTER_ERROR"}
                 else:
+                    # Rewrite the CURIE prefix to the canonical allowlist case
+                    # (e.g. mesh: -> MESH:) so OAK, which keys on uppercase OBO
+                    # prefixes, resolves the label instead of returning None.
+                    canonical_prefix = pool.canonical_prefix(prefix)
+                    lookup_curie = curie
+                    if canonical_prefix and prefix != canonical_prefix:
+                        lookup_curie = f"{canonical_prefix}:{curie.split(':', 1)[1]}"
                     rec = classify(
-                        curie=curie, label=label, adapter=adapter, policy=policy, scope=scope
+                        curie=curie, label=label, adapter=adapter, policy=policy,
+                        scope=scope, lookup_curie=lookup_curie,
                     )
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
                 if rec["verdict"] not in ("OK_CANONICAL", "OK_SYNONYM", "SKIPPED_NO_ADAPTER"):
@@ -326,6 +410,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "MISMATCH",
         "ID_NOT_FOUND",
         "EMPTY_LABEL",
+        "ADAPTER_ERROR",
         "SKIPPED_NO_ADAPTER",
     ):
         if verdict in counts:

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -122,11 +122,16 @@ class AdapterPool:
         return self._cache[prefix]
 
 
-def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, set[str], bool]:
+def accepted_labels(
+    adapter: Any, curie: str, scope: str, *, with_synonyms: bool = True
+) -> tuple[str | None, set[str], bool]:
     """Return (canonical_label, accepted_normalized_set, id_found).
 
     ``accepted_normalized_set`` always contains the canonical label; with a
     non-``canonical`` policy the caller widens it via ``scope`` synonyms.
+    When ``with_synonyms`` is False (e.g. a strict ``canonical`` policy) the
+    synonym lookup is skipped entirely — those aliases would never be
+    accepted, so building them is wasted work.
     ``id_found`` is False when the id is absent from the ontology.
     """
     try:
@@ -136,14 +141,15 @@ def accepted_labels(adapter: Any, curie: str, scope: str) -> tuple[str | None, s
     if canonical is None:
         return None, set(), False
     accepted = {normalize(canonical)}
-    alias_map: dict[str, list[str]] = {}
-    try:
-        alias_map = adapter.entity_alias_map(curie) or {}
-    except Exception:
-        alias_map = {}
-    for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
-        for alias in alias_map.get(pred, []) or []:
-            accepted.add(normalize(alias))
+    if with_synonyms:
+        alias_map: dict[str, list[str]] = {}
+        try:
+            alias_map = adapter.entity_alias_map(curie) or {}
+        except Exception:
+            alias_map = {}
+        for pred in _SYNONYM_PREDICATES.get(scope, _SYNONYM_PREDICATES["exact"]):
+            for alias in alias_map.get(pred, []) or []:
+                accepted.add(normalize(alias))
     return canonical, accepted, True
 
 
@@ -156,7 +162,9 @@ def classify(
     scope: str,
 ) -> dict[str, Any]:
     """Classify one (id, label) pair into a verdict dict."""
-    canonical, accepted, found = accepted_labels(adapter, curie, scope)
+    canonical, accepted, found = accepted_labels(
+        adapter, curie, scope, with_synonyms=(policy != "canonical")
+    )
     base = {"id": curie, "label": label, "canonical": canonical or ""}
     if not found:
         return {**base, "verdict": "ID_NOT_FOUND"}
@@ -172,32 +180,51 @@ def classify(
 
 # -- target readers -------------------------------------------------------
 
-def _read_tabular_rows(path: Path, fmt: str) -> tuple[list[str], list[dict[str, str]]]:
-    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines."""
+def _read_tabular_rows(
+    path: Path, fmt: str
+) -> tuple[list[str], list[dict[str, str]], list[int]]:
+    """Read a TSV/CSV, skipping SSSOM ``#`` comment-prelude lines.
+
+    Also returns the true physical (1-based) file line number for each data
+    row, so locators stay accurate even when a ``#`` prelude was stripped.
+    Assumes one physical line per row (true for these SSSOM/TSV/CSV artifacts
+    — no multi-line quoted fields).
+    """
     delim = "," if fmt == "csv" else "\t"
     with path.open(newline="", encoding="utf-8") as fh:
-        lines = [ln for ln in fh if not ln.lstrip().startswith("#")]
-    if not lines:
-        return [], []
+        kept = [(n, ln) for n, ln in enumerate(fh, start=1)
+                if not ln.lstrip().startswith("#")]
+    if not kept:
+        return [], [], []
+    line_nums = [n for n, _ in kept]
+    lines = [ln for _, ln in kept]
     reader = csv.DictReader(lines, delimiter=delim)
-    return list(reader.fieldnames or []), list(reader)
+    rows = list(reader)
+    # kept[0] is the header; data rows start at the next physical line.
+    row_lines = line_nums[1:1 + len(rows)]
+    return list(reader.fieldnames or []), rows, row_lines
 
 
 def iter_tabular(path: Path, fmt: str, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) for each configured id/label column pair."""
-    fields, rows = _read_tabular_rows(path, fmt)
+    fields, rows, row_lines = _read_tabular_rows(path, fmt)
     field_set = set(fields)
     usable = [(i, l) for (i, l) in pairs if i in field_set and l in field_set]
-    for n, row in enumerate(rows, start=2):  # row 1 is the header
+    for row, phys_line in zip(rows, row_lines):  # phys_line = true file line
         for id_col, label_col in usable:
             curie = (row.get(id_col) or "").strip()
             if not curie:
                 continue
             label = (row.get(label_col) or "").strip()
-            yield f"row {n} [{id_col}/{label_col}]", curie, label
+            yield f"line {phys_line} [{id_col}/{label_col}]", curie, label
 
 
-def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[tuple[str, str, str]]:
+def _walk_yaml(
+    node: Any,
+    pairs: list[tuple[str, str]],
+    path: str,
+    exclude_keys: frozenset[str] = frozenset(),
+) -> Iterator[tuple[str, str, str]]:
     if isinstance(node, dict):
         for id_key, label_key in pairs:
             if id_key in node and label_key in node:
@@ -207,13 +234,20 @@ def _walk_yaml(node: Any, pairs: list[tuple[str, str]], path: str) -> Iterator[t
                     label = label if isinstance(label, str) else ""
                     yield f"{path}.{id_key}", curie.strip(), (label or "").strip()
         for k, v in node.items():
-            yield from _walk_yaml(v, pairs, f"{path}.{k}")
+            # Skip excluded grounding blocks (e.g. mediaingredientmech_chebi_term,
+            # whose label is intentionally MIM's preferred_term, not the OBO
+            # canonical label, so a `canonical` policy would false-MISMATCH it).
+            if k in exclude_keys:
+                continue
+            yield from _walk_yaml(v, pairs, f"{path}.{k}", exclude_keys)
     elif isinstance(node, list):
         for idx, item in enumerate(node):
-            yield from _walk_yaml(item, pairs, f"{path}[{idx}]")
+            yield from _walk_yaml(item, pairs, f"{path}[{idx}]", exclude_keys)
 
 
-def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, str]]:
+def iter_yaml(
+    path: Path, pairs: list[list[str]], exclude_keys: frozenset[str] = frozenset()
+) -> Iterator[tuple[str, str, str]]:
     """Yield (locator, id, label) from a YAML doc by recursively finding dicts
     that carry BOTH an id key and its sibling label key."""
     try:
@@ -221,7 +255,7 @@ def iter_yaml(path: Path, pairs: list[list[str]]) -> Iterator[tuple[str, str, st
     except Exception as exc:  # pragma: no cover
         print(f"  ! failed to parse {path}: {exc}", file=sys.stderr)
         return
-    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name)
+    yield from _walk_yaml(doc, [(a, b) for a, b in pairs], path.name, exclude_keys)
 
 
 # -- driver ---------------------------------------------------------------
@@ -249,6 +283,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         policy = target.get("policy", "canonical_or_synonym")
         scope = target.get("synonym_scope", default_scope)
         pairs = target.get("pairs", [])
+        exclude_keys = frozenset(target.get("exclude_keys", []) or [])
         globs = target.get("glob")
         glob_list = globs if isinstance(globs, list) else [globs]
         paths: list[Path] = []
@@ -260,7 +295,7 @@ def run(config_path: Path, report_path: Path | None) -> int:
         for path in paths:
             rel = _safe_rel(path)
             if kind == "yaml":
-                pairs_iter = iter_yaml(path, pairs)
+                pairs_iter = iter_yaml(path, pairs, exclude_keys)
             else:
                 pairs_iter = iter_tabular(path, target.get("format", "tsv"), pairs)
             for locator, curie, label in pairs_iter:

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -11,6 +11,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
   culturemech: https://w3id.org/culturemech/
   biolink: https://w3id.org/biolink/vocab/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   # Chemicals
   CHEBI: http://purl.obolibrary.org/obo/CHEBI_
   # Organisms
@@ -645,7 +646,11 @@ classes:
         required: true
         range: string
       label:
-        description: Ontology term label
+        slot_uri: rdfs:label
+        description: >-
+          CANONICAL ontology label for `id` (e.g. "magnesium sulfate" for
+          CHEBI:32599). Verified against the ontology by the id↔label gate;
+          the sibling `preferred_term` holds the free/source name.
         range: string
       confidence:
         description: Confidence score for the mapping (0.0-1.0). Populated by automated grounding pipelines.
@@ -684,12 +689,20 @@ classes:
       term:
         description: Primary ontology grounding (CHEBI, FOODON, UBERON, ENVO, or upstream mediadive.compound).
         range: ChemicalEntityTerm
+        # id↔label gate: range-less binding → `linkml-term-validator --labels`
+        # verifies term.label is the canonical OBO label for term.id.
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         recommended: true
         inlined: true
 
       chebi_term:
         description: CHEBI-only grounding kept alongside `term` when `term` carries the upstream identifier (e.g. mediadive.compound on solution compositions).
         range: ChebiTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         recommended: false
         inlined: true
 
@@ -873,6 +886,9 @@ classes:
       term:
         description: NCBITaxon identifier
         range: OrganismTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         required: false
         inlined: true
 
@@ -965,6 +981,9 @@ classes:
       term:
         description: ENVO ontology term for the environment
         range: EnvironmentTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         recommended: true
         inlined: true
         comments:
@@ -993,6 +1012,9 @@ classes:
       term:
         description: CHEBI term for the cofactor
         range: ChemicalEntityTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         recommended: true
         inlined: true
 
@@ -1008,6 +1030,9 @@ classes:
       precursor_term:
         description: CHEBI term for precursor
         range: ChemicalEntityTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         inlined: true
 
       ec_associations:
@@ -1749,6 +1774,9 @@ classes:
       substrate_terms:
         description: CHEBI terms for substrates
         range: ChemicalEntityTerm
+        bindings:
+          - binds_value_of: id
+            obligation_level: REQUIRED
         multivalued: true
         inlined_as_list: true
 


### PR DESCRIPTION
## Summary

Makes **id↔label correspondence** a checked invariant: every ontology ID must carry its **correct** ontology label — not just exist. `linkml-term-validator validate-data --labels` silently passed wrong labels because `--labels` only fires for slots with a LinkML `binding`, and the schema had none.

## Two engines

**Engine A — LinkML-native gate (YAML).** `culturemech.yaml` marks `Term.label` `slot_uri: rdfs:label` and gives every descriptor term slot (ingredient `term`/`chebi_term`, organism `term`, environment `term`, cofactor/precursor/substrate terms) a **range-less** `binding` (`binds_value_of: id`). A range-less binding triggers the OAK label check *without* an enum-membership check (which would need per-ontology tree expansion). `validate-terms` (and the 3-layer `validate`) now **fail** on label drift.

**Engine B — shared OAK validator (products).** `scripts/validate_id_label_correspondence.py` (config-driven; **vendored byte-identical** across the Mech repos) checks `output/*.sssom.tsv` (`subject_*`/`object_*`) against the canonical label + exact/related synonyms. `conf/id_label_targets.yaml` lists surfaces + the OAK adapter allowlist.

## Policy (Hybrid)

Schema `term.label` = **canonical** OBO label (source/recipe names live in `preferred_term`); product `*_label` columns accept canonical **or** an exact/related synonym.

## Rollout = report → baseline → enforce

- Recipes: `validate-terms-all`, `validate-products`, `report-label-drift`.
- CI workflow `label-correspondence.yaml` is **report-only / non-blocking** (uploads `reports/label_drift.tsv`). Blocking gates are intentionally **not** wired into CI yet.

## Testing

- Schema passes plain `linkml-validate` (structural, "No issues found").
- `validate-terms` on a corrupted `CHEBI:15377` label **fails (exit 1)** with "Label mismatch" — and surfaced real drift (data had "Distilled water" where canonical is "water"; `KH2PO4` vs "potassium dihydrogen phosphate"; empty labels).
- Engine B vendored byte-identical (md5 matches MIM/CommunityMech).

Docs: `docs/ID_LABEL_CORRESPONDENCE.md` + `.claude/skills/id-label-correspondence/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)