### PR TITLE
Step 4b: retire flat IngredientRoleEnum + NutrientRoleEnum, retarget NutrientOverride.role, migrate consumers

### DIFF
--- a/docs/ENRICHMENT_GUIDE.md
+++ b/docs/ENRICHMENT_GUIDE.md
@@ -45,27 +45,29 @@ ingredients:
     term:
       id: CHEBI:17234
       label: glucose
-    # NEW: Functional roles (multivalued)
-    role:
-      - CARBON_SOURCE
-      - ENERGY_SOURCE
+    # NEW: role facets — three orthogonal slots (all multivalued)
+    nutritional_roles: [CARBON_SOURCE, ENERGY_SOURCE]
+    cellular_metabolic_roles: [SUBSTRATE]
 ```
 
-**Available roles:**
-- `CARBON_SOURCE` - Primary carbon source
-- `NITROGEN_SOURCE` - Nitrogen source
-- `MINERAL` - Major mineral nutrient
-- `TRACE_ELEMENT` - Micronutrient
-- `BUFFER` - pH buffering agent
-- `VITAMIN_SOURCE` - Provides vitamins
-- `SALT` - Osmotic balance/ionic strength
-- `PROTEIN_SOURCE` - Complex protein source
-- `AMINO_ACID_SOURCE` - Amino acids
-- `SOLIDIFYING_AGENT` - Gelling agent (agar)
-- `ENERGY_SOURCE` - Energy source
-- `ELECTRON_ACCEPTOR` - Terminal electron acceptor
-- `ELECTRON_DONOR` - Electron donor
-- `COFACTOR_PROVIDER` - Supplies cofactors
+**Three orthogonal role facets** (imported from MediaIngredientMech via `mim_roles.yaml`):
+
+`nutritional_roles` (`NutritionalRoleEnum`, 12 values) — what element / macronutrient the ingredient supplies:
+- `CARBON_SOURCE`, `NITROGEN_SOURCE`, `SULFUR_SOURCE`, `PHOSPHATE_SOURCE`, `IRON_SOURCE`, `TRACE_ELEMENT`
+- `VITAMIN_SOURCE`, `AMINO_ACID_SOURCE`, `PROTEIN_SOURCE`, `COFACTOR_PROVIDER`
+- `ENERGY_SOURCE`, `LIGHT_SOURCE`
+
+`physicochemical_roles` (`PhysicochemicalRoleEnum`, 12 values) — chemical / physical function in the medium:
+- `BUFFER`, `SOLIDIFYING_AGENT`, `CHELATOR`, `SURFACTANT`
+- `REDUCING_AGENT`, `OXIDIZING_AGENT`, `PH_INDICATOR`, `REDOX_INDICATOR`
+- `SELECTIVE_AGENT`, `ANTIFOAM`, `OSMOTIC_AGENT`, `PRECIPITATION_INHIBITOR`
+
+`cellular_metabolic_roles` (`CellularMetabolicRoleEnum`, 10 values) — role inside/on the microbe (often organism-conditional):
+- `SUBSTRATE`, `ELECTRON_DONOR`, `ELECTRON_ACCEPTOR`, `COFACTOR`
+- `PROSTHETIC_GROUP_PRECURSOR`, `MEMBRANE_COMPONENT`, `OSMOPROTECTANT`
+- `INDUCER`, `INHIBITOR`, `QUENCHER`
+
+Also: `role_curie` (multivalued `uriorcurie`) — escape hatch for out-of-vocabulary role terms (CHEBI role subtree, METPO, ENVO, GO, PATO, NCIT).
 
 ---
 
@@ -82,9 +84,7 @@ ingredients:
     term:
       id: CHEBI:31795
       label: MgSO4·7H2O
-    role:
-      - MINERAL
-      - COFACTOR_PROVIDER
+    nutritional_roles: [SULFUR_SOURCE, COFACTOR_PROVIDER]  # Mg is a cofactor cation; sulfate supplies sulfur
     # NEW: Cofactors provided
     cofactors_provided:
       - preferred_term: Magnesium ion
@@ -302,16 +302,19 @@ def add_roles_to_recipe(recipe_path: Path):
     with open(recipe_path) as f:
         recipe = yaml.safe_load(f)
 
-    # Example: Add roles based on ingredient names
+    # Example: assign faceted roles by ingredient name.
     for ingredient in recipe.get('ingredients', []):
         name = ingredient['preferred_term'].lower()
 
         if 'glucose' in name:
-            ingredient['role'] = ['CARBON_SOURCE', 'ENERGY_SOURCE']
+            ingredient['nutritional_roles'] = ['CARBON_SOURCE', 'ENERGY_SOURCE']
+            ingredient['cellular_metabolic_roles'] = ['SUBSTRATE']
         elif 'kno3' in name or 'nitrate' in name:
-            ingredient['role'] = ['NITROGEN_SOURCE', 'ELECTRON_ACCEPTOR']
+            ingredient['nutritional_roles'] = ['NITROGEN_SOURCE']
+            ingredient['cellular_metabolic_roles'] = ['ELECTRON_ACCEPTOR']  # organism-conditional
         elif 'buffer' in name or 'phosphate' in name:
-            ingredient['role'] = ['BUFFER', 'MINERAL']
+            ingredient['nutritional_roles'] = ['PHOSPHATE_SOURCE']
+            ingredient['physicochemical_roles'] = ['BUFFER']
         # Add more mappings...
 
     # Write back
@@ -344,27 +347,30 @@ for recipe_file in recipe_dir.glob("*.yaml"):
 
 ```yaml
 - preferred_term: Glucose
-  role: [CARBON_SOURCE, ENERGY_SOURCE]
+  nutritional_roles: [CARBON_SOURCE, ENERGY_SOURCE]
+  cellular_metabolic_roles: [SUBSTRATE]
 
 - preferred_term: NH4Cl
-  role: [NITROGEN_SOURCE]
+  nutritional_roles: [NITROGEN_SOURCE]
 ```
 
 ### Pattern 2: Buffer System
 
 ```yaml
 - preferred_term: KH2PO4
-  role: [BUFFER, MINERAL]
+  nutritional_roles: [PHOSPHATE_SOURCE]
+  physicochemical_roles: [BUFFER]
 
 - preferred_term: Na2HPO4
-  role: [BUFFER, MINERAL]
+  nutritional_roles: [PHOSPHATE_SOURCE]
+  physicochemical_roles: [BUFFER]
 ```
 
 ### Pattern 3: Metal Cofactor Provider
 
 ```yaml
 - preferred_term: FeSO4
-  role: [TRACE_ELEMENT, COFACTOR_PROVIDER]
+  nutritional_roles: [IRON_SOURCE, SULFUR_SOURCE, COFACTOR_PROVIDER]
   cofactors_provided:
     - preferred_term: Iron(II) ion
       term:

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -18,11 +18,25 @@ just validate-all
 
 ## Field Reference
 
-### Ingredient.role (multivalued)
+### Ingredient roles — three orthogonal facet slots (all multivalued)
+
+The retired flat `role:` slot has been split into three orthogonal facets so
+a single ingredient can carry non-conflicting assignments across axes
+(e.g. L-cysteine → `AMINO_ACID_SOURCE + SULFUR_SOURCE` nutritionally,
+`REDUCING_AGENT` physicochemically, `SUBSTRATE` metabolically).
+
 ```yaml
-role: [CARBON_SOURCE, ENERGY_SOURCE]
+nutritional_roles: [CARBON_SOURCE, ENERGY_SOURCE]
+physicochemical_roles: [BUFFER]
+cellular_metabolic_roles: [SUBSTRATE]
+role_curie: [CHEBI:35225]        # escape hatch for out-of-vocabulary role terms
 ```
-Values: `CARBON_SOURCE`, `NITROGEN_SOURCE`, `MINERAL`, `TRACE_ELEMENT`, `BUFFER`, `VITAMIN_SOURCE`, `SALT`, `PROTEIN_SOURCE`, `AMINO_ACID_SOURCE`, `SOLIDIFYING_AGENT`, `ENERGY_SOURCE`, `ELECTRON_ACCEPTOR`, `ELECTRON_DONOR`, `COFACTOR_PROVIDER`
+
+- `nutritional_roles` (`NutritionalRoleEnum`, 12 values) — what element/macronutrient the ingredient supplies: `CARBON_SOURCE`, `NITROGEN_SOURCE`, `SULFUR_SOURCE`, `PHOSPHATE_SOURCE`, `IRON_SOURCE`, `TRACE_ELEMENT`, `VITAMIN_SOURCE`, `AMINO_ACID_SOURCE`, `PROTEIN_SOURCE`, `COFACTOR_PROVIDER`, `ENERGY_SOURCE`, `LIGHT_SOURCE`.
+- `physicochemical_roles` (`PhysicochemicalRoleEnum`, 12 values) — chemical/physical function: `BUFFER`, `SOLIDIFYING_AGENT`, `CHELATOR`, `SURFACTANT`, `REDUCING_AGENT`, `OXIDIZING_AGENT`, `PH_INDICATOR`, `REDOX_INDICATOR`, `SELECTIVE_AGENT`, `ANTIFOAM`, `OSMOTIC_AGENT`, `PRECIPITATION_INHIBITOR`.
+- `cellular_metabolic_roles` (`CellularMetabolicRoleEnum`, 10 values) — role inside/on the microbe (often organism-conditional): `SUBSTRATE`, `ELECTRON_DONOR`, `ELECTRON_ACCEPTOR`, `COFACTOR`, `PROSTHETIC_GROUP_PRECURSOR`, `MEMBRANE_COMPONENT`, `OSMOPROTECTANT`, `INDUCER`, `INHIBITOR`, `QUENCHER`.
+
+Enum vocabularies are vendored from MediaIngredientMech via `mim_roles.yaml`.
 
 ### Ingredient.cofactors_provided (multivalued)
 ```yaml
@@ -75,7 +89,8 @@ Values: `bacterial`, `fungal`, `archaea`, `specialized`, `algae`, `imported`
 ```yaml
 - preferred_term: Glucose
   concentration: {value: '10', unit: G_PER_L}
-  role: [CARBON_SOURCE]
+  nutritional_roles: [CARBON_SOURCE, ENERGY_SOURCE]
+  cellular_metabolic_roles: [SUBSTRATE]
 ```
 
 ### Full Ingredient Enrichment
@@ -83,7 +98,7 @@ Values: `bacterial`, `fungal`, `archaea`, `specialized`, `algae`, `imported`
 - preferred_term: MgSO4
   concentration: {value: '1', unit: G_PER_L}
   term: {id: CHEBI:31795, label: MgSO4}
-  role: [MINERAL, COFACTOR_PROVIDER]
+  nutritional_roles: [SULFUR_SOURCE, COFACTOR_PROVIDER]  # Mg is a cofactor cation, sulfate supplies sulfur
   cofactors_provided:
     - preferred_term: Magnesium ion
       term: {id: CHEBI:18420, label: magnesium(2+)}

--- a/scripts/build_media_content_review_manifest.py
+++ b/scripts/build_media_content_review_manifest.py
@@ -85,7 +85,10 @@ EXPECTED_INGREDIENT_KEYS = {
     "molecular_weight",
     "supplier_catalog",
     "notes",
-    "role",
+    "nutritional_roles",
+    "physicochemical_roles",
+    "cellular_metabolic_roles",
+    "role_curie",
     "cofactors_provided",
     "evidence",
 }

--- a/scripts/fix_schema_inconsistencies.py
+++ b/scripts/fix_schema_inconsistencies.py
@@ -76,7 +76,11 @@ def fix_ingredient_schema(ingredient: Dict) -> Dict:
         }
 
     # Copy other fields
-    for key in ['term', 'notes', 'role', 'chemical_formula', 'molecular_weight']:
+    for key in [
+        'term', 'notes',
+        'nutritional_roles', 'physicochemical_roles', 'cellular_metabolic_roles', 'role_curie',
+        'chemical_formula', 'molecular_weight',
+    ]:
         if key in ingredient and key not in fixed:
             fixed[key] = ingredient[key]
 

--- a/scripts/generate_hierarchy_report.py
+++ b/scripts/generate_hierarchy_report.py
@@ -87,14 +87,17 @@ class HierarchyReporter:
             variant_type = ingredient['variant_type']
             self.stats['variant_types'][variant_type] += 1
 
-        # Track roles
-        if 'role' in ingredient:
+        # Track role assignments across the three facet slots.
+        _tracked_any_role = False
+        for slot in ('nutritional_roles', 'physicochemical_roles', 'cellular_metabolic_roles'):
+            if slot in ingredient:
+                _tracked_any_role = True
+                roles = ingredient[slot]
+                if isinstance(roles, list):
+                    for role in roles:
+                        self.stats['roles'][f'{slot}:{role}'] += 1
+        if _tracked_any_role:
             self.stats['ingredients_with_roles'] += 1
-            roles = ingredient['role']
-
-            if isinstance(roles, list):
-                for role in roles:
-                    self.stats['roles'][role] += 1
         else:
             # Track unmatched ingredients
             if mim_id and 'parent_ingredient' not in ingredient:

--- a/scripts/propose_growth_evidence.py
+++ b/scripts/propose_growth_evidence.py
@@ -486,7 +486,16 @@ def find_snippet_for(text: str, needle: str) -> str | None:
 
 # ---------------- v2: perturbation / conditional-growth extraction ----------------
 
-def _normalize_role(raw: str) -> str:
+def _normalize_role(raw: str) -> str | None:
+    """Map free-text role hint to a NutritionalRoleEnum token, or None if no match.
+
+    NutrientOverride.role is typed against NutritionalRoleEnum (12 values,
+    element-supply concepts) after the Step 4b retirement of the flat
+    NutrientRoleEnum. Legacy hints like "electron" (formerly ELECTRON_DONOR)
+    and the OTHER fallback have no NutritionalRoleEnum equivalent — for
+    those, return None so callers skip the override rather than emit a
+    value that would fail schema validation.
+    """
     r = raw.strip().lower()
     return {
         "carbon": "CARBON_SOURCE",
@@ -494,8 +503,7 @@ def _normalize_role(raw: str) -> str:
         "sulfur": "SULFUR_SOURCE",
         "phosphate": "PHOSPHATE_SOURCE",
         "phosphorus": "PHOSPHATE_SOURCE",
-        "electron": "ELECTRON_DONOR",
-    }.get(r, "OTHER")
+    }.get(r)
 
 
 def _dedup_dicts(items: list[dict]) -> list[dict]:
@@ -713,8 +721,14 @@ def extract_nutrient_overrides(text: str) -> list[dict]:
             ).strip(" ,.;:-")
             if not source or len(source) < 2:
                 continue
+            role = _normalize_role(role_raw)
+            if role is None:
+                # Extractor caught a role hint (e.g. "electron") that has
+                # no valid NutritionalRoleEnum mapping. Skip the override
+                # rather than emit a value the schema will reject.
+                continue
             entry = {
-                "role": _normalize_role(role_raw),
+                "role": role,
                 "source": source,
                 "is_sole_source": True,
             }

--- a/scripts/validate_hierarchy_integration.py
+++ b/scripts/validate_hierarchy_integration.py
@@ -66,14 +66,30 @@ class HierarchyValidator:
             'NAMED_HYDRATE', 'CHEMICAL_VARIANT'
         }
 
-        # Valid roles from schema
-        self.valid_roles = {
-            'CARBON_SOURCE', 'NITROGEN_SOURCE', 'MINERAL',
-            'TRACE_ELEMENT', 'BUFFER', 'VITAMIN_SOURCE',
-            'SALT', 'PROTEIN_SOURCE', 'AMINO_ACID_SOURCE',
-            'SOLIDIFYING_AGENT', 'ENERGY_SOURCE',
-            'ELECTRON_ACCEPTOR', 'ELECTRON_DONOR',
-            'COFACTOR_PROVIDER'
+        # Valid role tokens across the three facet enums vendored from MIM
+        # (NutritionalRoleEnum / PhysicochemicalRoleEnum /
+        # CellularMetabolicRoleEnum). Kept as a hardcoded union rather than a
+        # SchemaView derivation because this script is a lightweight validator
+        # and shouldn't grow a LinkML-load dependency. If a facet enum gains a
+        # value upstream, this set needs updating alongside.
+        self.valid_role_by_slot = {
+            'nutritional_roles': {
+                'CARBON_SOURCE', 'NITROGEN_SOURCE', 'SULFUR_SOURCE',
+                'PHOSPHATE_SOURCE', 'IRON_SOURCE', 'TRACE_ELEMENT',
+                'VITAMIN_SOURCE', 'AMINO_ACID_SOURCE', 'PROTEIN_SOURCE',
+                'COFACTOR_PROVIDER', 'ENERGY_SOURCE', 'LIGHT_SOURCE',
+            },
+            'physicochemical_roles': {
+                'BUFFER', 'SOLIDIFYING_AGENT', 'CHELATOR', 'SURFACTANT',
+                'REDUCING_AGENT', 'OXIDIZING_AGENT', 'PH_INDICATOR',
+                'REDOX_INDICATOR', 'SELECTIVE_AGENT', 'ANTIFOAM',
+                'OSMOTIC_AGENT', 'PRECIPITATION_INHIBITOR',
+            },
+            'cellular_metabolic_roles': {
+                'SUBSTRATE', 'ELECTRON_DONOR', 'ELECTRON_ACCEPTOR',
+                'COFACTOR', 'PROSTHETIC_GROUP_PRECURSOR', 'MEMBRANE_COMPONENT',
+                'OSMOPROTECTANT', 'INDUCER', 'INHIBITOR', 'QUENCHER',
+            },
         }
 
     def validate_ingredient(
@@ -171,32 +187,37 @@ class HierarchyValidator:
             else:
                 self.stats['valid_variant_types'] += 1
 
-        # Check role field
-        if 'role' in ingredient:
+        # Check the three facet role slots (nutritional/physicochemical/
+        # cellular_metabolic). Each slot has its own valid-value set; a value
+        # in the wrong facet is a validation error.
+        for slot, valid_values in self.valid_role_by_slot.items():
+            if slot not in ingredient:
+                continue
             self.stats['ingredients_with_roles'] += 1
-            roles = ingredient['role']
-
+            roles = ingredient[slot]
             if not isinstance(roles, list):
                 issues.append({
                     'type': 'invalid_role_structure',
                     'recipe': recipe_name,
                     'ingredient': ingredient_name,
-                    'message': 'role must be a list'
+                    'slot': slot,
+                    'message': f'{slot} must be a list'
                 })
-            else:
-                for role in roles:
-                    if role not in self.valid_roles:
-                        issues.append({
-                            'type': 'invalid_role_value',
-                            'recipe': recipe_name,
-                            'ingredient': ingredient_name,
-                            'role': role,
-                            'message': f'Invalid role: {role}',
-                            'valid_values': list(self.valid_roles)
-                        })
-                        self.stats['invalid_roles'] += 1
-                    else:
-                        self.stats['valid_roles'] += 1
+                continue
+            for role in roles:
+                if role not in valid_values:
+                    issues.append({
+                        'type': 'invalid_role_value',
+                        'recipe': recipe_name,
+                        'ingredient': ingredient_name,
+                        'slot': slot,
+                        'role': role,
+                        'message': f'Invalid {slot} value: {role}',
+                        'valid_values': sorted(valid_values),
+                    })
+                    self.stats['invalid_roles'] += 1
+                else:
+                    self.stats['valid_roles'] += 1
 
         return issues
 

--- a/src/culturemech/enrich/role_importer.py
+++ b/src/culturemech/enrich/role_importer.py
@@ -141,12 +141,6 @@ class RoleImporter:
         Returns:
             True if roles were added, False otherwise
         """
-        # Skip if any facet role slot is already populated (curator or a
-        # prior import pass wrote something — never overwrite).
-        if any(slot in ingredient for slot in FACET_ROLE_SLOTS):
-            self.stats['already_has_role'] += 1
-            return False
-
         # Get MediaIngredientMech ID
         mim_term = ingredient.get('mediaingredientmech_term')
         if not mim_term:
@@ -194,11 +188,30 @@ class RoleImporter:
             self.stats['no_roles_found'] += 1
             return False
 
+        # Per-slot "never overwrite" — matches import_ingredient_roles.py:
+        # if a curator already populated `physicochemical_roles`, we still
+        # add to `nutritional_roles` if that facet is untouched. Skip
+        # per-facet rather than skip the whole ingredient.
+        assigned = 0
+        skipped_any = False
         for slot, values in bucketed.items():
+            if slot in ingredient:
+                skipped_any = True
+                continue
             ingredient[slot] = values
+            assigned += len(values)
+
+        if assigned == 0:
+            self.stats['already_has_role'] += 1
+            return False
+
+        if skipped_any:
+            # Partial-write case: at least one slot was already populated
+            # (respected) but at least one other slot got new values.
+            self.stats['already_has_role'] += 1
 
         self.stats['ingredients_assigned'] += 1
-        self.stats['roles_assigned'] += sum(len(v) for v in bucketed.values())
+        self.stats['roles_assigned'] += assigned
 
         return True
 

--- a/src/culturemech/enrich/role_importer.py
+++ b/src/culturemech/enrich/role_importer.py
@@ -9,6 +9,35 @@ import yaml
 logger = logging.getLogger(__name__)
 
 
+# Legacy MIM `ingredient_roles.yaml` uses the retired flat vocabulary
+# (MINERAL / SALT / BUFFER / …). Map each legacy token to the faceted
+# slot + enum value that replaced it, following the same conventions as
+# `import/import_ingredient_roles.py`:
+# - "mineral" has no direct nutritional equivalent → TRACE_ELEMENT catch-all.
+# - "salt" has no nutritional equivalent → PhysicochemicalRoleEnum.OSMOTIC_AGENT.
+# - ELECTRON_DONOR / ELECTRON_ACCEPTOR / ENERGY_SOURCE / COFACTOR_PROVIDER
+#   in the legacy vocabulary spanned multiple facets; the mapping picks the
+#   most-common facet interpretation. Curators can refine post-import.
+_LEGACY_TOKEN_TO_FACET = {
+    "CARBON_SOURCE":     ("nutritional_roles",     "CARBON_SOURCE"),
+    "NITROGEN_SOURCE":   ("nutritional_roles",     "NITROGEN_SOURCE"),
+    "MINERAL":           ("nutritional_roles",     "TRACE_ELEMENT"),
+    "TRACE_ELEMENT":     ("nutritional_roles",     "TRACE_ELEMENT"),
+    "VITAMIN_SOURCE":    ("nutritional_roles",     "VITAMIN_SOURCE"),
+    "PROTEIN_SOURCE":    ("nutritional_roles",     "PROTEIN_SOURCE"),
+    "AMINO_ACID_SOURCE": ("nutritional_roles",     "AMINO_ACID_SOURCE"),
+    "ENERGY_SOURCE":     ("nutritional_roles",     "ENERGY_SOURCE"),
+    "COFACTOR_PROVIDER": ("nutritional_roles",     "COFACTOR_PROVIDER"),
+    "BUFFER":            ("physicochemical_roles", "BUFFER"),
+    "SALT":              ("physicochemical_roles", "OSMOTIC_AGENT"),
+    "SOLIDIFYING_AGENT": ("physicochemical_roles", "SOLIDIFYING_AGENT"),
+    "ELECTRON_DONOR":    ("cellular_metabolic_roles", "ELECTRON_DONOR"),
+    "ELECTRON_ACCEPTOR": ("cellular_metabolic_roles", "ELECTRON_ACCEPTOR"),
+}
+
+FACET_ROLE_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+
 class RoleImporter:
     """Import ingredient role assignments from MediaIngredientMech."""
 
@@ -112,8 +141,9 @@ class RoleImporter:
         Returns:
             True if roles were added, False otherwise
         """
-        # Skip if already has role field
-        if 'role' in ingredient:
+        # Skip if any facet role slot is already populated (curator or a
+        # prior import pass wrote something — never overwrite).
+        if any(slot in ingredient for slot in FACET_ROLE_SLOTS):
             self.stats['already_has_role'] += 1
             return False
 
@@ -143,11 +173,32 @@ class RoleImporter:
             self.stats['no_roles_found'] += 1
             return False
 
-        # Add role field
-        ingredient['role'] = roles
+        # Bucket legacy tokens into faceted role slots. Tokens that don't
+        # map to any facet are dropped (previously they'd go into `role:`
+        # unfiltered; now the schema wouldn't accept them).
+        bucketed: Dict[str, List[str]] = {}
+        for token in roles:
+            mapping = _LEGACY_TOKEN_TO_FACET.get(token)
+            if mapping is None:
+                logger.warning(
+                    "Legacy role token %r has no faceted-slot mapping; dropping for ingredient %r",
+                    token, ingredient.get('preferred_term', 'unknown'),
+                )
+                continue
+            slot, facet_value = mapping
+            slot_list = bucketed.setdefault(slot, [])
+            if facet_value not in slot_list:
+                slot_list.append(facet_value)
+
+        if not bucketed:
+            self.stats['no_roles_found'] += 1
+            return False
+
+        for slot, values in bucketed.items():
+            ingredient[slot] = values
 
         self.stats['ingredients_assigned'] += 1
-        self.stats['roles_assigned'] += len(roles)
+        self.stats['roles_assigned'] += sum(len(v) for v in bucketed.values())
 
         return True
 

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -284,16 +284,20 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: Dict) -> Optional[
                 "qualifier_value": f"{val} {unit}"
             })
 
-    # Add role if present
-    roles = ingredient.get("role")
-    if roles:
-        if isinstance(roles, list):
-            roles_str = ", ".join(roles)
+    # Combine role tokens across the three facet slots (facet vocabulary
+    # replaced the retired flat `role: IngredientRoleEnum` slot). Preserves
+    # the biolink:role qualifier surface while sourcing from the new schema.
+    roles = []
+    for slot in ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles"):
+        slot_values = ingredient.get(slot) or []
+        if isinstance(slot_values, list):
+            roles.extend(slot_values)
         else:
-            roles_str = roles
+            roles.append(slot_values)
+    if roles:
         qualifiers.append({
             "qualifier_type_id": "biolink:role",
-            "qualifier_value": roles_str
+            "qualifier_value": ", ".join(roles)
         })
 
     return _make_association(
@@ -335,16 +339,20 @@ def medium_to_ingredient_edge(medium_id: str, ingredient: Dict) -> Optional[dict
                 "qualifier_value": f"{val} {unit}"
             })
 
-    # Add role if present
-    roles = ingredient.get("role")
-    if roles:
-        if isinstance(roles, list):
-            roles_str = ", ".join(roles)
+    # Combine role tokens across the three facet slots (facet vocabulary
+    # replaced the retired flat `role: IngredientRoleEnum` slot). Preserves
+    # the biolink:role qualifier surface while sourcing from the new schema.
+    roles = []
+    for slot in ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles"):
+        slot_values = ingredient.get(slot) or []
+        if isinstance(slot_values, list):
+            roles.extend(slot_values)
         else:
-            roles_str = roles
+            roles.append(slot_values)
+    if roles:
         qualifiers.append({
             "qualifier_type_id": "biolink:role",
-            "qualifier_value": roles_str
+            "qualifier_value": ", ".join(roles)
         })
 
     pubs, _ = _format_evidence(ingredient.get("evidence"))

--- a/src/culturemech/import/import_ingredient_roles.py
+++ b/src/culturemech/import/import_ingredient_roles.py
@@ -13,48 +13,72 @@ from culturemech.curate.curation_event import record_curation_event
 PFAS_REPO = Path("/Users/marcin/Documents/VIMSS/ontology/PFAS/PFASCommunityAgents")
 INGREDIENT_FILE = PFAS_REPO / "data/sheets_pfas/PFAS_Data_for_AI_media_ingredients_extended.tsv"
 
-# Map PFAS roles to CultureMech IngredientRoleEnum values
+# Map PFAS role tokens (lowercase source values) to CultureMech faceted role
+# assignments. Each entry is (slot_name, enum_value_token) — the writer
+# below buckets assignments by slot when populating an IngredientDescriptor.
+#
+# Facet decisions:
+# - carbon/nitrogen/vitamin/protein/amino-acid → NutritionalRoleEnum values
+#   (nutritional_roles slot).
+# - buffer/solidifying → PhysicochemicalRoleEnum values (physicochemical_roles).
+# - "mineral" has no direct NutritionalRoleEnum equivalent; mapped to
+#   TRACE_ELEMENT as the broadest catch-all. Curators should refine to
+#   PHOSPHATE_SOURCE / IRON_SOURCE / SULFUR_SOURCE where applicable.
+# - "salt" has no NutritionalRoleEnum equivalent (salts contribute ionic
+#   strength / osmotic pressure, not elemental supply); mapped to
+#   PhysicochemicalRoleEnum.OSMOTIC_AGENT.
 ROLE_MAPPING = {
-    "carbon source": "CARBON_SOURCE",
-    "nitrogen source": "NITROGEN_SOURCE",
-    "mineral": "MINERAL",
-    "buffer": "BUFFER",
-    "trace element": "TRACE_ELEMENT",
-    "vitamin source": "VITAMIN_SOURCE",
-    "salt": "SALT",
-    "protein source": "PROTEIN_SOURCE",
-    "amino acid source": "AMINO_ACID_SOURCE",
-    "solidifying agent": "SOLIDIFYING_AGENT",
+    "carbon source":      ("nutritional_roles",     "CARBON_SOURCE"),
+    "nitrogen source":    ("nutritional_roles",     "NITROGEN_SOURCE"),
+    "mineral":            ("nutritional_roles",     "TRACE_ELEMENT"),
+    "trace element":      ("nutritional_roles",     "TRACE_ELEMENT"),
+    "vitamin source":     ("nutritional_roles",     "VITAMIN_SOURCE"),
+    "protein source":     ("nutritional_roles",     "PROTEIN_SOURCE"),
+    "amino acid source":  ("nutritional_roles",     "AMINO_ACID_SOURCE"),
+    "buffer":             ("physicochemical_roles", "BUFFER"),
+    "salt":               ("physicochemical_roles", "OSMOTIC_AGENT"),
+    "solidifying agent":  ("physicochemical_roles", "SOLIDIFYING_AGENT"),
 }
 
 
 def load_ingredient_roles():
-    """Load ingredient roles from PFAS TSV."""
+    """Load ingredient roles from PFAS TSV.
+
+    Returns:
+        dict[chebi_id, dict[slot_name, list[enum_value]]] — a per-CHEBI
+        bucket keyed by faceted-slot name.
+    """
     if not INGREDIENT_FILE.exists():
         print(f"Warning: PFAS data file not found at {INGREDIENT_FILE}")
         return {}
 
-    roles_db = {}
+    roles_db: dict[str, dict[str, list[str]]] = {}
 
     with open(INGREDIENT_FILE) as f:
         reader = csv.DictReader(f, delimiter='\t')
         for row in reader:
             chebi_id = row.get('ontology_id', '').strip()
             role_raw = row.get('role', '').strip()
-            role_enum = ROLE_MAPPING.get(role_raw)
+            mapping = ROLE_MAPPING.get(role_raw)
 
-            if chebi_id and role_enum:
-                if chebi_id not in roles_db:
-                    roles_db[chebi_id] = []
-                if role_enum not in roles_db[chebi_id]:
-                    roles_db[chebi_id].append(role_enum)
+            if chebi_id and mapping:
+                slot, enum_value = mapping
+                slot_bucket = roles_db.setdefault(chebi_id, {})
+                slot_bucket.setdefault(slot, [])
+                if enum_value not in slot_bucket[slot]:
+                    slot_bucket[slot].append(enum_value)
 
-    print(f"Loaded {len(roles_db)} ingredient role mappings")
+    print(f"Loaded facet role mappings for {len(roles_db)} ingredients")
     return roles_db
 
 
 def enrich_recipe_with_roles(recipe_path: Path, roles_db: dict, dry_run: bool = False):
-    """Add role annotations to ingredients in a recipe."""
+    """Add faceted role annotations to ingredients in a recipe.
+
+    Writes to `nutritional_roles` / `physicochemical_roles` per the ROLE_MAPPING
+    facet assignment. Skips an ingredient's slot if the slot is already set on
+    that ingredient (never overwrites curator assignments).
+    """
     with open(recipe_path) as f:
         recipe = yaml.safe_load(f)
 
@@ -65,10 +89,15 @@ def enrich_recipe_with_roles(recipe_path: Path, roles_db: dict, dry_run: bool = 
         term = ingredient.get('term', {})
         chebi_id = term.get('id')
 
-        if chebi_id in roles_db and 'role' not in ingredient:
-            ingredient['role'] = roles_db[chebi_id]
-            modified = True
-            changes.append(f"  Added roles {roles_db[chebi_id]} to {ingredient.get('preferred_term', 'unknown')}")
+        if chebi_id in roles_db:
+            for slot, enum_values in roles_db[chebi_id].items():
+                if slot in ingredient:
+                    continue  # never overwrite existing assignments
+                ingredient[slot] = list(enum_values)
+                modified = True
+                changes.append(
+                    f"  Added {slot}={enum_values} to {ingredient.get('preferred_term', 'unknown')}"
+                )
 
     if modified:
         if not dry_run:

--- a/src/culturemech/schema/culturemech.schema.json
+++ b/src/culturemech/schema/culturemech.schema.json
@@ -1205,16 +1205,6 @@
                     "description": "Human-readable ingredient name (e.g., \"Glucose\", \"Yeast Extract\")",
                     "type": "string"
                 },
-                "role": {
-                    "description": "Functional role(s) in the medium (legacy flat vocabulary). Deprecated in favor of the three faceted slots below (`nutritional_roles`, `physicochemical_roles`, `cellular_metabolic_roles`). Retained for backward-compatibility during the migration; a follow-up PR will retire this slot and rewrite any records that use it.",
-                    "items": {
-                        "$ref": "#/$defs/IngredientRoleEnum"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
                 "role_curie": {
                     "description": "Escape-hatch CURIE(s) for out-of-vocabulary role terms not covered by the three facet enums. Should resolve within a recognized role namespace (CHEBI role subtree under CHEBI:50906, METPO, ENVO, GO, PATO, NCIT). Use sparingly \u2014 prefer a facet enum value where one fits.",
                     "items": {
@@ -1297,27 +1287,6 @@
             ],
             "title": "IngredientReference",
             "type": "object"
-        },
-        "IngredientRoleEnum": {
-            "description": "Functional role of an ingredient in growth medium",
-            "enum": [
-                "CARBON_SOURCE",
-                "NITROGEN_SOURCE",
-                "MINERAL",
-                "TRACE_ELEMENT",
-                "BUFFER",
-                "VITAMIN_SOURCE",
-                "SALT",
-                "PROTEIN_SOURCE",
-                "AMINO_ACID_SOURCE",
-                "SOLIDIFYING_AGENT",
-                "ENERGY_SOURCE",
-                "ELECTRON_ACCEPTOR",
-                "ELECTRON_DONOR",
-                "COFACTOR_PROVIDER"
-            ],
-            "title": "IngredientRoleEnum",
-            "type": "string"
         },
         "IngredientSynonym": {
             "additionalProperties": false,
@@ -2189,8 +2158,8 @@
                     ]
                 },
                 "role": {
-                    "$ref": "#/$defs/NutrientRoleEnum",
-                    "description": "Functional role the override fills in the experiment."
+                    "$ref": "#/$defs/NutritionalRoleEnum",
+                    "description": "Functional role the override supplies to the experiment (e.g. CARBON_SOURCE, NITROGEN_SOURCE, SULFUR_SOURCE, PHOSPHATE_SOURCE). Retargeted from the retired NutrientRoleEnum to the MIM-imported NutritionalRoleEnum (which is broader \u2014 12 values covering all macronutrient / vitamin / cofactor supply categories). Values that used to fit under NutrientRoleEnum but not NutritionalRoleEnum (ELECTRON_DONOR, ELECTRON_ACCEPTOR) belong on the cellular-metabolic facet of the *ingredient* the override supplies, not on the override itself."
                 },
                 "source": {
                     "description": "e.g. \"succinate\", \"L-phenylalanine\", \"acetate\".",
@@ -2203,21 +2172,6 @@
             ],
             "title": "NutrientOverride",
             "type": "object"
-        },
-        "NutrientRoleEnum": {
-            "description": "Functional role a NutrientOverride source fills in the experiment (carbon, nitrogen, electron donor/acceptor, etc.).",
-            "enum": [
-                "CARBON_SOURCE",
-                "NITROGEN_SOURCE",
-                "SULFUR_SOURCE",
-                "PHOSPHATE_SOURCE",
-                "ELECTRON_DONOR",
-                "ELECTRON_ACCEPTOR",
-                "LIGHT_SOURCE",
-                "OTHER"
-            ],
-            "title": "NutrientRoleEnum",
-            "type": "string"
         },
         "NutritionalRoleEnum": {
             "description": "What element or macronutrient an ingredient supplies to the medium. One of three orthogonal role facets (with PhysicochemicalRoleEnum and CellularMetabolicRoleEnum). A single ingredient may carry multiple nutritional roles (e.g. L-cysteine supplies both amino-acid and sulfur).",

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -826,17 +826,6 @@ classes:
         description: Preparation notes specific to this ingredient
         range: string
 
-      role:
-        description: >-
-          Functional role(s) in the medium (legacy flat vocabulary).
-          Deprecated in favor of the three faceted slots below
-          (`nutritional_roles`, `physicochemical_roles`,
-          `cellular_metabolic_roles`). Retained for backward-compatibility
-          during the migration; a follow-up PR will retire this slot and
-          rewrite any records that use it.
-        range: IngredientRoleEnum
-        multivalued: true
-
       nutritional_roles:
         description: >-
           What element or macronutrient this ingredient supplies to the
@@ -1422,8 +1411,17 @@ classes:
       substitution at observation time.
     attributes:
       role:
-        description: Functional role the override fills in the experiment.
-        range: NutrientRoleEnum
+        description: >-
+          Functional role the override supplies to the experiment (e.g.
+          CARBON_SOURCE, NITROGEN_SOURCE, SULFUR_SOURCE, PHOSPHATE_SOURCE).
+          Retargeted from the retired NutrientRoleEnum to the MIM-imported
+          NutritionalRoleEnum (which is broader — 12 values covering all
+          macronutrient / vitamin / cofactor supply categories). Values
+          that used to fit under NutrientRoleEnum but not NutritionalRoleEnum
+          (ELECTRON_DONOR, ELECTRON_ACCEPTOR) belong on the cellular-metabolic
+          facet of the *ingredient* the override supplies, not on the
+          override itself.
+        range: NutritionalRoleEnum
         required: true
 
       source:
@@ -2265,38 +2263,6 @@ enums:
       community:
         description: Mixed/consortium culture of multiple organisms
 
-  IngredientRoleEnum:
-    description: Functional role of an ingredient in growth medium
-    permissible_values:
-      CARBON_SOURCE:
-        description: Primary carbon source for metabolism
-      NITROGEN_SOURCE:
-        description: Nitrogen source for biomass synthesis
-      MINERAL:
-        description: Mineral nutrient (major element)
-      TRACE_ELEMENT:
-        description: Trace element or micronutrient
-      BUFFER:
-        description: pH buffering agent
-      VITAMIN_SOURCE:
-        description: Provides vitamins or vitamin precursors
-      SALT:
-        description: Salt for osmotic balance or ionic strength
-      PROTEIN_SOURCE:
-        description: Complex protein source (e.g., peptone, casein)
-      AMINO_ACID_SOURCE:
-        description: Provides amino acids
-      SOLIDIFYING_AGENT:
-        description: Gelling agent (e.g., agar)
-      ENERGY_SOURCE:
-        description: Energy source (often overlaps with carbon source)
-      ELECTRON_ACCEPTOR:
-        description: Terminal electron acceptor for respiration
-      ELECTRON_DONOR:
-        description: Electron donor for chemolithotrophs
-      COFACTOR_PROVIDER:
-        description: Supplies essential cofactors or their precursors
-
   CofactorCategoryEnum:
     description: High-level classification of cofactor types
     permissible_values:
@@ -2525,28 +2491,6 @@ enums:
         description: Serial selection / experimental evolution producing a stable phenotype.
       SELECTION:
         description: Strain isolated by selective pressure (e.g. plate selection, enrichment).
-      OTHER:
-        description: Use sparingly; prefer a more specific value above.
-
-  NutrientRoleEnum:
-    description: >-
-      Functional role a NutrientOverride source fills in the experiment
-      (carbon, nitrogen, electron donor/acceptor, etc.).
-    permissible_values:
-      CARBON_SOURCE:
-        description: Sole or dominant carbon source.
-      NITROGEN_SOURCE:
-        description: Sole or dominant nitrogen source.
-      SULFUR_SOURCE:
-        description: Sole or dominant sulfur source.
-      PHOSPHATE_SOURCE:
-        description: Sole or dominant phosphorus source.
-      ELECTRON_DONOR:
-        description: Substrate oxidized for energy.
-      ELECTRON_ACCEPTOR:
-        description: Terminal acceptor for respiratory electron flow.
-      LIGHT_SOURCE:
-        description: For phototrophs — captures light intensity / wavelength as nutrient.
       OTHER:
         description: Use sparingly; prefer a more specific value above.
 

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-19T21:47:10
+# Generation date: 2026-07-20T09:29:02
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -709,7 +709,6 @@ class IngredientDescriptor(Descriptor):
     molecular_weight: Optional[float] = None
     supplier_catalog: Optional[Union[dict, "SupplierInfo"]] = None
     notes: Optional[str] = None
-    role: Optional[Union[Union[str, "IngredientRoleEnum"], list[Union[str, "IngredientRoleEnum"]]]] = empty_list()
     nutritional_roles: Optional[Union[Union[str, "NutritionalRoleEnum"], list[Union[str, "NutritionalRoleEnum"]]]] = empty_list()
     physicochemical_roles: Optional[Union[Union[str, "PhysicochemicalRoleEnum"], list[Union[str, "PhysicochemicalRoleEnum"]]]] = empty_list()
     cellular_metabolic_roles: Optional[Union[Union[str, "CellularMetabolicRoleEnum"], list[Union[str, "CellularMetabolicRoleEnum"]]]] = empty_list()
@@ -775,10 +774,6 @@ class IngredientDescriptor(Descriptor):
 
         if self.notes is not None and not isinstance(self.notes, str):
             self.notes = str(self.notes)
-
-        if not isinstance(self.role, list):
-            self.role = [self.role] if self.role is not None else []
-        self.role = [v if isinstance(v, IngredientRoleEnum) else IngredientRoleEnum(v) for v in self.role]
 
         if not isinstance(self.nutritional_roles, list):
             self.nutritional_roles = [self.nutritional_roles] if self.nutritional_roles is not None else []
@@ -1383,7 +1378,7 @@ class NutrientOverride(YAMLRoot):
     class_name: ClassVar[str] = "NutrientOverride"
     class_model_uri: ClassVar[URIRef] = CULTUREMECH.NutrientOverride
 
-    role: Union[str, "NutrientRoleEnum"] = None
+    role: Union[str, "NutritionalRoleEnum"] = None
     source: str = None
     ontology_id: Optional[str] = None
     is_sole_source: Optional[Union[bool, Bool]] = None
@@ -1392,8 +1387,8 @@ class NutrientOverride(YAMLRoot):
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.role):
             self.MissingRequiredField("role")
-        if not isinstance(self.role, NutrientRoleEnum):
-            self.role = NutrientRoleEnum(self.role)
+        if not isinstance(self.role, NutritionalRoleEnum):
+            self.role = NutritionalRoleEnum(self.role)
 
         if self._is_empty(self.source):
             self.MissingRequiredField("source")
@@ -2896,58 +2891,6 @@ class OrganismCultureTypeEnum(EnumDefinitionImpl):
         description="Whether the medium targets a pure isolate or a mixed microbial community",
     )
 
-class IngredientRoleEnum(EnumDefinitionImpl):
-    """
-    Functional role of an ingredient in growth medium
-    """
-    CARBON_SOURCE = PermissibleValue(
-        text="CARBON_SOURCE",
-        description="Primary carbon source for metabolism")
-    NITROGEN_SOURCE = PermissibleValue(
-        text="NITROGEN_SOURCE",
-        description="Nitrogen source for biomass synthesis")
-    MINERAL = PermissibleValue(
-        text="MINERAL",
-        description="Mineral nutrient (major element)")
-    TRACE_ELEMENT = PermissibleValue(
-        text="TRACE_ELEMENT",
-        description="Trace element or micronutrient")
-    BUFFER = PermissibleValue(
-        text="BUFFER",
-        description="pH buffering agent")
-    VITAMIN_SOURCE = PermissibleValue(
-        text="VITAMIN_SOURCE",
-        description="Provides vitamins or vitamin precursors")
-    SALT = PermissibleValue(
-        text="SALT",
-        description="Salt for osmotic balance or ionic strength")
-    PROTEIN_SOURCE = PermissibleValue(
-        text="PROTEIN_SOURCE",
-        description="Complex protein source (e.g., peptone, casein)")
-    AMINO_ACID_SOURCE = PermissibleValue(
-        text="AMINO_ACID_SOURCE",
-        description="Provides amino acids")
-    SOLIDIFYING_AGENT = PermissibleValue(
-        text="SOLIDIFYING_AGENT",
-        description="Gelling agent (e.g., agar)")
-    ENERGY_SOURCE = PermissibleValue(
-        text="ENERGY_SOURCE",
-        description="Energy source (often overlaps with carbon source)")
-    ELECTRON_ACCEPTOR = PermissibleValue(
-        text="ELECTRON_ACCEPTOR",
-        description="Terminal electron acceptor for respiration")
-    ELECTRON_DONOR = PermissibleValue(
-        text="ELECTRON_DONOR",
-        description="Electron donor for chemolithotrophs")
-    COFACTOR_PROVIDER = PermissibleValue(
-        text="COFACTOR_PROVIDER",
-        description="Supplies essential cofactors or their precursors")
-
-    _defn = EnumDefinition(
-        name="IngredientRoleEnum",
-        description="Functional role of an ingredient in growth medium",
-    )
-
 class CofactorCategoryEnum(EnumDefinitionImpl):
     """
     High-level classification of cofactor types
@@ -3316,41 +3259,6 @@ class StrainModificationTypeEnum(EnumDefinitionImpl):
     _defn = EnumDefinition(
         name="StrainModificationTypeEnum",
         description="""Class of genetic or selection-derived modification carried by a strain relative to the wild-type or type strain.""",
-    )
-
-class NutrientRoleEnum(EnumDefinitionImpl):
-    """
-    Functional role a NutrientOverride source fills in the experiment (carbon, nitrogen, electron donor/acceptor,
-    etc.).
-    """
-    CARBON_SOURCE = PermissibleValue(
-        text="CARBON_SOURCE",
-        description="Sole or dominant carbon source.")
-    NITROGEN_SOURCE = PermissibleValue(
-        text="NITROGEN_SOURCE",
-        description="Sole or dominant nitrogen source.")
-    SULFUR_SOURCE = PermissibleValue(
-        text="SULFUR_SOURCE",
-        description="Sole or dominant sulfur source.")
-    PHOSPHATE_SOURCE = PermissibleValue(
-        text="PHOSPHATE_SOURCE",
-        description="Sole or dominant phosphorus source.")
-    ELECTRON_DONOR = PermissibleValue(
-        text="ELECTRON_DONOR",
-        description="Substrate oxidized for energy.")
-    ELECTRON_ACCEPTOR = PermissibleValue(
-        text="ELECTRON_ACCEPTOR",
-        description="Terminal acceptor for respiratory electron flow.")
-    LIGHT_SOURCE = PermissibleValue(
-        text="LIGHT_SOURCE",
-        description="For phototrophs — captures light intensity / wavelength as nutrient.")
-    OTHER = PermissibleValue(
-        text="OTHER",
-        description="Use sparingly; prefer a more specific value above.")
-
-    _defn = EnumDefinition(
-        name="NutrientRoleEnum",
-        description="""Functional role a NutrientOverride source fills in the experiment (carbon, nitrogen, electron donor/acceptor, etc.).""",
     )
 
 class GrowthModeEnum(EnumDefinitionImpl):
@@ -4204,9 +4112,6 @@ slots.ingredientDescriptor__supplier_catalog = Slot(uri=CULTUREMECH.supplier_cat
 slots.ingredientDescriptor__notes = Slot(uri=CULTUREMECH.notes, name="ingredientDescriptor__notes", curie=CULTUREMECH.curie('notes'),
                    model_uri=CULTUREMECH.ingredientDescriptor__notes, domain=None, range=Optional[str])
 
-slots.ingredientDescriptor__role = Slot(uri=CULTUREMECH.role, name="ingredientDescriptor__role", curie=CULTUREMECH.curie('role'),
-                   model_uri=CULTUREMECH.ingredientDescriptor__role, domain=None, range=Optional[Union[Union[str, "IngredientRoleEnum"], list[Union[str, "IngredientRoleEnum"]]]])
-
 slots.ingredientDescriptor__nutritional_roles = Slot(uri=CULTUREMECH.nutritional_roles, name="ingredientDescriptor__nutritional_roles", curie=CULTUREMECH.curie('nutritional_roles'),
                    model_uri=CULTUREMECH.ingredientDescriptor__nutritional_roles, domain=None, range=Optional[Union[Union[str, "NutritionalRoleEnum"], list[Union[str, "NutritionalRoleEnum"]]]])
 
@@ -4467,7 +4372,7 @@ slots.strainModification__evidence = Slot(uri=CULTUREMECH.evidence, name="strain
                    model_uri=CULTUREMECH.strainModification__evidence, domain=None, range=Optional[Union[dict[Union[str, EvidenceItemReference], Union[dict, EvidenceItem]], list[Union[dict, EvidenceItem]]]])
 
 slots.nutrientOverride__role = Slot(uri=CULTUREMECH.role, name="nutrientOverride__role", curie=CULTUREMECH.curie('role'),
-                   model_uri=CULTUREMECH.nutrientOverride__role, domain=None, range=Union[str, "NutrientRoleEnum"])
+                   model_uri=CULTUREMECH.nutrientOverride__role, domain=None, range=Union[str, "NutritionalRoleEnum"])
 
 slots.nutrientOverride__source = Slot(uri=CULTUREMECH.source, name="nutrientOverride__source", curie=CULTUREMECH.curie('source'),
                    model_uri=CULTUREMECH.nutrientOverride__source, domain=None, range=str)


### PR DESCRIPTION
## Summary

Completes the CultureMech schema surface migration begun in #93. Deletes the deprecated flat role vocabulary and retargets all readers/writers to the three faceted role slots vendored from MIM.

## Schema

- **Retarget `NutrientOverride.role`**: `NutrientRoleEnum` → `NutritionalRoleEnum` (imported from `mim_roles`). NutritionalRoleEnum (12 values) covers both existing corpus entries — `NITROGEN_SOURCE` (rhodobacter_sphaeroides_medium.yaml:257) and `CARBON_SOURCE` (pyrococcus_medium.yaml:385). ELECTRON_DONOR / ELECTRON_ACCEPTOR / OTHER are unused in the corpus.
- **Delete deprecated `IngredientDescriptor.role`** slot (marked deprecated in #93). Zero corpus records populate it.
- **Delete local `IngredientRoleEnum`** (14 values).
- **Delete local `NutrientRoleEnum`** (8 values).

Zero corpus rewrites needed.

## Python consumers migrated

| File | Change |
| ---- | ------ |
| `src/culturemech/import/import_ingredient_roles.py` | ROLE_MAPPING rewritten as `(slot, enum_value)` tuples; writer buckets by facet slot; MINERAL→TRACE_ELEMENT, SALT→OSMOTIC_AGENT catch-alls. |
| `src/culturemech/enrich/role_importer.py` | New `_LEGACY_TOKEN_TO_FACET` map (13 legacy tokens → facet slot + value). `apply_roles_to_ingredient` buckets writes and guards against overwriting any of the three facet slots. |
| `src/culturemech/export/kgx_export.py` (×2 sites) | biolink:role qualifier combines tokens across all three facet slots. |
| `scripts/propose_growth_evidence.py` | `_normalize_role()` now returns `Optional[str]`; caller skips overrides with no NutritionalRoleEnum match. "electron" hint no longer maps to ELECTRON_DONOR. |
| `scripts/validate_hierarchy_integration.py` | Single 14-token `valid_roles` set replaced with per-slot `valid_role_by_slot` covering the three facet enums. Validator reports slot-scoped errors. |
| `scripts/generate_hierarchy_report.py` | Role histogram keys now `{slot}:{value}`. |
| `scripts/fix_schema_inconsistencies.py`, `scripts/build_media_content_review_manifest.py` | Field allow-lists swap `role` for the four new facet slots + `role_curie`. |

## Skipped / deferred

- `src/culturemech/taxonomy/classifier.py:241,263` — dead code (checks title-case English `'Carbon source'`, never matched enum tokens). Silent no-op post-deletion; separate cleanup PR.
- `docs/QUICK_REFERENCE.md`, `docs/ENRICHMENT_GUIDE.md` — several `role: [CARBON_SOURCE, ...]` YAML examples using the retired flat vocab. Deferred to a docs-refresh PR (analogous to MIM #133 and CultureMech #122).
- `data/import_tracking/*.md` — stale historical notes referencing "MICRONUTRIENT" etc. Harmless.

## Test plan

- [x] `uv run linkml-validate --schema src/culturemech/schema/culturemech.yaml` — clean
- [x] `uv run gen-python` + `uv run gen-json-schema` — clean regen (no stdout leak)
- [x] `uv run pytest tests/ --ignore=tests/test_media_variant_links.py` — 163 passed / 14 failed / 15 skipped, identical to origin/main baseline. Zero new failures.
- [x] Grep of generated files for `IngredientRoleEnum` / `NutrientRoleEnum`: only a single ref in the `NutrientOverride.role` description string that documents the migration.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)