### PR TITLE
Render datasets + knowledge-gap discussions in media pages (claw#7 Phase 1)

### DIFF
--- a/src/culturemech/templates/_partials/datasets.html.j2
+++ b/src/culturemech/templates/_partials/datasets.html.j2
@@ -1,0 +1,18 @@
+<section id="datasets">
+<h2>Datasets <span class="muted">({{ medium.datasets|length }})</span></h2>
+<table class="datasets">
+<thead>
+<tr><th>Dataset</th><th>Type</th><th>Repository</th><th>Accession</th></tr>
+</thead>
+<tbody>
+{% for ds in medium.datasets %}
+<tr>
+  <td>{{ ds.title or ds.accession }}{% if ds.description %}<br><span class="muted small prewrap">{{ ds.description }}</span>{% endif %}</td>
+  <td>{% if ds.dataset_type %}<span class="badge">{{ ds.dataset_type }}</span>{% endif %}</td>
+  <td class="small">{{ ds.repository or '' }}</td>
+  <td class="small">{% if ds.url %}<a href="{{ ds.url }}" rel="nofollow noreferrer">{{ ds.accession or ds.url }}</a>{% else %}{{ ds.accession or '' }}{% endif %}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+</section>

--- a/src/culturemech/templates/_partials/discussions.html.j2
+++ b/src/culturemech/templates/_partials/discussions.html.j2
@@ -1,0 +1,41 @@
+<section id="discussions">
+<h2>Knowledge gaps &amp; discussions <span class="muted">({{ medium.discussions|length }})</span></h2>
+{% for d in medium.discussions %}
+<div class="discussion">
+  <h3>
+    {% if d.kind %}<span class="badge">{{ d.kind }}</span>{% endif %}
+    {% if d.status %}<span class="badge">{{ d.status }}</span>{% endif %}
+    {{ d.prompt }}
+  </h3>
+  {% if d.rationale %}<p class="prewrap">{{ d.rationale }}</p>{% endif %}
+  {% if d.attaches_to %}<p class="muted small">Attaches to: {% for a in d.attaches_to %}<code>{{ a }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>{% endif %}
+  {% if d.proposed_experiments %}
+  <details>
+    <summary class="muted small">{{ d.proposed_experiments|length }} proposed experiment(s)</summary>
+    {% for exp in d.proposed_experiments %}
+    <div class="experiment">
+      <strong>{{ exp.name or exp.experiment_id or 'Experiment ' ~ loop.index }}</strong>
+      {% if exp.approach %}<br><span class="small">Approach: {{ exp.approach }}</span>{% endif %}
+      {% if exp.decision_criterion %}<br><span class="small">Decision: {{ exp.decision_criterion }}</span>{% endif %}
+    </div>
+    {% endfor %}
+  </details>
+  {% endif %}
+  {% if d.evidence %}
+  <details>
+    <summary class="muted small">{{ d.evidence|length }} evidence item(s)</summary>
+    {% for ev in d.evidence %}
+    <div class="evidence">
+      {% if ev.evidence_source %}<span class="badge small">{{ ev.evidence_source }}</span>{% endif %}
+      {% if ev.supports %}<span class="badge small">{{ ev.supports }}</span>{% endif %}
+      {% if ev.reference %}{% set ref = ev.reference %}{% if ref.startswith('PMID:') %}<a href="https://pubmed.ncbi.nlm.nih.gov/{{ ref|replace('PMID:','') }}/" rel="nofollow noreferrer">{{ ref }}</a>{% else %}{{ ref }}{% endif %}{% endif %}
+      {% if ev.snippet %}<p class="small prewrap">{{ ev.snippet }}</p>{% endif %}
+      {% if ev.explanation %}<p class="muted small prewrap">{{ ev.explanation }}</p>{% endif %}
+    </div>
+    {% endfor %}
+  </details>
+  {% endif %}
+  {% if d.resolution_note %}<p class="small"><em>Resolution:</em> {{ d.resolution_note }}</p>{% endif %}
+</div>
+{% endfor %}
+</section>

--- a/src/culturemech/templates/media.html.j2
+++ b/src/culturemech/templates/media.html.j2
@@ -48,6 +48,8 @@
 {% include "_partials/ingredients.html.j2" %}
 {% if medium.preparation_steps %}{% include "_partials/preparation.html.j2" %}{% endif %}
 {% if medium.solutions %}{% include "_partials/solutions.html.j2" %}{% endif %}
+{% if medium.datasets %}{% include "_partials/datasets.html.j2" %}{% endif %}
+{% if medium.discussions %}{% include "_partials/discussions.html.j2" %}{% endif %}
 {% include "_partials/provenance.html.j2" %}
 
 <footer>


### PR DESCRIPTION
Adds guarded `datasets` + `discussions` partials to `media.html.j2` (after solutions), mirroring CommunityMech's markup. Template-only — no MediaRecipe carries these fields yet, so the build-signature regenerates pages on the next `gen-pages` once data lands. Verified `just gen-pages` runs clean (errors: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)