### PR TITLE
Landing page redesign + pastel orange/green theme

### DIFF
--- a/app/browser.html
+++ b/app/browser.html
@@ -1,0 +1,611 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CultureMech - Microbial Growth Media Browser</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: #f5f5f5;
+            color: #1a1a1a;
+            line-height: 1.6;
+        }
+
+        .header {
+            background: linear-gradient(135deg, #FFE0B5 0%, #CDEBC5 100%);
+            color: #1a1a1a;
+            padding: 2rem;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+
+        .header h1 {
+            font-size: 2rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .header p {
+            opacity: 0.9;
+        }
+
+        .header-nav {
+            margin-top: 1rem;
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        .header-nav a {
+            display: inline-block;
+            padding: 8px 18px;
+            background: rgba(255,255,255,0.5);
+            color: #1a1a1a;
+            text-decoration: none;
+            border-radius: 6px;
+            font-size: 14px;
+            transition: background 0.2s;
+            backdrop-filter: blur(6px);
+        }
+
+        .header-nav a:hover {
+            background: rgba(255,255,255,0.8);
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        .search-bar {
+            background: white;
+            padding: 1.5rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            margin-bottom: 2rem;
+        }
+
+        .search-input {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            font-size: 1rem;
+            border: 2px solid #e2e8f0;
+            border-radius: 6px;
+            transition: border-color 0.3s;
+        }
+
+        .search-input:focus {
+            outline: none;
+            border-color: #4B9E5F;
+        }
+
+        .main-content {
+            display: grid;
+            grid-template-columns: 280px 1fr;
+            gap: 2rem;
+        }
+
+        .facets {
+            background: white;
+            padding: 1.5rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            height: fit-content;
+        }
+
+        .facet {
+            margin-bottom: 1.5rem;
+        }
+
+        .facet h3 {
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            color: #4B9E5F;
+            margin-bottom: 0.75rem;
+        }
+
+        .facet-option {
+            display: flex;
+            align-items: center;
+            padding: 0.4rem 0;
+            cursor: pointer;
+            transition: color 0.2s;
+        }
+
+        .facet-option:hover {
+            color: #4B9E5F;
+        }
+
+        .facet-option input[type="checkbox"] {
+            margin-right: 0.5rem;
+        }
+
+        .facet-count {
+            margin-left: auto;
+            color: #999;
+            font-size: 0.85rem;
+        }
+
+        .results {
+            background: white;
+            padding: 1.5rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .results-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid #e2e8f0;
+        }
+
+        .results-count {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: #4B9E5F;
+        }
+
+        .result-item {
+            padding: 1.5rem;
+            border-bottom: 1px solid #e2e8f0;
+            transition: background 0.2s;
+        }
+
+        .result-item:hover {
+            background: #f8f9fa;
+        }
+
+        .result-item:last-child {
+            border-bottom: none;
+        }
+
+        .result-title {
+            font-size: 1.3rem;
+            font-weight: 600;
+            color: #4B9E5F;
+            margin-bottom: 0.5rem;
+            text-decoration: none;
+            display: inline-block;
+        }
+
+        .result-title:hover {
+            text-decoration: underline;
+        }
+
+        .result-badges {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .badge {
+            padding: 0.25rem 0.75rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: white;
+        }
+
+        .result-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 0.75rem;
+            font-size: 0.9rem;
+        }
+
+        .result-meta-item {
+            display: flex;
+            align-items: center;
+        }
+
+        .result-meta-label {
+            font-weight: 600;
+            margin-right: 0.5rem;
+            color: #666;
+        }
+
+        .result-description {
+            color: #555;
+            line-height: 1.5;
+        }
+
+        .tag {
+            display: inline-block;
+            padding: 0.2rem 0.5rem;
+            background: #e2e8f0;
+            border-radius: 3px;
+            margin-right: 0.25rem;
+            margin-bottom: 0.25rem;
+            font-size: 0.85rem;
+        }
+
+        .no-results {
+            text-align: center;
+            padding: 3rem;
+            color: #999;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 3rem;
+            color: #4B9E5F;
+        }
+
+        .clear-filters {
+            padding: 0.5rem 1rem;
+            background: #f8f9fa;
+            border: 1px solid #e2e8f0;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.9rem;
+        }
+
+        .clear-filters:hover {
+            background: #e2e8f0;
+        }
+
+        @media (max-width: 768px) {
+            .main-content {
+                grid-template-columns: 1fr;
+            }
+
+            .facets {
+                order: 2;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🧫 CultureMech</h1>
+        <p>Microbial Growth Media Knowledge Base</p>
+        <nav class="header-nav">
+            <a href="index.html">🏠 Home</a>
+            <a href="umap.html">📊 Media UMAP</a>
+            <a href="ingredient_umap.html">🔬 Ingredient UMAP</a>
+        </nav>
+    </div>
+
+    <div class="container">
+        <div class="search-bar">
+            <input
+                type="text"
+                id="searchInput"
+                class="search-input"
+                placeholder="Search media by name, organism, ingredient, or application..."
+            />
+        </div>
+
+        <div class="main-content">
+            <aside class="facets" id="facetsContainer">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+                    <h2 style="font-size: 1.1rem;">Filters</h2>
+                    <button class="clear-filters" onclick="clearAllFilters()">Clear All</button>
+                </div>
+                <div id="facetsList"></div>
+            </aside>
+
+            <main class="results">
+                <div class="results-header">
+                    <div class="results-count" id="resultsCount">Loading...</div>
+                </div>
+                <div id="resultsContainer">
+                    <div class="loading">Loading recipes...</div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="schema.js"></script>
+    <script src="data.js"></script>
+    <script>
+        let allRecipes = [];
+        let filteredRecipes = [];
+        let selectedFilters = {};
+        let searchQuery = '';
+
+        // Wait for data to load (or use already-loaded data if event already fired)
+        function onDataReady() {
+            allRecipes = window.culturemechData || [];
+            filteredRecipes = [...allRecipes];
+            initializeFacets();
+            renderResults();
+        }
+        if (window.culturemechData) {
+            onDataReady();
+        } else {
+            window.addEventListener('culturemechDataReady', onDataReady);
+        }
+
+        // Search functionality
+        document.getElementById('searchInput').addEventListener('input', (e) => {
+            searchQuery = e.target.value.toLowerCase();
+            applyFilters();
+        });
+
+        function initializeFacets() {
+            const facetsContainer = document.getElementById('facetsList');
+            const schema = window.searchSchema;
+
+            schema.facets.forEach(facet => {
+                const facetDiv = document.createElement('div');
+                facetDiv.className = 'facet';
+
+                const facetTitle = document.createElement('h3');
+                facetTitle.textContent = facet.label;
+                facetDiv.appendChild(facetTitle);
+
+                const values = extractFacetValues(facet.field, facet.type);
+                values.forEach(({ value, count }) => {
+                    const option = document.createElement('label');
+                    option.className = 'facet-option';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.dataset.facet = facet.field;
+                    checkbox.dataset.value = value;
+                    checkbox.addEventListener('change', handleFacetChange);
+
+                    const label = document.createElement('span');
+                    label.textContent = value;
+
+                    const countSpan = document.createElement('span');
+                    countSpan.className = 'facet-count';
+                    countSpan.textContent = count;
+
+                    option.appendChild(checkbox);
+                    option.appendChild(label);
+                    option.appendChild(countSpan);
+                    facetDiv.appendChild(option);
+                });
+
+                facetsContainer.appendChild(facetDiv);
+            });
+        }
+
+        function extractFacetValues(field, type) {
+            const valueMap = new Map();
+
+            allRecipes.forEach(recipe => {
+                const value = recipe[field];
+                if (type === 'array' && Array.isArray(value)) {
+                    value.forEach(v => {
+                        if (v) valueMap.set(v, (valueMap.get(v) || 0) + 1);
+                    });
+                } else if (value) {
+                    valueMap.set(value, (valueMap.get(value) || 0) + 1);
+                }
+            });
+
+            return Array.from(valueMap.entries())
+                .map(([value, count]) => ({ value, count }))
+                .sort((a, b) => b.count - a.count);
+        }
+
+        function handleFacetChange(e) {
+            const facet = e.target.dataset.facet;
+            const value = e.target.dataset.value;
+
+            if (!selectedFilters[facet]) {
+                selectedFilters[facet] = [];
+            }
+
+            if (e.target.checked) {
+                selectedFilters[facet].push(value);
+            } else {
+                selectedFilters[facet] = selectedFilters[facet].filter(v => v !== value);
+            }
+
+            applyFilters();
+        }
+
+        function clearAllFilters() {
+            selectedFilters = {};
+            searchQuery = '';
+            document.getElementById('searchInput').value = '';
+            document.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.checked = false);
+            applyFilters();
+        }
+
+        function applyFilters() {
+            filteredRecipes = allRecipes.filter(recipe => {
+                // Text search
+                if (searchQuery) {
+                    const searchableText = window.searchSchema.searchableFields
+                        .map(field => {
+                            const value = recipe[field];
+                            if (Array.isArray(value)) return value.join(' ');
+                            return String(value || '');
+                        })
+                        .join(' ')
+                        .toLowerCase();
+
+                    if (!searchableText.includes(searchQuery)) {
+                        return false;
+                    }
+                }
+
+                // Facet filters
+                for (const [facet, values] of Object.entries(selectedFilters)) {
+                    if (values.length === 0) continue;
+
+                    // Get facet type from schema
+                    const facetConfig = window.searchSchema.facets.find(f => f.field === facet);
+                    const facetType = facetConfig ? facetConfig.type : 'string';
+
+                    const recipeValue = recipe[facet];
+
+                    if (Array.isArray(recipeValue)) {
+                        if (!recipeValue.some(v => values.includes(v))) {
+                            return false;
+                        }
+                    } else {
+                        // For boolean facets, convert string values to booleans for comparison
+                        if (facetType === 'boolean') {
+                            const booleanRecipeValue = String(recipeValue);
+                            if (!values.includes(booleanRecipeValue)) {
+                                return false;
+                            }
+                        } else {
+                            if (!values.includes(recipeValue)) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+
+                return true;
+            });
+
+            renderResults();
+        }
+
+        function renderResults() {
+            const container = document.getElementById('resultsContainer');
+            const countElement = document.getElementById('resultsCount');
+
+            countElement.textContent = `${filteredRecipes.length} recipe${filteredRecipes.length !== 1 ? 's' : ''}`;
+
+            if (filteredRecipes.length === 0) {
+                container.innerHTML = '<div class="no-results">No recipes found matching your criteria.</div>';
+                return;
+            }
+
+            container.innerHTML = '';
+            filteredRecipes.forEach(recipe => {
+                const item = createResultItem(recipe);
+                container.appendChild(item);
+            });
+        }
+
+        function createResultItem(recipe) {
+            const div = document.createElement('div');
+            div.className = 'result-item';
+
+            // Title
+            const title = document.createElement('a');
+            title.href = `../pages/${recipe.html_page}`;
+            title.className = 'result-title';
+            title.textContent = recipe.name;
+            div.appendChild(title);
+
+            // Badges
+            const badges = document.createElement('div');
+            badges.className = 'result-badges';
+
+            const categoryBadge = createBadge(recipe.category, getColor(recipe.category));
+            const typeBadge = createBadge(recipe.medium_type, getColor(recipe.medium_type));
+
+            badges.appendChild(categoryBadge);
+            badges.appendChild(typeBadge);
+            div.appendChild(badges);
+
+            // Meta info
+            const meta = document.createElement('div');
+            meta.className = 'result-meta';
+
+            if (recipe.physical_state) {
+                meta.appendChild(createMetaItem('State', recipe.physical_state));
+            }
+            if (recipe.num_ingredients) {
+                meta.appendChild(createMetaItem('Ingredients', recipe.num_ingredients));
+            }
+            if (recipe.media_database_id) {
+                meta.appendChild(createMetaItem('Database', recipe.media_database_id, true));
+            }
+
+            div.appendChild(meta);
+
+            // Organisms
+            if (recipe.target_organism_names && recipe.target_organism_names.length > 0) {
+                const organisms = document.createElement('div');
+                organisms.style.marginBottom = '0.5rem';
+                const label = document.createElement('strong');
+                label.textContent = 'Organisms: ';
+                organisms.appendChild(label);
+
+                recipe.target_organism_names.slice(0, 3).forEach(org => {
+                    organisms.appendChild(createTag(org));
+                });
+
+                div.appendChild(organisms);
+            }
+
+            // Description
+            if (recipe.description) {
+                const desc = document.createElement('div');
+                desc.className = 'result-description';
+                desc.textContent = truncate(recipe.description, 200);
+                div.appendChild(desc);
+            }
+
+            return div;
+        }
+
+        function createBadge(text, color) {
+            const badge = document.createElement('span');
+            badge.className = 'badge';
+            badge.textContent = text;
+            badge.style.backgroundColor = color;
+            return badge;
+        }
+
+        function createMetaItem(label, value, isLink = false) {
+            const item = document.createElement('div');
+            item.className = 'result-meta-item';
+
+            const labelSpan = document.createElement('span');
+            labelSpan.className = 'result-meta-label';
+            labelSpan.textContent = label + ':';
+            item.appendChild(labelSpan);
+
+            if (isLink && value.includes(':')) {
+                const [prefix] = value.split(':');
+                const resolver = window.searchSchema.linkResolvers[prefix];
+                if (resolver) {
+                    const link = document.createElement('a');
+                    link.href = resolver(value);
+                    link.textContent = value;
+                    link.target = '_blank';
+                    item.appendChild(link);
+                } else {
+                    item.appendChild(document.createTextNode(value));
+                }
+            } else {
+                item.appendChild(document.createTextNode(value));
+            }
+
+            return item;
+        }
+
+        function createTag(text) {
+            const tag = document.createElement('span');
+            tag.className = 'tag';
+            tag.textContent = text;
+            return tag;
+        }
+
+        function getColor(value) {
+            return window.searchSchema.colors[value] || '#6b7280';
+        }
+
+        function truncate(text, length) {
+            if (text.length <= length) return text;
+            return text.substring(0, length) + '...';
+        }
+    </script>
+</body>
+</html>

--- a/app/index.html
+++ b/app/index.html
@@ -1,610 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CultureMech - Microbial Growth Media Browser</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: #f5f5f5;
-            color: #333;
-            line-height: 1.6;
-        }
-
-        .header {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
-            padding: 2rem;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        }
-
-        .header h1 {
-            font-size: 2rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .header p {
-            opacity: 0.9;
-        }
-
-        .header-nav {
-            margin-top: 1rem;
-            display: flex;
-            gap: 10px;
-            flex-wrap: wrap;
-            justify-content: center;
-        }
-
-        .header-nav a {
-            display: inline-block;
-            padding: 8px 18px;
-            background: rgba(255,255,255,0.18);
-            color: white;
-            text-decoration: none;
-            border-radius: 6px;
-            font-size: 14px;
-            transition: background 0.2s;
-            backdrop-filter: blur(6px);
-        }
-
-        .header-nav a:hover {
-            background: rgba(255,255,255,0.32);
-        }
-
-        .container {
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 2rem;
-        }
-
-        .search-bar {
-            background: white;
-            padding: 1.5rem;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-            margin-bottom: 2rem;
-        }
-
-        .search-input {
-            width: 100%;
-            padding: 0.75rem 1rem;
-            font-size: 1rem;
-            border: 2px solid #e2e8f0;
-            border-radius: 6px;
-            transition: border-color 0.3s;
-        }
-
-        .search-input:focus {
-            outline: none;
-            border-color: #667eea;
-        }
-
-        .main-content {
-            display: grid;
-            grid-template-columns: 280px 1fr;
-            gap: 2rem;
-        }
-
-        .facets {
-            background: white;
-            padding: 1.5rem;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-            height: fit-content;
-        }
-
-        .facet {
-            margin-bottom: 1.5rem;
-        }
-
-        .facet h3 {
-            font-size: 0.9rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            color: #667eea;
-            margin-bottom: 0.75rem;
-        }
-
-        .facet-option {
-            display: flex;
-            align-items: center;
-            padding: 0.4rem 0;
-            cursor: pointer;
-            transition: color 0.2s;
-        }
-
-        .facet-option:hover {
-            color: #667eea;
-        }
-
-        .facet-option input[type="checkbox"] {
-            margin-right: 0.5rem;
-        }
-
-        .facet-count {
-            margin-left: auto;
-            color: #999;
-            font-size: 0.85rem;
-        }
-
-        .results {
-            background: white;
-            padding: 1.5rem;
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        }
-
-        .results-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1.5rem;
-            padding-bottom: 1rem;
-            border-bottom: 2px solid #e2e8f0;
-        }
-
-        .results-count {
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: #667eea;
-        }
-
-        .result-item {
-            padding: 1.5rem;
-            border-bottom: 1px solid #e2e8f0;
-            transition: background 0.2s;
-        }
-
-        .result-item:hover {
-            background: #f8f9fa;
-        }
-
-        .result-item:last-child {
-            border-bottom: none;
-        }
-
-        .result-title {
-            font-size: 1.3rem;
-            font-weight: 600;
-            color: #667eea;
-            margin-bottom: 0.5rem;
-            text-decoration: none;
-            display: inline-block;
-        }
-
-        .result-title:hover {
-            text-decoration: underline;
-        }
-
-        .result-badges {
-            display: flex;
-            gap: 0.5rem;
-            margin-bottom: 0.75rem;
-            flex-wrap: wrap;
-        }
-
-        .badge {
-            padding: 0.25rem 0.75rem;
-            border-radius: 4px;
-            font-size: 0.85rem;
-            font-weight: 500;
-            color: white;
-        }
-
-        .result-meta {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 0.75rem;
-            margin-bottom: 0.75rem;
-            font-size: 0.9rem;
-        }
-
-        .result-meta-item {
-            display: flex;
-            align-items: center;
-        }
-
-        .result-meta-label {
-            font-weight: 600;
-            margin-right: 0.5rem;
-            color: #666;
-        }
-
-        .result-description {
-            color: #555;
-            line-height: 1.5;
-        }
-
-        .tag {
-            display: inline-block;
-            padding: 0.2rem 0.5rem;
-            background: #e2e8f0;
-            border-radius: 3px;
-            margin-right: 0.25rem;
-            margin-bottom: 0.25rem;
-            font-size: 0.85rem;
-        }
-
-        .no-results {
-            text-align: center;
-            padding: 3rem;
-            color: #999;
-        }
-
-        .loading {
-            text-align: center;
-            padding: 3rem;
-            color: #667eea;
-        }
-
-        .clear-filters {
-            padding: 0.5rem 1rem;
-            background: #f8f9fa;
-            border: 1px solid #e2e8f0;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 0.9rem;
-        }
-
-        .clear-filters:hover {
-            background: #e2e8f0;
-        }
-
-        @media (max-width: 768px) {
-            .main-content {
-                grid-template-columns: 1fr;
-            }
-
-            .facets {
-                order: 2;
-            }
-        }
-    </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CultureMech — culture media</title>
+<style>
+  :root{
+    --pastel-a:#FFE0B5;      /* pastel orange */
+    --pastel-b:#CDEBC5;      /* pastel green */
+    --accent:#4B9E5F;
+    --ink:#1a1a1a;
+    --muted:#555;
+    --card:#ffffff;
+    --line:rgba(0,0,0,.10);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+       color:var(--ink);background:var(--pastel-b);line-height:1.55}
+  a{color:var(--accent);text-decoration:none}
+  a:hover{text-decoration:underline}
+  .hero{background:linear-gradient(135deg,var(--pastel-a),var(--pastel-b));
+        padding:64px 24px 52px;text-align:center;border-bottom:1px solid var(--line)}
+  .hero h1{margin:0 0 .2em;font-size:2.7rem;letter-spacing:-.02em}
+  .hero .tagline{margin:0 auto;max-width:660px;font-size:1.15rem}
+  .stats{display:flex;flex-wrap:wrap;gap:24px;justify-content:center;margin-top:30px}
+  .stat{background:rgba(255,255,255,.6);border:1px solid var(--line);border-radius:12px;
+        padding:12px 22px;min-width:120px}
+  .stat b{display:block;font-size:1.7rem;line-height:1.1}
+  .stat span{font-size:.74rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em}
+  .wrap{max-width:980px;margin:0 auto;padding:48px 24px}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:22px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:28px;
+        box-shadow:0 1px 3px rgba(0,0,0,.05);transition:transform .15s ease,box-shadow .15s ease}
+  .card:hover{transform:translateY(-3px);box-shadow:0 10px 26px rgba(0,0,0,.10)}
+  .card .ic{font-size:2.1rem}
+  .card h2{margin:.45em 0 .35em;font-size:1.25rem}
+  .card p{margin:0 0 1.2em;color:var(--muted);font-size:.95rem}
+  .btn{display:inline-block;background:var(--accent);color:#fff;padding:.5em 1.15em;
+       border-radius:999px;font-size:.9rem;font-weight:600}
+  .btn:hover{filter:brightness(.93);text-decoration:none}
+  footer{border-top:1px solid var(--line);background:rgba(255,255,255,.45);
+         padding:30px 24px;text-align:center;font-size:.9rem;color:var(--muted)}
+  footer .fam{margin:.2em 0}
+  footer .fam a{margin:0 .45em;white-space:nowrap}
+  footer strong{color:var(--ink)}
+</style>
 </head>
 <body>
-    <div class="header">
-        <h1>🧫 CultureMech</h1>
-        <p>Microbial Growth Media Knowledge Base</p>
-        <nav class="header-nav">
-            <a href="umap.html">📊 Media UMAP</a>
-            <a href="ingredient_umap.html">🔬 Ingredient UMAP</a>
-        </nav>
+  <header class="hero">
+    <h1>CultureMech</h1>
+    <p class="tagline">Microbial growth-media knowledge base — curated culture-media recipes from MediaDive, JCM, KOMODO and more.</p>
+    <div class="stats">
+      <div class="stat"><b>10,657</b><span>recipes</span></div>
+      <div class="stat"><b>5</b><span>categories</span></div>
+      <div class="stat"><b>512-D</b><span>v3 embeddings</span></div>
     </div>
-
-    <div class="container">
-        <div class="search-bar">
-            <input
-                type="text"
-                id="searchInput"
-                class="search-input"
-                placeholder="Search media by name, organism, ingredient, or application..."
-            />
-        </div>
-
-        <div class="main-content">
-            <aside class="facets" id="facetsContainer">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-                    <h2 style="font-size: 1.1rem;">Filters</h2>
-                    <button class="clear-filters" onclick="clearAllFilters()">Clear All</button>
-                </div>
-                <div id="facetsList"></div>
-            </aside>
-
-            <main class="results">
-                <div class="results-header">
-                    <div class="results-count" id="resultsCount">Loading...</div>
-                </div>
-                <div id="resultsContainer">
-                    <div class="loading">Loading recipes...</div>
-                </div>
-            </main>
-        </div>
+  </header>
+  <main class="wrap">
+    <div class="cards">
+      <div class="card">
+        <div class="ic">&#128270;</div>
+        <h2>Record browser</h2>
+        <p>Faceted search across every media recipe — filter by category, medium type, physical state, target organism, and key ingredients.</p>
+        <a class="btn" href="browser.html">Browse records &rarr;</a>
+      </div>
+      <div class="card">
+        <div class="ic">&#128506;&#65039;</div>
+        <h2>Embedding browser</h2>
+        <p>Interactive UMAP of media similarity from KG-Microbe deepwalk embeddings.</p>
+        <a class="btn" href="umap.html">Explore UMAP &rarr;</a>
+      </div>
+      <div class="card">
+        <div class="ic">&#128187;</div>
+        <h2>GitHub</h2>
+        <p>Source code, data, schema, and the curation workflow.</p>
+        <a class="btn" href="https://github.com/CultureBotAI/CultureMech">View on GitHub &rarr;</a>
+      </div>
     </div>
-
-    <script src="schema.js"></script>
-    <script src="data.js"></script>
-    <script>
-        let allRecipes = [];
-        let filteredRecipes = [];
-        let selectedFilters = {};
-        let searchQuery = '';
-
-        // Wait for data to load (or use already-loaded data if event already fired)
-        function onDataReady() {
-            allRecipes = window.culturemechData || [];
-            filteredRecipes = [...allRecipes];
-            initializeFacets();
-            renderResults();
-        }
-        if (window.culturemechData) {
-            onDataReady();
-        } else {
-            window.addEventListener('culturemechDataReady', onDataReady);
-        }
-
-        // Search functionality
-        document.getElementById('searchInput').addEventListener('input', (e) => {
-            searchQuery = e.target.value.toLowerCase();
-            applyFilters();
-        });
-
-        function initializeFacets() {
-            const facetsContainer = document.getElementById('facetsList');
-            const schema = window.searchSchema;
-
-            schema.facets.forEach(facet => {
-                const facetDiv = document.createElement('div');
-                facetDiv.className = 'facet';
-
-                const facetTitle = document.createElement('h3');
-                facetTitle.textContent = facet.label;
-                facetDiv.appendChild(facetTitle);
-
-                const values = extractFacetValues(facet.field, facet.type);
-                values.forEach(({ value, count }) => {
-                    const option = document.createElement('label');
-                    option.className = 'facet-option';
-
-                    const checkbox = document.createElement('input');
-                    checkbox.type = 'checkbox';
-                    checkbox.dataset.facet = facet.field;
-                    checkbox.dataset.value = value;
-                    checkbox.addEventListener('change', handleFacetChange);
-
-                    const label = document.createElement('span');
-                    label.textContent = value;
-
-                    const countSpan = document.createElement('span');
-                    countSpan.className = 'facet-count';
-                    countSpan.textContent = count;
-
-                    option.appendChild(checkbox);
-                    option.appendChild(label);
-                    option.appendChild(countSpan);
-                    facetDiv.appendChild(option);
-                });
-
-                facetsContainer.appendChild(facetDiv);
-            });
-        }
-
-        function extractFacetValues(field, type) {
-            const valueMap = new Map();
-
-            allRecipes.forEach(recipe => {
-                const value = recipe[field];
-                if (type === 'array' && Array.isArray(value)) {
-                    value.forEach(v => {
-                        if (v) valueMap.set(v, (valueMap.get(v) || 0) + 1);
-                    });
-                } else if (value) {
-                    valueMap.set(value, (valueMap.get(value) || 0) + 1);
-                }
-            });
-
-            return Array.from(valueMap.entries())
-                .map(([value, count]) => ({ value, count }))
-                .sort((a, b) => b.count - a.count);
-        }
-
-        function handleFacetChange(e) {
-            const facet = e.target.dataset.facet;
-            const value = e.target.dataset.value;
-
-            if (!selectedFilters[facet]) {
-                selectedFilters[facet] = [];
-            }
-
-            if (e.target.checked) {
-                selectedFilters[facet].push(value);
-            } else {
-                selectedFilters[facet] = selectedFilters[facet].filter(v => v !== value);
-            }
-
-            applyFilters();
-        }
-
-        function clearAllFilters() {
-            selectedFilters = {};
-            searchQuery = '';
-            document.getElementById('searchInput').value = '';
-            document.querySelectorAll('input[type="checkbox"]').forEach(cb => cb.checked = false);
-            applyFilters();
-        }
-
-        function applyFilters() {
-            filteredRecipes = allRecipes.filter(recipe => {
-                // Text search
-                if (searchQuery) {
-                    const searchableText = window.searchSchema.searchableFields
-                        .map(field => {
-                            const value = recipe[field];
-                            if (Array.isArray(value)) return value.join(' ');
-                            return String(value || '');
-                        })
-                        .join(' ')
-                        .toLowerCase();
-
-                    if (!searchableText.includes(searchQuery)) {
-                        return false;
-                    }
-                }
-
-                // Facet filters
-                for (const [facet, values] of Object.entries(selectedFilters)) {
-                    if (values.length === 0) continue;
-
-                    // Get facet type from schema
-                    const facetConfig = window.searchSchema.facets.find(f => f.field === facet);
-                    const facetType = facetConfig ? facetConfig.type : 'string';
-
-                    const recipeValue = recipe[facet];
-
-                    if (Array.isArray(recipeValue)) {
-                        if (!recipeValue.some(v => values.includes(v))) {
-                            return false;
-                        }
-                    } else {
-                        // For boolean facets, convert string values to booleans for comparison
-                        if (facetType === 'boolean') {
-                            const booleanRecipeValue = String(recipeValue);
-                            if (!values.includes(booleanRecipeValue)) {
-                                return false;
-                            }
-                        } else {
-                            if (!values.includes(recipeValue)) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-
-                return true;
-            });
-
-            renderResults();
-        }
-
-        function renderResults() {
-            const container = document.getElementById('resultsContainer');
-            const countElement = document.getElementById('resultsCount');
-
-            countElement.textContent = `${filteredRecipes.length} recipe${filteredRecipes.length !== 1 ? 's' : ''}`;
-
-            if (filteredRecipes.length === 0) {
-                container.innerHTML = '<div class="no-results">No recipes found matching your criteria.</div>';
-                return;
-            }
-
-            container.innerHTML = '';
-            filteredRecipes.forEach(recipe => {
-                const item = createResultItem(recipe);
-                container.appendChild(item);
-            });
-        }
-
-        function createResultItem(recipe) {
-            const div = document.createElement('div');
-            div.className = 'result-item';
-
-            // Title
-            const title = document.createElement('a');
-            title.href = `../pages/${recipe.html_page}`;
-            title.className = 'result-title';
-            title.textContent = recipe.name;
-            div.appendChild(title);
-
-            // Badges
-            const badges = document.createElement('div');
-            badges.className = 'result-badges';
-
-            const categoryBadge = createBadge(recipe.category, getColor(recipe.category));
-            const typeBadge = createBadge(recipe.medium_type, getColor(recipe.medium_type));
-
-            badges.appendChild(categoryBadge);
-            badges.appendChild(typeBadge);
-            div.appendChild(badges);
-
-            // Meta info
-            const meta = document.createElement('div');
-            meta.className = 'result-meta';
-
-            if (recipe.physical_state) {
-                meta.appendChild(createMetaItem('State', recipe.physical_state));
-            }
-            if (recipe.num_ingredients) {
-                meta.appendChild(createMetaItem('Ingredients', recipe.num_ingredients));
-            }
-            if (recipe.media_database_id) {
-                meta.appendChild(createMetaItem('Database', recipe.media_database_id, true));
-            }
-
-            div.appendChild(meta);
-
-            // Organisms
-            if (recipe.target_organism_names && recipe.target_organism_names.length > 0) {
-                const organisms = document.createElement('div');
-                organisms.style.marginBottom = '0.5rem';
-                const label = document.createElement('strong');
-                label.textContent = 'Organisms: ';
-                organisms.appendChild(label);
-
-                recipe.target_organism_names.slice(0, 3).forEach(org => {
-                    organisms.appendChild(createTag(org));
-                });
-
-                div.appendChild(organisms);
-            }
-
-            // Description
-            if (recipe.description) {
-                const desc = document.createElement('div');
-                desc.className = 'result-description';
-                desc.textContent = truncate(recipe.description, 200);
-                div.appendChild(desc);
-            }
-
-            return div;
-        }
-
-        function createBadge(text, color) {
-            const badge = document.createElement('span');
-            badge.className = 'badge';
-            badge.textContent = text;
-            badge.style.backgroundColor = color;
-            return badge;
-        }
-
-        function createMetaItem(label, value, isLink = false) {
-            const item = document.createElement('div');
-            item.className = 'result-meta-item';
-
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'result-meta-label';
-            labelSpan.textContent = label + ':';
-            item.appendChild(labelSpan);
-
-            if (isLink && value.includes(':')) {
-                const [prefix] = value.split(':');
-                const resolver = window.searchSchema.linkResolvers[prefix];
-                if (resolver) {
-                    const link = document.createElement('a');
-                    link.href = resolver(value);
-                    link.textContent = value;
-                    link.target = '_blank';
-                    item.appendChild(link);
-                } else {
-                    item.appendChild(document.createTextNode(value));
-                }
-            } else {
-                item.appendChild(document.createTextNode(value));
-            }
-
-            return item;
-        }
-
-        function createTag(text) {
-            const tag = document.createElement('span');
-            tag.className = 'tag';
-            tag.textContent = text;
-            return tag;
-        }
-
-        function getColor(value) {
-            return window.searchSchema.colors[value] || '#6b7280';
-        }
-
-        function truncate(text, length) {
-            if (text.length <= length) return text;
-            return text.substring(0, length) + '...';
-        }
-    </script>
+  </main>
+  <footer>
+    <div class="fam"><strong>KG-Microbe Mechs:</strong>
+      <a href="https://culturebotai.github.io/CultureMech/">CultureMech</a>&middot;<a href="https://culturebotai.github.io/MediaIngredientMech/">MediaIngredientMech</a>&middot;<a href="https://culturebotai.github.io/CommunityMech/">CommunityMech</a>&middot;<a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>
+    </div>
+    <div class="fam">
+      <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://w3id.org/metpo">METPO</a>
+    </div>
+  </footer>
 </body>
 </html>

--- a/app/ingredient_umap.html
+++ b/app/ingredient_umap.html
@@ -14,21 +14,20 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #1a7a4a 0%, #2d9665 100%);
-            color: #333;
+            background: linear-gradient(135deg, #FFE0B5 0%, #CDEBC5 100%);
+            color: #1a1a1a;
             padding: 20px;
         }
 
         header {
             text-align: center;
-            color: white;
+            color: #1a1a1a;
             margin-bottom: 30px;
         }
 
         header h1 {
             font-size: 2.4em;
             margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
         }
 
         header p {
@@ -40,8 +39,8 @@
             display: inline-block;
             margin-top: 15px;
             padding: 10px 20px;
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
+            background: rgba(255, 255, 255, 0.5);
+            color: #1a1a1a;
             text-decoration: none;
             border-radius: 6px;
             font-size: 14px;
@@ -50,7 +49,7 @@
         }
 
         .nav-link:hover {
-            background: rgba(255, 255, 255, 0.3);
+            background: rgba(255, 255, 255, 0.8);
         }
 
         .container {
@@ -68,7 +67,7 @@
         .plot-panel h2 {
             font-size: 1.5em;
             margin-bottom: 5px;
-            color: #1a7a4a;
+            color: #4B9E5F;
         }
 
         .plot-panel .subtitle {
@@ -146,7 +145,7 @@
 
         .search-container input:focus {
             outline: none;
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .filter-group {
@@ -166,13 +165,13 @@
         }
 
         .filter-btn:hover {
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .filter-btn.active {
-            background: #1a7a4a;
+            background: #4B9E5F;
             color: white;
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .stats-bar {
@@ -185,7 +184,7 @@
         }
 
         .stat-item strong {
-            color: #1a7a4a;
+            color: #4B9E5F;
         }
 
         .legend {
@@ -253,7 +252,8 @@
             top500: 394 &nbsp;|&nbsp;
             other: 159
         </p>
-        <a href="../index.html" class="nav-link">&larr; Back to Media Browser</a>
+        <a href="index.html" class="nav-link">&#127968; Home</a>
+        <a href="browser.html" class="nav-link">&larr; Back to Media Browser</a>
     </header>
 
     <div class="container">

--- a/app/umap.html
+++ b/app/umap.html
@@ -14,21 +14,20 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: #333;
+            background: linear-gradient(135deg, #FFE0B5 0%, #CDEBC5 100%);
+            color: #1a1a1a;
             padding: 20px;
         }
 
         header {
             text-align: center;
-            color: white;
+            color: #1a1a1a;
             margin-bottom: 30px;
         }
 
         header h1 {
             font-size: 2.5em;
             margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
         }
 
         header p {
@@ -40,8 +39,8 @@
             display: inline-block;
             margin-top: 15px;
             padding: 10px 20px;
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
+            background: rgba(255, 255, 255, 0.5);
+            color: #1a1a1a;
             text-decoration: none;
             border-radius: 6px;
             font-size: 14px;
@@ -50,7 +49,7 @@
         }
 
         .nav-link:hover {
-            background: rgba(255, 255, 255, 0.3);
+            background: rgba(255, 255, 255, 0.8);
         }
 
         .container {
@@ -71,7 +70,7 @@
         .plot-panel h2 {
             font-size: 1.5em;
             margin-bottom: 5px;
-            color: #667eea;
+            color: #4B9E5F;
         }
 
         .plot-panel p {
@@ -139,7 +138,7 @@
 
         .search-container input:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .filter-container {
@@ -160,13 +159,13 @@
         }
 
         .filter-btn:hover {
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .filter-btn.active {
-            background: #667eea;
+            background: #4B9E5F;
             color: white;
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .stats {
@@ -184,7 +183,7 @@
         }
 
         .stat-item strong {
-            color: #667eea;
+            color: #4B9E5F;
         }
 
         circle {
@@ -208,7 +207,8 @@
     <header>
         <h1>🧫 CultureMech Media UMAP Visualization</h1>
         <p>Explore 14940 culture media recipes through semantic similarity</p>
-        <a href="../index.html" class="nav-link">← Back to Media Browser</a>
+        <a href="index.html" class="nav-link">🏠 Home</a>
+        <a href="browser.html" class="nav-link">← Back to Media Browser</a>
     </header>
 
     <div class="container">

--- a/src/culturemech/templates/ingredient_umap.html
+++ b/src/culturemech/templates/ingredient_umap.html
@@ -14,21 +14,20 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #1a7a4a 0%, #2d9665 100%);
-            color: #333;
+            background: linear-gradient(135deg, #FFE0B5 0%, #CDEBC5 100%);
+            color: #1a1a1a;
             padding: 20px;
         }
 
         header {
             text-align: center;
-            color: white;
+            color: #1a1a1a;
             margin-bottom: 30px;
         }
 
         header h1 {
             font-size: 2.4em;
             margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
         }
 
         header p {
@@ -40,8 +39,8 @@
             display: inline-block;
             margin-top: 15px;
             padding: 10px 20px;
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
+            background: rgba(255, 255, 255, 0.5);
+            color: #1a1a1a;
             text-decoration: none;
             border-radius: 6px;
             font-size: 14px;
@@ -50,7 +49,7 @@
         }
 
         .nav-link:hover {
-            background: rgba(255, 255, 255, 0.3);
+            background: rgba(255, 255, 255, 0.8);
         }
 
         .container {
@@ -68,7 +67,7 @@
         .plot-panel h2 {
             font-size: 1.5em;
             margin-bottom: 5px;
-            color: #1a7a4a;
+            color: #4B9E5F;
         }
 
         .plot-panel .subtitle {
@@ -146,7 +145,7 @@
 
         .search-container input:focus {
             outline: none;
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .filter-group {
@@ -166,13 +165,13 @@
         }
 
         .filter-btn:hover {
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .filter-btn.active {
-            background: #1a7a4a;
+            background: #4B9E5F;
             color: white;
-            border-color: #1a7a4a;
+            border-color: #4B9E5F;
         }
 
         .stats-bar {
@@ -185,7 +184,7 @@
         }
 
         .stat-item strong {
-            color: #1a7a4a;
+            color: #4B9E5F;
         }
 
         .legend {
@@ -253,7 +252,8 @@
             top500: {{ tier_counts.top500 }} &nbsp;|&nbsp;
             other: {{ tier_counts.other }}
         </p>
-        <a href="../index.html" class="nav-link">&larr; Back to Media Browser</a>
+        <a href="index.html" class="nav-link">&#127968; Home</a>
+        <a href="browser.html" class="nav-link">&larr; Back to Media Browser</a>
     </header>
 
     <div class="container">

--- a/src/culturemech/templates/media_umap.html
+++ b/src/culturemech/templates/media_umap.html
@@ -14,21 +14,20 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: #333;
+            background: linear-gradient(135deg, #FFE0B5 0%, #CDEBC5 100%);
+            color: #1a1a1a;
             padding: 20px;
         }
 
         header {
             text-align: center;
-            color: white;
+            color: #1a1a1a;
             margin-bottom: 30px;
         }
 
         header h1 {
             font-size: 2.5em;
             margin-bottom: 10px;
-            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
         }
 
         header p {
@@ -40,8 +39,8 @@
             display: inline-block;
             margin-top: 15px;
             padding: 10px 20px;
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
+            background: rgba(255, 255, 255, 0.5);
+            color: #1a1a1a;
             text-decoration: none;
             border-radius: 6px;
             font-size: 14px;
@@ -50,7 +49,7 @@
         }
 
         .nav-link:hover {
-            background: rgba(255, 255, 255, 0.3);
+            background: rgba(255, 255, 255, 0.8);
         }
 
         .container {
@@ -71,7 +70,7 @@
         .plot-panel h2 {
             font-size: 1.5em;
             margin-bottom: 5px;
-            color: #667eea;
+            color: #4B9E5F;
         }
 
         .plot-panel p {
@@ -139,7 +138,7 @@
 
         .search-container input:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .filter-container {
@@ -160,13 +159,13 @@
         }
 
         .filter-btn:hover {
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .filter-btn.active {
-            background: #667eea;
+            background: #4B9E5F;
             color: white;
-            border-color: #667eea;
+            border-color: #4B9E5F;
         }
 
         .stats {
@@ -184,7 +183,7 @@
         }
 
         .stat-item strong {
-            color: #667eea;
+            color: #4B9E5F;
         }
 
         circle {
@@ -208,7 +207,8 @@
     <header>
         <h1>🧫 CultureMech Media UMAP Visualization</h1>
         <p>Explore {{ unique_count }} culture media recipes through semantic similarity</p>
-        <a href="../index.html" class="nav-link">← Back to Media Browser</a>
+        <a href="index.html" class="nav-link">🏠 Home</a>
+        <a href="browser.html" class="nav-link">← Back to Media Browser</a>
     </header>
 
     <div class="container">

--- a/src/culturemech/templates/style.css
+++ b/src/culturemech/templates/style.css
@@ -2,8 +2,8 @@
   --fg: #222;
   --muted: #666;
   --line: #e5e7eb;
-  --bg-soft: #f6f8fa;
-  --accent: #0969da;
+  --bg-soft: #eef7ec;
+  --accent: #4B9E5F;
   --pass: #2c8a3a;
   --warn: #d68f00;
   --fail: #b8302c;


### PR DESCRIPTION
Restyles the site: the main page is now a clean landing (branded hero + summary stats + three cards → record browser, embedding/UMAP browser, GitHub) with a footer cross-linking the other Mechs, kg-microbe, and METPO. **No facets on the main page** — the faceted record browser lives on its own page. Site-wide pastel **orange/green** theme with a common black body font.

Part of the cross-Mech web redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)