### PR TITLE
Add NCBITaxon term groundings to 33 organisms (closes #36 follow-up)

### DIFF
--- a/data/normalized_yaml/bacterial/KOMODO_319_SPOROHALOBACTER_LORTETII_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_319_SPOROHALOBACTER_LORTETII_medium.yaml
@@ -391,6 +391,9 @@ curation_history:
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: SPOROHALOBACTER LORTETII
+  term:
+    id: NCBITaxon:974
+    label: Sporohalobacter lortetii
 parent_media:
   path: data/normalized_yaml/bacterial/sporohalobacter_lortetii_medium.yaml
   relationship: SOURCE_DUPLICATE

--- a/data/normalized_yaml/bacterial/bacto_marine_broth_difco_2216_for_dsm_11879.yaml
+++ b/data/normalized_yaml/bacterial/bacto_marine_broth_difco_2216_for_dsm_11879.yaml
@@ -250,6 +250,9 @@ curation_history:
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
 target_organisms:
 - preferred_term: Cellulophaga algicola
+  term:
+    id: NCBITaxon:59600
+    label: Cellulophaga algicola
   strain: IC166T
   evidence:
   - reference: doi:10.4056/sigs.1543845
@@ -260,6 +263,9 @@ target_organisms:
     snippet: C. algicola IC166T, DSM 14237, was grown in DSMZ medium 514 (BACTO marine
       broth) at 15C.
 - preferred_term: Kangiella koreensis
+  term:
+    id: NCBITaxon:261964
+    label: Kangiella koreensis
   strain: SW-125T
   evidence:
   - reference: doi:10.4056/sigs.36635
@@ -281,6 +287,9 @@ target_organisms:
       for 24 h in marine broth 2216 with shaking, visible growth was observed at 20C
       but not at 28C (100 rpm).
 - preferred_term: Roseobacter ponti
+  term:
+    id: NCBITaxon:1891787
+    label: Roseobacter ponti
   strain: DSM 106830T
   evidence:
   - reference: doi:10.1093/gbe/evaa114
@@ -301,6 +310,9 @@ target_organisms:
     snippet: J. marina strain En5T was isolated by dilution-plating on marine agar
       2216 (Difco).
 - preferred_term: Rhodothermus profundi
+  term:
+    id: NCBITaxon:633813
+    label: Rhodothermus profundi
   strain: PRI 2902T
   evidence:
   - reference: doi:10.1099/ijs.0.012724-0

--- a/data/normalized_yaml/bacterial/caldicellulosiruptor_medium_for_dsm_10319.yaml
+++ b/data/normalized_yaml/bacterial/caldicellulosiruptor_medium_for_dsm_10319.yaml
@@ -316,6 +316,9 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Caldicellulosiruptor bescii
+  term:
+    id: NCBITaxon:31899
+    label: Caldicellulosiruptor bescii
   strain: DSM 6725
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -327,6 +330,9 @@ target_organisms:
       ... into modified DSMZ medium 640 ... grown at 70C with orbital shaking; 50
       ml in 125 ml serum bottle, N2 headspace, 24 h.
 - preferred_term: Caldicellulosiruptor saccharolyticus
+  term:
+    id: NCBITaxon:44001
+    label: Caldicellulosiruptor saccharolyticus
   strain: DSM 8903
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -336,6 +342,9 @@ target_organisms:
     snippet: Subcultured into modified DSMZ 640; reported to grow on xylose, glucose,
       Avicel, pretreated switchgrass, and yeast extract control.
 - preferred_term: Caldicellulosiruptor hydrothermalis
+  term:
+    id: NCBITaxon:413888
+    label: Caldicellulosiruptor hydrothermalis
   strain: DSM 18901
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -352,6 +361,9 @@ target_organisms:
     snippet: Subcultured into modified DSMZ 640; explicitly noted to grow on xylose,
       to lower density than C. saccharolyticus.
 - preferred_term: Caldicellulosiruptor kronotskyensis
+  term:
+    id: NCBITaxon:413889
+    label: Caldicellulosiruptor kronotskyensis
   strain: DSM 18902
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -369,6 +381,9 @@ target_organisms:
     snippet: Subcultured into modified DSMZ 640; explicitly reported as showing no
       growth on glucose in this comparison.
 - preferred_term: Caldicellulosiruptor owensensis
+  term:
+    id: NCBITaxon:55205
+    label: Caldicellulosiruptor owensensis
   strain: DSM 13100
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -377,6 +392,9 @@ target_organisms:
     snippet: Subcultured into modified DSMZ 640 and included among seven species grown
       on selected substrates.
 - preferred_term: Caldicellulosiruptor acetigenus
+  term:
+    id: NCBITaxon:301953
+    label: Caldicellulosiruptor acetigenus
   strain: DSM 7040
   evidence:
   - reference: doi:10.1128/AEM.01400-10
@@ -386,6 +404,9 @@ target_organisms:
     snippet: Listed in Table 1 as available from DSMZ and stated in methods as among
       Caldicellulosiruptor species subcultured into modified DSMZ 640.
 - preferred_term: Thermoanaerobacterium calidifontis
+  term:
+    id: NCBITaxon:715028
+    label: Thermoanaerobacterium calidifontis
   strain: Rx1
   evidence:
   - reference: doi:10.1007/s00203-013-0895-5

--- a/data/normalized_yaml/bacterial/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.yaml
+++ b/data/normalized_yaml/bacterial/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.yaml
@@ -277,6 +277,9 @@ target_organisms:
       formate and fumarate. Each species was grown anaerobically without agitation
       at 37C for 24 or 48 hours.
 - preferred_term: Parabacteroides distasonis
+  term:
+    id: NCBITaxon:823
+    label: Parabacteroides distasonis
   strain: ATCC 8503
   evidence:
   - reference: doi:10.1038/s41598-023-47003-0
@@ -286,6 +289,9 @@ target_organisms:
     snippet: Parabacteroides distasonis (ATCC 8503) was cultivated in ATCC 1490 Modified
       Chopped Meat medium at 37C anaerobically.
 - preferred_term: Fusobacterium nucleatum
+  term:
+    id: NCBITaxon:851
+    label: Fusobacterium nucleatum
   strain: ATCC 25586
   evidence:
   - reference: doi:10.1186/1471-2334-11-200
@@ -295,6 +301,9 @@ target_organisms:
     snippet: Fusobacterium nucleatum ATCC 25586 ... grown in ATCC medium 1490 (Modified
       chopped meat medium), anaerobically at 37C for 24 or 48 h.
 - preferred_term: Porphyromonas levii
+  term:
+    id: NCBITaxon:28114
+    label: Porphyromonas levii
   strain: ATCC 29147
   evidence:
   - reference: doi:10.1186/1471-2334-11-200
@@ -304,6 +313,9 @@ target_organisms:
     snippet: Porphyromonas levii ATCC 29147 [was] grown in ATCC medium 1490 (Modified
       chopped meat medium), anaerobically at 37C for 24 or 48 h.
 - preferred_term: Prevotella bivia
+  term:
+    id: NCBITaxon:28125
+    label: Prevotella bivia
   strain: ATCC 29303
   evidence:
   - reference: doi:10.1186/1471-2334-11-200
@@ -313,6 +325,9 @@ target_organisms:
     snippet: Prevotella bivia ATCC 29303 ... [was] grown in ATCC medium 1490 (Modified
       chopped meat medium), anaerobically at 37C for 24 or 48 h.
 - preferred_term: Lactobacillus crispatus
+  term:
+    id: NCBITaxon:47770
+    label: Lactobacillus crispatus
   strain: ATCC 33820
   evidence:
   - reference: doi:10.1186/1471-2334-11-200
@@ -322,6 +337,9 @@ target_organisms:
     snippet: Lactobacillus crispatus ATCC 33820 was grown in ATCC medium 1490 (Modified
       chopped meat medium) anaerobically without agitation at 37C for 24 h.
 - preferred_term: Fusobacterium necrophorum
+  term:
+    id: NCBITaxon:859
+    label: Fusobacterium necrophorum
   strain: ATCC 27852
   evidence:
   - reference: doi:10.1002/ptr.765

--- a/data/normalized_yaml/bacterial/gluconobacter_oxydans_medium.yaml
+++ b/data/normalized_yaml/bacterial/gluconobacter_oxydans_medium.yaml
@@ -95,6 +95,9 @@ curation_history:
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: GLUCONOBACTER OXYDANS
+  term:
+    id: NCBITaxon:442
+    label: Gluconobacter oxydans
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_105_GLUCONOBACTER_OXYDANS_medium.yaml
   relationship: SOURCE_DUPLICATE

--- a/data/normalized_yaml/bacterial/ignicoccus_medium_for_dsm_18386.yaml
+++ b/data/normalized_yaml/bacterial/ignicoccus_medium_for_dsm_18386.yaml
@@ -272,6 +272,9 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Ignicoccus hospitalis
+  term:
+    id: NCBITaxon:160233
+    label: Ignicoccus hospitalis
   strain: KIN4/I (= KIN4/IT), DSM 18386T
   genome_assembly_id:
   - GCA_000017945.1
@@ -287,6 +290,9 @@ target_organisms:
       at 90C under H2/CO2 (80:20, v/v) at 250 kPa, H2 as electron donor and elemental
       sulfur as electron acceptor.
 - preferred_term: Ignicoccus islandicus
+  term:
+    id: NCBITaxon:54259
+    label: Ignicoccus islandicus
   strain: Kol8, DSM 13165T
   genome_assembly_id:
   - GCA_001481685.1
@@ -300,6 +306,9 @@ target_organisms:
     snippet: Ignicoccus pacificus LPC33, DSM 13166T • Ignicoccus islandicus Kol8, DSM
       13165T
 - preferred_term: Ignicoccus pacificus
+  term:
+    id: NCBITaxon:114376
+    label: Ignicoccus pacificus
   strain: LPC33, DSM 13166T
   evidence:
   - reference: doi:10.5283/epub.34741

--- a/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
+++ b/data/normalized_yaml/bacterial/magnetospirillum_gryphiswaldense_medium.yaml
@@ -150,6 +150,9 @@ curation_history:
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: MAGNETOSPIRILLUM GRYPHISWALDENSE
+  term:
+    id: NCBITaxon:55518
+    label: Magnetospirillum gryphiswaldense
 - preferred_term: Magnetospirillum gryphiswaldense
   term:
     id: NCBITaxon:55518

--- a/data/normalized_yaml/bacterial/medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397.yaml
+++ b/data/normalized_yaml/bacterial/medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397.yaml
@@ -507,6 +507,9 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Pelotomaculum sp.
+  term:
+    id: NCBITaxon:2053590
+    label: Pelotomaculum sp.
   strain: strain JT
   evidence:
   - reference: doi:10.1128/AEM.70.3.1617-1626.2004
@@ -517,6 +520,9 @@ target_organisms:
       is not text-verified in this source. | Identifiers: 16S rRNA GenBank AB091329
       (set AB091323-AB091329); no culture-collection ID reported'
 - preferred_term: Methanospirillum hungatei
+  term:
+    id: NCBITaxon:2203
+    label: Methanospirillum hungatei
   strain: NBRC 100397T (= DSM 864T = ATCC 27890T), JF-1T
   evidence:
   - reference: doi:10.1128/AEM.70.3.1617-1626.2004

--- a/data/normalized_yaml/bacterial/methylovirgula_ligni_medium.yaml
+++ b/data/normalized_yaml/bacterial/methylovirgula_ligni_medium.yaml
@@ -197,6 +197,9 @@ curation_history:
 organism_culture_type: isolate
 target_organisms:
 - preferred_term: METHYLOVIRGULA LIGNI
+  term:
+    id: NCBITaxon:569860
+    label: Methylovirgula ligni
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_1219_METHYLOVIRGULA_LIGNI_medium.yaml
   relationship: SOURCE_DUPLICATE

--- a/data/normalized_yaml/bacterial/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
+++ b/data/normalized_yaml/bacterial/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
@@ -294,6 +294,9 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Acidianus brierleyi
+  term:
+    id: NCBITaxon:41673
+    label: Acidianus brierleyi
   scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: DSM 3772 (also DSM 1651)
   evidence:
@@ -303,6 +306,9 @@ target_organisms:
       the anaerobic parent (no Na2S/N2 reported); aerobic vented-bottle cultivation.
       | Identifiers: DSM 3772; DSM 1651'
 - preferred_term: Metallosphaera hakonensis
+  term:
+    id: NCBITaxon:79601
+    label: Metallosphaera hakonensis
   scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: HO1-1, DSM 7519
   genome_assembly_id:
@@ -321,6 +327,9 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NOT the anaerobic
       parent formulation. | Identifiers: DSM 10039'
 - preferred_term: Sulfurisphaera ohwakuensis
+  term:
+    id: NCBITaxon:69656
+    label: Sulfurisphaera ohwakuensis
   scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: TA-1, DSM 12421
   evidence:
@@ -329,6 +338,9 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. Vented bottles;
       not anaerobic parent. | Identifiers: DSM 12421'
 - preferred_term: Sulfurisphaera tokodaii
+  term:
+    id: NCBITaxon:111955
+    label: Sulfurisphaera tokodaii
   scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: str. 7, DSM 16993
   evidence:
@@ -337,6 +349,9 @@ target_organisms:
     explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NH4Cl, no Na2S,
       vented bottles; not the anaerobic parent. | Identifiers: DSM 16993'
 - preferred_term: Sulfodiicoccus acidiphilus
+  term:
+    id: NCBITaxon:1670455
+    label: Sulfodiicoccus acidiphilus
   scoped_to_variant: reduced_anaerobic_mbsy_h2_co2
   strain: HS-1T (= JCM 31740T = InaCC Ar79T)
   genome_assembly_id:

--- a/data/normalized_yaml/bacterial/sulfolobus_medium_for_dsm_5348.yaml
+++ b/data/normalized_yaml/bacterial/sulfolobus_medium_for_dsm_5348.yaml
@@ -282,6 +282,9 @@ solutions:
   name: Unknown solution
 target_organisms:
 - preferred_term: Metallosphaera sedula
+  term:
+    id: NCBITaxon:43687
+    label: Metallosphaera sedula
   strain: DSM 5348T (TH2)
   genome_assembly_id:
   - GCA_000016605.1
@@ -296,6 +299,9 @@ target_organisms:
       oil bath at 70 rpm on DSMZ 88 medium (pH 2), supplemented with 0.1% yeast extract
       (YE).'
 - preferred_term: Sulfuracidifex metallicus
+  term:
+    id: NCBITaxon:47303
+    label: Sulfuracidifex metallicus
   strain: DSM 6482
   genome_assembly_id:
   - GCA_009729515.1


### PR DESCRIPTION
## What
Adds `term` (NCBITaxon) groundings to target_organisms that had a `preferred_term` but no taxon grounding, so taxon-keyed KG edges can link.

## How
Each organism name is resolved against OAK `sqlite:obo:ncbitaxon` (exact label or exact-synonym, case-insensitive across surface forms). A `term {id, canonical label}` is added **only on a single unambiguous exact hit** — no fuzzy guessing.

- **33 organisms grounded** across 11 records (e.g. *Metallosphaera sedula*→NCBITaxon:43687, *Sulfuracidifex metallicus*→47303).
- **15 left ungrounded** (reported, not guessed): 3 parse artifacts ("EGGC Liquid", "LACTATE SULFATE", "Zahorchak et") and 12 reclassified/novel species with no exact NCBITaxon match (*Bacteroides ureolyticus*→*Campylobacter*, *Thiobacillus novellus*→*Starkeya*, *Metallosphaera prunae*, …) — left for targeted curation rather than risk a wrong grounding.

Labels are the OAK canonical NCBITaxon label, so they satisfy the organism-context canonical check from the label-drift PR. `linkml-validate`: No issues found; `check-chebi-grounding` passes (109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)