### PR TITLE
fix(qc): validate-schema/terms/references exit non-zero on failure (add set -e)

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -767,6 +767,7 @@ validate file:
 [group('QC')]
 validate-schema file:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Validating schema structure..."
     uv run linkml-validate --schema {{schema_path}} --target-class MediaRecipe "{{file}}"
     echo "✓ Schema validation passed"
@@ -774,6 +775,7 @@ validate-schema file:
 [group('QC')]
 validate-terms file:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Validating ontology terms..."
     uv run linkml-term-validator validate-data {{file}} -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}}
     echo "✓ Term validation passed"
@@ -781,6 +783,7 @@ validate-terms file:
 [group('QC')]
 validate-references file:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Validating evidence references..."
     uv run linkml-reference-validator validate data {{file}} --schema {{schema_path}} --target-class MediaRecipe
     echo "✓ Reference validation passed"


### PR DESCRIPTION
The single-file `validate-schema`, `validate-terms`, and `validate-references` recipes in `project.justfile` are `#!/usr/bin/env bash` shebang recipes **with no `set -e`**. When the underlying validator failed — or crashed with a traceback (e.g. `linkml-term-validator` raising `ValueError: No such slot …` on an unknown field) — the recipe still ran its final `echo "✓ … passed"` and exited 0, **masking the failure** from any gate keyed on the exit code.

Fix: add `set -euo pipefail` after the shebang in all three (the idiom already used by `validate-terms-all` and the composite `validate` recipe, which were already correct).

**Verified:**
- `validate-schema` on a valid recipe → exit 0, "✓ passed" (happy path intact)
- `validate-terms` on an invalid record → exit 1 + traceback, **no** false "✓ Term validation passed"
- `validate-references` on an invalid record → exit 1, no false pass

Found while exercising the `/dynamic-review` workflow's static-gate step against a deliberately-invalid record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)