### PR TITLE
skills: sharpen vague descriptions (manage-identifiers, manage-ingredient-hierarchy)

### DIFF
--- a/.claude/skills/manage-identifiers/skill.md
+++ b/.claude/skills/manage-identifiers/skill.md
@@ -1,6 +1,6 @@
 ---
 name: manage-identifiers
-description: Generic identifier management for X-Mech repositories - finding highest IDs, minting new IDs, and adding records with proper ID placement
+description: Use this skill to manage CultureMech record identifiers — find the highest existing CultureMech id, mint the next id, and insert new media/solution records with correct id placement. Use when adding or importing recipe records, or reconciling id collisions.
 category: workflow
 requires_database: false
 requires_internet: false

--- a/.claude/skills/manage-ingredient-hierarchy/skill.md
+++ b/.claude/skills/manage-ingredient-hierarchy/skill.md
@@ -1,6 +1,6 @@
 ---
 name: manage-ingredient-hierarchy
-description: Manage ingredient hierarchy integration from MediaIngredientMech
+description: Use this skill to integrate the MediaIngredientMech ingredient variant hierarchy (parent/child relationships — purity levels, hydrates, stereoisomers) into CultureMech recipe ingredient references. Use when linking recipe ingredients to their canonical MIM records or resolving variant forms.
 category: workflow
 requires_database: false
 requires_internet: true


### PR DESCRIPTION
Per [author-skills guidance](https://ai4curation.io/aidocs/how-tos/author-skills/): replaced the placeholder "Generic identifier management for X-Mech repositories" (manage-identifiers) with a CultureMech-specific "Use when…" description, and expanded the terse manage-ingredient-hierarchy one-liner to state what + when.

🤖 Generated with [Claude Code](https://claude.com/claude-code)