### PR TITLE
Triage id-label drift + make label waiver context-based (fixes #41 over-correction)

### DIFF
--- a/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
@@ -178,7 +178,7 @@ target_organisms:
 - preferred_term: Richelia intracellularis
   term:
     id: NCBITaxon:98443
-    label: Richelia intracellularis
+    label: Richelia
   evidence:
   - reference: PMID:33083143
     supports: SUPPORT

--- a/data/normalized_yaml/algae/Bristol_Medium.yaml
+++ b/data/normalized_yaml/algae/Bristol_Medium.yaml
@@ -102,7 +102,7 @@ target_organisms:
 - preferred_term: Chlorella pyrenoidosa
   term:
     id: NCBITaxon:3077
-    label: Chlorella pyrenoidosa
+    label: Chlorella vulgaris
   growth_metrics:
   - measurement_conditions: Commercial Bristol medium comparator in settled and
       activated sewage growth study.

--- a/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
+++ b/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
@@ -235,9 +235,11 @@ source_environment:
 - preferred_term: laboratory bioreactor
   term:
     id: ENVO:01001405
+    label: laboratory environment
 - preferred_term: freshwater environment
   term:
     id: ENVO:01000306
+    label: freshwater environment
   notes: 'Natural algae-bacteria association from freshwater habitat, maintained in
     laboratory culture to study nitrogen stress responses and mutualistic interactions.
     The consortium demonstrates stable co-occurrence and metabolic cooperation under

--- a/data/normalized_yaml/algae/Spirulina_Medium.yaml
+++ b/data/normalized_yaml/algae/Spirulina_Medium.yaml
@@ -100,7 +100,7 @@ target_organisms:
 - preferred_term: Arthrospira platensis
   term:
     id: NCBITaxon:118562
-    label: Arthrospira platensis
+    label: Limnospira platensis
   growth_metrics:
   - measurement_conditions: Conventional Spirulina medium control compared with
       effluent-based medium during Arthrospira platensis cultivation.

--- a/data/normalized_yaml/algae/f_2.yaml
+++ b/data/normalized_yaml/algae/f_2.yaml
@@ -257,6 +257,7 @@ source_environment:
 - preferred_term: marine environment
   term:
     id: ENVO:00002149
+    label: sea water
   notes: 'Synthetic community assembled in laboratory culture to model diatom-bacteria
     interactions in marine phytoplankton. Members were isolated from marine environments
     and maintained under controlled conditions to study dynamic relationships between

--- a/data/normalized_yaml/bacterial/9k_medium.yaml
+++ b/data/normalized_yaml/bacterial/9k_medium.yaml
@@ -133,8 +133,6 @@ curation_history:
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
 source_environment:
 - preferred_term: mine tailing
-  term:
-    id: ENVO:00000072
   notes: 'Industrial copper sulfide ore heap leach operation. Crushed low-grade ore
     is piled in heaps and irrigated with acidic solution (pH 1.5-2.5) containing the
     microbial consortium. The heaps provide a heterogeneous environment with spatial
@@ -148,6 +146,7 @@ source_environment:
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
+    label: contaminated water
   notes: 'Extremely acidic (pH <2), metal-rich environments including natural acid
     mine drainage and industrial biomining operations. The consortium thrives on pyrite
     (FeS₂) and chalcopyrite (CuFeS₂) surfaces where ferrous iron concentrations are

--- a/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
+++ b/data/normalized_yaml/bacterial/Nitrogen_Free_Medium_for_Leptospirillum_ferrodiazotrophum.yaml
@@ -109,6 +109,7 @@ source_environment:
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
+    label: contaminated water
   notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
     interface of underground AMD streams and pools within the Richmond Mine. The mine
     contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,

--- a/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
+++ b/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
@@ -109,3 +109,4 @@ source_environment:
 - preferred_term: compost
   term:
     id: ENVO:00002170
+    label: compost

--- a/data/normalized_yaml/bacterial/TOGO_M1547_Marine_Agar_2216.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1547_Marine_Agar_2216.yaml
@@ -82,7 +82,7 @@ target_organisms:
 - preferred_term: Sneathiella glossodoripedis
   term:
     id: NCBITaxon:1236958
-    label: Sneathiella glossodoripedis
+    label: Sneathiella glossodoripedis JCM 23214
   genome_assembly_id:
   - GCA_000616095
   - GCF_000616095.1

--- a/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
+++ b/data/normalized_yaml/bacterial/luria_bertani_lb_medium.yaml
@@ -93,3 +93,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/mannitol_agar.yaml
+++ b/data/normalized_yaml/bacterial/mannitol_agar.yaml
@@ -89,3 +89,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/mineral_medium.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium.yaml
@@ -192,8 +192,6 @@ variant_children:
   notes: Same source medium number and matching ingredient/concentration signature.
 source_environment:
 - preferred_term: sulfate-free anaerobic environment
-  term:
-    id: ENVO:01001405
   notes: 'Grown in continuous culture on lactate without sulfate under strict anaerobic
     conditions. In the absence of sulfate, D. vulgaris cannot use its typical respiratory
     pathway and must rely on syntrophic partnership with a H2-consuming organism.
@@ -204,9 +202,11 @@ source_environment:
 - preferred_term: soil
   term:
     id: ENVO:00001998
+    label: soil
 - preferred_term: acid mine drainage
   term:
     id: ENVO:00002186
+    label: contaminated water
   notes: 'Extremely acidic (pH 0.5-1.0) subaerial biofilm formed at the air-solution
     interface of underground AMD streams and pools within the Richmond Mine. The mine
     contains massive pyrite (FeS₂) deposits that undergo microbially-mediated oxidation,
@@ -216,8 +216,6 @@ source_environment:
 
     '
 - preferred_term: anaerobic environment
-  term:
-    id: ENVO:00002229
   notes: 'Isolated from anaerobic granular sludge. Grown as syntrophic coculture under
     strict anaerobic conditions. S. fumaroxidans oxidizes propionate syntrophically
     in co-culture with the hydrogen- and formate-utilizing M. hungatei. The consortium

--- a/data/normalized_yaml/bacterial/r2a_agar.yaml
+++ b/data/normalized_yaml/bacterial/r2a_agar.yaml
@@ -147,3 +147,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
+++ b/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
@@ -242,7 +242,7 @@ target_organisms:
 - preferred_term: Rhodobacter sphaeroides
   term:
     id: NCBITaxon:1063
-    label: Rhodobacter sphaeroides
+    label: Cereibacter sphaeroides
   growth_metrics:
   - doubling_time_minutes: 1080.0
     evidence:

--- a/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_agar.yaml
@@ -204,3 +204,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
@@ -260,3 +260,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Glycerol_Fermentation_Medium_for_DIET_Coculture.yaml
@@ -169,6 +169,7 @@ source_environment:
 - preferred_term: laboratory culture
   term:
     id: ENVO:01001405
+    label: laboratory environment
   notes: 'Laboratory synthetic coculture developed to optimize glycerol fermentation
     toward 1,3-propanediol production. Cultured under strict anaerobic conditions
     using Hungate techniques at 35°C with N2 gas phase. DIET occurs through physical

--- a/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
+++ b/data/normalized_yaml/specialized/Half_strength_Murashige_Skoog_medium_for_Arabidopsis_growth.yaml
@@ -88,3 +88,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_DSM_120_Medium_for_DIET_Coculture.yaml
@@ -113,6 +113,7 @@ source_environment:
 - preferred_term: sediment
   term:
     id: ENVO:00002007
+    label: sediment
   notes: 'Isolated from anaerobic sediments and biofilms. DIET is an important process
     in anaerobic soils and sediments generating methane. Cocultures form aggregates
     under strict anaerobic conditions, with direct cell-to-cell electron transfer

--- a/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
+++ b/data/normalized_yaml/specialized/Modified_Freshwater_Medium_for_DIET_Coculture.yaml
@@ -93,6 +93,7 @@ source_environment:
 - preferred_term: sediment
   term:
     id: ENVO:00002007
+    label: sediment
   notes: 'Isolated from anaerobic sediments. DIET is an important process in anaerobic
     soils and sediments generating methane. Cocultures form conductive aggregates
     under strict anaerobic conditions, with direct cell-to-cell electron transfer

--- a/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
+++ b/data/normalized_yaml/specialized/Nitrogen_free_plant_nutrient_solution_for_soybean_growth.yaml
@@ -97,3 +97,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
+++ b/data/normalized_yaml/specialized/nitrogen_free_b_d_medium_for_lotus_japonicus_growth.yaml
@@ -97,3 +97,4 @@ source_environment:
 - preferred_term: rhizosphere
   term:
     id: ENVO:00005801
+    label: rhizosphere

--- a/scripts/.validate_id_label_correspondence.sha256
+++ b/scripts/.validate_id_label_correspondence.sha256
@@ -1,1 +1,1 @@
-3fefc09be01299855f1ad76404c44d98249eb3739affff97ff1b8dabbdf28698  scripts/validate_id_label_correspondence.py
+4b66a268f0ba982df4314c0c0e218ab9a9bff4c7b3e2c36b9f8151e2d000f1b8  scripts/validate_id_label_correspondence.py

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -119,6 +119,16 @@ _ERROR_VERDICTS = {
     "UNKNOWN_PREFIX",
 }
 
+# Path segments under which a `term`/`chebi_term` label-waiver does NOT apply:
+# organism (NCBITaxon) and environment (ENVO) groundings must carry the canonical
+# ontology label. Everywhere else a waived key is an INGREDIENT grounding whose
+# label is a curator formula/common-name (CHEBI "NaCl", FOODON "Yeast extract",
+# UBERON "Calf brains") and stays waived regardless of ontology.
+_CANONICAL_LABEL_CONTEXTS = (
+    "target_organisms",
+    "source_environment",
+)
+
 # Verdicts that are accepted (do NOT get recorded as findings and never fail
 # enforce). OK_ID_ONLY is a pass: the id resolved and the slot's label was
 # intentionally waived (curator-intended formula/common name).
@@ -463,14 +473,19 @@ def _walk_yaml(
                     label = node.get(label_key)
                     label = label if isinstance(label, str) else ""
                     cur = curie.strip()
-                    # Scope the label waiver to CHEMISTRY (CHEBI) groundings: the
-                    # waiver exists for curator formula/common-name labels on
-                    # chemical terms (e.g. CHEBI:15377 "Distilled water"). A bare
-                    # `term` key also appears on organism (NCBITaxon) and
-                    # environment (ENVO) blocks, whose labels MUST stay canonical
-                    # (per the skill spec) — so a wrong NCBITaxon/ENVO label must
-                    # not be silently waived just because it sits under `term`.
-                    effective_waived = waived and cur.startswith("CHEBI:")
+                    # Scope the label waiver to INGREDIENT groundings by context.
+                    # The waiver exists for curator formula/common-name labels on
+                    # ingredient terms (CHEBI "NaCl", FOODON "Yeast extract",
+                    # UBERON "Calf brains"). The `term` key is reused on organism
+                    # (target_organisms) and environment (source_environment)
+                    # blocks, whose labels MUST stay canonical (per the skill
+                    # spec) — so a `term`/`chebi_term` waiver does NOT apply when
+                    # the term sits in an organism/environment context, even
+                    # though the key name matches. Keying on context (not the id
+                    # prefix) keeps curator ingredient labels of every ontology
+                    # waived while still canonical-checking taxon/environment.
+                    in_canonical_ctx = any(seg in path for seg in _CANONICAL_LABEL_CONTEXTS)
+                    effective_waived = waived and not in_canonical_ctx
                     yield f"{path}.{id_key}", cur, (label or "").strip(), effective_waived, None
         for k, v in node.items():
             # Skip excluded grounding blocks entirely (no checks at all).


### PR DESCRIPTION
## Background
Follow-up #1 from the merge train. PR #41 surfaced new id↔label drift by un-waiving organism/environment labels — but its **CHEBI-only** waiver scoping over-corrected: it also un-waived **FOODON (1491)** and **UBERON (4)** *ingredient* term labels, which legitimately carry curator common-names.

## Validator fix (the core change)
Replace the CHEBI-prefix waiver scope with a **context** check: a `term`/`chebi_term` label waiver no longer applies under `target_organisms` / `source_environment` (so organism NCBITaxon + environment ENVO labels stay canonical), while ingredient terms of **every** ontology stay waived. Re-pinned the vendored sha256.

This removes the 1491 FOODON + 4 UBERON false positives while keeping the genuine organism/environment drift visible.

## Recipe-YAML drift fixed (canonical labels from OAK)
- **5 NCBITaxon organism labels** canonicalized to current accepted names: *Arthrospira platensis*→*Limnospira platensis*, *Rhodobacter*→*Cereibacter sphaeroides*, *Chlorella pyrenoidosa*→*vulgaris*, *Richelia*, *Sneathiella* strain node.
- **~19 ENVO** `source_environment` empty labels filled with the canonical label.
- **3 wrong-id environment groundings de-grounded** (preferred_term unrelated to the node — 'mine tailing'→aquaduct, 'anaerobic environment'→arenosol, 'sulfate-free anaerobic environment'→laboratory environment): removed rather than papered over with a misleading canonical label.

## Documented backlog (out of scope here)
- 45 empty + 243 mismatch **CHEBI labels in the SSSOM export** (`output/*.sssom.tsv`) — a generated product; fix belongs in the export generator.
- 335 ID_NOT_FOUND, 51 `jcm.grmd` UNKNOWN_PREFIX — deeper curation / no-adapter prefix handling.

`just check-chebi-grounding` still passes (109). The vendored validator change should also be re-synced to MediaIngredientMech (a follow-up to PR #54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)