### PR TITLE
skills: progressive-disclosure refactor of review-recipes (851 → 193 lines)

### DIFF
--- a/.claude/skills/review-recipes/reference/linkage-and-duplicates.md
+++ b/.claude/skills/review-recipes/reference/linkage-and-duplicates.md
@@ -1,0 +1,130 @@
+# Ingredient Linkage Validation & Recipe Fingerprinting
+
+*Reference for the **review-recipes** skill — see [`../skill.md`](../skill.md) for the overview, workflows, and rule summary.*
+
+---
+
+## Ingredient Linkage Validation
+
+### MediaIngredientMech Coverage Check
+
+```python
+from culturemech.utils.ingredient_validator import IngredientValidator
+
+validator = IngredientValidator()
+
+# Check single recipe
+recipe_path = "data/normalized_yaml/bacterial/LB_Broth.yaml"
+coverage = validator.check_mediaingredientmech_coverage(recipe_path)
+
+print(f"Total ingredients: {coverage['total']}")
+print(f"Linked: {coverage['linked']} ({coverage['percentage']:.1f}%)")
+print(f"Unlinked: {', '.join(coverage['unlinked_terms'])}")
+```
+
+### Batch Coverage Report
+
+```bash
+# Generate coverage report for all recipes
+PYTHONPATH=src python scripts/generate_coverage_report.py \
+  --output reports/mediaingredientmech_coverage_$(date +%Y%m%d).md
+
+# Check specific category
+PYTHONPATH=src python scripts/generate_coverage_report.py \
+  --category solutions \
+  --output reports/solutions_coverage.md
+```
+
+**Output Example:**
+```markdown
+# MediaIngredientMech Coverage Report
+
+## Overall Statistics
+- Total recipes: 15,450
+- Total ingredient instances: 118,818
+- Linked instances: 99,547 (83.8%)
+- Unlinked instances: 19,271 (16.2%)
+
+## By Category
+| Category | Recipes | Ingredients | Linked | Coverage |
+|----------|---------|-------------|--------|----------|
+| bacterial | 8,234 | 67,123 | 54,321 | 80.9% |
+| algae | 4,567 | 32,456 | 28,901 | 89.0% |
+| solutions | 90 | 456 | 384 | 84.2% |
+
+## Top Unlinked Ingredients
+1. Soil extract (1,234 instances, 45 recipes)
+2. Beef extract (987 instances, 23 recipes)
+3. Malt extract (765 instances, 34 recipes)
+```
+
+### Cross-Reference Validation
+
+```python
+from culturemech.utils.cross_reference_validator import CrossReferenceValidator
+
+validator = CrossReferenceValidator()
+
+# Check all solution references in a recipe
+recipe_path = "data/normalized_yaml/algae/J_Medium.yaml"
+issues = validator.validate_solution_references(recipe_path)
+
+for issue in issues:
+    print(f"P{issue['priority']}: {issue['description']}")
+    if issue['suggested_fix']:
+        print(f"  Fix: {issue['suggested_fix']}")
+```
+
+---
+
+## Recipe Fingerprinting
+
+### Detect Duplicates
+
+```bash
+# Find potential duplicate recipes
+PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
+  --threshold 0.95 \
+  --output reports/duplicates_$(date +%Y%m%d).json
+
+# Check specific category
+PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
+  --category bacterial \
+  --threshold 0.90
+```
+
+**Fingerprinting Algorithm:**
+1. Extract sorted ingredient list with concentrations
+2. Normalize ingredient names (case-insensitive, whitespace)
+3. Normalize concentration units
+4. Generate hash of normalized composition
+5. Calculate Jaccard similarity between ingredient sets
+6. Flag pairs with similarity > threshold
+
+**Output:**
+```json
+{
+  "duplicate_pairs": [
+    {
+      "recipe1": {
+        "id": "CultureMech:001234",
+        "name": "LB Broth",
+        "path": "data/normalized_yaml/bacterial/LB_Broth.yaml"
+      },
+      "recipe2": {
+        "id": "CultureMech:005678",
+        "name": "Luria-Bertani Medium",
+        "path": "data/normalized_yaml/bacterial/Luria_Bertani_Medium.yaml"
+      },
+      "similarity": 0.98,
+      "differences": [
+        "recipe1 has pH 7.0, recipe2 has pH 7.2"
+      ],
+      "recommendation": "MERGE - Near-identical recipes"
+    }
+  ]
+}
+```
+
+---
+

--- a/.claude/skills/review-recipes/reference/operations.md
+++ b/.claude/skills/review-recipes/reference/operations.md
@@ -1,0 +1,123 @@
+# Operations: Error Handling · Validation Checklist · Output Examples
+
+*Reference for the **review-recipes** skill — see [`../skill.md`](../skill.md) for the overview, workflows, and rule summary.*
+
+---
+
+## Error Handling
+
+### Common Issues and Solutions
+
+**Issue:** Schema validation fails with "Unknown enum value"
+**Solution:** Check enum is defined in `src/culturemech/schema/culturemech.yaml`
+
+**Issue:** MediaIngredientMech ID not found
+**Solution:** Verify ID exists in `MediaIngredientMech/data/curated/mapped_ingredients.yaml`
+
+**Issue:** Duplicate CultureMech IDs
+**Solution:** Run `python -c "from culturemech.utils.id_utils import rebuild_culturemech_registry; rebuild_culturemech_registry()"`
+
+**Issue:** Solution reference broken
+**Solution:** Check solution exists in `data/normalized_yaml/solutions/`
+
+**Issue:** Concentration units invalid
+**Solution:** Convert to enum value from schema (e.g., "g/L" → "G_PER_L")
+
+---
+
+## Validation Checklist
+
+Before committing a recipe:
+
+- ✅ Schema validates (`just validate-schema`)
+- ✅ CultureMech ID unique and in registry
+- ✅ Required fields present (name, medium_type, physical_state, ingredients)
+- ✅ No P1 critical errors
+- ✅ MediaIngredientMech coverage > 50% (for solutions: > 80%)
+- ✅ No duplicate recipes detected
+- ✅ Ingredient names standardized
+- ✅ Concentration units use enums
+- ✅ No placeholder text
+- ✅ Curation history entry added
+- ✅ References/source documented
+- ✅ Category directory correct
+
+---
+
+## Output Examples
+
+### Interactive Review Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Recipe Review: LB_Broth
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ID: CultureMech:015432
+Category: bacterial
+Medium Type: COMPLEX
+Physical State: LIQUID
+
+Validation Results:
+  ✅ Schema valid
+  ✅ CultureMech ID unique
+  ✅ Required fields present
+  ⚠️  P3.2: 1/4 ingredients missing MediaIngredientMech linkage
+  ⚠️  P3.6: pH not specified
+
+Ingredient Coverage:
+  Total ingredients: 4
+  MediaIngredientMech linked: 3 (75.0%)
+  Unlinked: ["Yeast extract"]
+
+Suggestions:
+  1. Add MediaIngredientMech ID for "Yeast extract"
+     → MediaIngredientMech:000234 (preferred term: "Yeast extract")
+  2. Add pH value (typical: 7.0 ± 0.2)
+
+Apply fixes? [y/N]:
+```
+
+### Batch Review Summary
+
+```markdown
+# Recipe Validation Report - Bacterial Media
+Date: 2026-03-16
+
+## Summary Statistics
+- Total recipes: 8,234
+- Validated: 8,234 (100%)
+- P1 Critical Errors: 0 (0.0%)
+- P2 High Priority: 23 (0.3%)
+- P3 Medium Priority: 456 (5.5%)
+- P4 Low Priority: 1,234 (15.0%)
+
+## Issue Breakdown
+
+### P1 Critical (0)
+None! 🎉
+
+### P2 High Priority (23)
+1. P2.1 - Invalid MediaIngredientMech ID: 12 recipes
+2. P2.3 - Concentration mismatch: 8 recipes
+3. P2.5 - Duplicate recipe: 3 pairs
+
+### P3 Medium Priority (456)
+1. P3.1 - Placeholder text: 234 recipes
+2. P3.2 - Missing MediaIngredientMech linkage: 123 recipes
+3. P3.6 - pH not specified: 99 recipes
+
+## Top Action Items
+1. Fix 12 broken MediaIngredientMech IDs
+2. Remove placeholder text from 234 recipes
+3. Merge 3 duplicate recipe pairs
+4. Add MediaIngredientMech linkage to 123 recipes
+
+## Coverage Metrics
+- Overall MediaIngredientMech coverage: 80.9%
+- Recipes with >80% coverage: 6,789 (82.5%)
+- Recipes with <50% coverage: 234 (2.8%)
+```
+
+---
+

--- a/.claude/skills/review-recipes/reference/pipeline-and-patterns.md
+++ b/.claude/skills/review-recipes/reference/pipeline-and-patterns.md
@@ -1,0 +1,174 @@
+# Data-Quality Pipeline · Validation Patterns · MediaIngredientMech Integration
+
+*Reference for the **review-recipes** skill — see [`../skill.md`](../skill.md) for the overview, workflows, and rule summary.*
+
+---
+
+## Data Quality Pipeline Integration
+
+### Current Pipeline (justfile)
+
+```bash
+# Full quality pipeline
+just fix-all-data-quality
+
+# Individual steps
+just cleanup-ingredients          # Standardize ingredient names
+just fix-placeholder-text         # Remove "See source" patterns
+just standardize-units            # Convert to enum units
+just enrich-mediaingredientmech   # Add MediaIngredientMech IDs
+```
+
+### Adding Recipe Review to Pipeline
+
+```bash
+# Add to .justfile
+validate-recipes:
+    PYTHONPATH=src python scripts/batch_review_recipes.py \
+      --output reports/validation_latest \
+      --format md,json \
+      --priority P1,P2,P3
+
+# Run as part of pre-commit
+pre-commit: validate-recipes validate-schema
+```
+
+---
+
+## Common Validation Patterns
+
+### Pattern 1: New Recipe Validation
+
+**Scenario:** Created LB_Broth.yaml, need to validate before commit
+
+**Workflow:**
+```bash
+# 1. Schema validation
+just validate-schema data/normalized_yaml/bacterial/LB_Broth.yaml
+
+# 2. Interactive review
+/review-recipes "LB_Broth"
+
+# 3. Check for duplicates
+PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
+  --target data/normalized_yaml/bacterial/LB_Broth.yaml
+
+# 4. Coverage check
+PYTHONPATH=src python scripts/generate_coverage_report.py \
+  --single data/normalized_yaml/bacterial/LB_Broth.yaml
+```
+
+### Pattern 2: Solution Validation
+
+**Scenario:** Created DAS_Vitamin_Cocktail.yaml solution
+
+**Workflow:**
+```bash
+# 1. Validate composition
+/review-recipes "DAS_Vitamin_Cocktail"
+
+# 2. Check ingredient linkages
+PYTHONPATH=src python scripts/validate_ingredients.py \
+  data/normalized_yaml/solutions/DAS_Vitamin_Cocktail.yaml
+
+# 3. Find usage in media
+grep -r "DAS_Vitamin_Cocktail" data/normalized_yaml/algae/
+
+# 4. Validate cross-references
+PYTHONPATH=src python scripts/validate_solution_references.py \
+  --solution "DAS_Vitamin_Cocktail"
+```
+
+### Pattern 3: Batch Category Review
+
+**Scenario:** Review all algae media for quality issues
+
+**Workflow:**
+```bash
+# 1. Batch review
+PYTHONPATH=src python scripts/batch_review_recipes.py \
+  --category algae \
+  --output reports/algae_validation \
+  --priority P1,P2,P3
+
+# 2. Fix auto-correctable issues
+PYTHONPATH=src python scripts/fix_data_quality.py \
+  --category algae \
+  --apply --types placeholders,units
+
+# 3. Generate coverage report
+PYTHONPATH=src python scripts/generate_coverage_report.py \
+  --category algae
+
+# 4. Regenerate indexes
+just generate-indexes data/normalized_yaml/algae
+```
+
+### Pattern 4: Pre-Export KG Check
+
+**Scenario:** Validate all recipes before KG export
+
+**Workflow:**
+```bash
+# 1. Full batch review (P1 only)
+PYTHONPATH=src python scripts/batch_review_recipes.py \
+  --priority P1 \
+  --output reports/pre_export_validation
+
+# 2. Check for critical errors
+grep "^P1" reports/pre_export_validation.md
+
+# 3. Fix blocking errors
+# (Manual fixes for P1 issues)
+
+# 4. Re-validate
+PYTHONPATH=src python scripts/batch_review_recipes.py --priority P1
+
+# 5. Export when P1 count = 0
+just export-kg
+```
+
+---
+
+## Integration with MediaIngredientMech
+
+### Enrichment Workflow
+
+```bash
+# 1. Check current coverage
+PYTHONPATH=src python scripts/generate_coverage_report.py
+
+# 2. Run enrichment
+PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py \
+  --category solutions \
+  --mediaingredientmech-repo /path/to/MediaIngredientMech
+
+# 3. Validate linkages
+PYTHONPATH=src python scripts/validate_ingredients.py \
+  --check-mediaingredientmech
+
+# 4. Re-check coverage
+PYTHONPATH=src python scripts/generate_coverage_report.py
+```
+
+### Syncing with MediaIngredientMech Updates
+
+When MediaIngredientMech adds new ingredients:
+
+```bash
+# 1. Pull latest MediaIngredientMech
+cd /path/to/MediaIngredientMech && git pull
+
+# 2. Re-run enrichment on CultureMech
+cd /path/to/CultureMech
+PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py \
+  --incremental \
+  --mediaingredientmech-repo /path/to/MediaIngredientMech
+
+# 3. Check improvement
+PYTHONPATH=src python scripts/generate_coverage_report.py \
+  --compare-with reports/mediaingredientmech_coverage_previous.md
+```
+
+---
+

--- a/.claude/skills/review-recipes/reference/validation-rules.md
+++ b/.claude/skills/review-recipes/reference/validation-rules.md
@@ -1,0 +1,208 @@
+# Validation Rule Definitions
+
+*Reference for the **review-recipes** skill — see [`../skill.md`](../skill.md) for the overview, workflows, and rule summary.*
+
+---
+
+### Rule Definitions
+
+#### P1 - Critical Errors
+
+**Rule P1.1: Schema Validation Failure**
+```yaml
+id: P1.1
+description: Recipe does not validate against LinkML schema
+check: linkml-validate fails
+impact: Cannot parse or export to KG
+fix: Add missing required fields or correct field types
+```
+
+**Rule P1.2: Invalid CultureMech ID**
+```yaml
+id: P1.2
+description: CultureMech ID missing, malformed, or duplicate
+check: Regex ^CultureMech:\d{6}$, uniqueness check
+impact: Identifier conflicts in KG
+fix: Mint new ID or correct format
+```
+
+**Rule P1.3: Missing Required Fields**
+```yaml
+id: P1.3
+description: Required fields missing (name, medium_type, physical_state)
+check: Schema validation via LinkML
+impact: Invalid YAML structure
+fix: Add missing required fields
+```
+
+**Rule P1.4: Invalid Enum Values**
+```yaml
+id: P1.4
+description: Enum values not in schema (medium_type, physical_state, units)
+check: Compare against schema enums
+impact: Parser failures
+fix: Correct to valid enum value
+```
+
+**Rule P1.5: Broken Solution Reference**
+```yaml
+id: P1.5
+description: Referenced solution does not exist
+check: Solution CultureMech ID lookup fails
+impact: Incomplete recipe composition
+fix: Create missing solution or update reference
+```
+
+#### P2 - High-Priority Warnings
+
+**Rule P2.1: Invalid MediaIngredientMech ID**
+```yaml
+id: P2.1
+description: MediaIngredientMech ID does not exist
+check: Lookup in MediaIngredientMech mapped_ingredients.yaml
+impact: Broken ingredient linkage
+fix: Update to correct MediaIngredientMech ID or remove
+```
+
+**Rule P2.2: Invalid CHEBI ID**
+```yaml
+id: P2.2
+description: CHEBI term ID does not exist
+check: OAK/OLS lookup returns 404
+impact: Broken ontology linkage
+fix: Update to correct CHEBI ID or remove
+```
+
+**Rule P2.3: Concentration Mismatch**
+```yaml
+id: P2.3
+description: Concentration units incompatible with physical_state
+check: E.g., G_PER_L for SOLID medium (should be percentage)
+impact: Incorrect concentration interpretation
+fix: Convert to appropriate units
+```
+
+**Rule P2.4: Category Mismatch**
+```yaml
+id: P2.4
+description: File category doesn't match target_organisms
+check: E.g., bacterial/ directory but target is algae
+impact: Organizational confusion
+fix: Move to correct category directory
+```
+
+**Rule P2.5: Duplicate Recipe**
+```yaml
+id: P2.5
+description: Recipe fingerprint matches existing recipe
+check: Ingredient composition + concentrations fingerprinting
+threshold: > 95% similarity
+impact: Data redundancy
+fix: Merge duplicates or document as variant
+```
+
+#### P3 - Medium-Priority Warnings
+
+**Rule P3.1: Placeholder Text**
+```yaml
+id: P3.1
+description: Placeholder text in ingredients or notes
+patterns: "See source", "original amount:", "Unknown", "TBD"
+impact: Incomplete data
+fix: Extract actual data from source or research
+```
+
+**Rule P3.2: Missing MediaIngredientMech Linkage**
+```yaml
+id: P3.2
+description: Ingredient has no mediaingredientmech_term field
+check: Ingredient lacks mediaingredientmech_term.id
+impact: Reduced traceability to ontologies
+fix: Enrich with MediaIngredientMech ID
+```
+
+**Rule P3.3: Non-Standard Ingredient Name**
+```yaml
+id: P3.3
+description: Ingredient preferred_term doesn't match MediaIngredientMech
+check: Fuzzy match against MediaIngredientMech preferred terms
+impact: Inconsistent naming across recipes
+fix: Standardize to MediaIngredientMech preferred term
+```
+
+**Rule P3.4: Missing Preparation Steps**
+```yaml
+id: P3.4
+description: No preparation_steps field for complex media
+check: medium_type = COMPLEX and preparation_steps empty
+impact: Incomplete protocol information
+fix: Extract from source or add basic steps
+```
+
+**Rule P3.5: Sterilization Not Specified**
+```yaml
+id: P3.5
+description: No sterilization method specified
+check: sterilization field missing
+impact: Critical safety information missing
+fix: Add sterilization from preparation_steps or source
+```
+
+**Rule P3.6: pH Not Specified**
+```yaml
+id: P3.6
+description: No pH value for DEFINED or SEMI_DEFINED media
+check: medium_type in [DEFINED, SEMI_DEFINED] and ph_value missing
+impact: Important growth parameter missing
+fix: Extract from source or mark as "not specified"
+```
+
+#### P4 - Low-Priority Info
+
+**Rule P4.1: Low MediaIngredientMech Coverage**
+```yaml
+id: P4.1
+description: < 50% of ingredients have MediaIngredientMech IDs
+check: Count linked vs total ingredients
+impact: Potential enrichment opportunity
+fix: Run enrichment script on unmapped ingredients
+```
+
+**Rule P4.2: Missing Target Organisms**
+```yaml
+id: P4.2
+description: No target_organisms specified
+check: target_organisms field empty
+impact: Reduced searchability
+fix: Extract from source or media name
+```
+
+**Rule P4.3: Missing References**
+```yaml
+id: P4.3
+description: No source references (DOI, URL, citation)
+check: references field empty
+impact: Reduced provenance
+fix: Add source reference
+```
+
+**Rule P4.4: Incomplete Curation History**
+```yaml
+id: P4.4
+description: Curation history has only creation event
+check: curation_history length = 1
+impact: No change tracking
+fix: Add curation events as changes are made
+```
+
+**Rule P4.5: Solution Could Be Extracted**
+```yaml
+id: P4.5
+description: Complex ingredient used in multiple recipes
+check: Same multi-component ingredient in 3+ recipes
+impact: Duplication instead of reusable solution
+fix: Extract to shared solution record
+```
+
+---
+

--- a/.claude/skills/review-recipes/skill.md
+++ b/.claude/skills/review-recipes/skill.md
@@ -1,7 +1,7 @@
 ---
 name: review-recipes
-description: Quality assurance and validation for growth media recipes, solutions, and ingredient linkages
-version: 1.0.0
+description: Use this skill to quality-check CultureMech growth-media and solution recipes — verify schema/structure, MediaIngredientMech ingredient linkages and CHEBI mappings, solution references, data quality (placeholders, units, concentrations), and categorization. Use after creating/editing a recipe, before a KG export, or for periodic maintenance. Issues are graded P1 (blocking) → P4 (optional); P3/P4 can be auto-fixed.
+version: 1.1.0
 tags: [validation, quality-assurance, recipes, media, solutions, ingredients, linkage]
 author: CultureMech Team
 created: 2026-03-16
@@ -11,27 +11,23 @@ created: 2026-03-16
 
 ## Overview
 
-The **Review Recipes** skill provides comprehensive quality assurance and validation for growth media and solution recipes in CultureMech. It systematically verifies that:
+The **Review Recipes** skill provides quality assurance for growth-media and solution
+recipes in CultureMech. It verifies that:
 
-1. **Recipe structure is valid** - Schema compliance, required fields present
-2. **Ingredient linkages are correct** - MediaIngredientMech IDs exist, CHEBI mappings valid
-3. **Solution references are valid** - Solutions exist, proper composition
-4. **Data quality is high** - No placeholders, concentrations specified, units valid
-5. **Preparation steps are logical** - Proper sequencing, sterilization appropriate
-6. **Categorization is correct** - Medium type, physical state, category match content
+1. **Recipe structure is valid** — schema compliance, required fields present
+2. **Ingredient linkages are correct** — MediaIngredientMech IDs exist, CHEBI mappings valid
+3. **Solution references are valid** — solutions exist, proper composition
+4. **Data quality is high** — no placeholders, concentrations/units specified
+5. **Preparation steps are logical** — proper sequencing, sterilization appropriate
+6. **Categorization is correct** — medium type, physical state, category match content
 
-**Technology Stack:**
-- **LinkML Schema**: Validate YAML structure and field constraints
-- **MediaIngredientMech Integration**: Verify ingredient ID linkages
-- **Recipe Fingerprinting**: Detect duplicates and variants
-- **Data Quality Pipeline**: Automated fixes for common issues
-- **Cross-reference Validation**: Solution → Ingredient traceability
+**Technology stack:** LinkML schema validation, MediaIngredientMech integration (ID
+linkages), recipe fingerprinting (duplicate detection), an auto-fix data-quality pipeline,
+and cross-reference (solution → ingredient) validation.
 
-**Current Dataset:** 15,450 total records
-- 15,360 media recipes across 5 categories (bacterial, algae, archaea, fungal, specialized)
-- 90 solution records (stock solutions, buffers, trace metals)
-- ~118k ingredient instances across all recipes
-- 1,048 MediaIngredientMech linkages (84.1% coverage for solutions)
+**Dataset:** ~15,450 records — ~15,360 media recipes across 5 categories (bacterial, algae,
+archaea, fungal, specialized) + ~90 solutions; ~118k ingredient instances; ~1,048
+MediaIngredientMech linkages (84.1% solution coverage).
 
 ---
 
@@ -47,805 +43,151 @@ The **Review Recipes** skill provides comprehensive quality assurance and valida
 | **Duplicate detection** | Find potential merge candidates | Low |
 | **Data quality cleanup** | Fix placeholders and missing data | High |
 
-**Decision Table:**
-
 ```
-IF newly created recipe → Use interactive review
-IF full category check → Use batch review
-IF data quality issues → Use auto-fix pipeline
-IF critical errors → Use batch review with P1 filter
-IF ingredient linkage check → Use validate_ingredients.py
-IF duplicate detection → Use recipe fingerprinting
+IF newly created recipe   → interactive review
+IF full category check    → batch review
+IF data quality issues    → auto-fix pipeline
+IF critical errors        → batch review with P1 filter
+IF ingredient linkage     → validate_ingredients.py
+IF duplicate detection    → recipe fingerprinting
 ```
 
 ---
 
 ## Review Workflows
 
-### 1. Interactive Review (Single Recipe)
-
-**Use case:** Verify a specific recipe after creation or modification
+### 1. Interactive Review (single recipe)
 
 ```bash
-# Review by recipe name
-PYTHONPATH=src python scripts/review_recipe.py "LB_Broth"
-
-# Review by file path
-PYTHONPATH=src python scripts/review_recipe.py data/normalized_yaml/bacterial/LB_Broth.yaml
-
-# Review by CultureMech ID
-PYTHONPATH=src python scripts/review_recipe.py --id CultureMech:015432
-
-# Review with auto-correction suggestions
-PYTHONPATH=src python scripts/review_recipe.py "TAP_Medium" --suggest-fixes
+PYTHONPATH=src python scripts/review_recipe.py "LB_Broth"                                  # by name
+PYTHONPATH=src python scripts/review_recipe.py data/normalized_yaml/bacterial/LB_Broth.yaml # by path
+PYTHONPATH=src python scripts/review_recipe.py --id CultureMech:015432                      # by ID
+PYTHONPATH=src python scripts/review_recipe.py "TAP_Medium" --suggest-fixes                 # with fixes
 ```
 
-**Output:**
-- Rich UI panel showing current recipe structure
-- Validation results (P1-P4 issues)
-- Suggested corrections with apply/skip options
-- Ingredient linkage status (% MediaIngredientMech coverage)
-- Solution reference validation
+Output: Rich panel with recipe structure, P1–P4 results, suggested corrections, ingredient
+linkage % (MediaIngredientMech coverage), and solution-reference validation.
 
-### 2. Batch Review (Category or All Recipes)
-
-**Use case:** Validate entire dataset or category, generate comprehensive report
+### 2. Batch Review (category or all)
 
 ```bash
-# Review all bacterial media
 PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --category bacterial \
-  --output reports/validation_bacterial_$(date +%Y%m%d) \
-  --format md,json,html
+  --category bacterial --output reports/validation_bacterial_$(date +%Y%m%d) --format md,json,html
 
-# Review all solutions
-PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --category solutions \
-  --priority P1,P2
-
-# Review all recipes
-PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --output reports/validation_all \
-  --threads 8
-
-# Filter by medium type
-PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --medium-type DEFINED \
-  --limit 100 --dry-run
+PYTHONPATH=src python scripts/batch_review_recipes.py --category solutions --priority P1,P2
+PYTHONPATH=src python scripts/batch_review_recipes.py --output reports/validation_all --threads 8
+PYTHONPATH=src python scripts/batch_review_recipes.py --medium-type DEFINED --limit 100 --dry-run
 ```
 
-**Output:**
-- `validation_report.md`: Human-readable summary with statistics
-- `validation_data.json`: Machine-readable issues + corrections
-- `dashboard.html`: Interactive sortable/filterable dashboard
-- Category-level statistics (% valid, common issues, coverage metrics)
+Output: `validation_report.md`, `validation_data.json`, `dashboard.html`, plus category-level
+statistics.
 
 ### 3. Automated Data Quality Fixes
 
-**Use case:** Auto-fix common issues that don't require human review
-
 ```bash
-# Dry-run to preview changes
-PYTHONPATH=src python scripts/fix_data_quality.py --dry-run
-
-# Apply safe corrections (P3/P4 only)
-PYTHONPATH=src python scripts/fix_data_quality.py --apply
-
-# Fix specific issue types
+PYTHONPATH=src python scripts/fix_data_quality.py --dry-run                         # preview
+PYTHONPATH=src python scripts/fix_data_quality.py --apply                           # all safe (P3/P4)
 PYTHONPATH=src python scripts/fix_data_quality.py --apply --types concentration_units
-
-# Fix placeholder text
 PYTHONPATH=src python scripts/fix_data_quality.py --apply --types placeholders
-
-# Standardize chemical names
 PYTHONPATH=src python scripts/fix_data_quality.py --apply --types ingredient_names
 ```
 
-**Safe corrections (auto-applied):**
-- Standardize concentration units (g/L → G_PER_L)
-- Remove placeholder text ("See source for composition")
-- Normalize ingredient names to MediaIngredientMech preferred terms
-- Fix whitespace/capitalization issues
-- Add missing water ingredient where obvious
-
-**Unsafe corrections (manual review required):**
-- Change medium_type classification
-- Merge duplicate recipes
-- Modify preparation steps
-- Change categorization
+**Safe (auto-applied):** standardize concentration units (g/L → G_PER_L), remove placeholder
+text, normalize ingredient names to MIM preferred terms, fix whitespace/capitalization, add
+obvious missing water.
+**Unsafe (manual review):** change `medium_type`, merge duplicates, modify preparation steps,
+change categorization.
 
 ### 4. Claude Code-Assisted Review
 
-**Use case:** Interactive validation with Claude's assistance
-
 ```bash
-# Use this skill
-/review-recipes
-
-# Or invoke via Skill tool with specific recipe
-/review-recipes "LB_Broth"
-
-# Review a solution
-/review-recipes "DAS_Vitamin_Cocktail"
+/review-recipes                       # interactive
+/review-recipes "LB_Broth"            # specific recipe
+/review-recipes "DAS_Vitamin_Cocktail" # a solution
 ```
 
-**Claude will:**
-1. Load recipe from YAML
-2. Run validation via `RecipeReviewer`
-3. Explain issues in plain language
-4. Check ingredient linkages to MediaIngredientMech
-5. Validate solution references
-6. Propose corrections with rationale
-7. Apply fixes if user approves
-8. Update curation_history
+Claude loads the YAML, runs validation via `RecipeReviewer`, explains issues, checks MIM
+linkages and solution references, proposes corrections with rationale, applies on approval,
+and updates `curation_history`.
 
 ---
 
-## Validation Rule Catalog
+## Validation Rules
 
-### Priority Levels
+Issues are graded by priority. Full definitions (checks, impact, fixes) are in
+[`reference/validation-rules.md`](reference/validation-rules.md).
 
-| Level | Description | Action Required | Count Target |
-|-------|-------------|-----------------|--------------|
+| Level | Meaning | Action | Target |
+|-------|---------|--------|--------|
 | **P1** | Critical errors blocking KG export | Fix immediately | 0 |
 | **P2** | High-priority warnings needing review | Manual review | < 1% |
 | **P3** | Medium-priority data quality issues | Auto-correct when possible | < 5% |
-| **P4** | Low-priority info/suggestions | Optional improvements | Any |
-
-### Rule Definitions
-
-#### P1 - Critical Errors
-
-**Rule P1.1: Schema Validation Failure**
-```yaml
-id: P1.1
-description: Recipe does not validate against LinkML schema
-check: linkml-validate fails
-impact: Cannot parse or export to KG
-fix: Add missing required fields or correct field types
-```
-
-**Rule P1.2: Invalid CultureMech ID**
-```yaml
-id: P1.2
-description: CultureMech ID missing, malformed, or duplicate
-check: Regex ^CultureMech:\d{6}$, uniqueness check
-impact: Identifier conflicts in KG
-fix: Mint new ID or correct format
-```
-
-**Rule P1.3: Missing Required Fields**
-```yaml
-id: P1.3
-description: Required fields missing (name, medium_type, physical_state)
-check: Schema validation via LinkML
-impact: Invalid YAML structure
-fix: Add missing required fields
-```
-
-**Rule P1.4: Invalid Enum Values**
-```yaml
-id: P1.4
-description: Enum values not in schema (medium_type, physical_state, units)
-check: Compare against schema enums
-impact: Parser failures
-fix: Correct to valid enum value
-```
-
-**Rule P1.5: Broken Solution Reference**
-```yaml
-id: P1.5
-description: Referenced solution does not exist
-check: Solution CultureMech ID lookup fails
-impact: Incomplete recipe composition
-fix: Create missing solution or update reference
-```
-
-#### P2 - High-Priority Warnings
-
-**Rule P2.1: Invalid MediaIngredientMech ID**
-```yaml
-id: P2.1
-description: MediaIngredientMech ID does not exist
-check: Lookup in MediaIngredientMech mapped_ingredients.yaml
-impact: Broken ingredient linkage
-fix: Update to correct MediaIngredientMech ID or remove
-```
-
-**Rule P2.2: Invalid CHEBI ID**
-```yaml
-id: P2.2
-description: CHEBI term ID does not exist
-check: OAK/OLS lookup returns 404
-impact: Broken ontology linkage
-fix: Update to correct CHEBI ID or remove
-```
-
-**Rule P2.3: Concentration Mismatch**
-```yaml
-id: P2.3
-description: Concentration units incompatible with physical_state
-check: E.g., G_PER_L for SOLID medium (should be percentage)
-impact: Incorrect concentration interpretation
-fix: Convert to appropriate units
-```
-
-**Rule P2.4: Category Mismatch**
-```yaml
-id: P2.4
-description: File category doesn't match target_organisms
-check: E.g., bacterial/ directory but target is algae
-impact: Organizational confusion
-fix: Move to correct category directory
-```
-
-**Rule P2.5: Duplicate Recipe**
-```yaml
-id: P2.5
-description: Recipe fingerprint matches existing recipe
-check: Ingredient composition + concentrations fingerprinting
-threshold: > 95% similarity
-impact: Data redundancy
-fix: Merge duplicates or document as variant
-```
-
-#### P3 - Medium-Priority Warnings
-
-**Rule P3.1: Placeholder Text**
-```yaml
-id: P3.1
-description: Placeholder text in ingredients or notes
-patterns: "See source", "original amount:", "Unknown", "TBD"
-impact: Incomplete data
-fix: Extract actual data from source or research
-```
-
-**Rule P3.2: Missing MediaIngredientMech Linkage**
-```yaml
-id: P3.2
-description: Ingredient has no mediaingredientmech_term field
-check: Ingredient lacks mediaingredientmech_term.id
-impact: Reduced traceability to ontologies
-fix: Enrich with MediaIngredientMech ID
-```
-
-**Rule P3.3: Non-Standard Ingredient Name**
-```yaml
-id: P3.3
-description: Ingredient preferred_term doesn't match MediaIngredientMech
-check: Fuzzy match against MediaIngredientMech preferred terms
-impact: Inconsistent naming across recipes
-fix: Standardize to MediaIngredientMech preferred term
-```
-
-**Rule P3.4: Missing Preparation Steps**
-```yaml
-id: P3.4
-description: No preparation_steps field for complex media
-check: medium_type = COMPLEX and preparation_steps empty
-impact: Incomplete protocol information
-fix: Extract from source or add basic steps
-```
-
-**Rule P3.5: Sterilization Not Specified**
-```yaml
-id: P3.5
-description: No sterilization method specified
-check: sterilization field missing
-impact: Critical safety information missing
-fix: Add sterilization from preparation_steps or source
-```
-
-**Rule P3.6: pH Not Specified**
-```yaml
-id: P3.6
-description: No pH value for DEFINED or SEMI_DEFINED media
-check: medium_type in [DEFINED, SEMI_DEFINED] and ph_value missing
-impact: Important growth parameter missing
-fix: Extract from source or mark as "not specified"
-```
-
-#### P4 - Low-Priority Info
-
-**Rule P4.1: Low MediaIngredientMech Coverage**
-```yaml
-id: P4.1
-description: < 50% of ingredients have MediaIngredientMech IDs
-check: Count linked vs total ingredients
-impact: Potential enrichment opportunity
-fix: Run enrichment script on unmapped ingredients
-```
-
-**Rule P4.2: Missing Target Organisms**
-```yaml
-id: P4.2
-description: No target_organisms specified
-check: target_organisms field empty
-impact: Reduced searchability
-fix: Extract from source or media name
-```
-
-**Rule P4.3: Missing References**
-```yaml
-id: P4.3
-description: No source references (DOI, URL, citation)
-check: references field empty
-impact: Reduced provenance
-fix: Add source reference
-```
-
-**Rule P4.4: Incomplete Curation History**
-```yaml
-id: P4.4
-description: Curation history has only creation event
-check: curation_history length = 1
-impact: No change tracking
-fix: Add curation events as changes are made
-```
-
-**Rule P4.5: Solution Could Be Extracted**
-```yaml
-id: P4.5
-description: Complex ingredient used in multiple recipes
-check: Same multi-component ingredient in 3+ recipes
-impact: Duplication instead of reusable solution
-fix: Extract to shared solution record
-```
-
----
-
-## Ingredient Linkage Validation
-
-### MediaIngredientMech Coverage Check
-
-```python
-from culturemech.utils.ingredient_validator import IngredientValidator
-
-validator = IngredientValidator()
-
-# Check single recipe
-recipe_path = "data/normalized_yaml/bacterial/LB_Broth.yaml"
-coverage = validator.check_mediaingredientmech_coverage(recipe_path)
-
-print(f"Total ingredients: {coverage['total']}")
-print(f"Linked: {coverage['linked']} ({coverage['percentage']:.1f}%)")
-print(f"Unlinked: {', '.join(coverage['unlinked_terms'])}")
-```
-
-### Batch Coverage Report
-
-```bash
-# Generate coverage report for all recipes
-PYTHONPATH=src python scripts/generate_coverage_report.py \
-  --output reports/mediaingredientmech_coverage_$(date +%Y%m%d).md
-
-# Check specific category
-PYTHONPATH=src python scripts/generate_coverage_report.py \
-  --category solutions \
-  --output reports/solutions_coverage.md
-```
-
-**Output Example:**
-```markdown
-# MediaIngredientMech Coverage Report
-
-## Overall Statistics
-- Total recipes: 15,450
-- Total ingredient instances: 118,818
-- Linked instances: 99,547 (83.8%)
-- Unlinked instances: 19,271 (16.2%)
-
-## By Category
-| Category | Recipes | Ingredients | Linked | Coverage |
-|----------|---------|-------------|--------|----------|
-| bacterial | 8,234 | 67,123 | 54,321 | 80.9% |
-| algae | 4,567 | 32,456 | 28,901 | 89.0% |
-| solutions | 90 | 456 | 384 | 84.2% |
-
-## Top Unlinked Ingredients
-1. Soil extract (1,234 instances, 45 recipes)
-2. Beef extract (987 instances, 23 recipes)
-3. Malt extract (765 instances, 34 recipes)
-```
-
-### Cross-Reference Validation
-
-```python
-from culturemech.utils.cross_reference_validator import CrossReferenceValidator
-
-validator = CrossReferenceValidator()
-
-# Check all solution references in a recipe
-recipe_path = "data/normalized_yaml/algae/J_Medium.yaml"
-issues = validator.validate_solution_references(recipe_path)
-
-for issue in issues:
-    print(f"P{issue['priority']}: {issue['description']}")
-    if issue['suggested_fix']:
-        print(f"  Fix: {issue['suggested_fix']}")
-```
-
----
-
-## Recipe Fingerprinting
-
-### Detect Duplicates
-
-```bash
-# Find potential duplicate recipes
-PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
-  --threshold 0.95 \
-  --output reports/duplicates_$(date +%Y%m%d).json
-
-# Check specific category
-PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
-  --category bacterial \
-  --threshold 0.90
-```
-
-**Fingerprinting Algorithm:**
-1. Extract sorted ingredient list with concentrations
-2. Normalize ingredient names (case-insensitive, whitespace)
-3. Normalize concentration units
-4. Generate hash of normalized composition
-5. Calculate Jaccard similarity between ingredient sets
-6. Flag pairs with similarity > threshold
-
-**Output:**
-```json
-{
-  "duplicate_pairs": [
-    {
-      "recipe1": {
-        "id": "CultureMech:001234",
-        "name": "LB Broth",
-        "path": "data/normalized_yaml/bacterial/LB_Broth.yaml"
-      },
-      "recipe2": {
-        "id": "CultureMech:005678",
-        "name": "Luria-Bertani Medium",
-        "path": "data/normalized_yaml/bacterial/Luria_Bertani_Medium.yaml"
-      },
-      "similarity": 0.98,
-      "differences": [
-        "recipe1 has pH 7.0, recipe2 has pH 7.2"
-      ],
-      "recommendation": "MERGE - Near-identical recipes"
-    }
-  ]
-}
-```
-
----
-
-## Data Quality Pipeline Integration
-
-### Current Pipeline (justfile)
-
-```bash
-# Full quality pipeline
-just fix-all-data-quality
-
-# Individual steps
-just cleanup-ingredients          # Standardize ingredient names
-just fix-placeholder-text         # Remove "See source" patterns
-just standardize-units            # Convert to enum units
-just enrich-mediaingredientmech   # Add MediaIngredientMech IDs
-```
-
-### Adding Recipe Review to Pipeline
-
-```bash
-# Add to .justfile
-validate-recipes:
-    PYTHONPATH=src python scripts/batch_review_recipes.py \
-      --output reports/validation_latest \
-      --format md,json \
-      --priority P1,P2,P3
-
-# Run as part of pre-commit
-pre-commit: validate-recipes validate-schema
-```
-
----
-
-## Common Validation Patterns
-
-### Pattern 1: New Recipe Validation
-
-**Scenario:** Created LB_Broth.yaml, need to validate before commit
-
-**Workflow:**
-```bash
-# 1. Schema validation
-just validate-schema data/normalized_yaml/bacterial/LB_Broth.yaml
-
-# 2. Interactive review
-/review-recipes "LB_Broth"
-
-# 3. Check for duplicates
-PYTHONPATH=src python scripts/detect_duplicate_recipes.py \
-  --target data/normalized_yaml/bacterial/LB_Broth.yaml
-
-# 4. Coverage check
-PYTHONPATH=src python scripts/generate_coverage_report.py \
-  --single data/normalized_yaml/bacterial/LB_Broth.yaml
-```
-
-### Pattern 2: Solution Validation
-
-**Scenario:** Created DAS_Vitamin_Cocktail.yaml solution
-
-**Workflow:**
-```bash
-# 1. Validate composition
-/review-recipes "DAS_Vitamin_Cocktail"
-
-# 2. Check ingredient linkages
-PYTHONPATH=src python scripts/validate_ingredients.py \
-  data/normalized_yaml/solutions/DAS_Vitamin_Cocktail.yaml
-
-# 3. Find usage in media
-grep -r "DAS_Vitamin_Cocktail" data/normalized_yaml/algae/
-
-# 4. Validate cross-references
-PYTHONPATH=src python scripts/validate_solution_references.py \
-  --solution "DAS_Vitamin_Cocktail"
-```
-
-### Pattern 3: Batch Category Review
-
-**Scenario:** Review all algae media for quality issues
-
-**Workflow:**
-```bash
-# 1. Batch review
-PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --category algae \
-  --output reports/algae_validation \
-  --priority P1,P2,P3
-
-# 2. Fix auto-correctable issues
-PYTHONPATH=src python scripts/fix_data_quality.py \
-  --category algae \
-  --apply --types placeholders,units
-
-# 3. Generate coverage report
-PYTHONPATH=src python scripts/generate_coverage_report.py \
-  --category algae
-
-# 4. Regenerate indexes
-just generate-indexes data/normalized_yaml/algae
-```
-
-### Pattern 4: Pre-Export KG Check
-
-**Scenario:** Validate all recipes before KG export
-
-**Workflow:**
-```bash
-# 1. Full batch review (P1 only)
-PYTHONPATH=src python scripts/batch_review_recipes.py \
-  --priority P1 \
-  --output reports/pre_export_validation
-
-# 2. Check for critical errors
-grep "^P1" reports/pre_export_validation.md
-
-# 3. Fix blocking errors
-# (Manual fixes for P1 issues)
-
-# 4. Re-validate
-PYTHONPATH=src python scripts/batch_review_recipes.py --priority P1
-
-# 5. Export when P1 count = 0
-just export-kg
-```
-
----
-
-## Integration with MediaIngredientMech
-
-### Enrichment Workflow
-
-```bash
-# 1. Check current coverage
-PYTHONPATH=src python scripts/generate_coverage_report.py
-
-# 2. Run enrichment
-PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py \
-  --category solutions \
-  --mediaingredientmech-repo /path/to/MediaIngredientMech
-
-# 3. Validate linkages
-PYTHONPATH=src python scripts/validate_ingredients.py \
-  --check-mediaingredientmech
-
-# 4. Re-check coverage
-PYTHONPATH=src python scripts/generate_coverage_report.py
-```
-
-### Syncing with MediaIngredientMech Updates
-
-When MediaIngredientMech adds new ingredients:
-
-```bash
-# 1. Pull latest MediaIngredientMech
-cd /path/to/MediaIngredientMech && git pull
-
-# 2. Re-run enrichment on CultureMech
-cd /path/to/CultureMech
-PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py \
-  --incremental \
-  --mediaingredientmech-repo /path/to/MediaIngredientMech
-
-# 3. Check improvement
-PYTHONPATH=src python scripts/generate_coverage_report.py \
-  --compare-with reports/mediaingredientmech_coverage_previous.md
-```
-
----
-
-## Error Handling
-
-### Common Issues and Solutions
-
-**Issue:** Schema validation fails with "Unknown enum value"
-**Solution:** Check enum is defined in `src/culturemech/schema/culturemech.yaml`
-
-**Issue:** MediaIngredientMech ID not found
-**Solution:** Verify ID exists in `MediaIngredientMech/data/curated/mapped_ingredients.yaml`
-
-**Issue:** Duplicate CultureMech IDs
-**Solution:** Run `python -c "from culturemech.utils.id_utils import rebuild_culturemech_registry; rebuild_culturemech_registry()"`
-
-**Issue:** Solution reference broken
-**Solution:** Check solution exists in `data/normalized_yaml/solutions/`
-
-**Issue:** Concentration units invalid
-**Solution:** Convert to enum value from schema (e.g., "g/L" → "G_PER_L")
-
----
-
-## Validation Checklist
-
-Before committing a recipe:
-
-- ✅ Schema validates (`just validate-schema`)
-- ✅ CultureMech ID unique and in registry
-- ✅ Required fields present (name, medium_type, physical_state, ingredients)
-- ✅ No P1 critical errors
-- ✅ MediaIngredientMech coverage > 50% (for solutions: > 80%)
-- ✅ No duplicate recipes detected
-- ✅ Ingredient names standardized
-- ✅ Concentration units use enums
-- ✅ No placeholder text
-- ✅ Curation history entry added
-- ✅ References/source documented
-- ✅ Category directory correct
-
----
-
-## Output Examples
-
-### Interactive Review Output
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Recipe Review: LB_Broth
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-ID: CultureMech:015432
-Category: bacterial
-Medium Type: COMPLEX
-Physical State: LIQUID
-
-Validation Results:
-  ✅ Schema valid
-  ✅ CultureMech ID unique
-  ✅ Required fields present
-  ⚠️  P3.2: 1/4 ingredients missing MediaIngredientMech linkage
-  ⚠️  P3.6: pH not specified
-
-Ingredient Coverage:
-  Total ingredients: 4
-  MediaIngredientMech linked: 3 (75.0%)
-  Unlinked: ["Yeast extract"]
-
-Suggestions:
-  1. Add MediaIngredientMech ID for "Yeast extract"
-     → MediaIngredientMech:000234 (preferred term: "Yeast extract")
-  2. Add pH value (typical: 7.0 ± 0.2)
-
-Apply fixes? [y/N]:
-```
-
-### Batch Review Summary
-
-```markdown
-# Recipe Validation Report - Bacterial Media
-Date: 2026-03-16
-
-## Summary Statistics
-- Total recipes: 8,234
-- Validated: 8,234 (100%)
-- P1 Critical Errors: 0 (0.0%)
-- P2 High Priority: 23 (0.3%)
-- P3 Medium Priority: 456 (5.5%)
-- P4 Low Priority: 1,234 (15.0%)
-
-## Issue Breakdown
-
-### P1 Critical (0)
-None! 🎉
-
-### P2 High Priority (23)
-1. P2.1 - Invalid MediaIngredientMech ID: 12 recipes
-2. P2.3 - Concentration mismatch: 8 recipes
-3. P2.5 - Duplicate recipe: 3 pairs
-
-### P3 Medium Priority (456)
-1. P3.1 - Placeholder text: 234 recipes
-2. P3.2 - Missing MediaIngredientMech linkage: 123 recipes
-3. P3.6 - pH not specified: 99 recipes
-
-## Top Action Items
-1. Fix 12 broken MediaIngredientMech IDs
-2. Remove placeholder text from 234 recipes
-3. Merge 3 duplicate recipe pairs
-4. Add MediaIngredientMech linkage to 123 recipes
-
-## Coverage Metrics
-- Overall MediaIngredientMech coverage: 80.9%
-- Recipes with >80% coverage: 6,789 (82.5%)
-- Recipes with <50% coverage: 234 (2.8%)
-```
+| **P4** | Low-priority info/suggestions | Optional | Any |
+
+| Rule | Summary |
+|------|---------|
+| **P1.1** | Schema validation failure |
+| **P1.2** | Invalid CultureMech ID |
+| **P1.3** | Missing required fields |
+| **P1.4** | Invalid enum values |
+| **P1.5** | Broken solution reference |
+| **P2.1** | Invalid MediaIngredientMech ID |
+| **P2.2** | Invalid CHEBI ID |
+| **P2.3** | Concentration mismatch |
+| **P2.4** | Category mismatch |
+| **P2.5** | Duplicate recipe |
+| **P3.1** | Placeholder text |
+| **P3.2** | Missing MediaIngredientMech linkage |
+| **P3.3** | Non-standard ingredient name |
+| **P3.4** | Missing preparation steps |
+| **P3.5** | Sterilization not specified |
+| **P3.6** | pH not specified |
+| **P4.1** | Low MediaIngredientMech coverage |
+| **P4.2** | Missing target organisms |
+| **P4.3** | Missing references |
+| **P4.4** | Incomplete curation history |
+| **P4.5** | Solution could be extracted |
 
 ---
 
 ## Related Skills
 
-- `create-recipe` - Create new media/solution YAML records
-- `manage-identifiers` - CultureMech ID assignment and management
-- `manage-ingredient-hierarchy` - MediaIngredientMech integration
+- [`create-recipe`](../create-recipe/skill.md) — create new media/solution YAML records
+- [`manage-identifiers`](../manage-identifiers/skill.md) — CultureMech ID assignment
+- [`manage-ingredient-hierarchy`](../manage-ingredient-hierarchy/skill.md) — MediaIngredientMech integration
 
 ---
 
 ## Script Support
 
-Helper scripts available:
-- `scripts/review_recipe.py` - Interactive single recipe review
-- `scripts/batch_review_recipes.py` - Batch validation with reports
-- `scripts/fix_data_quality.py` - Automated corrections
-- `scripts/detect_duplicate_recipes.py` - Fingerprinting and duplicate detection
-- `scripts/generate_coverage_report.py` - MediaIngredientMech coverage analysis
-- `scripts/validate_ingredients.py` - Ingredient linkage validation
-- `scripts/enrich_with_mediaingredientmech.py` - Add MediaIngredientMech IDs
+`scripts/review_recipe.py` (interactive), `batch_review_recipes.py` (batch + reports),
+`fix_data_quality.py` (auto-fix), `detect_duplicate_recipes.py` (fingerprinting),
+`generate_coverage_report.py` (MIM coverage), `validate_ingredients.py` (linkage),
+`enrich_with_mediaingredientmech.py` (add MIM IDs).
 
 ---
 
 ## Quick Reference
 
 ```bash
-# Single recipe review
-/review-recipes "recipe_name"
-
-# Batch validation
-PYTHONPATH=src python scripts/batch_review_recipes.py --category {category}
-
-# Auto-fix data quality
-just fix-all-data-quality
-
-# Coverage report
-PYTHONPATH=src python scripts/generate_coverage_report.py
-
-# Detect duplicates
-PYTHONPATH=src python scripts/detect_duplicate_recipes.py
-
-# Full validation workflow
-just validate-recipes && just validate-schema && just generate-indexes
+/review-recipes "recipe_name"                                              # single review
+PYTHONPATH=src python scripts/batch_review_recipes.py --category {category} # batch
+just fix-all-data-quality                                                  # auto-fix
+PYTHONPATH=src python scripts/generate_coverage_report.py                  # coverage
+PYTHONPATH=src python scripts/detect_duplicate_recipes.py                  # duplicates
+just validate-recipes && just validate-schema && just generate-indexes     # full workflow
 ```
+
+> **Remember:** validate before committing, keep solution MediaIngredientMech coverage
+> above 80%, and keep P1 errors at zero.
 
 ---
 
-**Remember**: Always validate recipes before committing, maintain >80% MediaIngredientMech coverage for solutions, and keep P1 errors at zero!
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [`reference/validation-rules.md`](reference/validation-rules.md) | Full definitions for all 21 P1–P4 rules: checks, impact, fixes |
+| [`reference/linkage-and-duplicates.md`](reference/linkage-and-duplicates.md) | MediaIngredientMech coverage checks (single + batch report), cross-reference validation, and recipe fingerprinting / duplicate detection |
+| [`reference/pipeline-and-patterns.md`](reference/pipeline-and-patterns.md) | Data-quality pipeline (justfile) integration, the four validation patterns (new recipe, solution, batch category, pre-export), and MediaIngredientMech enrichment/sync workflows |
+| [`reference/operations.md`](reference/operations.md) | Error handling, the validation checklist, and interactive/batch output examples |


### PR DESCRIPTION
Per the [author-skills guidance](https://ai4curation.io/aidocs/how-tos/author-skills/), large SKILL.md bodies degrade reasoning and bulk content should move to bundled reference files.

`skill.md` now holds the core (**193 lines, down from 851**): overview, when-to-use, the 4 workflows, priority levels + a one-line summary of all 21 rules, related skills, script support, and a quick reference. Deep material moved **verbatim** into `reference/`:

| File | Contents |
|---|---|
| `validation-rules.md` | full P1–P4 rule definitions |
| `linkage-and-duplicates.md` | MIM coverage checks + recipe fingerprinting |
| `pipeline-and-patterns.md` | data-quality pipeline, 4 validation patterns, MIM enrichment/sync |
| `operations.md` | error handling, validation checklist, output examples |

Description also sharpened to the action-oriented "Use this skill to…/Use when…" form. No procedural content lost (verified by spot-checking unique strings across the new file set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)