### PR TITLE
Wire knowledge-gap scan recipe + config (claw#7 Item 2)

### DIFF
--- a/conf/kgscan_config.yaml
+++ b/conf/kgscan_config.yaml
@@ -1,0 +1,10 @@
+# CultureMech knowledge-gap scan config — drives kg_microbe_kgscan (in culturebotai-claw).
+# Europe PMC (free) per-record gap-signal search over canonical merged media records.
+repo_name: CultureMech
+record_glob: ../data/merge_yaml/merged_2026/*.yaml
+name_fields: [name, preferred_term]
+synonym_field: synonyms
+id_field: id
+discussions_field: discussions
+topic_context_terms: ["culture medium", "growth medium", "cultivation", "microbial", "microbiology"]
+min_score: 8

--- a/justfile
+++ b/justfile
@@ -32,6 +32,13 @@ gen-qc-dashboard:
     PYTHONPATH=../culturebotai-claw/src /opt/homebrew/bin/python3.13 \
       -m kg_microbe_qc --config conf/qc_config.yaml --output dashboard
 
+# Knowledge-gap scan (Europe PMC, free) via shared kg_microbe_kgscan in claw.
+# Dry-run by default → reports/knowledge_gap_scan.{json,md}. Pass `--apply`
+# (and e.g. --limit/--min-score) to seed Discussion(kind=KNOWLEDGE_GAP).
+knowledge-gap-scan *args:
+    PYTHONPATH=../culturebotai-claw/src /opt/homebrew/bin/python3.13 \
+      -m kg_microbe_kgscan --config conf/kgscan_config.yaml {{args}}
+
 # Composite: media pages + QC dashboard (Phase 2 outputs).
 gen-phase2: gen-media-pages gen-qc-dashboard
 


### PR DESCRIPTION
Adds `conf/kgscan_config.yaml` + a `knowledge-gap-scan` recipe (shared `kg_microbe_kgscan`, free Europe PMC). Initial seed found 0 strong gaps (media recipe names phrase-match Europe PMC poorly) → no auto-writes; recipe wired for triage/tuning. Completes Item 2 wiring across all four Mechs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)