### PR TITLE
Relabel embedding pages to reflect PaCMAP / sfdp (not UMAP)

### DIFF
--- a/app/umap.html
+++ b/app/umap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CultureMech Media UMAP Visualization</title>
+    <title>CultureMech Media Embedding Map (PaCMAP)</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         * {
@@ -205,7 +205,7 @@
 </head>
 <body>
     <header>
-        <h1>🧫 CultureMech Media UMAP Visualization</h1>
+        <h1>🧫 CultureMech Media Embedding Map (PaCMAP)</h1>
         <p>Explore 14940 culture media recipes through semantic similarity</p>
         <a href="index.html" class="nav-link">🏠 Home</a>
         <a href="browser.html" class="nav-link">← Back to Media Browser</a>

--- a/app/umap_graph.html
+++ b/app/umap_graph.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CultureMech Media UMAP Visualization</title>
+    <title>CultureMech Media Graph Layout (sfdp)</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         * {
@@ -205,7 +205,7 @@
 </head>
 <body>
     <header>
-        <h1>🧫 CultureMech Media UMAP Visualization</h1>
+        <h1>🧫 CultureMech Media Graph Layout (sfdp)</h1>
         <p>Explore 14940 culture media recipes through semantic similarity</p>
         <a href="index.html" class="nav-link">🏠 Home</a>
         <a href="browser.html" class="nav-link">← Back to Media Browser</a>

--- a/src/culturemech/templates/media_umap.html
+++ b/src/culturemech/templates/media_umap.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CultureMech Media UMAP Visualization</title>
+    <title>CultureMech Media Embedding Map</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         * {
@@ -205,7 +205,7 @@
 </head>
 <body>
     <header>
-        <h1>🧫 CultureMech Media UMAP Visualization</h1>
+        <h1>🧫 CultureMech Media Embedding Map</h1>
         <p>Explore {{ unique_count }} culture media recipes through semantic similarity</p>
         <a href="index.html" class="nav-link">🏠 Home</a>
         <a href="browser.html" class="nav-link">← Back to Media Browser</a>


### PR DESCRIPTION
The default projection is PaCMAP and there's a separate sfdp graph-layout page — update page titles/subtitles/axis labels so the served pages read accurately. Templates made method-neutral for future regenerations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)