### PR TITLE
Add OrganismDescriptor.scoped_to_variant slot (closes #36 Sc_B gap)

### DIFF
--- a/data/normalized_yaml/bacterial/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
+++ b/data/normalized_yaml/bacterial/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
@@ -294,6 +294,7 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Acidianus brierleyi
+  scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: DSM 3772 (also DSM 1651)
   evidence:
   - reference: doi:10.1128/mbio.01033-24
@@ -302,6 +303,7 @@ target_organisms:
       the anaerobic parent (no Na2S/N2 reported); aerobic vented-bottle cultivation.
       | Identifiers: DSM 3772; DSM 1651'
 - preferred_term: Metallosphaera hakonensis
+  scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: HO1-1, DSM 7519
   genome_assembly_id:
   - GCA_003201675.2
@@ -311,6 +313,7 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. Differs from anaerobic
       parent: NH4Cl vs (NH4)2SO4, no Na2S, no N2 phase. | Identifiers: DSM 7519'
 - preferred_term: Metallosphaera prunae
+  scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: RON 12/II, DSM 10039
   evidence:
   - reference: doi:10.1128/mbio.01033-24
@@ -318,6 +321,7 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NOT the anaerobic
       parent formulation. | Identifiers: DSM 10039'
 - preferred_term: Sulfurisphaera ohwakuensis
+  scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: TA-1, DSM 12421
   evidence:
   - reference: doi:10.1128/mbio.01033-24
@@ -325,6 +329,7 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. Vented bottles;
       not anaerobic parent. | Identifiers: DSM 12421'
 - preferred_term: Sulfurisphaera tokodaii
+  scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: str. 7, DSM 16993
   evidence:
   - reference: doi:10.1128/mbio.01033-24
@@ -332,6 +337,7 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NH4Cl, no Na2S,
       vented bottles; not the anaerobic parent. | Identifiers: DSM 16993'
 - preferred_term: Sulfodiicoccus acidiphilus
+  scoped_to_variant: reduced_anaerobic_mbsy_h2_co2
   strain: HS-1T (= JCM 31740T = InaCC Ar79T)
   genome_assembly_id:
   - GCA_003967175.1

--- a/src/culturemech/schema/culturemech.schema.json
+++ b/src/culturemech/schema/culturemech.schema.json
@@ -57,7 +57,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -91,7 +91,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -333,7 +333,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -461,7 +461,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -548,7 +548,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -1070,7 +1070,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -1104,7 +1104,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -1138,7 +1138,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -2008,6 +2008,13 @@
                     "description": "Organism name (e.g., \"Escherichia coli\")",
                     "type": "string"
                 },
+                "scoped_to_variant": {
+                    "description": "Name of the `variants[]` entry this organism's growth evidence is scoped to, when growth is verified only on a specific variant of the medium and NOT on the parent recipe. Must match a `variants[].name` on the same record. Downstream KG builds should attach the organism<->medium edge to the named variant rather than the parent, so variant-only evidence is not propagated as a parent-medium claim.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "strain": {
                     "description": "Specific strain designation (e.g., \"K-12\", \"MG1655\")",
                     "type": [
@@ -2077,7 +2084,7 @@
                     "type": "string"
                 },
                 "label": {
-                    "description": "Ontology term label",
+                    "description": "CANONICAL ontology label for `id` (e.g. \"magnesium sulfate\" for CHEBI:32599). Verified against the ontology by the id\u2194label gate; the sibling `preferred_term` holds the free/source name.",
                     "type": [
                         "string",
                         "null"
@@ -3049,7 +3056,8 @@
                 "synonym_match_ambiguous",
                 "manual_curated",
                 "automated_expert_mapping",
-                "fuzzy"
+                "fuzzy",
+                "corpus_consensus"
             ],
             "title": "TermMatchTypeEnum",
             "type": "string"

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -914,6 +914,16 @@ classes:
         required: false
         inlined: true
 
+      scoped_to_variant:
+        description: >-
+          Name of the `variants[]` entry this organism's growth evidence is
+          scoped to, when growth is verified only on a specific variant of the
+          medium and NOT on the parent recipe. Must match a `variants[].name`
+          on the same record. Downstream KG builds should attach the
+          organism<->medium edge to the named variant rather than the parent,
+          so variant-only evidence is not propagated as a parent-medium claim.
+        range: string
+
       gtdb_term:
         description: GTDB genome or lineage identifier (alternative to NCBITaxon)
         range: GTDBTerm

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-06-09T23:36:11
+# Generation date: 2026-06-13T12:24:51
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -96,6 +96,7 @@ KOMODO_MEDIUM = CurieNamespace('komodo_medium', 'http://example.org/UNKNOWN/komo
 LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
 MEDIADIVE_COMPOUND = CurieNamespace('mediadive_compound', 'https://mediadive.dsmz.de/compound/')
 MEDIADIVE_MEDIUM = CurieNamespace('mediadive_medium', 'http://example.org/UNKNOWN/mediadive.medium/')
+RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
 SIGMA = CurieNamespace('sigma', 'https://www.sigmaaldrich.com/catalog/product/')
 SRA = CurieNamespace('sra', 'https://www.ncbi.nlm.nih.gov/sra/')
 THERMOFISHER = CurieNamespace('thermofisher', 'https://www.thermofisher.com/order/catalog/product/')
@@ -860,6 +861,7 @@ class OrganismDescriptor(Descriptor):
 
     preferred_term: Union[str, OrganismDescriptorPreferredTerm] = None
     term: Optional[Union[dict, "OrganismTerm"]] = None
+    scoped_to_variant: Optional[str] = None
     gtdb_term: Optional[Union[dict, "GTDBTerm"]] = None
     genome_assembly_id: Optional[Union[str, list[str]]] = empty_list()
     strain: Optional[str] = None
@@ -881,6 +883,9 @@ class OrganismDescriptor(Descriptor):
 
         if self.term is not None and not isinstance(self.term, OrganismTerm):
             self.term = OrganismTerm(**as_dict(self.term))
+
+        if self.scoped_to_variant is not None and not isinstance(self.scoped_to_variant, str):
+            self.scoped_to_variant = str(self.scoped_to_variant)
 
         if self.gtdb_term is not None and not isinstance(self.gtdb_term, GTDBTerm):
             self.gtdb_term = GTDBTerm(**as_dict(self.gtdb_term))
@@ -3515,7 +3520,7 @@ slots.mergeMetadata__fingerprint_mode = Slot(uri=CULTUREMECH.fingerprint_mode, n
 slots.term__id = Slot(uri=CULTUREMECH.id, name="term__id", curie=CULTUREMECH.curie('id'),
                    model_uri=CULTUREMECH.term__id, domain=None, range=URIRef)
 
-slots.term__label = Slot(uri=CULTUREMECH.label, name="term__label", curie=CULTUREMECH.curie('label'),
+slots.term__label = Slot(uri=RDFS.label, name="term__label", curie=RDFS.curie('label'),
                    model_uri=CULTUREMECH.term__label, domain=None, range=Optional[str])
 
 slots.term__confidence = Slot(uri=CULTUREMECH.confidence, name="term__confidence", curie=CULTUREMECH.curie('confidence'),
@@ -3634,6 +3639,9 @@ slots.organismDescriptor__preferred_term = Slot(uri=CULTUREMECH.preferred_term, 
 
 slots.organismDescriptor__term = Slot(uri=CULTUREMECH.term, name="organismDescriptor__term", curie=CULTUREMECH.curie('term'),
                    model_uri=CULTUREMECH.organismDescriptor__term, domain=None, range=Optional[Union[dict, OrganismTerm]])
+
+slots.organismDescriptor__scoped_to_variant = Slot(uri=CULTUREMECH.scoped_to_variant, name="organismDescriptor__scoped_to_variant", curie=CULTUREMECH.curie('scoped_to_variant'),
+                   model_uri=CULTUREMECH.organismDescriptor__scoped_to_variant, domain=None, range=Optional[str])
 
 slots.organismDescriptor__gtdb_term = Slot(uri=CULTUREMECH.gtdb_term, name="organismDescriptor__gtdb_term", curie=CULTUREMECH.curie('gtdb_term'),
                    model_uri=CULTUREMECH.organismDescriptor__gtdb_term, domain=None, range=Optional[Union[dict, GTDBTerm]])


### PR DESCRIPTION
## What
Adds an optional `scoped_to_variant` slot to `OrganismDescriptor` that names the `variants[]` entry an organism's growth evidence is scoped to.

## Why
Follow-up to PR #36 review (Sc_B): several organisms are verified only on a specific medium *variant*, not the parent recipe, but the schema had no way to express that — the scoping survived only in free-text `explanation`, so the structured data still asserted an unverified organism↔parent-medium association. A downstream KG build can now attach the edge to the named variant instead.

## Changes
- **schema**: `scoped_to_variant` (range string; must match a sibling `variants[].name`).
- **regenerated** `culturemech_dataclasses.py` + `culturemech.schema.json` (also folds in the `term__label` → `rdfs:label` uri from #41, which wasn't regenerated at the time).
- **data**: `sulfolobus_medium_anaerobic_for_dsm_2162` — 5 aerobic organisms scoped to `aerobic_brocks_salts_dsm88_sulfur_yeast_extract`, *Sulfodiicoccus acidiphilus* to `reduced_anaerobic_mbsy_h2_co2`.

`linkml-validate`: No issues found. Each `scoped_to_variant` value matches a defined variant name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)