### PR TITLE
Ignore jcm.grmd prefix in id-label validator config

### DIFF
--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -45,6 +45,7 @@ ignored_prefixes:
   - mediadive.medium       # MediaDive medium nodes
   - MEDIADB                # MediaDive medium DB ids (MEDIADB:NNN)
   - komodo.medium          # KOMODO media identifiers
+  - jcm.grmd               # JCM GRMD media identifiers (media_term ids, no ontology adapter)
   - DSMZ                   # DSMZ culture-collection ids
   - ATCC                   # ATCC culture-collection ids
   - TOGO                   # TogoMedia ids


### PR DESCRIPTION
## What
Adds `jcm.grmd` to the validator config's `ignored_prefixes`.

## Why
The JCM GRMD `media_term` ids (`jcm.grmd:NNNN`, introduced with the JCM ingestion in #35) have no ontology adapter, so the id-label validator flagged 51 of them as **UNKNOWN_PREFIX errors**. They're legitimate non-ontology media-record ids, exactly like `mediadive.medium`, `komodo.medium`, `MEDIADB`, etc. that are already ignored. Now they resolve to SKIPPED_NO_ADAPTER, while a genuine typo (`CHBEI:`) still fails as intended.

Config-only and per-repo (no validator-script change, nothing to sync to siblings). Verified: `jcm.grmd:1462` → SKIPPED_NO_ADAPTER, `CHBEI:999` → UNKNOWN_PREFIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)