### PR TITLE
Add toggleable dark theme + reduced-motion guard to the site

### DIFF
--- a/app/browser.html
+++ b/app/browser.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CultureMech - Microbial Growth Media Browser</title>
     <style>
+        /* Token layer — matches the hard-coded light values above; the only
+           consumer is the injected theme-toggle button, so light look is unchanged. */
+        :root{
+            --card:#ffffff;
+            --ink:#1a1a1a;
+            --line:#e2e8f0;
+            --accent:#4B9E5F;
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -265,6 +274,65 @@
             .facets {
                 order: 2;
             }
+        }
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:#12160f;color:#eaf0e6}
+            :root:not([data-theme="light"]) .header{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) .header-nav a{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .header-nav a:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .search-bar,
+            :root:not([data-theme="light"]) .facets,
+            :root:not([data-theme="light"]) .results{background:#1c2118;box-shadow:0 2px 8px rgba(0,0,0,.4)}
+            :root:not([data-theme="light"]) .search-input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .facet h3,
+            :root:not([data-theme="light"]) .results-count,
+            :root:not([data-theme="light"]) .result-title,
+            :root:not([data-theme="light"]) .loading{color:#6cc47f}
+            :root:not([data-theme="light"]) .facet-option:hover{color:#6cc47f}
+            :root:not([data-theme="light"]) .facet-count,
+            :root:not([data-theme="light"]) .no-results{color:#9db09a}
+            :root:not([data-theme="light"]) .results-header{border-bottom-color:#2e3a2c}
+            :root:not([data-theme="light"]) .result-item{border-bottom-color:#2e3a2c}
+            :root:not([data-theme="light"]) .result-item:hover{background:#24331d}
+            :root:not([data-theme="light"]) .result-meta-label{color:#eaf0e6}
+            :root:not([data-theme="light"]) .result-description{color:#9db09a}
+            :root:not([data-theme="light"]) .tag{background:#2e3a2c;color:#eaf0e6}
+            :root:not([data-theme="light"]) .clear-filters{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+            :root:not([data-theme="light"]) .clear-filters:hover{background:#2e3a2c}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:#12160f;color:#eaf0e6}
+        :root[data-theme="dark"] .header{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] .header-nav a{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .header-nav a:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .search-bar,
+        :root[data-theme="dark"] .facets,
+        :root[data-theme="dark"] .results{background:#1c2118;box-shadow:0 2px 8px rgba(0,0,0,.4)}
+        :root[data-theme="dark"] .search-input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .facet h3,
+        :root[data-theme="dark"] .results-count,
+        :root[data-theme="dark"] .result-title,
+        :root[data-theme="dark"] .loading{color:#6cc47f}
+        :root[data-theme="dark"] .facet-option:hover{color:#6cc47f}
+        :root[data-theme="dark"] .facet-count,
+        :root[data-theme="dark"] .no-results{color:#9db09a}
+        :root[data-theme="dark"] .results-header{border-bottom-color:#2e3a2c}
+        :root[data-theme="dark"] .result-item{border-bottom-color:#2e3a2c}
+        :root[data-theme="dark"] .result-item:hover{background:#24331d}
+        :root[data-theme="dark"] .result-meta-label{color:#eaf0e6}
+        :root[data-theme="dark"] .result-description{color:#9db09a}
+        :root[data-theme="dark"] .tag{background:#2e3a2c;color:#eaf0e6}
+        :root[data-theme="dark"] .clear-filters{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+        :root[data-theme="dark"] .clear-filters:hover{background:#2e3a2c}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
         }
     </style>
 </head>
@@ -607,5 +675,6 @@
             return text.substring(0, length) + '...';
         }
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -46,6 +46,39 @@
   footer .fam{margin:.2em 0}
   footer .fam a{margin:0 .45em;white-space:nowrap}
   footer strong{color:var(--ink)}
+
+  /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+  @media (prefers-color-scheme: dark){
+    :root:not([data-theme="light"]){
+      --pastel-a:#24331d;   /* hero gradient tint */
+      --pastel-b:#12160f;   /* page ground */
+      --accent:#6cc47f;
+      --ink:#eaf0e6;
+      --muted:#9db09a;
+      --card:#1c2118;
+      --line:#2e3a2c;
+    }
+    :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
+    :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
+    :root:not([data-theme="light"]) .btn{color:#12160f}
+  }
+  :root[data-theme="dark"]{
+    --pastel-a:#24331d;
+    --pastel-b:#12160f;
+    --accent:#6cc47f;
+    --ink:#eaf0e6;
+    --muted:#9db09a;
+    --card:#1c2118;
+    --line:#2e3a2c;
+  }
+  :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
+  :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
+  :root[data-theme="dark"] .btn{color:#12160f}
+
+  @media (prefers-reduced-motion: reduce){
+    *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+      transition-duration:.01ms!important;scroll-behavior:auto!important;}
+  }
 </style>
 </head>
 <body>
@@ -88,5 +121,6 @@
       <a href="https://github.com/Knowledge-Graph-Hub/kg-microbe">kg-microbe</a>&middot;<a href="https://bioportal.bioontology.org/ontologies/METPO">METPO</a>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/app/ingredient_umap.html
+++ b/app/ingredient_umap.html
@@ -241,6 +241,59 @@
         .reset-zoom:hover {
             background: #e8e8e8;
         }
+
+        /* Token layer — light values match the hard-coded look above; consumed
+           only by the injected theme-toggle button, so light appearance is unchanged. */
+        :root{--card:#ffffff;--ink:#1a1a1a;--line:#e2e8f0;--accent:#4B9E5F;}
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) header{color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .plot-panel{background:#1c2118}
+            :root:not([data-theme="light"]) .plot-panel h2{color:#6cc47f}
+            :root:not([data-theme="light"]) .plot-panel .subtitle{color:#9db09a}
+            :root:not([data-theme="light"]) svg{background:#12160f}
+            :root:not([data-theme="light"]) .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-container input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .filter-btn:hover{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+            :root:not([data-theme="light"]) .stats-bar{color:#9db09a}
+            :root:not([data-theme="light"]) .stat-item strong{color:#6cc47f}
+            :root:not([data-theme="light"]) .legend-size-hint{color:#9db09a}
+            :root:not([data-theme="light"]) circle:hover{stroke:#eaf0e6}
+            :root:not([data-theme="light"]) .reset-zoom{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+            :root:not([data-theme="light"]) .reset-zoom:hover{background:#2e3a2c}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] header{color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .plot-panel{background:#1c2118}
+        :root[data-theme="dark"] .plot-panel h2{color:#6cc47f}
+        :root[data-theme="dark"] .plot-panel .subtitle{color:#9db09a}
+        :root[data-theme="dark"] svg{background:#12160f}
+        :root[data-theme="dark"] .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-container input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .filter-btn:hover{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+        :root[data-theme="dark"] .stats-bar{color:#9db09a}
+        :root[data-theme="dark"] .stat-item strong{color:#6cc47f}
+        :root[data-theme="dark"] .legend-size-hint{color:#9db09a}
+        :root[data-theme="dark"] circle:hover{stroke:#eaf0e6}
+        :root[data-theme="dark"] .reset-zoom{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+        :root[data-theme="dark"] .reset-zoom:hover{background:#2e3a2c}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
     </style>
 </head>
 <body>
@@ -444,5 +497,6 @@
             applyFilters();
         });
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/app/theme-toggle.js
+++ b/app/theme-toggle.js
@@ -1,0 +1,74 @@
+/* Mech theme toggle — vendored byte-identical across all Mech sites.
+ * Applies the saved theme to <html data-theme> (falling back to the OS
+ * preference) before paint, and injects a self-contained fixed toggle button.
+ * No dependencies; no per-page markup or CSS required beyond loading this file.
+ * The page's own dark palette is supplied via :root[data-theme="dark"] and the
+ * prefers-color-scheme media query in that page's stylesheet. */
+(function () {
+  var KEY = 'mech-theme';
+  var root = document.documentElement;
+
+  function osDark() {
+    return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  }
+  function current() {
+    return root.getAttribute('data-theme') || (osDark() ? 'dark' : 'light');
+  }
+
+  // Apply the saved preference as early as possible to avoid a flash.
+  try {
+    var saved = localStorage.getItem(KEY);
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) {}
+
+  function setIcon(btn) {
+    var dark = current() === 'dark';
+    btn.querySelector('.theme-toggle-icon').textContent = dark ? '☀' : '☾'; // sun / moon
+    btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+  }
+  function toggle(btn) {
+    var next = current() === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem(KEY, next); } catch (e) {}
+    setIcon(btn);
+  }
+  function mount() {
+    if (document.querySelector('.theme-toggle')) return;
+
+    var css =
+      '.theme-toggle{position:fixed;bottom:18px;right:18px;z-index:2000;width:40px;height:40px;' +
+      'border-radius:50%;border:1px solid var(--line,var(--border,rgba(128,128,128,.4)));' +
+      'background:var(--card,var(--surface,var(--card-bg,#fff)));' +
+      'color:var(--ink,var(--text,var(--fg,#1a1a1a)));font-size:18px;line-height:1;cursor:pointer;' +
+      'display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);' +
+      'transition:border-color .15s,transform .15s;}' +
+      '.theme-toggle:hover{border-color:var(--accent,var(--primary,var(--brand-1,#888)));transform:translateY(-1px);}' +
+      '.theme-toggle:focus-visible{outline:2px solid var(--accent,var(--primary,#888));outline-offset:2px;}' +
+      '@media (prefers-reduced-motion: reduce){.theme-toggle{transition:none;}}';
+    var st = document.createElement('style');
+    st.textContent = css;
+    document.head.appendChild(st);
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'theme-toggle';
+    btn.setAttribute('aria-label', 'Toggle dark mode');
+    btn.title = 'Toggle light / dark';
+    btn.innerHTML = '<span class="theme-toggle-icon" aria-hidden="true"></span>';
+    btn.addEventListener('click', function () { toggle(btn); });
+    document.body.appendChild(btn);
+    setIcon(btn);
+
+    // If the visitor has no explicit choice, follow live OS-theme changes.
+    if (window.matchMedia) {
+      try {
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function () {
+          if (!root.getAttribute('data-theme')) setIcon(btn);
+        });
+      } catch (e) {}
+    }
+  }
+
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', mount);
+  else mount();
+})();

--- a/app/umap.html
+++ b/app/umap.html
@@ -249,6 +249,61 @@
             font-size: 0.8rem;
             color: #64748b;
         }
+
+        /* Token layer — light values match the hard-coded look above; consumed
+           only by the injected theme-toggle button, so light appearance is unchanged. */
+        :root{--card:#ffffff;--ink:#1a1a1a;--line:#e2e8f0;--accent:#4B9E5F;}
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) header{color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .plot-panel{background:#1c2118}
+            :root:not([data-theme="light"]) .plot-panel h2{color:#6cc47f}
+            :root:not([data-theme="light"]) .plot-panel p{color:#9db09a}
+            :root:not([data-theme="light"]) svg{background:#12160f}
+            :root:not([data-theme="light"]) .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-container input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .filter-btn:hover{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+            :root:not([data-theme="light"]) .stats{color:#9db09a}
+            :root:not([data-theme="light"]) .stat-item strong{color:#6cc47f}
+            :root:not([data-theme="light"]) circle:hover{stroke:#eaf0e6}
+            :root:not([data-theme="light"]) .facets{background:#1c2118;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .facets h3{color:#9db09a}
+            :root:not([data-theme="light"]) label.facet-opt .cnt{color:#9db09a}
+            :root:not([data-theme="light"]) .facet-showing{color:#9db09a}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] header{color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .plot-panel{background:#1c2118}
+        :root[data-theme="dark"] .plot-panel h2{color:#6cc47f}
+        :root[data-theme="dark"] .plot-panel p{color:#9db09a}
+        :root[data-theme="dark"] svg{background:#12160f}
+        :root[data-theme="dark"] .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-container input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .filter-btn:hover{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+        :root[data-theme="dark"] .stats{color:#9db09a}
+        :root[data-theme="dark"] .stat-item strong{color:#6cc47f}
+        :root[data-theme="dark"] circle:hover{stroke:#eaf0e6}
+        :root[data-theme="dark"] .facets{background:#1c2118;border-color:#2e3a2c}
+        :root[data-theme="dark"] .facets h3{color:#9db09a}
+        :root[data-theme="dark"] label.facet-opt .cnt{color:#9db09a}
+        :root[data-theme="dark"] .facet-showing{color:#9db09a}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
     </style>
 </head>
 <body>
@@ -583,5 +638,6 @@
         // Initial paint (applies all-checked facet state).
         applyAllFilters();
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/app/umap_graph.html
+++ b/app/umap_graph.html
@@ -249,6 +249,61 @@
             font-size: 0.8rem;
             color: #64748b;
         }
+
+        /* Token layer — light values match the hard-coded look above; consumed
+           only by the injected theme-toggle button, so light appearance is unchanged. */
+        :root{--card:#ffffff;--ink:#1a1a1a;--line:#e2e8f0;--accent:#4B9E5F;}
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) header{color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .plot-panel{background:#1c2118}
+            :root:not([data-theme="light"]) .plot-panel h2{color:#6cc47f}
+            :root:not([data-theme="light"]) .plot-panel p{color:#9db09a}
+            :root:not([data-theme="light"]) svg{background:#12160f}
+            :root:not([data-theme="light"]) .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-container input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .filter-btn:hover{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+            :root:not([data-theme="light"]) .stats{color:#9db09a}
+            :root:not([data-theme="light"]) .stat-item strong{color:#6cc47f}
+            :root:not([data-theme="light"]) circle:hover{stroke:#eaf0e6}
+            :root:not([data-theme="light"]) .facets{background:#1c2118;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .facets h3{color:#9db09a}
+            :root:not([data-theme="light"]) label.facet-opt .cnt{color:#9db09a}
+            :root:not([data-theme="light"]) .facet-showing{color:#9db09a}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] header{color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .plot-panel{background:#1c2118}
+        :root[data-theme="dark"] .plot-panel h2{color:#6cc47f}
+        :root[data-theme="dark"] .plot-panel p{color:#9db09a}
+        :root[data-theme="dark"] svg{background:#12160f}
+        :root[data-theme="dark"] .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-container input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .filter-btn:hover{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+        :root[data-theme="dark"] .stats{color:#9db09a}
+        :root[data-theme="dark"] .stat-item strong{color:#6cc47f}
+        :root[data-theme="dark"] circle:hover{stroke:#eaf0e6}
+        :root[data-theme="dark"] .facets{background:#1c2118;border-color:#2e3a2c}
+        :root[data-theme="dark"] .facets h3{color:#9db09a}
+        :root[data-theme="dark"] label.facet-opt .cnt{color:#9db09a}
+        :root[data-theme="dark"] .facet-showing{color:#9db09a}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
     </style>
 </head>
 <body>
@@ -583,5 +638,6 @@
         // Initial paint (applies all-checked facet state).
         applyAllFilters();
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/culturemech/templates/ingredient_umap.html
+++ b/src/culturemech/templates/ingredient_umap.html
@@ -241,6 +241,59 @@
         .reset-zoom:hover {
             background: #e8e8e8;
         }
+
+        /* Token layer — light values match the hard-coded look above; consumed
+           only by the injected theme-toggle button, so light appearance is unchanged. */
+        :root{--card:#ffffff;--ink:#1a1a1a;--line:#e2e8f0;--accent:#4B9E5F;}
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) header{color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .plot-panel{background:#1c2118}
+            :root:not([data-theme="light"]) .plot-panel h2{color:#6cc47f}
+            :root:not([data-theme="light"]) .plot-panel .subtitle{color:#9db09a}
+            :root:not([data-theme="light"]) svg{background:#12160f}
+            :root:not([data-theme="light"]) .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-container input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .filter-btn:hover{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+            :root:not([data-theme="light"]) .stats-bar{color:#9db09a}
+            :root:not([data-theme="light"]) .stat-item strong{color:#6cc47f}
+            :root:not([data-theme="light"]) .legend-size-hint{color:#9db09a}
+            :root:not([data-theme="light"]) circle:hover{stroke:#eaf0e6}
+            :root:not([data-theme="light"]) .reset-zoom{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+            :root:not([data-theme="light"]) .reset-zoom:hover{background:#2e3a2c}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] header{color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .plot-panel{background:#1c2118}
+        :root[data-theme="dark"] .plot-panel h2{color:#6cc47f}
+        :root[data-theme="dark"] .plot-panel .subtitle{color:#9db09a}
+        :root[data-theme="dark"] svg{background:#12160f}
+        :root[data-theme="dark"] .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-container input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .filter-btn:hover{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+        :root[data-theme="dark"] .stats-bar{color:#9db09a}
+        :root[data-theme="dark"] .stat-item strong{color:#6cc47f}
+        :root[data-theme="dark"] .legend-size-hint{color:#9db09a}
+        :root[data-theme="dark"] circle:hover{stroke:#eaf0e6}
+        :root[data-theme="dark"] .reset-zoom{background:#24331d;border-color:#2e3a2c;color:#eaf0e6}
+        :root[data-theme="dark"] .reset-zoom:hover{background:#2e3a2c}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
     </style>
 </head>
 <body>
@@ -444,5 +497,6 @@
             applyFilters();
         });
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/culturemech/templates/media_umap.html
+++ b/src/culturemech/templates/media_umap.html
@@ -249,6 +249,61 @@
             font-size: 0.8rem;
             color: #64748b;
         }
+
+        /* Token layer — light values match the hard-coded look above; consumed
+           only by the injected theme-toggle button, so light appearance is unchanged. */
+        :root{--card:#ffffff;--ink:#1a1a1a;--line:#e2e8f0;--accent:#4B9E5F;}
+
+        /* ---- Dark theme (OS default; superseded by the toggle) ---- */
+        @media (prefers-color-scheme: dark){
+            :root:not([data-theme="light"]){--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+            :root:not([data-theme="light"]) body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+            :root:not([data-theme="light"]) header{color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+            :root:not([data-theme="light"]) .nav-link:hover{background:rgba(255,255,255,.12)}
+            :root:not([data-theme="light"]) .plot-panel{background:#1c2118}
+            :root:not([data-theme="light"]) .plot-panel h2{color:#6cc47f}
+            :root:not([data-theme="light"]) .plot-panel p{color:#9db09a}
+            :root:not([data-theme="light"]) svg{background:#12160f}
+            :root:not([data-theme="light"]) .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .search-container input:focus{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .filter-btn:hover{border-color:#6cc47f}
+            :root:not([data-theme="light"]) .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+            :root:not([data-theme="light"]) .stats{color:#9db09a}
+            :root:not([data-theme="light"]) .stat-item strong{color:#6cc47f}
+            :root:not([data-theme="light"]) circle:hover{stroke:#eaf0e6}
+            :root:not([data-theme="light"]) .facets{background:#1c2118;border-color:#2e3a2c}
+            :root:not([data-theme="light"]) .facets h3{color:#9db09a}
+            :root:not([data-theme="light"]) label.facet-opt .cnt{color:#9db09a}
+            :root:not([data-theme="light"]) .facet-showing{color:#9db09a}
+        }
+        :root[data-theme="dark"]{--card:#1c2118;--ink:#eaf0e6;--line:#2e3a2c;--accent:#6cc47f;}
+        :root[data-theme="dark"] body{background:linear-gradient(135deg,#24331d 0%,#12160f 100%);color:#eaf0e6}
+        :root[data-theme="dark"] header{color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link{background:rgba(255,255,255,.06);color:#eaf0e6}
+        :root[data-theme="dark"] .nav-link:hover{background:rgba(255,255,255,.12)}
+        :root[data-theme="dark"] .plot-panel{background:#1c2118}
+        :root[data-theme="dark"] .plot-panel h2{color:#6cc47f}
+        :root[data-theme="dark"] .plot-panel p{color:#9db09a}
+        :root[data-theme="dark"] svg{background:#12160f}
+        :root[data-theme="dark"] .search-container input{background:#12160f;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .search-container input:focus{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn{background:#1c2118;color:#eaf0e6;border-color:#2e3a2c}
+        :root[data-theme="dark"] .filter-btn:hover{border-color:#6cc47f}
+        :root[data-theme="dark"] .filter-btn.active{background:#6cc47f;color:#12160f;border-color:#6cc47f}
+        :root[data-theme="dark"] .stats{color:#9db09a}
+        :root[data-theme="dark"] .stat-item strong{color:#6cc47f}
+        :root[data-theme="dark"] circle:hover{stroke:#eaf0e6}
+        :root[data-theme="dark"] .facets{background:#1c2118;border-color:#2e3a2c}
+        :root[data-theme="dark"] .facets h3{color:#9db09a}
+        :root[data-theme="dark"] label.facet-opt .cnt{color:#9db09a}
+        :root[data-theme="dark"] .facet-showing{color:#9db09a}
+
+        @media (prefers-reduced-motion: reduce){
+            *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;
+                transition-duration:.01ms!important;scroll-behavior:auto!important;}
+        }
     </style>
 </head>
 <body>
@@ -583,5 +638,6 @@
         // Initial paint (applies all-checked facet state).
         applyAllFilters();
     </script>
+    <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/src/culturemech/templates/style.css
+++ b/src/culturemech/templates/style.css
@@ -66,3 +66,40 @@ footer { margin-top: 3em; padding-top: 1em;
          border-top: 1px solid var(--line); color: var(--muted);
          font-size: 0.85em; }
 a { color: var(--accent); }
+
+/* ---- Dark theme (OS default; superseded by the toggle) ---- */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --fg: #eaf0e6;
+    --muted: #9db09a;
+    --line: #2e3a2c;
+    --bg-soft: #1c2118;
+    --accent: #6cc47f;
+    --pass: #34d399;
+    --warn: #fbbf24;
+    --fail: #f87171;
+  }
+  :root:not([data-theme="light"]) body { background: #12160f; }
+  :root:not([data-theme="light"]) .badge { color: var(--fg); }
+}
+:root[data-theme="dark"] {
+  --fg: #eaf0e6;
+  --muted: #9db09a;
+  --line: #2e3a2c;
+  --bg-soft: #1c2118;
+  --accent: #6cc47f;
+  --pass: #34d399;
+  --warn: #fbbf24;
+  --fail: #f87171;
+}
+:root[data-theme="dark"] body { background: #12160f; }
+:root[data-theme="dark"] .badge { color: var(--fg); }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
Adds a **user-toggleable dark theme** (OS `prefers-color-scheme` default + a persisted `data-theme` toggle) and a **reduced-motion guard** to every reviewed page of the CultureMech site. All changes are **additive** — the light appearance is unchanged; the base `:root` values are untouched and dark rules live only under `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` and `:root[data-theme="dark"]`.

## Dark palette (role → hex)
`--bg #12160f` · surface/card `#1c2118` · ink `#eaf0e6` · muted `#9db09a` · line `#2e3a2c` · accent `#6cc47f` · heroA `#24331d`. Status colors brightened: pass `#34d399`, warn `#fbbf24`, fail `#f87171`.

## Changes
- **`app/theme-toggle.js`** — vendored byte-identical shared Mech toggle (reads `localStorage`, sets `data-theme` before paint, injects a self-contained ☾/☀ button). Loaded from all 5 reviewed pages at web-root depth.
- **`app/index.html`** — dark tokens mapped by role: `--pastel-b`→bg, `--pastel-a`→heroA (hero gradient becomes heroA→dark); dark overrides for the translucent-white `.stat`/`footer` blobs and for the white `.btn` text (→ dark bg color).
- **`app/browser.html`** — no `:root` existed; added a small token layer (light values match the existing look, consumed only by the toggle button) + targeted dark overrides (body, header gradient, cards, borders, inputs, hover stripes, tags).
- **`app/umap.html` + `app/umap_graph.html`** (both generated from `src/culturemech/templates/media_umap.html`) — identical static dark block applied to the template **and** both generated files; SVG plot background → dark, circle hover halo → light.
- **`app/ingredient_umap.html`** (generated from `src/culturemech/templates/ingredient_umap.html`) — same treatment; the ordinal red/orange/blue tier palette is left untouched (surfaces only).
- **`src/culturemech/templates/style.css`** (record pages) — dark redefinition of the token system (`--fg/--muted/--line/--bg-soft/--accent/--pass/--warn/--fail`) + body background → `--bg` + `.badge` text fix; reduced-motion guard. (The gitignored deployed copy `pages/style.css` was synced locally.)

## Notes
- Generated UMAP pages were **edit-both** (template + output), not regenerated — no embedding pipeline run, dark blocks are byte-identical between template and output.
- Record pages get dark styling via OS preference through the shared stylesheet but no floating toggle button (per spec, the toggle ships only on the 5 app pages).
- `app/discussions/` and the root redirect `index.html` were intentionally not touched.

**Do not merge** — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)