### PR TITLE
Dark mode: restore brand pastel pair on hero + card edges

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -61,6 +61,17 @@
     :root:not([data-theme="light"]) .stat{background:rgba(255,255,255,.05)}
     :root:not([data-theme="light"]) footer{background:rgba(255,255,255,.05)}
     :root:not([data-theme="light"]) .btn{color:#12160f}
+    /* keep the brand pastel PAIR visible in dark: darkened-pair hero fill + vivid-pair top edge */
+    :root:not([data-theme="light"]) .hero{
+      background:linear-gradient(135deg,#595341,#4a5646);
+      border-top:3px solid;
+      border-image:linear-gradient(90deg,#FFE0B5,#CDEBC5) 1;
+    }
+    :root:not([data-theme="light"]) .card{position:relative}
+    :root:not([data-theme="light"]) .card::before{
+      content:"";position:absolute;top:0;left:0;right:0;height:2px;
+      background:linear-gradient(90deg,#FFE0B5,#CDEBC5);border-radius:16px 16px 0 0;
+    }
   }
   :root[data-theme="dark"]{
     --pastel-a:#24331d;
@@ -74,6 +85,17 @@
   :root[data-theme="dark"] .stat{background:rgba(255,255,255,.05)}
   :root[data-theme="dark"] footer{background:rgba(255,255,255,.05)}
   :root[data-theme="dark"] .btn{color:#12160f}
+  /* keep the brand pastel PAIR visible in dark: darkened-pair hero fill + vivid-pair top edge */
+  :root[data-theme="dark"] .hero{
+    background:linear-gradient(135deg,#595341,#4a5646);
+    border-top:3px solid;
+    border-image:linear-gradient(90deg,#FFE0B5,#CDEBC5) 1;
+  }
+  :root[data-theme="dark"] .card{position:relative}
+  :root[data-theme="dark"] .card::before{
+    content:"";position:absolute;top:0;left:0;right:0;height:2px;
+    background:linear-gradient(90deg,#FFE0B5,#CDEBC5);border-radius:16px 16px 0 0;
+  }
 
   @media (prefers-reduced-motion: reduce){
     *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;


### PR DESCRIPTION
Small dark-mode refinement for the CultureMech landing page (`app/index.html`): bring the brand pastel **pair** back into the dark theme, which had neutralized it to greens.

## What changed (dark mode only, additive)
- **Hero**: darkened pastel-pair gradient fill (`#595341→#4a5646`) plus a thin full-strength pastel-pair top edge via `border-image` (`#FFE0B5→#CDEBC5`) — the brand signature.
- **Card**: subtle 2px vivid pastel-pair top edge via a `::before` bar (keeps the existing all-sides border intact).

Both rules are mirrored under **both** dark selectors:
- `@media (prefers-color-scheme: dark){ :root:not([data-theme="light"]) … }` (OS default)
- `:root[data-theme="dark"] …` (toggle)

## Guarantees
- **Light theme byte-identical** — every added line lives inside a dark selector; no existing line was modified.
- **Page background stays dark** — `--pastel-b` / `--bg` tokens untouched.
- Hero text stays legible on the darkened fill (light-ink contrast verified in the spec at ≥6.4:1).

Do **not** merge — leader merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)