### PR TITLE
Normalize malformed hydrate ingredient names to canonical ' x N H2O'

### DIFF
--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -1,0 +1,42 @@
+# Next Tasks — CultureMech backlog
+
+Deferred work, each entry with enough context to pick up cold. **Maintenance:**
+update this file as work is started/finished — move done items out, add new
+deferrals here instead of letting them live only in your head or a closed PR.
+Keep the cross-Mech items in sync with the sibling repos' `NEXT_TASKS.md`
+(MIM / CommunityMech / TraitMech).
+
+Last reconciled: 2026-06-14.
+
+## 1. Phase-2 id↔label enforcement rollout (report-only → blocking)
+
+The id↔label correspondence validator (`scripts/validate_id_label_correspondence.py`,
+byte-identical across the Mechs) is live but **report-only**. `validate-terms-all`
+and `validate-products` exist in `project.justfile` but are deliberately NOT in
+the `qc` gate, and CI only runs the non-blocking drift report.
+
+- Triage first: `just report-label-drift` → `reports/label_drift.tsv`, resolve
+  real MISMATCH/ID_NOT_FOUND rows (curate or add justified `exceptions`).
+- Then add `validate-terms-all` + `validate-products` to the `qc` recipe and
+  flip the CI step to blocking.
+- Don't flip the gate while drift rows remain — it will red-wall every PR.
+
+## 2. Page renderer skip logic ignores template/code changes
+
+`render_media_pages.py` skips a page when its HTML output is newer than the
+**source YAML** (mtime-based). It does NOT account for changes to the Jinja
+template or the renderer itself, so a template edit silently no-ops under
+`just gen-pages` — you must pass `--force` to actually re-render (discovered
+2026-06-14 fixing the wall-clock footer).
+
+- Improve: fold a hash of the template + renderer version into the skip decision
+  (re-render when either changes), or document the `--force` requirement
+  prominently so future template edits don't ship half-applied.
+
+## 3. Cross-Mech validator pin guard covers only the .py (cross-repo)
+
+The `verify-validator-pin` guard pins the validator **script** byte-for-byte
+across the Mechs, but NOT the vendored test files or the conf structure, so those
+can silently drift. Tracked in culturebotai-claw#6. Coordinate any fix across
+CultureMech / MIM / CommunityMech together (and decide whether TraitMech joins
+the trio — see TraitMech `NEXT_TASKS.md` item 2).

--- a/data/normalized_yaml/bacterial/TOGO_M2258_Pfennig_s_Medium_II_With_Salt.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M2258_Pfennig_s_Medium_II_With_Salt.yaml
@@ -134,7 +134,7 @@ ingredients:
     value: '0.5'
     unit: G_PER_L
   notes: 'Role: pH dependent redox indicator; Properties: Defined component, Solution'
-- preferred_term: MgSO4x7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.5'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium.yaml
@@ -143,7 +143,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31440
     label: copper(II) sulfate pentahydrate
-- preferred_term: AlK(SO4)2 x 12H2O
+- preferred_term: AlK(SO4)2 x 12 H2O
   concentration:
     value: '0.01'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M2595_Pfennig_s_Medium_II.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M2595_Pfennig_s_Medium_II.yaml
@@ -118,7 +118,7 @@ ingredients:
     value: '0.5'
     unit: G_PER_L
   notes: 'Role: pH dependent redox indicator; Properties: Defined component, Solution'
-- preferred_term: MgSO4x7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.5'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M514_Caldococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M514_Caldococcus_Medium.yaml
@@ -169,7 +169,7 @@ ingredients:
   term:
     id: CHEBI:31440
     label: ''
-- preferred_term: CoSO47H2O
+- preferred_term: CoSO4 x 7 H2O
   concentration:
     value: '1'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M599_Alicycliphilus_Denitrificans_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M599_Alicycliphilus_Denitrificans_Medium.yaml
@@ -74,7 +74,7 @@ ingredients:
   term:
     id: CHEBI:32954
     label: ''
-- preferred_term: CaCl22H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.11'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M600_Alicycliphilus_Denitrificans_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M600_Alicycliphilus_Denitrificans_Medium.yaml
@@ -74,7 +74,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:65242
     label: NaClO3
-- preferred_term: CaCl22H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.11'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/TOGO_M665_Thiophaeococcus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M665_Thiophaeococcus_Medium.yaml
@@ -27,7 +27,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgSO47H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '2'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/elusimicrobium_minutum_medium.yaml
+++ b/data/normalized_yaml/bacterial/elusimicrobium_minutum_medium.yaml
@@ -5,7 +5,7 @@ category: bacterial
 medium_type: COMPLEX
 physical_state: LIQUID
 ingredients:
-- preferred_term: MgSO4x7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '3.45'
     unit: G_PER_L
@@ -34,7 +34,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: CaCl2x2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.14'
     unit: G_PER_L
@@ -106,7 +106,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32139
     label: sodium hydrogencarbonate
-- preferred_term: Fe(NH4)2(SO4)2x7H2O
+- preferred_term: Fe(NH4)2(SO4)2 x 7 H2O
   concentration:
     value: '2'
     unit: G_PER_L
@@ -115,7 +115,7 @@ ingredients:
   term:
     id: CHEBI:131378
     label: ''
-- preferred_term: MgCl2x7H2O
+- preferred_term: MgCl2 x 7 H2O
   concentration:
     value: '2.75'
     unit: G_PER_L
@@ -179,7 +179,7 @@ ingredients:
     value: '0.368'
     unit: G_PER_L
   notes: 'Properties: Defined component, Simple component, Inorganic compound'
-- preferred_term: Na2MoO4xH2O
+- preferred_term: Na2MoO4 x H2O
   concentration:
     value: '0.03'
     unit: G_PER_L
@@ -224,7 +224,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: ''
-- preferred_term: NiCl2x6H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/formate_medium.yaml
+++ b/data/normalized_yaml/bacterial/formate_medium.yaml
@@ -29,7 +29,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:62946
     label: ammonium sulfate
-- preferred_term: MgSO4 ⋅ 7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.8'
     unit: G_PER_L
@@ -90,7 +90,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32145
     label: sodium hydroxide
-- preferred_term: Na2MoO4 ⋅ 2H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '1.8'
     unit: G_PER_L
@@ -99,7 +99,7 @@ ingredients:
   term:
     id: CHEBI:75215
     label: ''
-- preferred_term: FeSO4 ⋅ 7H2O
+- preferred_term: FeSO4 x 7 H2O
   concentration:
     value: '1.5'
     unit: G_PER_L
@@ -108,7 +108,7 @@ ingredients:
   term:
     id: CHEBI:75836
     label: ''
-- preferred_term: ZnSO4 ⋅ 7H2O
+- preferred_term: ZnSO4 x 7 H2O
   concentration:
     value: '2.4'
     unit: G_PER_L
@@ -117,7 +117,7 @@ ingredients:
   term:
     id: CHEBI:32312
     label: ''
-- preferred_term: CuSO4 ⋅ 5H2O
+- preferred_term: CuSO4 x 5 H2O
   concentration:
     value: '0.48'
     unit: G_PER_L
@@ -126,7 +126,7 @@ ingredients:
   term:
     id: CHEBI:31440
     label: ''
-- preferred_term: CoSO4 ⋅ 7H2O
+- preferred_term: CoSO4 x 7 H2O
   concentration:
     value: '4.02'
     unit: G_PER_L
@@ -135,7 +135,7 @@ ingredients:
   term:
     id: CHEBI:53470
     label: ''
-- preferred_term: MnSO4 ⋅ H2O
+- preferred_term: MnSO4 x H2O
   concentration:
     value: '2.4'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/kim_medium.yaml
+++ b/data/normalized_yaml/bacterial/kim_medium.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgSO4⋅7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -26,7 +26,7 @@ ingredients:
   term:
     id: CHEBI:31795
     label: magnesium sulfate heptahydrate
-- preferred_term: FeSO4⋅7H2O
+- preferred_term: FeSO4 x 7 H2O
   concentration:
     value: '44'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/modified_m30_medium.yaml
+++ b/data/normalized_yaml/bacterial/modified_m30_medium.yaml
@@ -22,7 +22,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgCl2⋅6H2O
+- preferred_term: MgCl2 x 6 H2O
   concentration:
     value: '0.5'
     unit: G_PER_L
@@ -60,7 +60,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:2509
     label: agar
-- preferred_term: MgSO4⋅7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '29.7'
     unit: G_PER_L
@@ -69,7 +69,7 @@ ingredients:
   term:
     id: CHEBI:31795
     label: magnesium sulfate heptahydrate
-- preferred_term: FeSO4⋅7H2O
+- preferred_term: FeSO4 x 7 H2O
   concentration:
     value: '99'
     unit: G_PER_L
@@ -90,13 +90,13 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:44557
     label: nitrilotriacetic acid
-- preferred_term: (NH4)6MoO7O24⋅4H2O
+- preferred_term: (NH4)6MoO7O24 x 4 H2O
   concentration:
     value: '9.3'
     unit: G_PER_L
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
-- preferred_term: CaCl2⋅7H2O
+- preferred_term: CaCl2 x 7 H2O
   concentration:
     value: '3.3'
     unit: G_PER_L
@@ -138,7 +138,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: CaCl2⋅2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -147,7 +147,7 @@ ingredients:
   term:
     id: CHEBI:86158
     label: ''
-- preferred_term: Na2MoO4⋅2H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '0.024'
     unit: G_PER_L
@@ -168,7 +168,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:33118
     label: boric acid
-- preferred_term: MnCl2⋅4H2O
+- preferred_term: MnCl2 x 4 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -177,7 +177,7 @@ ingredients:
   term:
     id: CHEBI:86368
     label: ''
-- preferred_term: CoCl2⋅6H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '0.024'
     unit: G_PER_L
@@ -186,7 +186,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: ''
-- preferred_term: NiCl2⋅6H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '0.12'
     unit: G_PER_L
@@ -195,7 +195,7 @@ ingredients:
   term:
     id: CHEBI:34887
     label: ''
-- preferred_term: ZnSO4⋅7H2O
+- preferred_term: ZnSO4 x 7 H2O
   concentration:
     value: '1.1'
     unit: G_PER_L
@@ -216,7 +216,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: FeCl2⋅6H2O
+- preferred_term: FeCl2 x 6 H2O
   concentration:
     value: '1.35'
     unit: G_PER_L
@@ -225,7 +225,7 @@ ingredients:
   term:
     id: CHEBI:30812
     label: ''
-- preferred_term: Na2B4O7⋅10H2O
+- preferred_term: Na2B4O7 x 10 H2O
   concentration:
     value: '0.018'
     unit: G_PER_L
@@ -240,7 +240,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Mineral source; Properties: Inorganic compound, Simple component,
     Complex component'
-- preferred_term: Na2HPO4⋅2H2O
+- preferred_term: Na2HPO4 x 2 H2O
   concentration:
     value: '0.01'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/obsidian_pool_fermentor_opf_medium_modified_from_m_b_allen_1959.yaml
+++ b/data/normalized_yaml/bacterial/obsidian_pool_fermentor_opf_medium_modified_from_m_b_allen_1959.yaml
@@ -53,7 +53,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Solvating media; Properties: Inorganic compound, Defined component,
     Simple component'
-- preferred_term: MgSO4 x7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.25'
     unit: G_PER_L
@@ -70,7 +70,7 @@ ingredients:
     value: '0.1'
     unit: G_PER_L
   notes: 'Role: Nutrient source; Properties: Undefined component'
-- preferred_term: CaCl2 x2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.07'
     unit: G_PER_L
@@ -112,7 +112,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:62946
     label: ammonium sulfate
-- preferred_term: FeCl3 x6H2O
+- preferred_term: FeCl3 x 6 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L
@@ -145,7 +145,7 @@ ingredients:
   mediaingredientmech_term:
     id: MediaIngredientMech:000170
     label: KNO3
-- preferred_term: CaSO4 x2H2O
+- preferred_term: CaSO4 x 2 H2O
   concentration:
     value: '0.17'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/oligotrophic_denitrification_liquid_medium.yaml
+++ b/data/normalized_yaml/bacterial/oligotrophic_denitrification_liquid_medium.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgCl2∙6H2O
+- preferred_term: MgCl2 x 6 H2O
   concentration:
     value: '0.01'
     unit: G_PER_L
@@ -64,7 +64,7 @@ ingredients:
   term:
     id: CHEBI:131527
     label: dipotassium hydrogen phosphate
-- preferred_term: FeSO4∙7H2O
+- preferred_term: FeSO4 x 7 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -73,7 +73,7 @@ ingredients:
   term:
     id: CHEBI:75836
     label: ''
-- preferred_term: CoCl2∙6H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '0.05'
     unit: G_PER_L
@@ -82,7 +82,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: ''
-- preferred_term: CuSO4∙5H2O
+- preferred_term: CuSO4 x 5 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/petc_mes_medium.yaml
+++ b/data/normalized_yaml/bacterial/petc_mes_medium.yaml
@@ -139,7 +139,7 @@ ingredients:
     value: '0.5'
     unit: G_PER_L
   notes: 'Role: pH dependent redox indicator; Properties: Defined component, Solution'
-- preferred_term: Cysteine-HCl∙H2O
+- preferred_term: Cysteine-HCl x H2O
   concentration:
     value: '0.4'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/s_medium.yaml
+++ b/data/normalized_yaml/bacterial/s_medium.yaml
@@ -99,7 +99,7 @@ ingredients:
     value: '12'
     unit: G_PER_L
   notes: 'Role: Solidifying component; Properties: Defined component'
-- preferred_term: Na2MoO42H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '20'
     unit: G_PER_L
@@ -123,19 +123,19 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:33118
     label: boric acid
-- preferred_term: MnCl24H2O
+- preferred_term: MnCl2 x 4 H2O
   concentration:
     value: '100'
     unit: G_PER_L
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
-- preferred_term: CoCl26H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '100'
     unit: G_PER_L
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
-- preferred_term: NiCl26H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '10'
     unit: G_PER_L
@@ -165,7 +165,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: FeCl36H2O
+- preferred_term: FeCl3 x 6 H2O
   concentration:
     value: '2000'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/saline_basal_medium.yaml
+++ b/data/normalized_yaml/bacterial/saline_basal_medium.yaml
@@ -85,7 +85,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Solvating media; Properties: Defined component, Inorganic compound,
     Solution'
-- preferred_term: CaCl2∙2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '2'
     unit: G_PER_L
@@ -94,7 +94,7 @@ ingredients:
   term:
     id: CHEBI:86158
     label: ''
-- preferred_term: Na2MoO4∙2H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '0.03'
     unit: G_PER_L
@@ -115,7 +115,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:33118
     label: boric acid
-- preferred_term: MnCl2∙4H2O
+- preferred_term: MnCl2 x 4 H2O
   concentration:
     value: '0.03'
     unit: G_PER_L
@@ -124,7 +124,7 @@ ingredients:
   term:
     id: CHEBI:86368
     label: ''
-- preferred_term: NiCl2∙6H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L
@@ -133,7 +133,7 @@ ingredients:
   term:
     id: CHEBI:34887
     label: ''
-- preferred_term: ZnSO4∙7H2O
+- preferred_term: ZnSO4 x 7 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -142,7 +142,7 @@ ingredients:
   term:
     id: CHEBI:32312
     label: ''
-- preferred_term: CoCl2∙6H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/sgp7_0.yaml
+++ b/data/normalized_yaml/bacterial/sgp7_0.yaml
@@ -5,7 +5,7 @@ category: bacterial
 medium_type: COMPLEX
 physical_state: LIQUID
 ingredients:
-- preferred_term: MgSO4∙7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.041'
     unit: G_PER_L
@@ -14,7 +14,7 @@ ingredients:
   term:
     id: CHEBI:31795
     label: magnesium sulfate heptahydrate
-- preferred_term: CaCl2∙2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.044'
     unit: G_PER_L
@@ -23,7 +23,7 @@ ingredients:
   term:
     id: CHEBI:86158
     label: ''
-- preferred_term: Na2HPO4∙12H2O
+- preferred_term: Na2HPO4 x 12 H2O
   concentration:
     value: '0.076'
     unit: G_PER_L
@@ -43,7 +43,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:46756
     label: HEPES
-- preferred_term: Na2SiO3∙9H2O
+- preferred_term: Na2SiO3 x 9 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -52,7 +52,7 @@ ingredients:
   term:
     id: CHEBI:132108
     label: ''
-- preferred_term: KH2PO4∙2H2O
+- preferred_term: KH2PO4 x 2 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/standard_petc_medium.yaml
+++ b/data/normalized_yaml/bacterial/standard_petc_medium.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgSO4⋅7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -43,7 +43,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: CaCl2⋅2H2O
+- preferred_term: CaCl2 x 2 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L
@@ -92,7 +92,7 @@ ingredients:
   concentration:
     value: '10'
     unit: G_PER_L
-- preferred_term: Na2MoO4⋅2H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L
@@ -101,7 +101,7 @@ ingredients:
   term:
     id: CHEBI:75215
     label: ''
-- preferred_term: CoCl2⋅6H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -110,7 +110,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: ''
-- preferred_term: NiCl2⋅6H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '0.02'
     unit: G_PER_L
@@ -119,7 +119,7 @@ ingredients:
   term:
     id: CHEBI:34887
     label: ''
-- preferred_term: ZnSO4⋅7H2O
+- preferred_term: ZnSO4 x 7 H2O
   concentration:
     value: '0.0002'
     unit: G_PER_L
@@ -128,7 +128,7 @@ ingredients:
   term:
     id: CHEBI:32312
     label: ''
-- preferred_term: CuCl2⋅2H2O
+- preferred_term: CuCl2 x 2 H2O
   concentration:
     value: '0.2'
     unit: G_PER_L
@@ -155,7 +155,7 @@ ingredients:
     unit: G_PER_L
   notes: 'Role: Mineral source; Properties: Inorganic compound, Defined component,
     Simple component'
-- preferred_term: MnSO4⋅H2O
+- preferred_term: MnSO4 x H2O
   concentration:
     value: '1'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/togo_medium_m3129.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m3129.yaml
@@ -65,7 +65,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:8806
     label: Resazurin
-- preferred_term: Na2S ∙ 9 H2O
+- preferred_term: Na2S x 9 H2O
   concentration:
     value: '0.05'
     unit: PERCENT_W_V
@@ -152,7 +152,7 @@ ingredients:
   term:
     id: CHEBI:18276
     label: ''
-- preferred_term: Na2MoO4 ∙ 2 H2O
+- preferred_term: Na2MoO4 x 2 H2O
   concentration:
     value: '36'
     unit: G_PER_L
@@ -173,7 +173,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:33118
     label: boric acid
-- preferred_term: MnCl2 ∙ 4 H2O
+- preferred_term: MnCl2 x 4 H2O
   concentration:
     value: '100'
     unit: G_PER_L
@@ -182,7 +182,7 @@ ingredients:
   term:
     id: CHEBI:86368
     label: ''
-- preferred_term: CoCl2 ∙ 6 H2O
+- preferred_term: CoCl2 x 6 H2O
   concentration:
     value: '224'
     unit: G_PER_L
@@ -191,7 +191,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: ''
-- preferred_term: NiCl2 ∙ 6 H2O
+- preferred_term: NiCl2 x 6 H2O
   concentration:
     value: '24'
     unit: G_PER_L
@@ -212,7 +212,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: FeCl2 ∙ 4 H2O
+- preferred_term: FeCl2 x 4 H2O
   concentration:
     value: '4'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/togo_medium_m3152.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m3152.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgSO4⋅7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -79,7 +79,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:8806
     label: Resazurin
-- preferred_term: Na2S⋅9H2O
+- preferred_term: Na2S x 9 H2O
   concentration:
     value: '0.5'
     unit: G_PER_L
@@ -100,7 +100,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32139
     label: sodium hydrogencarbonate
-- preferred_term: Cysteine-HCl⋅H2O
+- preferred_term: Cysteine-HCl x H2O
   concentration:
     value: '0.5'
     unit: G_PER_L

--- a/data/normalized_yaml/bacterial/togo_medium_m3153.yaml
+++ b/data/normalized_yaml/bacterial/togo_medium_m3153.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15377
     label: Distilled water
-- preferred_term: MgSO4⋅7H2O
+- preferred_term: MgSO4 x 7 H2O
   concentration:
     value: '0.1'
     unit: G_PER_L
@@ -79,7 +79,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:8806
     label: Resazurin
-- preferred_term: Na2S⋅9H2O
+- preferred_term: Na2S x 9 H2O
   concentration:
     value: '0.5'
     unit: G_PER_L
@@ -100,7 +100,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32139
     label: sodium hydrogencarbonate
-- preferred_term: Cysteine-HCl⋅H2O
+- preferred_term: Cysteine-HCl x H2O
   concentration:
     value: '0.5'
     unit: G_PER_L

--- a/data/normalized_yaml/specialized/mccas.yaml
+++ b/data/normalized_yaml/specialized/mccas.yaml
@@ -115,7 +115,7 @@ ingredients:
   term:
     id: CHEBI:31440
     label: ''
-- preferred_term: AlK(SO4)2 12H2O
+- preferred_term: AlK(SO4)2 x 12 H2O
   concentration:
     value: '0.0001'
     unit: G_PER_L

--- a/data/normalized_yaml/specialized/mccas_formate_so4.yaml
+++ b/data/normalized_yaml/specialized/mccas_formate_so4.yaml
@@ -115,7 +115,7 @@ ingredients:
   term:
     id: CHEBI:31440
     label: ''
-- preferred_term: AlK(SO4)2 12H2O
+- preferred_term: AlK(SO4)2 x 12 H2O
   concentration:
     value: '0.0001'
     unit: G_PER_L

--- a/data/normalized_yaml/specialized/mccas_mops.yaml
+++ b/data/normalized_yaml/specialized/mccas_mops.yaml
@@ -115,7 +115,7 @@ ingredients:
   term:
     id: CHEBI:31440
     label: ''
-- preferred_term: AlK(SO4)2 12H2O
+- preferred_term: AlK(SO4)2 x 12 H2O
   concentration:
     value: '0.0001'
     unit: G_PER_L


### PR DESCRIPTION
## What
Fixes parse-artifact hydrate `preferred_term`s (84 occurrences across 24 files) by mapping each to the corpus's dominant clean sibling (` x N H2O`) sharing its separator-stripped key.

## Targeted (genuinely malformed)
- **Concatenated, no separator:** `CaCl22H2O`→`CaCl2 x 2 H2O`, `CoSO47H2O`, `MnCl24H2O`, `Na2MoO42H2O`, `NiCl26H2O`, `FeCl36H2O`.
- **`x` without spaces:** `MgSO4x7H2O`→`MgSO4 x 7 H2O`, `CaCl2x2H2O`, `CaCl2 x2H2O`.
- **Rare dot-operator unicode** (U+22C5 `⋅` / U+2219 `∙`): `FeSO4⋅7H2O`/`MgSO4∙7H2O` → ` x ` form.

## Deliberately left untouched
- Established `·` (U+00B7) and `・` (U+30FB) middot notation — a widely-used style (hundreds of occurrences), not a parse artifact. Unifying all separators would be a ~7k-row cosmetic churn with no grounding benefit.
- Malformed forms with **no matching-hydrate** clean sibling (`CuCl2⋅4H2O`, `Na2Sx6H2O`, `Ni2SO4 ⋅ 6H2O`) — left as-is rather than mapped to a different hydrate.

Grounding (`term.id`) is unaffected; mapping is corpus-driven (only maps to an existing canonical of the **same** hydrate). `linkml-validate`: 24/24 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)