### PR TITLE
Add ProteinTraitsMech to the Mech family footer

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -82,7 +82,7 @@
   </main>
   <footer>
     <div class="fam"><strong>KG-Microbe Mechs:</strong>
-      <a href="https://culturebotai.github.io/CultureMech/">CultureMech</a>&middot;<a href="https://culturebotai.github.io/MediaIngredientMech/">MediaIngredientMech</a>&middot;<a href="https://culturebotai.github.io/CommunityMech/">CommunityMech</a>&middot;<a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>
+      <a href="https://culturebotai.github.io/CultureMech/">CultureMech</a>&middot;<a href="https://culturebotai.github.io/MediaIngredientMech/">MediaIngredientMech</a>&middot;<a href="https://culturebotai.github.io/CommunityMech/">CommunityMech</a>&middot;<a href="https://culturebotai.github.io/TraitMech/">TraitMech</a>&middot;<a href="https://culturebotai.github.io/proteintraitsmech/">ProteinTraitsMech</a>
     </div>
     <div class="fam">
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>


### PR DESCRIPTION
Cross-link the fifth sibling (ProteinTraitsMech) from the landing footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)