### PR TITLE
Enable Phase-2 id↔label enforcement (blocking gate)

### DIFF
--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -1,9 +1,15 @@
 name: label-correspondence
 
-# Phase 1 (report-only): generate the id↔label drift report and upload it as an
-# artifact. Does NOT fail the build — it surfaces existing label drift for
-# triage. Phase 2 will switch to the blocking gates (`just validate-terms-all`
-# + `just validate-products`).
+# Phase 2 (blocking): builds the SSSOM product, uploads the id↔label drift report
+# for triage (non-blocking), then ENFORCES id↔label correspondence with
+# `just validate-products` (Engine B) — the build fails on any ERROR-class verdict
+# (MISMATCH / ID_NOT_FOUND / EMPTY_LABEL / MISSING_COLUMN / MISSING_GLOB /
+# UNKNOWN_PREFIX) across recipe YAMLs + the SSSOM product.
+#
+# Engine B (single-process) is the CI gate; the per-file Engine A
+# (`just validate-terms-all`, linkml-term-validator) is a dev-only tool — it
+# reloads the schema+OAK per file (~hours over the full corpus) and covers the
+# same canonical-label surface Engine B already enforces in one pass.
 
 on:
   pull_request:
@@ -50,7 +56,14 @@ jobs:
       - name: Verify id↔label validator pin
         run: just verify-validator-pin
 
-      - name: Generate id↔label drift report (non-blocking)
+      # Build the SSSOM product so the `required: true` sssom target is satisfied
+      # (output/ is gitignored, so it is never checked in). The generator resolves
+      # canonical object labels via OAK, so the product is drift-free by construction.
+      - name: Build SSSOM product
+        run: just generate-sssom
+
+      # Triage artifact (non-blocking): full drift report across recipes + products.
+      - name: Generate id↔label drift report
         run: just report-label-drift
 
       - name: Upload drift report
@@ -60,3 +73,7 @@ jobs:
           name: label-drift-report-${{ github.run_id }}
           path: reports/label_drift.tsv
           if-no-files-found: warn
+
+      # Phase-2 blocking gate: fail the build on any ERROR-class id↔label verdict.
+      - name: Enforce id↔label correspondence (Engine B)
+        run: just validate-products

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -62,18 +62,21 @@ jobs:
       - name: Build SSSOM product
         run: just generate-sssom
 
-      # Triage artifact (non-blocking): full drift report across recipes + products.
-      - name: Generate id↔label drift report
+      # Phase-2 blocking gate: fail the build on any ERROR-class id↔label verdict.
+      # Single validator pass (the full corpus + OAK load is the expensive part).
+      - name: Enforce id↔label correspondence (Engine B)
+        run: just validate-products
+
+      # On FAILURE only, regenerate + upload the drift report so failures are
+      # triageable without paying the second validator pass on every green run.
+      - name: Generate id↔label drift report (on failure)
+        if: failure()
         run: just report-label-drift
 
-      - name: Upload drift report
-        if: always()
+      - name: Upload drift report (on failure)
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: label-drift-report-${{ github.run_id }}
           path: reports/label_drift.tsv
           if-no-files-found: warn
-
-      # Phase-2 blocking gate: fail the build on any ERROR-class id↔label verdict.
-      - name: Enforce id↔label correspondence (Engine B)
-        run: just validate-products

--- a/NEXT_TASKS.md
+++ b/NEXT_TASKS.md
@@ -8,18 +8,20 @@ Keep the cross-Mech items in sync with the sibling repos' `NEXT_TASKS.md`
 
 Last reconciled: 2026-06-14.
 
-## 1. Phase-2 id↔label enforcement rollout (report-only → blocking)
+## 1. Phase-2 id↔label enforcement rollout (report-only → blocking) — DONE
 
-The id↔label correspondence validator (`scripts/validate_id_label_correspondence.py`,
-byte-identical across the Mechs) is live but **report-only**. `validate-terms-all`
-and `validate-products` exist in `project.justfile` but are deliberately NOT in
-the `qc` gate, and CI only runs the non-blocking drift report.
+**Done** (2026-06-14): the drift backlog was triaged to zero and the gate flipped
+to blocking. The `label-correspondence` CI job now builds the SSSOM product, then
+runs `just validate-products` (Engine B) as a **blocking** step; `qc` does the
+same locally. Recipe id↔label is clean (0 MISMATCH / ID_NOT_FOUND / EMPTY_LABEL;
+`jcm.grmd` ignored), and `generate_sssom_mappings.py` emits canonical object
+labels so the product is drift-free by construction.
 
-- Triage first: `just report-label-drift` → `reports/label_drift.tsv`, resolve
-  real MISMATCH/ID_NOT_FOUND rows (curate or add justified `exceptions`).
-- Then add `validate-terms-all` + `validate-products` to the `qc` recipe and
-  flip the CI step to blocking.
-- Don't flip the gate while drift rows remain — it will red-wall every PR.
+Note: Engine B (single-process) is the gate. `validate-terms-all` (per-file
+linkml-term-validator, Engine A) is **deliberately NOT in CI/qc** — it reloads
+the schema+OAK per file (~hours over the full corpus) and re-checks the same
+canonical-label surface Engine B already enforces in one pass; keep it as a
+targeted dev tool (`just validate-terms <file>`).
 
 ## 2. Page renderer skip logic ignores template/code changes
 

--- a/project.justfile
+++ b/project.justfile
@@ -865,8 +865,13 @@ validate-all:
 [group('QC')]
 qc:
     #!/usr/bin/env bash
+    set -e
     echo "Running full QC pipeline..."
     just validate-all
+    echo ""
+    echo "Building SSSOM product + enforcing id↔label correspondence (Engine B)..."
+    just generate-sssom
+    just validate-products
     echo ""
     echo "✓ QC complete!"
 


### PR DESCRIPTION
## What
Flips the `label-correspondence` CI from **report-only (Phase 1)** to a **blocking gate (Phase 2)**, now that the id↔label drift backlog is zero.

## Why now
Prereqs are all merged: recipe ID_NOT_FOUND → 0 (#56), kg_fallback cleaned (#59), organism/env labels canonical + jcm.grmd ignored (#53/#57), and the SSSOM generator emits canonical object labels (#58). `just validate-products` (Engine B) was verified locally at **exit 0**.

## Changes
- **CI** (`label-correspondence.yaml`): build the SSSOM product (it's gitignored, so not checked in) → upload the drift report (non-blocking triage artifact) → run `just validate-products` as a **blocking** step. Fails on any ERROR-class verdict (MISMATCH / ID_NOT_FOUND / EMPTY_LABEL / MISSING_COLUMN / MISSING_GLOB / UNKNOWN_PREFIX) across recipe YAMLs + the SSSOM product.
- **`qc` recipe**: build SSSOM + `validate-products` (local Phase-2 gate).
- **NEXT_TASKS.md** item 1 marked done.

## Engine A vs B
Engine B (single-process, ~2-3 min) is the gate. `validate-terms-all` (per-file `linkml-term-validator`, Engine A) is **deliberately not** wired into CI/qc — it reloads schema+OAK per file (~8 h over ~16k files, measured) and re-checks the same canonical-label surface Engine B already enforces in one pass. It stays a targeted dev tool.

This PR's own CI exercises the new blocking gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)