### PR TITLE
Fix 321 ID_NOT_FOUND term groundings (re-ground absent ids; de-ground mixtures)

### DIFF
--- a/data/normalized_yaml/algae/CCAP_ASW 150 + barley  + barley grain_).yaml
+++ b/data/normalized_yaml/algae/CCAP_ASW 150 + barley  + barley grain_).yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_150, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_150.pdf'
@@ -92,7 +96,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/CCAP_ASW 225 + barley  + barley grain_).yaml
+++ b/data/normalized_yaml/algae/CCAP_ASW 225 + barley  + barley grain_).yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_225, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_225.pdf'
@@ -77,7 +81,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/CCAP_ASW 300 + barley  + barley grain_).yaml
+++ b/data/normalized_yaml/algae/CCAP_ASW 300 + barley  + barley grain_).yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_300, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_300.pdf'
@@ -92,7 +96,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/ant.yaml
+++ b/data/normalized_yaml/algae/ant.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ANT, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ANT.pdf'
@@ -83,7 +87,7 @@ ingredients:
   notes: From CCAP Medium MR_ANT.pdf; Curated from CCAP Medium MR_ANT.pdf specification
 - preferred_term: MnSO .4H O
   term:
-    id: CHEBI:75217
+    id: CHEBI:86358
     label: MnSO .4H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/asw_150_barley.yaml
+++ b/data/normalized_yaml/algae/asw_150_barley.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_150, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_150.pdf'
@@ -92,7 +96,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/asw_225_barley.yaml
+++ b/data/normalized_yaml/algae/asw_225_barley.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_225, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_225.pdf'
@@ -77,7 +81,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/asw_300_barley.yaml
+++ b/data/normalized_yaml/algae/asw_300_barley.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: ASW_300, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_ASW_300.pdf'
@@ -92,7 +96,7 @@ ingredients:
     specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/e26_biotin_ant.yaml
+++ b/data/normalized_yaml/algae/e26_biotin_ant.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: E26_Biotin_ANT, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_E26_Biotin_ANT.pdf'
@@ -152,7 +156,7 @@ ingredients:
     specification
 - preferred_term: MnSO .4H O
   term:
-    id: CHEBI:75217
+    id: CHEBI:86358
     label: MnSO .4H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/e31_ant.yaml
+++ b/data/normalized_yaml/algae/e31_ant.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: E31_ANT, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_E31_ANT.pdf'
@@ -122,7 +126,7 @@ ingredients:
     specification
 - preferred_term: MnSO .4H O
   term:
-    id: CHEBI:75217
+    id: CHEBI:86358
     label: MnSO .4H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/ea.yaml
+++ b/data/normalized_yaml/algae/ea.yaml
@@ -14,6 +14,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: EA, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_EA.pdf'
@@ -110,7 +114,7 @@ ingredients:
   notes: From CCAP Medium MR_EA.pdf; Curated from CCAP Medium MR_EA.pdf specification
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/pe.yaml
+++ b/data/normalized_yaml/algae/pe.yaml
@@ -15,6 +15,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: PE, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_PE.pdf'
@@ -57,7 +61,7 @@ references:
 ingredients:
 - preferred_term: Sodium nitrate
   term:
-    id: CHEBI:34754
+    id: CHEBI:63005
     label: sodium nitrate
   concentration:
     value: '0.2'

--- a/data/normalized_yaml/algae/s88_vitamins.yaml
+++ b/data/normalized_yaml/algae/s88_vitamins.yaml
@@ -14,6 +14,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: S88, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_S88.pdf'
@@ -288,7 +292,7 @@ ingredients:
   notes: From CCAP Medium MR_S88.pdf; Curated from CCAP Medium MR_S88.pdf specification
 - preferred_term: MnSO .4H O
   term:
-    id: CHEBI:75217
+    id: CHEBI:86358
     label: MnSO .4H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/algae/ucm.yaml
+++ b/data/normalized_yaml/algae/ucm.yaml
@@ -14,6 +14,10 @@ applications:
 - Phytoplankton culture
 - Microalgae research
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 3 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - curator: ccap-import
   action: Imported from CCAP Culture Collection
   notes: 'Source ID: UCM, PDF URL: https://www.ccap.ac.uk/wp-content/uploads/MR_UCM.pdf'
@@ -546,7 +550,7 @@ ingredients:
   notes: From CCAP Medium MR_UCM.pdf; Curated from CCAP Medium MR_UCM.pdf specification
 - preferred_term: Pyridoxamine.2HCl
   term:
-    id: CHEBI:8668
+    id: CHEBI:131532
     label: Pyridoxamine.2HCl
   curation_metadata:
     mapping_quality: LLM_ASSISTED
@@ -588,7 +592,7 @@ ingredients:
   notes: From CCAP Medium MR_UCM.pdf; Curated from CCAP Medium MR_UCM.pdf specification
 - preferred_term: Pyridoxamine.2HCl
   term:
-    id: CHEBI:8668
+    id: CHEBI:131532
     label: Pyridoxamine.2HCl
   curation_metadata:
     mapping_quality: LLM_ASSISTED
@@ -623,7 +627,7 @@ ingredients:
   source: CCAP Medium MR_UCM.pdf
 - preferred_term: MgCl .6H O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl .6H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED

--- a/data/normalized_yaml/archaea/halophile_starch_casein_medium.yaml
+++ b/data/normalized_yaml/archaea/halophile_starch_casein_medium.yaml
@@ -23,9 +23,6 @@ ingredients:
     id: CHEBI:28017
     label: Starch
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '10'
     unit: G_PER_L
@@ -88,6 +85,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.292941Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/JCM_J1029_RUMEN_BACTERIA_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/JCM_J1029_RUMEN_BACTERIA_MEDIUM.yaml
@@ -233,7 +233,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -266,6 +266,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.369897Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/JCM_J1203_TREPONEMA_SACCHAROPHILUM_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/JCM_J1203_TREPONEMA_SACCHAROPHILUM_MEDIUM.yaml
@@ -179,7 +179,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '0.2'
@@ -240,6 +240,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.997283Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/JCM_J246_PPES-II_AGAR_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/JCM_J246_PPES-II_AGAR_MEDIUM.yaml
@@ -24,9 +24,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Yeast extract
   concentration:
     value: '1'
@@ -108,6 +105,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.079682Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/JCM_J383_DESULFOBACTERIUM_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/JCM_J383_DESULFOBACTERIUM_MEDIUM.yaml
@@ -97,13 +97,13 @@ ingredients:
     unit: G_PER_L
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.27273'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: NaHCO3
   term:
@@ -337,6 +337,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.460568Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/JCM_J471_DESULFONAUTICUS_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/JCM_J471_DESULFONAUTICUS_MEDIUM.yaml
@@ -106,13 +106,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 383
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.27273'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 383
 - preferred_term: NaHCO3
@@ -368,6 +368,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.696173Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/KOMODO_1006_ALLISONELLA_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1006_ALLISONELLA_medium.yaml
@@ -237,7 +237,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -248,6 +248,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_1075_PPES-II_AGAR_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1075_PPES-II_AGAR_medium.yaml
@@ -25,9 +25,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Yeast extract
   concentration:
     value: '1'
@@ -105,6 +102,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_1132_LC_2.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1132_LC_2.yaml
@@ -44,7 +44,7 @@ ingredients:
     label: KNO3
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '0.4766'
@@ -179,6 +179,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_118_DAP-NUTRIENT_AGAR.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_118_DAP-NUTRIENT_AGAR.yaml
@@ -22,13 +22,13 @@ ingredients:
     unit: G_PER_L
 - preferred_term: Diaminopimelic acid
   term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
   concentration:
     value: '0.1'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
 - preferred_term: Agar
   term:
@@ -44,6 +44,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_1326_AURANTIMONAS_MANGANOXYDANS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1326_AURANTIMONAS_MANGANOXYDANS_medium.yaml
@@ -23,7 +23,7 @@ ingredients:
     unit: G_PER_L
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '4.766'
@@ -95,6 +95,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_155_BEGGIATOA_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_155_BEGGIATOA_medium.yaml
@@ -79,9 +79,6 @@ ingredients:
     id: CHEBI:2509
     label: Agar
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '35000'
     unit: G_PER_L
@@ -168,6 +165,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_212_SYNTHROPHOMONAS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_212_SYNTHROPHOMONAS_medium.yaml
@@ -403,7 +403,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -534,6 +534,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_323_TREPONEMA_SACCHAROPHILUM_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_323_TREPONEMA_SACCHAROPHILUM_medium.yaml
@@ -230,7 +230,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '130.34'
@@ -252,6 +252,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_328_PYG_medium_WITH_VOLATILE_FATTY_ACIDS.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_328_PYG_medium_WITH_VOLATILE_FATTY_ACIDS.yaml
@@ -207,7 +207,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -281,6 +281,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_330_RUMEN_BACTERIA_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_330_RUMEN_BACTERIA_medium.yaml
@@ -290,7 +290,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -321,6 +321,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_394_CHI_1776_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_394_CHI_1776_medium.yaml
@@ -36,13 +36,13 @@ ingredients:
     label: MgCl2
 - preferred_term: Diaminopimelic acid
   term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
   concentration:
     value: '0.1'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
 - preferred_term: Thymidine
   term:
@@ -67,6 +67,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_403_BSK-MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_403_BSK-MEDIUM.yaml
@@ -45,7 +45,7 @@ ingredients:
     unit: G_PER_L
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '6'
@@ -205,6 +205,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_469_YM-CATALASE_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_469_YM-CATALASE_medium.yaml
@@ -52,15 +52,16 @@ ingredients:
     id: CHEBI:62982
     label: NH4H2PO4
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.06'
     unit: G_PER_L
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_58_BIFIDOBACTERIUM_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_58_BIFIDOBACTERIUM_medium.yaml
@@ -29,9 +29,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -159,6 +156,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_645a_HEMIN_medium_FOR_MYCOBACTERIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_645a_HEMIN_medium_FOR_MYCOBACTERIUM.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_695_medium_FOR_ERYTHROBACTER_LONGUS.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_695_medium_FOR_ERYTHROBACTER_LONGUS.yaml
@@ -21,9 +21,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Yeast extract
   concentration:
     value: '1'
@@ -49,6 +46,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_704_BUTYRIVIBRIO_SP._medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_704_BUTYRIVIBRIO_SP._medium.yaml
@@ -286,7 +286,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -317,6 +317,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_748_CENS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_748_CENS_medium.yaml
@@ -107,9 +107,6 @@ ingredients:
   concentration:
     value: '4'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Na-pyruvate
   term:
     id: CHEBI:50144
@@ -233,6 +230,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/KOMODO_911_MIDDLEBROCK_7H11_AGAR.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_911_MIDDLEBROCK_7H11_AGAR.yaml
@@ -224,9 +224,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -243,6 +240,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/TOGO_M1062_Halophile_Starch-Casein_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1062_Halophile_Starch-Casein_Medium.yaml
@@ -76,9 +76,6 @@ ingredients:
     value: '10'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: Soluble starch
   concentration:
     value: '100'
@@ -122,6 +119,10 @@ notes: 'Source: https://togomedium.org/medium/M1062
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.850851Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1080_MMJHS-2_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1080_MMJHS-2_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -78,6 +78,10 @@ notes: 'Source: https://togomedium.org/medium/M1080
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.876197Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1094_Dissulfurimicrobium_Hydrothermale_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1094_Dissulfurimicrobium_Hydrothermale_Medium.yaml
@@ -84,8 +84,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -327,6 +327,10 @@ notes: 'Source: https://togomedium.org/medium/M1094
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.902600Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1097_ST65_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1097_ST65_Medium.yaml
@@ -90,8 +90,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -136,6 +136,10 @@ notes: 'Source: https://togomedium.org/medium/M1097
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.909848Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1118_Endomicrobium_Proavitum_RSA_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1118_Endomicrobium_Proavitum_RSA_Medium.yaml
@@ -133,8 +133,8 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Carbon source'
   term:
-    id: CHEBI:501520
-    label: ''
+    id: CHEBI:28631
+    label: 3-phenylpropionic acid
   mediaingredientmech_term:
     id: MediaIngredientMech:000689
     label: Phenyl propionic acid
@@ -181,6 +181,10 @@ notes: 'Source: https://togomedium.org/medium/M1118
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.953055Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1152_Desulfurella_TR1_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1152_Desulfurella_TR1_Medium.yaml
@@ -83,8 +83,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -146,6 +146,10 @@ notes: 'Source: https://togomedium.org/medium/M1152
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.019490Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1220_Natronospira_Proteinivora_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1220_Natronospira_Proteinivora_Medium.yaml
@@ -90,9 +90,6 @@ ingredients:
     value: '5'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: NaOH
   notes: 'Properties: Defined component, Inorganic compound, Solution'
   term:
@@ -117,6 +114,10 @@ notes: 'Source: https://togomedium.org/medium/M1220
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.158628Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1289_Treponema_Saccharophilum_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1289_Treponema_Saccharophilum_Medium.yaml
@@ -138,8 +138,8 @@ ingredients:
   notes: 'Role: Carbon source; Properties: Organic compound, Defined component, Simple
     component'
   term:
-    id: CHEBI:503742
-    label: ''
+    id: CHEBI:28484
+    label: isovaleric acid
   mediaingredientmech_term:
     id: MediaIngredientMech:000378
     label: iso-Valeric acid
@@ -214,6 +214,10 @@ notes: 'Source: https://togomedium.org/medium/M1289
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.293312Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1333_Thermoplasma_Kamchatkensis_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1333_Thermoplasma_Kamchatkensis_Medium.yaml
@@ -71,8 +71,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -129,6 +129,10 @@ notes: 'Source: https://togomedium.org/medium/M1333
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.371503Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M142_Pyrococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M142_Pyrococcus_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -315,6 +315,10 @@ notes: 'Source: https://togomedium.org/medium/M142
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.508138Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M150_Thermococcus_Celer_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M150_Thermococcus_Celer_Medium.yaml
@@ -45,8 +45,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -88,6 +88,10 @@ notes: 'Source: https://togomedium.org/medium/M150
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.520975Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M151_Thermococcus_Stetteri_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M151_Thermococcus_Stetteri_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -84,6 +84,10 @@ notes: 'Source: https://togomedium.org/medium/M151
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.522167Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M152_Thermococcus_Litoralis_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M152_Thermococcus_Litoralis_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -84,6 +84,10 @@ notes: 'Source: https://togomedium.org/medium/M152
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.523346Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1571_PPES-II_Agar_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1571_PPES-II_Agar_Medium.yaml
@@ -42,9 +42,6 @@ ingredients:
     value: '1'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Peptone
   concentration:
     value: '2'
@@ -134,6 +131,10 @@ notes: 'Source: https://togomedium.org/medium/M1571
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.855206Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1630_Pyrodictium_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1630_Pyrodictium_Medium.yaml
@@ -132,8 +132,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -335,6 +335,10 @@ notes: 'Source: https://togomedium.org/medium/M1630
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.006164Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1633_Thermoproteus_neutrophilus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1633_Thermoproteus_neutrophilus_Medium.yaml
@@ -162,8 +162,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -241,6 +241,10 @@ notes: 'Source: https://togomedium.org/medium/M1633
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.014276Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1641_Pyrococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1641_Pyrococcus_Medium.yaml
@@ -101,8 +101,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -192,6 +192,10 @@ notes: 'Source: https://togomedium.org/medium/M1641
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.033159Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M167_Acidianus_Infernus_Medium_A.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M167_Acidianus_Infernus_Medium_A.yaml
@@ -12,8 +12,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -55,6 +55,10 @@ notes: 'Source: https://togomedium.org/medium/M167
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.546014Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M168_Acidianus_Infernus_Medium_B.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M168_Acidianus_Infernus_Medium_B.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -92,6 +92,10 @@ notes: 'Source: https://togomedium.org/medium/M168
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.546847Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M169_Acidianus_Brierleyi_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M169_Acidianus_Brierleyi_Medium.yaml
@@ -69,8 +69,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -116,6 +116,10 @@ notes: 'Source: https://togomedium.org/medium/M169
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.547974Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M171_Stygiolobus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M171_Stygiolobus_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -92,6 +92,10 @@ notes: 'Source: https://togomedium.org/medium/M171
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.551443Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M176_Desulfurococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M176_Desulfurococcus_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -76,6 +76,10 @@ notes: 'Source: https://togomedium.org/medium/M176
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.558216Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1777_MMJS_medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1777_MMJS_medium.yaml
@@ -156,8 +156,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -463,6 +463,10 @@ notes: 'Source: https://togomedium.org/medium/M1777
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.335456Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M177_Pyrobaculum_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M177_Pyrobaculum_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -81,6 +81,10 @@ notes: 'Source: https://togomedium.org/medium/M177
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.559331Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M180_Desulfurococcus_Amylolyticus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M180_Desulfurococcus_Amylolyticus_Medium.yaml
@@ -123,8 +123,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -263,6 +263,10 @@ notes: 'Source: https://togomedium.org/medium/M180
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.563621Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M1846_MMJHS_medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1846_MMJHS_medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -434,6 +434,10 @@ notes: 'Source: https://togomedium.org/medium/M1846
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.495119Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M188_Thermoproteus_Neutrophilus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M188_Thermoproteus_Neutrophilus_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -94,6 +94,10 @@ notes: 'Source: https://togomedium.org/medium/M188
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.576837Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M189_Thermoproteus_Tenax_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M189_Thermoproteus_Tenax_Medium.yaml
@@ -117,8 +117,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -204,6 +204,10 @@ notes: 'Source: https://togomedium.org/medium/M189
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.578038Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M196_Pyrodictium_Brockii_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M196_Pyrodictium_Brockii_Medium.yaml
@@ -24,8 +24,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -83,6 +83,10 @@ notes: 'Source: https://togomedium.org/medium/M196
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.592827Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M197_Pyrodictium_Ocultum_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M197_Pyrodictium_Ocultum_Medium.yaml
@@ -24,8 +24,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -83,6 +83,10 @@ notes: 'Source: https://togomedium.org/medium/M197
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.594161Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M198_Pyrodictium_Abysii_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M198_Pyrodictium_Abysii_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -92,6 +92,10 @@ notes: 'Source: https://togomedium.org/medium/M198
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.595345Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M206_Archaeoglobus_Fulgidus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M206_Archaeoglobus_Fulgidus_Medium.yaml
@@ -150,10 +150,10 @@ ingredients:
   notes: 'Role: Carbon source; Properties: Organic compound, Defined component, Simple
     component'
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L--lactate
 - preferred_term: Yeast extract (BD-Difco)
   concentration:
@@ -201,6 +201,10 @@ notes: 'Source: https://togomedium.org/medium/M206
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.611926Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M228_Thermocladium_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M228_Thermocladium_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -103,6 +103,10 @@ notes: 'Source: https://togomedium.org/medium/M228
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.660823Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M233_Thermococcus_Fumicolans_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M233_Thermococcus_Fumicolans_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -84,6 +84,10 @@ notes: 'Source: https://togomedium.org/medium/M233
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.671135Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M236_Stetteria_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M236_Stetteria_Medium.yaml
@@ -69,8 +69,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -284,6 +284,10 @@ notes: 'Source: https://togomedium.org/medium/M236
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.678220Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M238_PPES-II_Agar_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M238_PPES-II_Agar_Medium.yaml
@@ -36,9 +36,6 @@ ingredients:
     value: '1'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Peptone
   concentration:
     value: '2'
@@ -123,6 +120,10 @@ notes: 'Source: https://togomedium.org/medium/M238
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.682598Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated.yaml
@@ -148,9 +148,6 @@ ingredients:
     value: '5'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Tryptone
   concentration:
     value: '15'
@@ -181,6 +178,10 @@ notes: 'Source: https://togomedium.org/medium/M2573
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.771347Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M259_AN1_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M259_AN1_Medium.yaml
@@ -60,8 +60,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -102,6 +102,10 @@ notes: 'Source: https://togomedium.org/medium/M259
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.717622Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M273_Thermococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M273_Thermococcus_Medium.yaml
@@ -120,8 +120,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -168,6 +168,10 @@ notes: 'Source: https://togomedium.org/medium/M273
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.740865Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M280_Hydrogenothermus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M280_Hydrogenothermus_Medium.yaml
@@ -120,8 +120,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: sulfur (powder)
@@ -209,6 +209,10 @@ notes: 'Source: https://togomedium.org/medium/M280
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.755432Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M281_WT1_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M281_WT1_Medium.yaml
@@ -123,8 +123,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -180,6 +180,10 @@ notes: 'Source: https://togomedium.org/medium/M281
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.757626Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M291_Vulcanisaeta_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M291_Vulcanisaeta_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -76,6 +76,10 @@ notes: 'Source: https://togomedium.org/medium/M291
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.778116Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M303_Acidilobus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M303_Acidilobus_Medium.yaml
@@ -99,8 +99,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -150,6 +150,10 @@ notes: 'Source: https://togomedium.org/medium/M303
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.816969Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M3130_Desulfurella_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M3130_Desulfurella_Medium.yaml
@@ -106,8 +106,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -370,6 +370,10 @@ notes: 'Source: https://togomedium.org/medium/M3130
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.486596Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M319_MMJY_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M319_MMJY_Medium.yaml
@@ -166,8 +166,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -318,6 +318,10 @@ notes: 'Source: https://togomedium.org/medium/M319
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.844707Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M342_SME_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M342_SME_Medium.yaml
@@ -69,8 +69,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -128,6 +128,10 @@ notes: 'Source: https://togomedium.org/medium/M342
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.878391Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M362_MJAIS_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M362_MJAIS_Medium.yaml
@@ -171,8 +171,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -368,6 +368,10 @@ notes: 'Source: https://togomedium.org/medium/M362
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.913366Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M378_Desulfobacterium_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M378_Desulfobacterium_Medium.yaml
@@ -135,10 +135,10 @@ ingredients:
   notes: 'Role: Carbon source; Properties: Simple component, Defined component, Organic
     compound'
   term:
-    id: CHEBI:867561
-    label: ''
+    id: CHEBI:232798
+    label: sodium L-lactate
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2SeO3
   concentration:
@@ -186,6 +186,10 @@ notes: 'Source: https://togomedium.org/medium/M378
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.945409Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M415_MJYTFSH_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M415_MJYTFSH_Medium.yaml
@@ -159,8 +159,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -240,6 +240,10 @@ notes: 'Source: https://togomedium.org/medium/M415
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.016403Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M418_MJAIS_MD_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M418_MJAIS_MD_Medium.yaml
@@ -180,8 +180,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -264,6 +264,10 @@ notes: 'Source: https://togomedium.org/medium/M418
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.022434Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M419_MMJHS_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M419_MMJHS_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -89,6 +89,10 @@ notes: 'Source: https://togomedium.org/medium/M419
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.025550Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M420_MMJHS_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M420_MMJHS_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -89,6 +89,10 @@ notes: 'Source: https://togomedium.org/medium/M420
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.028090Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M421_MMJHS_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M421_MMJHS_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -89,6 +89,10 @@ notes: 'Source: https://togomedium.org/medium/M421
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.029287Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M431_BN3_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M431_BN3_Medium.yaml
@@ -56,8 +56,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -304,6 +304,10 @@ notes: 'Source: https://togomedium.org/medium/M431
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.043130Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M447_Mjtso_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M447_Mjtso_Medium.yaml
@@ -125,8 +125,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -306,6 +306,10 @@ notes: 'Source: https://togomedium.org/medium/M447
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.077293Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M449_KA22_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M449_KA22_Medium.yaml
@@ -72,8 +72,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -136,6 +136,10 @@ notes: 'Source: https://togomedium.org/medium/M449
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.082841Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M479_Modified_MMJHS_Medium_For_GO25.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M479_Modified_MMJHS_Medium_For_GO25.yaml
@@ -165,8 +165,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -225,6 +225,10 @@ notes: 'Source: https://togomedium.org/medium/M479
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.128801Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M493_MMJ-TL_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M493_MMJ-TL_Medium.yaml
@@ -24,8 +24,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -210,6 +210,10 @@ notes: 'Source: https://togomedium.org/medium/M493
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.158435Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M494_MMJ-HO_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M494_MMJ-HO_Medium.yaml
@@ -36,8 +36,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -81,6 +81,10 @@ notes: 'Source: https://togomedium.org/medium/M494
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.160975Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M495_MMJ-MH_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M495_MMJ-MH_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -85,6 +85,10 @@ notes: 'Source: https://togomedium.org/medium/M495
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.162047Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M509_Modified_MMJS_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M509_Modified_MMJS_Medium.yaml
@@ -153,8 +153,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -256,6 +256,10 @@ notes: 'Source: https://togomedium.org/medium/M509
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.194237Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M563_1_2_SME_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M563_1_2_SME_Medium.yaml
@@ -144,8 +144,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -219,6 +219,10 @@ notes: 'Source: https://togomedium.org/medium/M563
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.310110Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M57_Cellulose_Agar.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M57_Cellulose_Agar.yaml
@@ -82,9 +82,6 @@ ingredients:
     value: '0.2'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: L--Asparagine
   concentration:
     value: '0.25'
@@ -142,6 +139,10 @@ notes: 'Source: https://togomedium.org/medium/M57
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.322037Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M638_Fervidobacterium_Tianchisum_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M638_Fervidobacterium_Tianchisum_Medium.yaml
@@ -120,8 +120,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -184,6 +184,10 @@ notes: 'Source: https://togomedium.org/medium/M638
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.442745Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M711_Aerobic_Sulfolobales_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M711_Aerobic_Sulfolobales_Medium.yaml
@@ -12,8 +12,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -161,6 +161,10 @@ notes: 'Source: https://togomedium.org/medium/M711
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.579760Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M715_Nautilia_Abyssi_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M715_Nautilia_Abyssi_Medium.yaml
@@ -102,8 +102,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -155,6 +155,10 @@ notes: 'Source: https://togomedium.org/medium/M715
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.586084Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M747_Ravot_Modified_Medium_For_Marinitoga_Litoralis.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M747_Ravot_Modified_Medium_For_Marinitoga_Litoralis.yaml
@@ -107,8 +107,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -169,6 +169,10 @@ notes: 'Source: https://togomedium.org/medium/M747
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.639374Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M748_Ravot_Modified_Medium_For_Thermoanaerovibrio_SP._R101.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M748_Ravot_Modified_Medium_For_Thermoanaerovibrio_SP._R101.yaml
@@ -83,8 +83,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -133,6 +133,10 @@ notes: 'Source: https://togomedium.org/medium/M748
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.641737Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M776_Modified_Nautilia_Lithotrophica_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M776_Modified_Nautilia_Lithotrophica_Medium.yaml
@@ -102,8 +102,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -147,6 +147,10 @@ notes: 'Source: https://togomedium.org/medium/M776
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.692090Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M836_BHI-S_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M836_BHI-S_Medium.yaml
@@ -57,8 +57,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -204,6 +204,10 @@ notes: 'Source: https://togomedium.org/medium/M836
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.803235Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M845_Thermococcales_Rich_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M845_Thermococcales_Rich_Medium.yaml
@@ -146,8 +146,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -209,6 +209,10 @@ notes: 'Source: https://togomedium.org/medium/M845
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.817417Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M880_Rsulfac1_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M880_Rsulfac1_Medium.yaml
@@ -119,8 +119,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -165,6 +165,10 @@ notes: 'Source: https://togomedium.org/medium/M880
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.888985Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M898_Acidiferrobacter_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M898_Acidiferrobacter_Medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -63,6 +63,10 @@ notes: 'Source: https://togomedium.org/medium/M898
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.920718Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M914_Phosphoac3_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M914_Phosphoac3_Medium.yaml
@@ -130,8 +130,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -172,6 +172,10 @@ notes: 'Source: https://togomedium.org/medium/M914
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.952749Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M934_Mbbs_Medium_For_Hydrogenobacter.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M934_Mbbs_Medium_For_Hydrogenobacter.yaml
@@ -12,8 +12,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -186,6 +186,10 @@ notes: 'Source: https://togomedium.org/medium/M934
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.988488Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M972_IRD_Mesotoga_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M972_IRD_Mesotoga_Medium.yaml
@@ -130,8 +130,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Simple component, Inorganic
     compound'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -180,6 +180,10 @@ notes: 'Source: https://togomedium.org/medium/M972
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.060191Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/TOGO_M980_Acidilobus_Saccharovorans_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M980_Acidilobus_Saccharovorans_Medium.yaml
@@ -99,8 +99,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -162,6 +162,10 @@ notes: 'Source: https://togomedium.org/medium/M980
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.077610Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/acidianus_medium.yaml
+++ b/data/normalized_yaml/bacterial/acidianus_medium.yaml
@@ -162,8 +162,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -242,6 +242,10 @@ notes: 'Source: https://togomedium.org/medium/M1884
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.579894Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/alifodinibius_medium_tsa_mod.yaml
+++ b/data/normalized_yaml/bacterial/alifodinibius_medium_tsa_mod.yaml
@@ -20,9 +20,6 @@ ingredients:
   concentration:
     value: '3'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: NaCl
   term:
     id: CHEBI:26710
@@ -40,6 +37,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.804447Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/allen_medium.yaml
+++ b/data/normalized_yaml/bacterial/allen_medium.yaml
@@ -29,7 +29,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Buffer; Properties: Defined component, Solution'
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   mediaingredientmech_term:
     id: MediaIngredientMech:000426
@@ -207,6 +207,10 @@ notes: 'Source: https://togomedium.org/medium/M2231'
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.185691Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/allisonella_medium.yaml
+++ b/data/normalized_yaml/bacterial/allisonella_medium.yaml
@@ -236,7 +236,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -255,6 +255,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:13.066244Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/alternative_rumen_bacteria_medium.yaml
+++ b/data/normalized_yaml/bacterial/alternative_rumen_bacteria_medium.yaml
@@ -354,7 +354,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -497,6 +497,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.482164Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/am5_medium_elusimicrobium_medium.yaml
+++ b/data/normalized_yaml/bacterial/am5_medium_elusimicrobium_medium.yaml
@@ -451,7 +451,7 @@ ingredients:
     label: Phenyl acetic acid
 - preferred_term: Phenyl propionic acid
   term:
-    id: CHEBI:501520
+    id: CHEBI:28631
     label: Phenyl propionic acid
   concentration:
     value: '0.020979'
@@ -514,6 +514,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.297556Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/anaerobic_sulfolobales_medium.yaml
+++ b/data/normalized_yaml/bacterial/anaerobic_sulfolobales_medium.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -80,6 +80,10 @@ notes: 'Source: https://togomedium.org/medium/M712
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.581869Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/archaeoglobus_fulgidus_medium.yaml
+++ b/data/normalized_yaml/bacterial/archaeoglobus_fulgidus_medium.yaml
@@ -121,13 +121,13 @@ ingredients:
     unit: G_PER_L
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '1.5'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 - preferred_term: Resazurin
   term:
@@ -252,6 +252,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.973991Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/as_medium.yaml
+++ b/data/normalized_yaml/bacterial/as_medium.yaml
@@ -144,8 +144,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -446,6 +446,10 @@ notes: 'Source: https://togomedium.org/medium/M1817
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.429275Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/aurantimonas_manganoxydans_medium.yaml
+++ b/data/normalized_yaml/bacterial/aurantimonas_manganoxydans_medium.yaml
@@ -22,7 +22,7 @@ ingredients:
     unit: G_PER_L
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '4.766'
@@ -100,6 +100,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.105010Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bacteriovorax_medium.yaml
+++ b/data/normalized_yaml/bacterial/bacteriovorax_medium.yaml
@@ -14,7 +14,7 @@ notes: 'Source: DSMZ'
 ingredients:
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '6'
@@ -58,6 +58,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:13.108168Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bacto_middlebrook_7h9_broth.yaml
+++ b/data/normalized_yaml/bacterial/bacto_middlebrook_7h9_broth.yaml
@@ -212,9 +212,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.003'
     unit: G_PER_L
@@ -235,6 +232,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:12.528434Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/beggiatoa_medium.yaml
+++ b/data/normalized_yaml/bacterial/beggiatoa_medium.yaml
@@ -78,9 +78,6 @@ ingredients:
     id: CHEBI:2509
     label: Agar
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '35000'
     unit: G_PER_L
@@ -172,6 +169,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.361190Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bifidobacterium_medium.yaml
+++ b/data/normalized_yaml/bacterial/bifidobacterium_medium.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -152,6 +149,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.062641Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/blood_agar.yaml
+++ b/data/normalized_yaml/bacterial/blood_agar.yaml
@@ -18,9 +18,6 @@ ingredients:
   concentration:
     value: '2.0'
     unit: G_PER_L
-  term:
-    id: FOODON:03309813
-    label: beef heart muscle tissue
   curation_metadata:
     mapping_quality: MANUAL
     confidence_score: 1.0
@@ -105,6 +102,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.680102Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bm_for_syntrophicus_schinkii.yaml
+++ b/data/normalized_yaml/bacterial/bm_for_syntrophicus_schinkii.yaml
@@ -81,13 +81,13 @@ ingredients:
     label: NaHCO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '100'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S x 9 H2O
   term:
@@ -260,6 +260,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.439931Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bsk_medium.yaml
+++ b/data/normalized_yaml/bacterial/bsk_medium.yaml
@@ -43,7 +43,7 @@ ingredients:
     unit: G_PER_L
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '6'
@@ -214,6 +214,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.055344Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/bsm_rc_medium.yaml
+++ b/data/normalized_yaml/bacterial/bsm_rc_medium.yaml
@@ -63,13 +63,13 @@ ingredients:
     label: NaNO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.24'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Yeast extract
   concentration:
@@ -311,6 +311,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.621431Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/butyrivibrio_sp_medium.yaml
+++ b/data/normalized_yaml/bacterial/butyrivibrio_sp_medium.yaml
@@ -288,7 +288,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -341,6 +341,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.974526Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/cellulose_agar.yaml
+++ b/data/normalized_yaml/bacterial/cellulose_agar.yaml
@@ -32,9 +32,6 @@ ingredients:
     id: CHEBI:16199
     label: Urea
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -123,6 +120,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.672290Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/cens_medium.yaml
+++ b/data/normalized_yaml/bacterial/cens_medium.yaml
@@ -106,9 +106,6 @@ ingredients:
   concentration:
     value: '4'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Na-pyruvate
   term:
     id: CHEBI:50144
@@ -237,6 +234,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:12.128908Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/chi_1776_medium.yaml
+++ b/data/normalized_yaml/bacterial/chi_1776_medium.yaml
@@ -35,13 +35,13 @@ ingredients:
     label: MgCl2
 - preferred_term: Diaminopimelic acid
   term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
   concentration:
     value: '0.1'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
 - preferred_term: Thymidine
   term:
@@ -74,6 +74,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.018174Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/complete_medium.yaml
+++ b/data/normalized_yaml/bacterial/complete_medium.yaml
@@ -80,9 +80,6 @@ ingredients:
     value: '7.5'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: Agar (if needed)
   concentration:
     value: '15'
@@ -101,6 +98,10 @@ notes: 'Source: https://togomedium.org/medium/M3059
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:59.253137Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/dap_nutrient_agar.yaml
+++ b/data/normalized_yaml/bacterial/dap_nutrient_agar.yaml
@@ -22,13 +22,13 @@ ingredients:
     unit: G_PER_L
 - preferred_term: Diaminopimelic acid
   term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
   concentration:
     value: '0.1'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:23674
+    id: CHEBI:23673
     label: Diaminopimelic acid
 - preferred_term: Agar
   term:
@@ -49,6 +49,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.203419Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/deferrisoma_paleochrorii_medium.yaml
+++ b/data/normalized_yaml/bacterial/deferrisoma_paleochrorii_medium.yaml
@@ -83,9 +83,6 @@ ingredients:
     id: CHEBI:32139
     label: NaHCO3
 - preferred_term: ''
-  term:
-    id: CHEBI:1
-    label: ''
   concentration:
     value: '10'
     unit: G_PER_L
@@ -326,6 +323,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.457711Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfobacterium_niacini_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfobacterium_niacini_medium.yaml
@@ -106,13 +106,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 383
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.27273'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 383
 - preferred_term: NaHCO3
@@ -366,6 +366,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.491323Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfobacterium_vacuolatum_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfobacterium_vacuolatum_medium.yaml
@@ -106,13 +106,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 383
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.27273'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 383
 - preferred_term: NaHCO3
@@ -366,6 +366,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.492847Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfohalobium_utahense_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfohalobium_utahense_medium.yaml
@@ -97,13 +97,13 @@ ingredients:
     label: NaHCO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '50'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S x 9 H2O
   term:
@@ -317,6 +317,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.129609Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfosarcina_ovata_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfosarcina_ovata_medium.yaml
@@ -106,13 +106,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 383 | Copied from JCM Medium 393
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.27273'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 383 | Copied from JCM Medium 393
 - preferred_term: NaHCO3
@@ -366,6 +366,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.497704Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfovibrio_arsenicitolerans_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_arsenicitolerans_medium.yaml
@@ -93,13 +93,13 @@ ingredients:
     label: Resazurin
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: NaHCO3
   term:
@@ -254,6 +254,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.736611Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfovibrio_mexicanus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_mexicanus_medium.yaml
@@ -128,13 +128,13 @@ ingredients:
     label: Na2S x 9 H2O
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '125'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S2O3 x 5 H2O
   term:
@@ -249,6 +249,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.508148Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/desulfovibrio_oceani_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_oceani_medium.yaml
@@ -93,13 +93,13 @@ ingredients:
     label: Resazurin
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '12.5'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: NaHCO3
   term:
@@ -254,6 +254,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.532916Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/dn_broth.yaml
+++ b/data/normalized_yaml/bacterial/dn_broth.yaml
@@ -15,7 +15,7 @@ media_term:
 ingredients:
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '6'
@@ -57,6 +57,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/dsmz_medium_854.yaml
+++ b/data/normalized_yaml/bacterial/dsmz_medium_854.yaml
@@ -126,7 +126,7 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
@@ -431,6 +431,10 @@ notes: 'Source: https://togomedium.org/medium/M3131'
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.490639Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/elbe_methanotroph_medium.yaml
+++ b/data/normalized_yaml/bacterial/elbe_methanotroph_medium.yaml
@@ -53,7 +53,7 @@ ingredients:
     label: NaNO3
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '5'
@@ -239,6 +239,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.988979Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/endomicrobium_proavitum_rsa_medium.yaml
+++ b/data/normalized_yaml/bacterial/endomicrobium_proavitum_rsa_medium.yaml
@@ -156,7 +156,7 @@ ingredients:
     label: Phenyl acetic acid
 - preferred_term: Phenyl propionic acid
   term:
-    id: CHEBI:501520
+    id: CHEBI:28631
     label: Phenyl propionic acid
   concentration:
     value: '0.75'
@@ -408,6 +408,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.450518Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/fervidicoccus_fontis_medium.yaml
+++ b/data/normalized_yaml/bacterial/fervidicoccus_fontis_medium.yaml
@@ -93,9 +93,6 @@ ingredients:
     id: CHEBI:8806
     label: Resazurin
 - preferred_term: ''
-  term:
-    id: CHEBI:1
-    label: ''
   concentration:
     value: '25.0'
     unit: G_PER_L
@@ -312,6 +309,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.053613Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/for_dsm_22980.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_22980.yaml
@@ -44,7 +44,7 @@ ingredients:
     label: KNO3
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '0.4766'
@@ -179,6 +179,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/halodesulfuriarchaeum_medium.yaml
+++ b/data/normalized_yaml/bacterial/halodesulfuriarchaeum_medium.yaml
@@ -53,7 +53,7 @@ ingredients:
     label: HEPES
 - preferred_term: Sulfur powder
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   concentration:
     value: '2'
@@ -309,6 +309,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.556838Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/halophile_starch_casein_medium.yaml
+++ b/data/normalized_yaml/bacterial/halophile_starch_casein_medium.yaml
@@ -76,9 +76,6 @@ ingredients:
     value: '10'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: Soluble starch
   concentration:
     value: '100'
@@ -111,6 +108,10 @@ notes: 'Source: https://togomedium.org/medium/M1061
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:53.849502Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/hso_medium.yaml
+++ b/data/normalized_yaml/bacterial/hso_medium.yaml
@@ -155,8 +155,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -351,6 +351,10 @@ notes: 'Source: https://togomedium.org/medium/M2108
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:59.069978Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/ird_mesotoga_medium.yaml
+++ b/data/normalized_yaml/bacterial/ird_mesotoga_medium.yaml
@@ -150,13 +150,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 875
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 875
 - preferred_term: Na2S x 9 H2O
@@ -285,6 +285,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.027624Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/kallotenue_medium.yaml
+++ b/data/normalized_yaml/bacterial/kallotenue_medium.yaml
@@ -14,7 +14,7 @@ notes: 'Source: DSMZ | Link: https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_
 ingredients:
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '3.53116'
@@ -350,6 +350,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.708001Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/lactate_sulfate_medium.yaml
+++ b/data/normalized_yaml/bacterial/lactate_sulfate_medium.yaml
@@ -28,13 +28,13 @@ ingredients:
     label: Na2SO4
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '6.71498'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: MgSO4 x 7 H2O
   term:
@@ -323,6 +323,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.356958Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/lc_2.yaml
+++ b/data/normalized_yaml/bacterial/lc_2.yaml
@@ -44,7 +44,7 @@ ingredients:
     label: KNO3
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '0.4766'
@@ -196,6 +196,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:13.472916Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/malt_soytone_agar_medium.yaml
+++ b/data/normalized_yaml/bacterial/malt_soytone_agar_medium.yaml
@@ -55,9 +55,6 @@ ingredients:
     value: '1'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 media_term:
   preferred_term: TOGO Medium M2083
   term:
@@ -71,6 +68,10 @@ notes: 'Source: https://togomedium.org/medium/M2083
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:59.025175Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/marine_agar_with_1_tween_20.yaml
+++ b/data/normalized_yaml/bacterial/marine_agar_with_1_tween_20.yaml
@@ -12,8 +12,8 @@ ingredients:
   notes: 'Role: Surfactant; Properties: Defined component, Organic compound, Simple
     component'
   term:
-    id: CHEBI:9784
-    label: ''
+    id: CHEBI:53424
+    label: polysorbate 20
   mediaingredientmech_term:
     id: MediaIngredientMech:000804
     label: Tween 20
@@ -30,6 +30,10 @@ notes: 'Source: https://togomedium.org/medium/M795
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:55.726395Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/mc.yaml
+++ b/data/normalized_yaml/bacterial/mc.yaml
@@ -13,9 +13,6 @@ media_term:
 notes: 'Source: CCAP | Link: https://www.ccap.ac.uk/wp-content/uploads/MR_MC.pdf'
 ingredients:
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '11.1111'
     unit: G_PER_L
@@ -80,6 +77,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.644606Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/mc_ii.yaml
+++ b/data/normalized_yaml/bacterial/mc_ii.yaml
@@ -13,9 +13,6 @@ media_term:
 notes: 'Source: CCAP | Link: https://www.ccap.ac.uk/wp-content/uploads/MR_MCII.pdf'
 ingredients:
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '11.1111'
     unit: G_PER_L
@@ -76,6 +73,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.647265Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/mediadive_1277_Trace_elements.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1277_Trace_elements.yaml
@@ -48,7 +48,7 @@ composition:
     id: mediadive.compound:596
     label: Na-tartrate
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
@@ -113,6 +113,10 @@ composition:
     confidence: 0.7
     match_type: corpus_consensus
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:15.419943Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_1371_Bacto_Middlebrook_OADC_enrichment.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1371_Bacto_Middlebrook_OADC_enrichment.yaml
@@ -42,11 +42,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: NaCl
   concentration:
     value: '8.5'
@@ -73,6 +68,10 @@ composition:
     match_type: corpus_consensus
 preparation_notes: 'Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:15.951515Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_1632_Main_sol_802.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1632_Main_sol_802.yaml
@@ -74,7 +74,7 @@ composition:
     id: mediadive.compound:452
     label: Tris-HCl
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
@@ -131,6 +131,10 @@ preparation_notes: Adjust pH to 7.8 (with NaOH) before autoclaving. To the steri
   g/l), 2 ml FeCl2/MnCl2 (FeCl2 x 4 H2O, 20 g/l and MnCl2 x 4 H2O, 20 g/l), and glucose
   to a final concentration of 2 g/l.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:17.446712Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_1732_Main_sol_845.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1732_Main_sol_845.yaml
@@ -90,11 +90,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '997.0089730807578'
@@ -119,6 +114,10 @@ preparation_notes: 'Dissolve ingredients except trace elements, vitamins and cat
 
   Original volume: 1003 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:18.001760Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_1750_ADC_Enrichment.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1750_ADC_Enrichment.yaml
@@ -30,11 +30,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '1000.0'
@@ -49,6 +44,10 @@ composition:
     match_type: corpus_consensus
 preparation_notes: 'Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:18.140434Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_1909_Main_sol_927.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_1909_Main_sol_927.yaml
@@ -72,7 +72,7 @@ composition:
     id: mediadive.compound:452
     label: Tris-HCl
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
@@ -113,6 +113,10 @@ preparation_notes: 'Prepare the medium, and adjust the pH to 7.6 with 5M NaOH.
   ml of the calcium chloride solution, and 0.25 ml of the Fe/Mn solution. This strain
   will not grow in normal media for halobacteria, such as DSM medium 372!'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:18.918311Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_2082_Main_sol_1024.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_2082_Main_sol_1024.yaml
@@ -47,7 +47,7 @@ composition:
     id: mediadive.compound:1312
     label: Sulfur powder
   chebi_term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
     confidence: 0.7
     match_type: corpus_consensus
@@ -58,6 +58,10 @@ preparation_notes: 'Prepare the medium under an atmosphere of H2/CO2 (80:20) wit
 
   Increase the 80% H2 + 20% CO2 gas phase pressure to 300 kPa. The final pH is 7.0.'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:19.989273Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_2271_Main_sol_1132.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_2271_Main_sol_1132.yaml
@@ -60,7 +60,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -88,6 +88,10 @@ preparation_notes: "Dispense 5 ml aliquots into Hungate tubes. After autoclaving
   \ The strain held in the DSMZ has been cultivated on methanol, but the original\
   \ publication indicates that the strain will also grow on methane."
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:21.075195Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_2281_Main_sol_1137.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_2281_Main_sol_1137.yaml
@@ -38,12 +38,16 @@ composition:
     id: mediadive.compound:452
     label: Tris-HCl
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
 preparation_notes: Adjust to pH 7.5
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:21.118949Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_2659_Main_sol_1326.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_2659_Main_sol_1326.yaml
@@ -26,7 +26,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -59,6 +59,10 @@ preparation_notes: After autoclaving add 20ml 1M HEPES sterile buffer (pH 7.8) a
   0.1ml of a sterile 3mg/ml of ferric ammonium citrate. Final pH is 7.5. The medium
   may be solidified by adding 15 g/l agar.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:23.101935Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_269_Main_sol_155.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_269_Main_sol_155.yaml
@@ -91,11 +91,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '1000'
@@ -111,6 +106,10 @@ composition:
 preparation_notes: Adjust pH to 7.4 using pH indicator paper before autoclaving. The
   catalase is added just before inoculation.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:23.314309Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3026_Main_sol_1478.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3026_Main_sol_1478.yaml
@@ -72,7 +72,7 @@ composition:
     id: mediadive.compound:1312
     label: Sulfur powder
   chebi_term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
     confidence: 0.7
     match_type: corpus_consensus
@@ -170,6 +170,10 @@ preparation_notes: 'Prepare the liquid medium. Dispense the medium into Hungate 
   or serum bottles under gassing with N2. Steam medium for 3h on each of 3 successive
   days. Before inoculation add from sterile stock solutions:'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:24.819486Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3029_Main_sol_1479.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3029_Main_sol_1479.yaml
@@ -60,7 +60,7 @@ composition:
     id: mediadive.compound:1312
     label: Sulfur powder
   chebi_term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
     confidence: 0.7
     match_type: corpus_consensus
@@ -134,6 +134,10 @@ preparation_notes: 'Prepare the liquid medium. Dispense the medium into Hungate 
   or serum bottles under gassing with N2. Steam medium for 3h on each of 3 successive
   days. Before inoculation add from sterile stock solutions:'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:24.835576Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3072_Solution_H.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3072_Solution_H.yaml
@@ -48,11 +48,6 @@ composition:
   term:
     id: mediadive.compound:1360
     label: Folinic acid
-  chebi_term:
-    id: CHEBI:42521
-    label: Folinic acid
-    confidence: 0.9
-    match_type: corpus_consensus
 - preferred_term: Nicotinamide
   concentration:
     value: '0.05'
@@ -107,6 +102,10 @@ preparation_notes: 'Prepare Solutions H, flush each with nitrogen to make them a
 
   Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:25.072987Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3124_Solution_A.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3124_Solution_A.yaml
@@ -11,11 +11,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Na2HPO4 x 7 H2O
   concentration:
     value: '0.44375'
@@ -45,6 +40,10 @@ preparation_notes: 'Adjust pH to > 8.0, autoclave at 110°C
 
   Original volume: 800 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:25.304877Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3132_Main_sol_1513.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3132_Main_sol_1513.yaml
@@ -83,7 +83,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -198,6 +198,10 @@ preparation_notes: 'Dissolve ingredients (except bicarbonate, thiosulfate and vi
 
   Original volume: 1002 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:25.324358Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3155_Main_sol_1525.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3155_Main_sol_1525.yaml
@@ -12,7 +12,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -139,6 +139,10 @@ preparation_notes: 'Dissolve ingredients (except glucose, peptone and vitamins) 
 
   Original volume: 1011 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:25.438669Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3364_Main_sol_1617.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3364_Main_sol_1617.yaml
@@ -11,11 +11,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Soya pepton
   concentration:
     value: '3'
@@ -73,6 +68,10 @@ composition:
     match_type: corpus_consensus
 preparation_notes: Adjust pH to 7.3.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:26.299612Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3386_Main_sol_1630b.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3386_Main_sol_1630b.yaml
@@ -118,11 +118,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '1000'
@@ -147,6 +142,10 @@ preparation_notes: 'Dissolve ingredients (except bicarbonate, trace elements, se
 
   Note: Use at least 5 - 10% (v/v) inoculum and incubate in the dark without shaking.'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:26.391590Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3427_Main_sol_1653.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3427_Main_sol_1653.yaml
@@ -47,7 +47,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -88,6 +88,10 @@ composition:
     confidence: 0.7
     match_type: corpus_consensus
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:26.554211Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3515_Main_sol_1697.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3515_Main_sol_1697.yaml
@@ -84,7 +84,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -145,6 +145,10 @@ preparation_notes: 'Dissolve ingredients (except HEPES buffer, magnesium chlorid
 
   Original volume: 1002 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:26.901032Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3692_Main_sol_J65.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3692_Main_sol_J65.yaml
@@ -35,11 +35,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: L-Asparagine
   concentration:
     value: '0.25'
@@ -152,6 +147,10 @@ composition:
     match_type: corpus_consensus
 preparation_notes: pH unadjusted.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:27.620413Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_3755_Main_sol_J117.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_3755_Main_sol_J117.yaml
@@ -23,13 +23,12 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 preparation_notes: Separately sterilize catalase by filtration.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:27.860526Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_4370_Main_sol_J556.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_4370_Main_sol_J556.yaml
@@ -83,7 +83,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -105,6 +105,10 @@ preparation_notes: "Mix components and autoclave. After cooling, add the followi
   \ rubber stoppers.\nFinally, replace the gas phase with 20% methane and 5% CO2 in\
   \ air (by volume).\n\nOriginal volume: 1002 mL"
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:30.938558Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5045_Main_sol_J1005.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5045_Main_sol_J1005.yaml
@@ -23,11 +23,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: KNO3
   concentration:
     value: '10'
@@ -92,6 +87,10 @@ preparation_notes: Add components to distilled water and bring volume to 1.0 L. 
   preparation of solid medium, add 20.0 g/L agar. Autoclave and adjust pH to 7.2 -
   7.5 with NaOH.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:34.688466Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5113_Aromatic_fatty_acids_solution.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5113_Aromatic_fatty_acids_solution.yaml
@@ -24,7 +24,7 @@ composition:
     id: mediadive.compound:1546
     label: Phenyl propionic acid
   chebi_term:
-    id: CHEBI:501520
+    id: CHEBI:28631
     label: Phenyl propionic acid
     confidence: 0.7
     match_type: corpus_consensus
@@ -69,6 +69,10 @@ preparation_notes: 'Autoclave and store under a N2 atmosphere.
 
   Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:35.106024Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5126_Main_sol_J1061.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5126_Main_sol_J1061.yaml
@@ -134,7 +134,7 @@ composition:
     id: mediadive.compound:452
     label: Tris-HCl
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
@@ -144,6 +144,10 @@ preparation_notes: 'Add components to distilled water and bring volume to 1.0 L.
 
   Original volume: 101 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:35.175775Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5245_Casein_solution_5_w_v.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5245_Casein_solution_5_w_v.yaml
@@ -11,11 +11,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '1000.0'
@@ -35,6 +30,10 @@ preparation_notes: 'Suspend casein in distilled water and keep at 50C. Titrate p
 
   Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:35.966532Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5319_Main_sol_J1200.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5319_Main_sol_J1200.yaml
@@ -70,7 +70,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -81,6 +81,10 @@ preparation_notes: "Mix components and autoclave. For preparation of solid mediu
   \ rubber stoppers. Finally, add methane to make a concentration of 50% in the gas\
   \ phase (by volume)."
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:36.458556Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5548_Aromatic_fatty_acids_solution.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5548_Aromatic_fatty_acids_solution.yaml
@@ -24,7 +24,7 @@ composition:
     id: mediadive.compound:1546
     label: Phenyl propionic acid
   chebi_term:
-    id: CHEBI:501520
+    id: CHEBI:28631
     label: Phenyl propionic acid
     confidence: 0.7
     match_type: corpus_consensus
@@ -66,6 +66,10 @@ composition:
     match_type: exact_match
 preparation_notes: 'Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:37.734708Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_5668_Bacto_Middelbrook_OADC_enrichment_Difco_212240.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_5668_Bacto_Middelbrook_OADC_enrichment_Difco_212240.yaml
@@ -42,11 +42,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: NaCl
   concentration:
     value: '8.5'
@@ -73,6 +68,10 @@ composition:
     match_type: corpus_consensus
 preparation_notes: 'Original volume: 100 mL'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:38.297606Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_6040_Mail_sol_C49.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_6040_Mail_sol_C49.yaml
@@ -11,11 +11,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Na2HPO4 x 7 H2O
   concentration:
     value: '2.77778'
@@ -91,6 +86,10 @@ preparation_notes: "To be added later:\nAdd  the  first six  constituents  in th
   Aseptically add the foetal calf serum to a final concentration of 10%.\nStore at\
   \ 4°C.\n\nOriginal volume: 900 mL"
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:39.470407Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_6189_Mail_sol_C50.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_6189_Mail_sol_C50.yaml
@@ -11,11 +11,6 @@ composition:
   term:
     id: mediadive.compound:1381
     label: Casein
-  chebi_term:
-    id: CHEBI:3448
-    label: Casein
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Na2HPO4
   concentration:
     value: '1.47222'
@@ -84,6 +79,10 @@ preparation_notes: "To be added later:\nAdd  the  first six  constituents  in th
   Aseptically add the foetal calf serum to a final concentration of 10%.\nStore at\
   \ 4°C.\n\nOriginal volume: 900 mL"
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:39.929569Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_6397_Main_sol_1012b.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_6397_Main_sol_1012b.yaml
@@ -12,7 +12,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -61,6 +61,10 @@ preparation_notes: 'Grow prey bacteria on agar plates using the medium indicated
   Inoculate the complete medium immediately after preparation and incubate the suspension
   with shaking until a decrease in turbidity is visible.'
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:40.389160Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_805_Main_sol_394.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_805_Main_sol_394.yaml
@@ -26,7 +26,7 @@ composition:
     id: mediadive.compound:452
     label: Tris-HCl
   chebi_term:
-    id: CHEBI:1185531
+    id: CHEBI:9754
     label: Tris-HCl
     confidence: 0.7
     match_type: kg_fallback
@@ -94,6 +94,10 @@ preparation_notes: "Autoclave, cool, and then add: \nMagnesium chloride should b
   \ sterilized separately by autoclaving, and the other ingredients should be sterilized\
   \ separately by filtration.\n\nOriginal volume: 1070 mL"
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:41.149775Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_819_Solution_A.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_819_Solution_A.yaml
@@ -40,7 +40,7 @@ composition:
     id: mediadive.compound:461
     label: HEPES buffer
   chebi_term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
     confidence: 0.7
     match_type: corpus_consensus
@@ -130,6 +130,10 @@ composition:
 preparation_notes: Stir slowly at 4 - 10°C for 3 hours, adjust pH to 7.6 with 5 M
   NaOH. Filter sterilize.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:41.231620Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/mediadive_961_Main_sol_469.yaml
+++ b/data/normalized_yaml/bacterial/mediadive_961_Main_sol_469.yaml
@@ -61,11 +61,6 @@ composition:
   term:
     id: mediadive.compound:270
     label: Catalase
-  chebi_term:
-    id: CHEBI:3463
-    label: Catalase
-    confidence: 0.7
-    match_type: corpus_consensus
 - preferred_term: Distilled water
   concentration:
     value: '980'
@@ -82,6 +77,10 @@ preparation_notes: Adjust pH to 7.0. Add catalase and MgSO4 to 10 ml of distille
   water each, and sterilize separately by filtration. Cool down autoclaved main solution
   to 50°C, and aseptically add catalase and MgSO4 solution.
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-13T06:20:41.694494Z'
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID

--- a/data/normalized_yaml/bacterial/medium_10.yaml
+++ b/data/normalized_yaml/bacterial/medium_10.yaml
@@ -166,7 +166,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -251,6 +251,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.785618Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/medium_2_for_sulfurospirillum.yaml
+++ b/data/normalized_yaml/bacterial/medium_2_for_sulfurospirillum.yaml
@@ -132,8 +132,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -436,6 +436,10 @@ notes: 'Source: https://togomedium.org/medium/M2135
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:59.146252Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/medium_330_modified_for_dsm_17630.yaml
+++ b/data/normalized_yaml/bacterial/medium_330_modified_for_dsm_17630.yaml
@@ -287,7 +287,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -318,6 +318,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:02.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16839.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16839.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16840.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16840.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16980.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16980.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16981.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_16981.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17042.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17042.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17774.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17774.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17775.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17775.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17776.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17776.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17777.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17777.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17778.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17778.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17779.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_17779.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20461.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20461.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20462.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20462.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20465.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20465.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20466.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20466.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20467.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20467.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20756.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20756.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20757.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20757.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20762.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20762.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20764.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20764.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20765.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_20765.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_21655.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_21655.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_24661.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_24661.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7198.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7198.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7199.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7199.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7200.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7200.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7201.yaml
+++ b/data/normalized_yaml/bacterial/medium_58_modified_for_dsm_7201.yaml
@@ -28,9 +28,6 @@ ingredients:
   concentration:
     value: '5'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Glucose
   term:
     id: CHEBI:17234
@@ -147,6 +144,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44338.yaml
+++ b/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44338.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44339.yaml
+++ b/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44339.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44482.yaml
+++ b/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44482.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44483.yaml
+++ b/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44483.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44680.yaml
+++ b/data/normalized_yaml/bacterial/medium_645_modified_for_dsm_44680.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_911_modified_for_dsm_44536.yaml
+++ b/data/normalized_yaml/bacterial/medium_911_modified_for_dsm_44536.yaml
@@ -224,9 +224,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -243,6 +240,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/medium_dh.yaml
+++ b/data/normalized_yaml/bacterial/medium_dh.yaml
@@ -11,7 +11,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Buffer; Properties: Defined component, Solution'
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   mediaingredientmech_term:
     id: MediaIngredientMech:000426
@@ -226,6 +226,10 @@ notes: 'Source: https://togomedium.org/medium/M2241'
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.210714Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/medium_for_erythrobacter_longus.yaml
+++ b/data/normalized_yaml/bacterial/medium_for_erythrobacter_longus.yaml
@@ -20,9 +20,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Yeast extract
   concentration:
     value: '1'
@@ -52,6 +49,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.952946Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/medium_for_strain_m6_x2.yaml
+++ b/data/normalized_yaml/bacterial/medium_for_strain_m6_x2.yaml
@@ -124,9 +124,6 @@ ingredients:
     value: '5'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Cysteine-HCl·H2O
   concentration:
     value: '0.5'
@@ -321,6 +318,10 @@ notes: 'Source: https://togomedium.org/medium/M2059
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.979062Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/methylomonas_medium_elbe.yaml
+++ b/data/normalized_yaml/bacterial/methylomonas_medium_elbe.yaml
@@ -43,7 +43,7 @@ ingredients:
     label: CaCl2 x 2 H2O
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '2.383'
@@ -244,6 +244,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.134309Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/methylosoma_difficile_medium.yaml
+++ b/data/normalized_yaml/bacterial/methylosoma_difficile_medium.yaml
@@ -63,7 +63,7 @@ ingredients:
     label: Na2SO4
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '5'
@@ -261,6 +261,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.924035Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/mic_cit_herriott_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mic_cit_herriott_et_al.yaml
@@ -263,13 +263,13 @@ ingredients:
     label: Hemin
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '7.13903'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 preparation_steps:
 - step_number: 1
@@ -282,6 +282,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:45.211189Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/mic_herriott_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mic_herriott_et_al.yaml
@@ -277,13 +277,13 @@ ingredients:
     label: Hemin
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '7.13903'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 preparation_steps:
 - step_number: 1
@@ -296,6 +296,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:45.200553Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/middelbrook_medium.yaml
+++ b/data/normalized_yaml/bacterial/middelbrook_medium.yaml
@@ -260,9 +260,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -279,6 +276,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/middlebrock_7h11_agar.yaml
+++ b/data/normalized_yaml/bacterial/middlebrock_7h11_agar.yaml
@@ -226,9 +226,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -256,6 +253,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:12.721777Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/middlebrook_7h10_plates_difco_supplemented_with_middlebrook_albumin_dextrose_catalase_and_tween_80.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h10_plates_difco_supplemented_with_middlebrook_albumin_dextrose_catalase_and_tween_80.yaml
@@ -104,9 +104,6 @@ ingredients:
     value: '0.0015'
     unit: G_PER_L
   notes: 'Properties: Defined component, Simple component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M2879
   term:
@@ -131,6 +128,10 @@ notes: 'Source: https://togomedium.org/medium/M2879
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.373444Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_7h11_agar.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h11_agar.yaml
@@ -292,9 +292,6 @@ ingredients:
     value: '0.03'
     unit: G_PER_L
   notes: 'Properties: Defined component, Simple component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M1946
   term:
@@ -322,6 +319,10 @@ notes: 'Source: https://togomedium.org/medium/M1946
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.718335Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_7h11_agar_difco.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h11_agar_difco.yaml
@@ -296,9 +296,6 @@ ingredients:
     value: '0.03'
     unit: G_PER_L
   notes: 'Properties: Defined component, Simple component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M2407
   term:
@@ -322,6 +319,10 @@ notes: 'Source: https://togomedium.org/medium/M2407
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.474494Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_7h11_solid_medium_supplemented_with_10_albumin_dextrose_and_catalase.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h11_solid_medium_supplemented_with_10_albumin_dextrose_and_catalase.yaml
@@ -241,9 +241,6 @@ ingredients:
     value: '0.0015'
     unit: G_PER_L
   notes: 'Properties: Simple component, Defined component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M2401
   term:
@@ -268,6 +265,10 @@ notes: 'Source: https://togomedium.org/medium/M2401
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.462214Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_7h9_difco_liquid_medium_supplemented_with_middlebrook_albumin_dextrose_catalase_and_tween_80.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h9_difco_liquid_medium_supplemented_with_middlebrook_albumin_dextrose_catalase_and_tween_80.yaml
@@ -104,9 +104,6 @@ ingredients:
     value: '0.0015'
     unit: G_PER_L
   notes: 'Properties: Simple component, Defined component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M2880
   term:
@@ -131,6 +128,10 @@ notes: 'Source: https://togomedium.org/medium/M2880
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.374710Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_7h9_liquid_medium_supplemented_with_10_albumin_dextrose_and_catalase.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h9_liquid_medium_supplemented_with_10_albumin_dextrose_and_catalase.yaml
@@ -249,9 +249,6 @@ ingredients:
     value: '0.0015'
     unit: G_PER_L
   notes: 'Properties: Defined component, Simple component'
-  term:
-    id: CHEBI:3463
-    label: Catalase
 media_term:
   preferred_term: TOGO Medium M2400
   term:
@@ -276,6 +273,10 @@ notes: 'Source: https://togomedium.org/medium/M2400
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.459711Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/middlebrook_medium.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_medium.yaml
@@ -259,9 +259,6 @@ ingredients:
     id: CHEBI:4167
     label: Dextrose
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.04'
     unit: G_PER_L
@@ -290,6 +287,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.822302Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/minimal_medium_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_tang_et_al_2009.yaml
@@ -134,13 +134,13 @@ ingredients:
     label: PIPES
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '30.0'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 preparation_steps:
 - step_number: 1
@@ -153,6 +153,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:44.226667Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_and_salt_stress_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_and_salt_stress_tang_et_al_2009.yaml
@@ -271,13 +271,13 @@ ingredients:
     label: PIPES
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '30.0'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 - preferred_term: Threonine
   concentration:
@@ -294,6 +294,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:44.259619Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_tang_et_al_2009.yaml
@@ -261,13 +261,13 @@ ingredients:
     label: PIPES
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '30.0'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 - preferred_term: Threonine
   concentration:
@@ -284,6 +284,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:44.247454Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/minimal_medium_with_salt_stress_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_with_salt_stress_tang_et_al_2009.yaml
@@ -144,13 +144,13 @@ ingredients:
     label: PIPES
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '30.0'
     unit: MILLIMOLAR
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 preparation_steps:
 - step_number: 1
@@ -163,6 +163,10 @@ preparation_steps:
   action: FILTER_STERILIZE
   description: Sterilize by filtration (0.22 μm) to preserve heat-sensitive components
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T07:21:44.237020Z'
   curator: mediadb-import
   action: Imported from MediaDB

--- a/data/normalized_yaml/bacterial/modified_am5_medium_2.yaml
+++ b/data/normalized_yaml/bacterial/modified_am5_medium_2.yaml
@@ -277,7 +277,7 @@ ingredients:
     label: Phenyl acetic acid
 - preferred_term: Phenyl propionic acid
   term:
-    id: CHEBI:501520
+    id: CHEBI:28631
     label: Phenyl propionic acid
   concentration:
     value: '0.75'
@@ -328,6 +328,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.407864Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/modified_mjys_medium.yaml
+++ b/data/normalized_yaml/bacterial/modified_mjys_medium.yaml
@@ -144,8 +144,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -443,6 +443,10 @@ notes: 'Source: https://togomedium.org/medium/M1988
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.802810Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/modified_mv_medium.yaml
+++ b/data/normalized_yaml/bacterial/modified_mv_medium.yaml
@@ -107,13 +107,13 @@ ingredients:
     label: Sodium pyruvate
 - preferred_term: Sodium L-lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: Sodium L-lactate
 - preferred_term: HCl
   term:
@@ -353,6 +353,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.402390Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/modified_tc_medium.yaml
+++ b/data/normalized_yaml/bacterial/modified_tc_medium.yaml
@@ -141,8 +141,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -469,6 +469,10 @@ notes: 'Source: https://togomedium.org/medium/M1989
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.807495Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/natranaeroarchaeum_medium_aarc1.yaml
+++ b/data/normalized_yaml/bacterial/natranaeroarchaeum_medium_aarc1.yaml
@@ -67,7 +67,7 @@ ingredients:
     label: NaHCO3
 - preferred_term: Sulfur powder
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   concentration:
     value: '2'
@@ -331,6 +331,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.552386Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/natronospira_proteinivora_medium.yaml
+++ b/data/normalized_yaml/bacterial/natronospira_proteinivora_medium.yaml
@@ -94,9 +94,6 @@ ingredients:
     id: CHEBI:31206
     label: NH4Cl
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '50'
     unit: G_PER_L
@@ -216,6 +213,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.772521Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/nitratiruptor_and_nitratifactor_medium.yaml
+++ b/data/normalized_yaml/bacterial/nitratiruptor_and_nitratifactor_medium.yaml
@@ -45,7 +45,7 @@ ingredients:
     label: Na2S2O3 x 5 H2O
 - preferred_term: Sulfur powder
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   concentration:
     value: '3'
@@ -348,6 +348,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:01.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/nitratiruptor_and_nitratifractor_medium.yaml
+++ b/data/normalized_yaml/bacterial/nitratiruptor_and_nitratifractor_medium.yaml
@@ -44,7 +44,7 @@ ingredients:
     label: Na2S2O3 x 5 H2O
 - preferred_term: Sulfur powder
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   concentration:
     value: '3'
@@ -358,6 +358,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:13.138222Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/nitrosopumilus_ureiphilus_medium.yaml
+++ b/data/normalized_yaml/bacterial/nitrosopumilus_ureiphilus_medium.yaml
@@ -103,9 +103,6 @@ ingredients:
     id: CHEBI:50144
     label: Na-pyruvate
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.0025'
     unit: G_PER_L
@@ -350,6 +347,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.053552Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/omiz_pat_medium_modified.yaml
+++ b/data/normalized_yaml/bacterial/omiz_pat_medium_modified.yaml
@@ -677,9 +677,6 @@ ingredients:
     id: CHEBI:27470
     label: Folic acid
 - preferred_term: Folinic acid
-  term:
-    id: CHEBI:42521
-    label: Folinic acid
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -1088,6 +1085,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.604316Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/phosphoac3_medium.yaml
+++ b/data/normalized_yaml/bacterial/phosphoac3_medium.yaml
@@ -139,13 +139,13 @@ ingredients:
     label: NaHCO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S x 9 H2O
   term:
@@ -270,6 +270,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.867340Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/ppes_ii_agar_medium.yaml
+++ b/data/normalized_yaml/bacterial/ppes_ii_agar_medium.yaml
@@ -24,9 +24,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Yeast extract
   concentration:
     value: '1'
@@ -108,6 +105,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:13.303821Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/pyg_medium_with_volatile_fatty_acids.yaml
+++ b/data/normalized_yaml/bacterial/pyg_medium_with_volatile_fatty_acids.yaml
@@ -206,7 +206,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -291,6 +291,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.808034Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/pyrodictium_occultum_medium.yaml
+++ b/data/normalized_yaml/bacterial/pyrodictium_occultum_medium.yaml
@@ -132,8 +132,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -346,6 +346,10 @@ notes: 'Source: https://togomedium.org/medium/M1631
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.010127Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/pyvg_medium.yaml
+++ b/data/normalized_yaml/bacterial/pyvg_medium.yaml
@@ -166,7 +166,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -199,6 +199,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.272408Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/r_agar_with_catalase.yaml
+++ b/data/normalized_yaml/bacterial/r_agar_with_catalase.yaml
@@ -22,9 +22,6 @@ ingredients:
     id: CHEBI:2509
     label: R agar
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.06'
     unit: G_PER_L
@@ -35,6 +32,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.758453Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/rumen_bacteria_medium.yaml
+++ b/data/normalized_yaml/bacterial/rumen_bacteria_medium.yaml
@@ -289,7 +289,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -334,6 +334,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.815161Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/s88_vitamins.yaml
+++ b/data/normalized_yaml/bacterial/s88_vitamins.yaml
@@ -237,7 +237,7 @@ ingredients:
   notes: From CCAP Medium MR_S88.pdf; Curated from CCAP Medium MR_S88.pdf specification
 - preferred_term: MnSO .4H O
   term:
-    id: CHEBI:75217
+    id: CHEBI:86358
     label: MnSO .4H O
   curation_metadata:
     mapping_quality: LLM_ASSISTED
@@ -342,6 +342,10 @@ applications:
 references:
 - reference: doi.org/10.1017/S0025315400019238
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.813284Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/scgyem_medium.yaml
+++ b/data/normalized_yaml/bacterial/scgyem_medium.yaml
@@ -16,9 +16,6 @@ ingredients:
     value: '100'
     unit: G_PER_L
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '12.5'
     unit: G_PER_L
@@ -147,6 +144,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.667295Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/seawater_starch_agar_sws.yaml
+++ b/data/normalized_yaml/bacterial/seawater_starch_agar_sws.yaml
@@ -29,9 +29,6 @@ ingredients:
     value: '1'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 media_term:
   preferred_term: TOGO Medium M1416
   term:
@@ -45,6 +42,10 @@ notes: 'Source: https://togomedium.org/medium/M1416
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.656903Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/selenomonas_wg_medium.yaml
+++ b/data/normalized_yaml/bacterial/selenomonas_wg_medium.yaml
@@ -132,7 +132,7 @@ ingredients:
     label: Butyric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -165,6 +165,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.350440Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/spirillum_d427_medium.yaml
+++ b/data/normalized_yaml/bacterial/spirillum_d427_medium.yaml
@@ -80,9 +80,6 @@ ingredients:
     id: CHEBI:2509
     label: Agar
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '1'
     unit: G_PER_L
@@ -249,6 +246,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: 2026-01-27T01:15:03.fZ
   curator: komodo-web-import
   action: Imported from KOMODO web table

--- a/data/normalized_yaml/bacterial/spirillum_winogradskyi_medium.yaml
+++ b/data/normalized_yaml/bacterial/spirillum_winogradskyi_medium.yaml
@@ -79,9 +79,6 @@ ingredients:
     id: CHEBI:2509
     label: Agar
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '1'
     unit: G_PER_L
@@ -264,6 +261,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:12.478664Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/starch_casein_agar_sca_ph_5_5.yaml
+++ b/data/normalized_yaml/bacterial/starch_casein_agar_sca_ph_5_5.yaml
@@ -91,9 +91,6 @@ ingredients:
     value: '0.3'
     unit: G_PER_L
   notes: 'Role: Nitrogen source; Properties: Undefined component'
-  term:
-    id: CHEBI:3448
-    label: ''
 - preferred_term: Soluble starch
   concentration:
     value: '10'
@@ -126,6 +123,10 @@ notes: 'Source: https://togomedium.org/medium/M1947
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.721276Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_2_nacl_and_lactate.yaml
+++ b/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_2_nacl_and_lactate.yaml
@@ -84,13 +84,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 552
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.29312'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 552
 - preferred_term: Resazurin
@@ -254,6 +254,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.128347Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_lactate.yaml
+++ b/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_lactate.yaml
@@ -78,13 +78,13 @@ ingredients:
     unit: G_PER_L
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.29312'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Resazurin
   term:
@@ -240,6 +240,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.914243Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_pyruvate.yaml
+++ b/data/normalized_yaml/bacterial/sulfate_reducing_bacterium_medium_with_pyruvate.yaml
@@ -85,13 +85,13 @@ ingredients:
   notes: Copied from referenced JCM Medium 552
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '2.29312'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   notes: Copied from referenced JCM Medium 552
 - preferred_term: Resazurin
@@ -256,6 +256,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:16.918221Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/sulfolobus_metallicus_medium.yaml
+++ b/data/normalized_yaml/bacterial/sulfolobus_metallicus_medium.yaml
@@ -138,8 +138,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -196,6 +196,10 @@ notes: 'Source: https://togomedium.org/medium/M1723
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.226005Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/sulfurimonas_gotlandica_medium.yaml
+++ b/data/normalized_yaml/bacterial/sulfurimonas_gotlandica_medium.yaml
@@ -76,7 +76,7 @@ ingredients:
     label: KNO3
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '2.37525'
@@ -384,6 +384,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:14.670472Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/superstespora_medium.yaml
+++ b/data/normalized_yaml/bacterial/superstespora_medium.yaml
@@ -30,9 +30,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Tropic Marine salt
   concentration:
     value: '20'
@@ -155,6 +152,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.290772Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/tcp_medium.yaml
+++ b/data/normalized_yaml/bacterial/tcp_medium.yaml
@@ -129,8 +129,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -398,6 +398,10 @@ notes: 'Source: https://togomedium.org/medium/M1697
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.159441Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/thermodesulfovibrio_medium_for_n1.yaml
+++ b/data/normalized_yaml/bacterial/thermodesulfovibrio_medium_for_n1.yaml
@@ -120,13 +120,13 @@ ingredients:
     label: NaHCO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Sodium thioglycolate
   term:
@@ -398,6 +398,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.436845Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/thermoproteus_and_vulcanisaeta_medium.yaml
+++ b/data/normalized_yaml/bacterial/thermoproteus_and_vulcanisaeta_medium.yaml
@@ -162,8 +162,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -220,6 +220,10 @@ notes: 'Source: https://togomedium.org/medium/M1644
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.038559Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/thermoproteus_tenax_medium_2.yaml
+++ b/data/normalized_yaml/bacterial/thermoproteus_tenax_medium_2.yaml
@@ -174,8 +174,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -242,6 +242,10 @@ notes: 'Source: https://togomedium.org/medium/M1635
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.020788Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/thiomonas_cuprina_medium.yaml
+++ b/data/normalized_yaml/bacterial/thiomonas_cuprina_medium.yaml
@@ -117,7 +117,7 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
+    id: CHEBI:33403
     label: Sulfur powder
   concentration:
     value: variable
@@ -270,6 +270,10 @@ notes: 'Source: https://togomedium.org/medium/M3034
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:59.206632Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/thiosocius_medium.yaml
+++ b/data/normalized_yaml/bacterial/thiosocius_medium.yaml
@@ -74,7 +74,7 @@ ingredients:
     label: K2HPO4
 - preferred_term: HEPES buffer
   term:
-    id: CHEBI:19708
+    id: CHEBI:46756
     label: HEPES buffer
   concentration:
     value: '4.766'
@@ -314,6 +314,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.273055Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/togo_medium_m1470.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m1470.yaml
@@ -402,8 +402,8 @@ ingredients:
   notes: 'Role: Carbon source; Properties: Organic compound, Defined component, Simple
     component'
   term:
-    id: CHEBI:503742
-    label: ''
+    id: CHEBI:28484
+    label: isovaleric acid
   mediaingredientmech_term:
     id: MediaIngredientMech:000378
     label: iso-Valeric acid
@@ -581,6 +581,10 @@ notes: 'Source: https://togomedium.org/medium/M1470
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:57.715629Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/togo_medium_m178.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m178.yaml
@@ -12,8 +12,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Defined component, Inorganic compound,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -55,6 +55,10 @@ notes: 'Source: https://togomedium.org/medium/M178
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.560523Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/togo_medium_m179.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m179.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Simple component, Inorganic compound,
     Defined component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -92,6 +92,10 @@ notes: 'Source: https://togomedium.org/medium/M179
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.561409Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/togo_medium_m1833.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m1833.yaml
@@ -411,8 +411,8 @@ ingredients:
   notes: 'Role: Carbon source; Properties: Organic compound, Defined component, Simple
     component'
   term:
-    id: CHEBI:503742
-    label: ''
+    id: CHEBI:28484
+    label: isovaleric acid
   mediaingredientmech_term:
     id: MediaIngredientMech:000378
     label: iso-Valeric acid
@@ -578,6 +578,10 @@ notes: 'Source: https://togomedium.org/medium/M1833
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:58.458862Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/togo_medium_m199.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m199.yaml
@@ -33,8 +33,8 @@ ingredients:
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
   term:
-    id: CHEBI:14258
-    label: ''
+    id: CHEBI:33403
+    label: elemental sulfur
   mediaingredientmech_term:
     id: MediaIngredientMech:001072
     label: Sulfur (powder)
@@ -235,6 +235,10 @@ notes: 'Source: https://togomedium.org/medium/M199
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:54.596655Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/treponema_rectale_medium.yaml
+++ b/data/normalized_yaml/bacterial/treponema_rectale_medium.yaml
@@ -402,7 +402,7 @@ ingredients:
     synonym_type: EXACT
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '30.0247'
@@ -567,6 +567,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.524462Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/treponema_saccharophilum_medium.yaml
+++ b/data/normalized_yaml/bacterial/treponema_saccharophilum_medium.yaml
@@ -227,7 +227,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '130.34'
@@ -254,6 +254,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:10.797459Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/tryptic_soy_agar_broth_with_5_sheep_blood_defibrinated.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_agar_broth_with_5_sheep_blood_defibrinated.yaml
@@ -159,9 +159,6 @@ ingredients:
     value: '5'
     unit: G_PER_L
   notes: 'Properties: Undefined component'
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Tryptone
   concentration:
     value: '15'
@@ -192,6 +189,10 @@ notes: 'Source: https://togomedium.org/medium/M2572
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-27T06:35:56.770218Z'
   curator: togo-import
   action: Imported from TOGO Medium

--- a/data/normalized_yaml/bacterial/tryptic_soy_broth_medium_sigma_t8907_1kg.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_broth_medium_sigma_t8907_1kg.yaml
@@ -13,9 +13,6 @@ media_term:
 notes: 'Source: DSMZ | Link: https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium1617.pdf'
 ingredients:
 - preferred_term: Casein
-  term:
-    id: CHEBI:3448
-    label: Casein
   concentration:
     value: '17'
     unit: G_PER_L
@@ -60,6 +57,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.021466Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/tsb.yaml
+++ b/data/normalized_yaml/bacterial/tsb.yaml
@@ -15,9 +15,6 @@ ingredients:
   concentration:
     value: '3'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: null
   notes: 'Mapping: micromediaparam (confidence: 0.95)'
 - preferred_term: D-Glucose
   concentration:
@@ -51,6 +48,10 @@ sources:
   database_id: TSB
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:14.887624+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/bacterial/tsb_yeastextract.yaml
+++ b/data/normalized_yaml/bacterial/tsb_yeastextract.yaml
@@ -15,9 +15,6 @@ ingredients:
   concentration:
     value: '3'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: null
   notes: 'Mapping: micromediaparam (confidence: 0.95)'
 - preferred_term: D-Glucose
   concentration:
@@ -59,6 +56,10 @@ sources:
   database_id: TSB_YeastExtract
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:14.894060+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/bacterial/widdel_freshwater_medium_with_lactate.yaml
+++ b/data/normalized_yaml/bacterial/widdel_freshwater_medium_with_lactate.yaml
@@ -94,13 +94,13 @@ ingredients:
     label: Resazurin
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '7.3'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S x 9 H2O
   term:
@@ -317,6 +317,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.080750Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/ycfa_medium.yaml
+++ b/data/normalized_yaml/bacterial/ycfa_medium.yaml
@@ -172,7 +172,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -307,6 +307,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.741367Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/ycfa_medium_modified.yaml
+++ b/data/normalized_yaml/bacterial/ycfa_medium_modified.yaml
@@ -164,7 +164,7 @@ ingredients:
     label: n-Valeric acid
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '31.0333'
@@ -295,6 +295,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:15.005756Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/ycfa_medium_with_10_rumen_fluid.yaml
+++ b/data/normalized_yaml/bacterial/ycfa_medium_with_10_rumen_fluid.yaml
@@ -188,7 +188,7 @@ ingredients:
   notes: Copied from referenced JCM Medium 1130
 - preferred_term: iso-Valeric acid
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: iso-Valeric acid
   concentration:
     value: '1'
@@ -329,6 +329,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:19.430175Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/bacterial/ym_catalase_medium.yaml
+++ b/data/normalized_yaml/bacterial/ym_catalase_medium.yaml
@@ -51,9 +51,6 @@ ingredients:
     id: CHEBI:62982
     label: NH4H2PO4
 - preferred_term: Catalase
-  term:
-    id: CHEBI:3463
-    label: Catalase
   concentration:
     value: '0.06'
     unit: G_PER_L
@@ -66,6 +63,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:11.275622Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/JCM_J913_MODIFIED_MARINE_AGAR_2216.yaml
+++ b/data/normalized_yaml/specialized/JCM_J913_MODIFIED_MARINE_AGAR_2216.yaml
@@ -30,9 +30,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Malt extract
   concentration:
     value: '1'
@@ -44,6 +41,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.988743Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/acy.yaml
+++ b/data/normalized_yaml/specialized/acy.yaml
@@ -281,7 +281,7 @@ ingredients:
     value: '0.025'
     unit: G_PER_L
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: null
   notes: 'Mapping: micromediaparam_legacy (confidence: 0.90); CAS: 503-74-2; MW: 102.13'
 - preferred_term: Proteose Peptone
@@ -337,6 +337,10 @@ sources:
   database_id: ACY
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:12.347223+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/specialized/marine_agar_with_1_tween_20.yaml
+++ b/data/normalized_yaml/specialized/marine_agar_with_1_tween_20.yaml
@@ -23,7 +23,7 @@ ingredients:
     label: Marine agar 2216
 - preferred_term: Tween 20
   term:
-    id: CHEBI:9784
+    id: CHEBI:53424
     label: Tween 20
   concentration:
     value: '10'
@@ -34,6 +34,10 @@ ingredients:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:17.541357Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/marine_chloroflexi_medium.yaml
+++ b/data/normalized_yaml/specialized/marine_chloroflexi_medium.yaml
@@ -27,7 +27,7 @@ ingredients:
   notes: From JCM Medium 1188; Curated from JCM Medium 1188 specification
 - preferred_term: MgCl2·6H2O
   term:
-    id: CHEBI:6635
+    id: CHEBI:86345
     label: MgCl2·6H2O
   curation_metadata:
     mapping_quality: LLM_ASSISTED
@@ -169,6 +169,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.951706Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/marine_srb_medium.yaml
+++ b/data/normalized_yaml/specialized/marine_srb_medium.yaml
@@ -117,13 +117,13 @@ ingredients:
     label: NaHCO3
 - preferred_term: L-Sodium lactate
   term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
   concentration:
     value: '20'
     unit: G_PER_L
   mediaingredientmech_chebi_term:
-    id: CHEBI:867561
+    id: CHEBI:232798
     label: L-Sodium lactate
 - preferred_term: Na2S x 9 H2O
   term:
@@ -338,6 +338,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.534365Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/mega.yaml
+++ b/data/normalized_yaml/specialized/mega.yaml
@@ -396,7 +396,7 @@ ingredients:
     value: '0.1'
     unit: G_PER_L
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: null
   notes: 'Mapping: micromediaparam_legacy (confidence: 0.90); CAS: 503-74-2; MW: 102.13'
 description: Mega medium
@@ -407,6 +407,10 @@ sources:
   database_id: Mega
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:13.556421+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/specialized/mgam.yaml
+++ b/data/normalized_yaml/specialized/mgam.yaml
@@ -55,9 +55,6 @@ ingredients:
   concentration:
     value: '1.2'
     unit: G_PER_L
-  term:
-    id: FOODON:03302129
-    label: Liver extract
   notes: 'Mapping: curated_dict (confidence: 0.98)'
 - preferred_term: D-Glucose
   concentration:
@@ -115,6 +112,10 @@ sources:
   database_id: mGAM
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:15.450402+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/specialized/modified_marine_agar_2216_with_5_nacl_ph_9.yaml
+++ b/data/normalized_yaml/specialized/modified_marine_agar_2216_with_5_nacl_ph_9.yaml
@@ -30,9 +30,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-  term:
-    id: CHEBI:8150
-    label: ''
 - preferred_term: Malt extract
   concentration:
     value: '1'
@@ -154,6 +151,10 @@ preparation_steps:
 applications:
 - Microbial cultivation
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 0 re-grounded to the correct CHEBI, 1 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-01-26T17:53:18.953111Z'
   curator: mediadive-import
   action: Imported from MediaDive

--- a/data/normalized_yaml/specialized/rch2_defined_tween.yaml
+++ b/data/normalized_yaml/specialized/rch2_defined_tween.yaml
@@ -34,7 +34,7 @@ ingredients:
     value: '0.5'
     unit: G_PER_L
   term:
-    id: CHEBI:9784
+    id: CHEBI:53424
     label: null
   notes: 'Mapping: micromediaparam_legacy (confidence: 0.90); CAS: 9005-64-5; MW:
     1227.54'
@@ -266,6 +266,10 @@ sources:
   database_id: RCH2 defined Tween
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:14.366223+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/data/normalized_yaml/specialized/ycfa.yaml
+++ b/data/normalized_yaml/specialized/ycfa.yaml
@@ -213,7 +213,7 @@ ingredients:
     value: '0.1'
     unit: G_PER_L
   term:
-    id: CHEBI:503742
+    id: CHEBI:28484
     label: null
   notes: 'Mapping: micromediaparam_legacy (confidence: 0.90); CAS: 503-74-2; MW: 102.13'
 description: Yeast Casitone Fatty Acids broth
@@ -224,6 +224,10 @@ sources:
   database_id: YCFA
   url: https://github.com/CultureBotAI/CultureBotHT
 curation_history:
+- timestamp: '2026-06-14T05:58:58.561437+00:00'
+  curator: idnf-grounding-fix-v1.0
+  action: Fixed ID_NOT_FOUND term groundings
+  notes: 'Absent/obsolete CHEBI term ids fixed - 1 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
 - timestamp: '2026-03-18T04:31:15.260608+00:00'
   curator: import_from_culturebotht.py
   action: IMPORTED

--- a/project.justfile
+++ b/project.justfile
@@ -888,13 +888,14 @@ validate-strict *args:
 # on the existing backlog (G24/G25). Re-baseline by bumping --max-allowed.
 # Baseline history: G25 Phase 1 promoting kg_fallback chebi_terms to corpus
 # consensus surfaced latent salt/hydrate/isomer name->multi-CHEBI ambiguities
-# (peaked at 111); the primary-term regrounding pass (483 wrong-id fixes) then
-# resolved two of them, tightening the reliable-layer backlog to 109.
+# (peaked at 111); the primary-term regrounding pass (483 wrong-id fixes) cut it
+# to 109; the ID_NOT_FOUND remediation (re-ground absent ids + de-ground mixtures)
+# cleared the last few, tightening the reliable-layer backlog to 101.
 [group('QC')]
 check-chebi-grounding *args:
     #!/usr/bin/env bash
     uv run python scripts/audit_chebi_consistency.py \
-        --out reports/chebi_consistency.tsv --max-allowed 109 {{args}}
+        --out reports/chebi_consistency.tsv --max-allowed 101 {{args}}
 
 # Scan-only collision check for CultureMech:NNNNNN IDs. Exits non-zero if any
 # cross-file duplicates are detected. Use as a pre-commit / CI safety net.

--- a/reports/chebi_consistency.tsv
+++ b/reports/chebi_consistency.tsv
@@ -15,7 +15,6 @@ A_name_multi_chebi	dextrose	{'CHEBI:17634': 16, 'CHEBI:17234': 157, 'CHEBI:4167'
 A_name_multi_chebi	fe(iii) citrate	{'CHEBI:144421': 265, 'CHEBI:4991': 6}
 A_name_multi_chebi	d(+)-glucose	{'CHEBI:17634': 237, 'CHEBI:42758': 3}
 A_name_multi_chebi	calcium chloride dihydrate	{'CHEBI:86158': 227, 'CHEBI:3312': 2}
-A_name_multi_chebi	mgcl2·6h2o	{'CHEBI:86345': 226, 'CHEBI:6635': 1}
 A_name_multi_chebi	hepes	{'CHEBI:46756': 157, 'CHEBI:42334': 65}
 A_name_multi_chebi	magnesium sulfate heptahydrate	{'CHEBI:31795': 58, 'CHEBI:32599': 2, 'CHEBI:86463': 160}
 A_name_multi_chebi	maltose	{'CHEBI:17306': 137, 'CHEBI:18167': 40}
@@ -39,9 +38,8 @@ A_name_multi_chebi	fructose	{'CHEBI:28645': 21, 'CHEBI:28757': 39, 'CHEBI:15824'
 A_name_multi_chebi	magnesium chloride hexahydrate	{'CHEBI:6636': 2, 'CHEBI:86345': 74}
 A_name_multi_chebi	voso4 x 2 h2o	{'CHEBI:87009': 54, 'CHEBI:87014': 11, 'CHEBI:33146': 9}
 A_name_multi_chebi	dl-dithiothreitol	{'CHEBI:18320': 64, 'CHEBI:42106': 1}
-A_name_multi_chebi	isovaleric acid	{'CHEBI:28484': 60, 'CHEBI:503742': 3}
 A_name_multi_chebi	na2s2o3	{'CHEBI:132112': 42, 'CHEBI:32150': 19}
-A_name_multi_chebi	sodium nitrate	{'CHEBI:65246': 1, 'CHEBI:63005': 56, 'CHEBI:34754': 1}
+A_name_multi_chebi	sodium nitrate	{'CHEBI:65246': 1, 'CHEBI:63005': 57}
 A_name_multi_chebi	d-fructose	{'CHEBI:15824': 44, 'CHEBI:48095': 9}
 A_name_multi_chebi	mnso4 x 4 h2o	{'CHEBI:86358': 46, 'CHEBI:86360': 6}
 A_name_multi_chebi	dithiothreitol	{'CHEBI:18320': 22, 'CHEBI:42106': 30}
@@ -50,18 +48,14 @@ A_name_multi_chebi	(nh4)3 citrate	{'CHEBI:63037': 40, 'CHEBI:72699': 4}
 A_name_multi_chebi	arginine	{'CHEBI:29016': 31, 'CHEBI:16467': 6, 'CHEBI:32696': 6}
 A_name_multi_chebi	tricine	{'CHEBI:35920': 29, 'CHEBI:39063': 12, 'CHEBI:9750': 1}
 A_name_multi_chebi	inositol	{'CHEBI:17268': 18, 'CHEBI:24848': 18}
-A_name_multi_chebi	bacto soytone	{'CHEBI:16247': 3, 'CHEBI:8150': 32}
 A_name_multi_chebi	fe(nh4)citrate	{'CHEBI:144421': 16, 'CHEBI:31604': 19}
 A_name_multi_chebi	(nh4)2hpo4	{'CHEBI:62476': 13, 'CHEBI:63051': 21}
-A_name_multi_chebi	l-sodium lactate	{'CHEBI:867561': 21, 'CHEBI:75228': 13}
-A_name_multi_chebi	iso-valeric acid	{'CHEBI:503742': 25, 'CHEBI:28484': 8}
+A_name_multi_chebi	l-sodium lactate	{'CHEBI:232798': 21, 'CHEBI:75228': 13}
 A_name_multi_chebi	mnso4 x 5 h2o	{'CHEBI:131524': 31, 'CHEBI:86360': 1}
-A_name_multi_chebi	sodium l-lactate	{'CHEBI:867561': 8, 'CHEBI:232798': 22}
 A_name_multi_chebi	n-acetyl-d-glucosamine	{'CHEBI:506227': 12, 'CHEBI:8006': 15}
 A_name_multi_chebi	malachite green	{'CHEBI:72449': 24, 'CHEBI:87106': 1}
 A_name_multi_chebi	thiamine pyrophosphate	{'CHEBI:18290': 21, 'CHEBI:9532': 2}
 A_name_multi_chebi	h2seo3	{'CHEBI:26642': 21, 'CHEBI:48854': 2}
-A_name_multi_chebi	soytone	{'CHEBI:8150': 17, 'CHEBI:16247': 6}
 A_name_multi_chebi	xanthine	{'CHEBI:15318': 6, 'CHEBI:17712': 15}
 A_name_multi_chebi	m-inositol	{'CHEBI:10642': 20, 'CHEBI:166917': 1}
 A_name_multi_chebi	na-butyrate	{'CHEBI:64103': 17, 'CHEBI:17968': 1}
@@ -86,7 +80,6 @@ A_name_multi_chebi	na-malate	{'CHEBI:91261': 3, 'CHEBI:91260': 5}
 A_name_multi_chebi	putrescine	{'CHEBI:326268': 2, 'CHEBI:17148': 6}
 A_name_multi_chebi	thioglycolate	{'CHEBI:30066': 3, 'CHEBI:47869': 4}
 A_name_multi_chebi	na malate	{'CHEBI:91261': 3, 'CHEBI:91260': 4}
-A_name_multi_chebi	diaminopimelic acid	{'CHEBI:23674': 4, 'CHEBI:23673': 2}
 A_name_multi_chebi	phenyl acetic acid	{'CHEBI:30745': 3, 'CHEBI:103822': 3}
 A_name_multi_chebi	na-dl-malate	{'CHEBI:91261': 2, 'CHEBI:91260': 4}
 A_name_multi_chebi	d-arabinose	{'CHEBI:17108': 2, 'CHEBI:46983': 4}
@@ -102,7 +95,6 @@ A_name_multi_chebi	na2sio3 x 5 h2o	{'CHEBI:60720': 2, 'CHEBI:86477': 2}
 A_name_multi_chebi	bicine	{'CHEBI:39065': 3, 'CHEBI:40957': 1}
 A_name_multi_chebi	cobalamine	{'CHEBI:30411': 3, 'CHEBI:28911': 1}
 A_name_multi_chebi	(nh4)h2po4	{'CHEBI:62982': 3, 'CHEBI:39745': 1}
-A_name_multi_chebi	tween 20	{'CHEBI:9784': 3, 'CHEBI:53424': 1}
 A_name_multi_chebi	na2seo4 x 10 h2o	{'CHEBI:77775': 2, 'CHEBI:32586': 1}
 A_name_multi_chebi	(nh4)hco3	{'CHEBI:184335': 2, 'CHEBI:17544': 1}
 A_name_multi_chebi	manganese sulfate monohydrate	{'CHEBI:86374': 2, 'CHEBI:86364': 1}
@@ -118,7 +110,7 @@ B_chebi_multi_compound	CHEBI:31206	{'chloride': 426, 'nh4cl': 4193, 'cl': 13}
 B_chebi_multi_compound	CHEBI:2509	{'agar': 4439, 'agar inorganic salts starch': 8, '2216 agar marine': 32, 'agar corn meal': 17, '7h10 agar bacto middlebrook': 11, 'agar r2a': 16, 'agar r': 8, 'agar czapek dox': 3, 'agar brucella': 2, 'agar anaerobe fastidious': 2, 'agar anaerobic brewer': 2, '7h10 agar middlebrook': 3, 'agar bl': 2, 'agar bcye': 2, 'agar enrichment legionella': 1, 'agar gam': 1, 'agar hinton ii mueller': 1, 'agar oatmeal': 4, 'agar asparagine glycerol': 2, 'agar extract malt': 1, 'agar base blood columbia': 1, 'agar bacteriological': 2}
 B_chebi_multi_compound	CHEBI:33118	{'acid boric': 325, 'h3bo3': 3901, 'b3': 2, 'h3bo4': 4, 'h3bo2': 1}
 B_chebi_multi_compound	CHEBI:32588	{'chloride': 226, 'kcl': 3714}
-B_chebi_multi_compound	CHEBI:86345	{'mgcl2': 3700, 'chloride': 121, 'chloride hexa': 74, 'mgcl': 2}
+B_chebi_multi_compound	CHEBI:86345	{'mgcl2': 3701, 'chloride': 121, 'chloride hexa': 74, 'mgcl': 2, '6h mgcl o': 8}
 B_chebi_multi_compound	CHEBI:75213	{'na2moo4': 3208, 'moo4': 28, 'na2mo4': 8, 'namoo4': 10, 'molybdate': 172, 'na2moso4': 6, 'na2moo7o4': 1, 'na2moo7': 1}
 B_chebi_multi_compound	CHEBI:34887	{'nicl2': 3220, 'chloride nickel': 92, 'nicl2x': 1, 'nicl': 5}
 B_chebi_multi_compound	CHEBI:32139	{'nahco3': 3019, 'bicarbonate': 134, 'nahco': 2}
@@ -172,7 +164,7 @@ B_chebi_multi_compound	CHEBI:86463	{'aluminum sulfate': 65, '7h o znso': 22, 'al
 B_chebi_multi_compound	CHEBI:144421	{'citrate': 135, 'citrate fe': 265, 'fecitrate': 16}
 B_chebi_multi_compound	CHEBI:53258	{'citrate na3': 53, 'citrate trisodium': 240, 'citrate': 70, 'acid citric': 50, 'citrate h2o trisodium': 1}
 B_chebi_multi_compound	CHEBI:6636	{'mgcl2': 399, 'mgcl2x': 5, 'chloride hexa': 2}
-B_chebi_multi_compound	CHEBI:63005	{'nano3': 334, 'nitrate': 56, 'no3': 5}
+B_chebi_multi_compound	CHEBI:63005	{'nano3': 334, 'nitrate': 57, 'no3': 5}
 B_chebi_multi_compound	CHEBI:32030	{'kbr': 353, 'hpo': 19, 'bromide': 5}
 B_chebi_multi_compound	CHEBI:48843	{'na2seo3': 333, 'selenite': 28, 'na2seo': 1, 'naseo3': 1}
 B_chebi_multi_compound	CHEBI:26836	{'h2so4': 333, 'acid sulfuric': 5}
@@ -205,6 +197,7 @@ B_chebi_multi_compound	CHEBI:86159	{'ca2': 194, 'nitrate tetra': 3}
 B_chebi_multi_compound	CHEBI:9754	{'buffer tris': 70, 'tromethamine': 21, 'tris': 50, 'base tris': 38, 'trismethylamine': 3, '1m buffer tris': 1, 'trisaminomethane': 10, 'acid nitrilotriacetic trisodium': 1}
 B_chebi_multi_compound	CHEBI:23414	{'cupric sulfate': 119, 'cuso4': 56, 'copper sulfate': 9, 'cuso': 2}
 B_chebi_multi_compound	CHEBI:18050	{'glutamine l': 184, 'glutamine': 2}
+B_chebi_multi_compound	CHEBI:46756	{'hepes': 157, 'buffer hepes': 27}
 B_chebi_multi_compound	CHEBI:16236	{'ethanol': 180, 'alcohol ethyl': 1}
 B_chebi_multi_compound	CHEBI:49553	{'chloride cupric': 77, 'cucl2': 99, 'cucl': 4}
 B_chebi_multi_compound	CHEBI:31604	{'ammmonium citrate': 1, 'citrate': 155, 'fecitrate': 19}
@@ -214,6 +207,7 @@ B_chebi_multi_compound	CHEBI:64220	{'glutamate': 149, 'glutamate monosodium': 8}
 B_chebi_multi_compound	CHEBI:63041	{'mncl2': 33, 'chloride manganese': 123}
 B_chebi_multi_compound	CHEBI:32583	{'caso4': 151, 'caso4 x': 1}
 B_chebi_multi_compound	CHEBI:17306	{'h2o maltose': 7, 'maltose': 137, 'd maltose': 4}
+B_chebi_multi_compound	CHEBI:232798	{'l lactate': 98, 'lactate': 4, 'dl lactate': 1, 'd l lactate': 40}
 B_chebi_multi_compound	CHEBI:16015	{'glutamate l': 73, 'acid glutamic l': 69}
 B_chebi_multi_compound	CHEBI:194474	{'4 acid aminobenzoic': 135, 'acid amino benzoic p': 7}
 B_chebi_multi_compound	CHEBI:17836	{'4 aminobenzoate': 94, 'aminobenzoate p': 43, 'paba': 1}
@@ -228,7 +222,6 @@ B_chebi_multi_compound	CHEBI:15971	{'histidine l': 118, 'histidin l': 2}
 B_chebi_multi_compound	CHEBI:17115	{'l serine': 117, 'l serin': 2}
 B_chebi_multi_compound	CHEBI:17295	{'phenylalanine': 27, 'l phenylalanine': 88}
 B_chebi_multi_compound	CHEBI:16414	{'valine': 24, 'l valine': 90}
-B_chebi_multi_compound	CHEBI:232798	{'l lactate': 68, 'lactate': 4, 'dl lactate': 1, 'd l lactate': 40}
 B_chebi_multi_compound	CHEBI:16467	{'arginine l': 104, 'arginine': 6}
 B_chebi_multi_compound	CHEBI:16135	{'acid isobutyric': 77, 'acid butyric iso': 31}
 B_chebi_multi_compound	CHEBI:16977	{'alanine': 50, 'alanine l': 58}
@@ -236,17 +229,17 @@ B_chebi_multi_compound	CHEBI:28869	{'k3 vitamin': 85, 'menadione': 22}
 B_chebi_multi_compound	CHEBI:78018	{'trypticase': 105, 'bacto tryptone': 1}
 B_chebi_multi_compound	CHEBI:17418	{'acid valeric': 62, 'acid n valeric': 42}
 B_chebi_multi_compound	CHEBI:39033	{'pipes': 101, 'buffer pipes': 1}
+B_chebi_multi_compound	CHEBI:33403	{'sulfur': 82, 'powder sulfur': 9, 'elemental sulphur': 6, 'elemental sulfur': 4}
+B_chebi_multi_compound	CHEBI:28484	{'acid isovaleric': 63, 'acid iso valeric': 33, '3 acid butyric methyl': 1, '3 acid methylbutyric': 2}
 B_chebi_multi_compound	CHEBI:17895	{'dl tyrosine': 18, 'l tyrosine': 79}
 B_chebi_multi_compound	CHEBI:8346	{'ki': 69, 'iodide': 25, 'kj': 2}
 B_chebi_multi_compound	CHEBI:32142	{'citrate': 76, 'citrate na3': 19, 'citrate trisodium': 1}
 B_chebi_multi_compound	CHEBI:132112	{'na2s2o3': 42, 'thiosulfate': 41, 'thiosulphate': 6, 'nas2o3': 3}
-B_chebi_multi_compound	CHEBI:14258	{'sulfur': 82, 'powder sulfur': 9}
 B_chebi_multi_compound	CHEBI:16857	{'dl threonine': 1, 'l threonine': 89}
 B_chebi_multi_compound	CHEBI:18320	{'dithiothreitol dl': 64, 'dithiothreitol': 22, 'dtt': 3}
-B_chebi_multi_compound	CHEBI:86358	{'mnso4': 75, 'manganese sulfate tetra': 2}
+B_chebi_multi_compound	CHEBI:86358	{'mnso4': 75, '4h mnso o': 5, 'manganese sulfate tetra': 2}
 B_chebi_multi_compound	CHEBI:17905	{'2 mercaptoethanesulfonate': 36, 'coenzyme m': 31, '2 acid mercaptoethanesulfonic': 10}
 B_chebi_multi_compound	CHEBI:44115	{'acid morpholinopropane sulfonic': 6, 'mops': 17, 'buffer mops': 18, '3 acid propanesulfonic': 32}
-B_chebi_multi_compound	CHEBI:28484	{'acid isovaleric': 60, 'acid iso valeric': 8, '3 acid butyric methyl': 1, '3 acid methylbutyric': 2}
 B_chebi_multi_compound	CHEBI:15824	{'d fructose': 44, 'fructose': 26}
 B_chebi_multi_compound	CHEBI:30812	{'chloride': 36, 'fecl2': 31}
 B_chebi_multi_compound	CHEBI:42334	{'hepes': 65, '1 4 acid piperazineethanesulfonic': 1}
@@ -265,7 +258,6 @@ B_chebi_multi_compound	CHEBI:91260	{'dl malate': 28, 'malate': 28}
 B_chebi_multi_compound	CHEBI:30729	{'edta fe': 55, 'edta': 1}
 B_chebi_multi_compound	CHEBI:113455	{'benzoate': 48, 'sodiumbenzoate': 2}
 B_chebi_multi_compound	CHEBI:76208	{'na2s': 41, 'sulfide': 4, 'h2o na2s': 5}
-B_chebi_multi_compound	CHEBI:8150	{'bacto soytone': 32, 'soytone': 17}
 B_chebi_multi_compound	CHEBI:30772	{'acid butyric': 27, 'acid butyric n': 18, 'acid butanoic': 2}
 B_chebi_multi_compound	CHEBI:18246	{'cellulose': 44, 'filter paper': 1}
 B_chebi_multi_compound	CHEBI:85357	{'sulfide': 9, 'nona sulfide': 36}
@@ -284,7 +276,6 @@ B_chebi_multi_compound	CHEBI:131378	{'fe22': 32, 'fe22x': 1}
 B_chebi_multi_compound	CHEBI:30627	{'moo3': 28, 'molybdenum trioxide': 4}
 B_chebi_multi_compound	CHEBI:42106	{'dithiothreitol dl': 1, 'dithiothreitol': 30}
 B_chebi_multi_compound	CHEBI:184335	{'nh4hco3': 28, 'hco3': 2}
-B_chebi_multi_compound	CHEBI:503742	{'acid iso valeric': 25, 'acid isovaleric': 3}
 B_chebi_multi_compound	CHEBI:75216	{'2h namoo o': 2, '2h moo o': 26}
 B_chebi_multi_compound	CHEBI:86466	{'k2s4o6': 26, 'tetrathionate': 2}
 B_chebi_multi_compound	CHEBI:22653	{'asparagine': 25, 'asparagine dl h2o': 3}
@@ -296,6 +287,7 @@ B_chebi_multi_compound	CHEBI:132089	{'beta glycerophosphate': 20, 'glycerolphosp
 B_chebi_multi_compound	CHEBI:26642	{'h2seo3': 21, 'acid selenous': 1}
 B_chebi_multi_compound	CHEBI:63051	{'2hpo4': 21, '2 hpo4': 1}
 B_chebi_multi_compound	CHEBI:132095	{'navo': 18, 'h2o n navo3': 3}
+B_chebi_multi_compound	CHEBI:131532	{'dihydrochloride pyridoxamine': 19, '2hcl pyridoxamine': 2}
 B_chebi_multi_compound	CHEBI:66870	{'dithionite': 19, 'na2s2o4': 1}
 B_chebi_multi_compound	CHEBI:31695	{'indigocarmine': 16, 'carmine indigo': 3}
 B_chebi_multi_compound	CHEBI:31346	{'caso4': 18, 'sulfate': 1}
@@ -320,10 +312,8 @@ B_chebi_multi_compound	CHEBI:15346	{'a coenzyme': 8, 'a coenzym': 2}
 B_chebi_multi_compound	CHEBI:27641	{'cycloheximid': 6, 'cycloheximide': 4}
 B_chebi_multi_compound	CHEBI:132767	{'pyrophosphate': 6, 'fe42': 4}
 B_chebi_multi_compound	CHEBI:36218	{'lactose': 9, 'beta lactose': 1}
-B_chebi_multi_compound	CHEBI:33403	{'elemental sulphur': 6, 'elemental sulfur': 4}
 B_chebi_multi_compound	CHEBI:16247	{'bacto soytone': 3, 'soytone': 6}
 B_chebi_multi_compound	CHEBI:17925	{'alpha d glucose': 7, 'd glucose': 2}
-B_chebi_multi_compound	CHEBI:6635	{'mgcl2': 1, '6h mgcl o': 8}
 B_chebi_multi_compound	CHEBI:85146	{'carboxymethyl cellulose': 5, 'carboxymethylcellulose': 2}
 B_chebi_multi_compound	CHEBI:16991	{'dna': 2, 'dna fish sperm': 5}
 B_chebi_multi_compound	CHEBI:64183	{'cacl2': 1, '2h cacl o': 6}


### PR DESCRIPTION
## What
Backlog item A from the drift triage. 321 recipe `term` ids didn't exist in their ontology (absent/obsolete CHEBI + 2 FOODON). Each absent id was verified **homogeneous** (one compound across all its occurrences), then either re-grounded to the correct OAK-resolved CHEBI or de-grounded.

## Re-grounded — 246 term refs across 12 ids
Sulfur (powder) 14258→33403, isovaleric acid 503742→28484, HEPES 19708→46756, sodium L-lactate 867561→232798, MgCl2·6H2O 6635→86345, 3-phenylpropionic acid 501520→28631, MnSO4·4H2O 75217→86358, diaminopimelic acid 23674→23673, Tween 20 9784→53424 (polysorbate 20), pyridoxamine·2HCl 8668→131532, sodium nitrate 34754→63005, Tris-HCl 1185531→9754 (tris). Empty labels filled with the new id's canonical label.

## De-grounded — 109 term refs across 7 ids
Soytone, Catalase, Casein, bogus `CHEBI:1`, Folinic acid (no verifiable parent id), FOODON liver extract / beef heart muscle tissue — mixtures/proteins with no single CHEBI ("better ungrounded than wrong").

## Effect
- ID_NOT_FOUND on recipe YAML: 321 → 0.
- Reliable-layer same-name→multi-CHEBI: **109 → 101**; consistency baseline tightened to 101.
- `linkml-validate`: No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)