### PR TITLE
feat: render-media-role-graph skill (mermaid facet-role graphs)

### DIFF
--- a/.claude/skills/render-media-role-graph/SKILL.md
+++ b/.claude/skills/render-media-role-graph/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: render-media-role-graph
+description: Render a MediaRecipe (or corpus roll-up) as a mermaid graph of ingredient ↔ role relationships across the three facet enums (nutritional / physicochemical / cellular-metabolic) plus organism community roles and nutrient overrides. Complementary to `kgx_export.py` which flattens roles into a single biolink qualifier — this skill preserves per-facet edges and dedupes shared role values.
+version: 1.0.0
+tags: [visualization, mermaid, media, ingredients, roles, facets]
+author: CultureMech Team
+created: 2026-07-21
+category: visualization
+requires_database: false
+requires_internet: false
+---
+
+# render-media-role-graph
+
+## Overview
+
+Emits a **mermaid flowchart** of a MediaRecipe showing the medium ↔ ingredient ↔ role structure that the three-facet migration (PRs #93/#94/#95) laid down. Three modes:
+
+- **single** — one recipe → one `.mmd` (the default when `--target` is a file path).
+- **batch** — many recipes → one `.mmd` per recipe.
+- **rollup** — cross-corpus aggregation of `(ingredient, facet, role-value)` frequencies → one summary `.mmd`.
+
+Output goes to `reports/media_role_graphs/*.mmd`; consumers render in-browser (mermaid.js supports the .mmd source directly) or via `mmdc` for static PNG/SVG.
+
+**Not** a Jinja template; standalone `.mmd` files. They can be embedded verbatim in markdown via a ```` ```mermaid ```` fence or referenced from `render_media_pages.py` (which already uses mermaid for the composition graph — this skill is a strict superset for the role axis).
+
+## When to Use
+
+| Scenario | Mode |
+| -------- | ---- |
+| "Show me what roles this specific recipe carries" | `single` |
+| Post-backfill sanity check: did PR #95 (or Step 7b) assign facets I expect? | `single` on a curator's spot-check recipe |
+| Review a batch of recipes for consistency of role assignments | `batch --limit N` |
+| "Which ingredients across the corpus most commonly co-occur with which facet role?" | `rollup` |
+| Building a docs page or PR body illustrating the role-facet model | `single --stdout` and paste under a ` ```mermaid ` fence |
+
+**Not for**: computing role assignments (that's #95 mechanistic + #7b literature). This is read-only visualization.
+
+## Inputs
+
+- **`--target <path>`** — a MediaRecipe YAML. Any file under `data/normalized_yaml/**/*.yaml` (or `data/merge_yaml/**/*.yaml`).
+- **`--yaml-dir <path>`** — for batch or rollup. Default target is `data/normalized_yaml/`.
+- **`--mode {single|batch|rollup}`** — explicit mode. Auto-detected from which of the above two is passed.
+
+Optional:
+
+- **`--out-dir <path>`** — where to write `.mmd` files (default `reports/media_role_graphs/`).
+- **`--max-ingredients <int>`** — cap on ingredients per graph (default 30, matching the `build_ingredient_composition_graph` sentinel in `culturebotai-claw/src/kg_microbe_browser/graph.py`). Beyond the cap: emits a `...N more` sentinel.
+- **`--limit <int>`** — batch/rollup: cap total recipes processed.
+- **`--include-notes`** — attach curator `notes:` free-text as dashed side-nodes (useful when the corpus still has role info as `notes: 'Role: Carbon source'` free text — most of the corpus today).
+- **`--stdout`** — emit to stdout instead of writing files.
+
+## Workflow
+
+### 1. Single recipe
+
+```bash
+uv run python scripts/render_media_role_graph.py \
+  --target data/normalized_yaml/specialized/ym.yaml
+# → wrote reports/media_role_graphs/ym.mmd
+```
+
+Preview by pasting into any mermaid renderer (Live editor at mermaid.live, GitHub PR/issue with a ` ```mermaid ` fence, or `mmdc -i reports/media_role_graphs/ym.mmd -o /tmp/ym.svg`).
+
+### 2. Batch (whole subcategory or the entire corpus)
+
+```bash
+# All bacterial media, dry-cap at 100 for smoke testing:
+uv run python scripts/render_media_role_graph.py \
+  --yaml-dir data/normalized_yaml/bacterial \
+  --mode batch --limit 100
+# → wrote 100 .mmd files to reports/media_role_graphs/
+```
+
+Each output file is named `<recipe_stem>.mmd`.
+
+### 3. Corpus roll-up
+
+```bash
+uv run python scripts/render_media_role_graph.py \
+  --yaml-dir data/normalized_yaml --mode rollup
+# → wrote reports/media_role_graphs/_rollup.mmd
+```
+
+The roll-up counts `(CHEBI-id, facet, role-value)` triples across every ingredient in every scanned recipe and emits one edge per pair with the count as the edge label. **Today (2026-07-21) the corpus is greenfield for faceted roles** — the roll-up will render an "empty state" node explaining this until #95 / #7b populate slots.
+
+## Output structure
+
+```
+reports/media_role_graphs/
+├── <recipe_stem>.mmd          # single or batch
+└── _rollup.mmd                # rollup
+```
+
+`.mmd` source layout (excerpt):
+
+```mermaid
+flowchart LR
+MEDIUM["**recipe name**"]:::medium
+CHEBI_17561["L-cysteine\n(CHEBI:17561)"]:::ingredient
+MEDIUM --> CHEBI_17561
+role_nutritional_roles_AMINO_ACID_SOURCE(("AMINO_ACID_SOURCE\n[nut]")):::nutritional_roles
+CHEBI_17561 --|nut|--> role_nutritional_roles_AMINO_ACID_SOURCE
+CHEBI_17561 --|nut|--> role_nutritional_roles_SULFUR_SOURCE
+CHEBI_17561 --|phys|--> role_physicochemical_roles_REDUCING_AGENT
+CHEBI_17561 --|cell|--> role_cellular_metabolic_roles_SUBSTRATE
+
+classDef nutritional_roles stroke:#2ca02c,stroke-width:2px,color:#2ca02c
+classDef physicochemical_roles stroke:#1f77b4,stroke-width:2px,color:#1f77b4
+classDef cellular_metabolic_roles stroke:#d62728,stroke-width:2px,color:#d62728
+```
+
+Facet color legend (matches matplotlib tab10 palette):
+- 🟢 green — `nutritional_roles`
+- 🔵 blue — `physicochemical_roles`
+- 🔴 red — `cellular_metabolic_roles`
+- 🟣 purple — `nutrient_overrides` (organism-scoped overrides)
+- 🟢 mint — `community_organism_role` (organism-in-community role)
+
+## Node & edge conventions
+
+| Element | Shape / style | Notes |
+| ------- | ------------- | ----- |
+| Medium (recipe root) | `["**bold**"]:::medium` | Single node named `MEDIUM`. |
+| Ingredient | `["preferred_term\n(id)"]:::ingredient` | Node id sanitized from CHEBI/FOODON/MICRO/mediadive-compound. |
+| Solution | `(["solution id"]):::solution` | Stadium shape. `MEDIUM -.-> solution` (dashed). |
+| Solution composition | `solution --> ingredient` | Ingredient inherits normal styling. |
+| Facet role value | `((value\n[facet-short])):::<facet>` | Circle. Deduped: one node per `(facet, value)` regardless of how many ingredients point at it. |
+| Facet edge | `ing --|<facet-short>|--> role` | Edge label carries the 3-4 char facet short-name (`nut` / `phys` / `cell`). |
+| `role_curie` escape hatch | `((curie\n[curie])):::role_curie` | Dashed stroke to distinguish from enum values. |
+| Target organism | `["preferred\n(NCBITaxon:id)"]:::organism` | `MEDIUM ==> organism` (thick edge). |
+| Community-organism role | `((value\n[org-role])):::community_role` | One node per role, deduped. |
+| Nutrient override | `["source (sole)\n[NutOverride: ROLE]"]:::nutrient_override` | Attached to the organism that carries the growth_metrics. |
+| Truncation sentinel | `["...N more ingredients (cap: M)"]:::truncated` | Only when `--max-ingredients` is exceeded. |
+| Curator notes (`--include-notes`) | `["_free-text_"]:::note` | Dashed side-edge from the ingredient. |
+
+## Design notes
+
+- **Facet dedup**: `L-cysteine → SULFUR_SOURCE` and `Na2S → SULFUR_SOURCE` both point at the same `role_nutritional_roles_SULFUR_SOURCE` node. This lets a curator visually spot which facet values recur across an ingredient panel.
+- **Solutions layered above ingredients**: a solution's `composition[]` ingredients are edged from the solution, not directly from the medium. Same structure `kgx_export.py` uses.
+- **`nutrient_overrides` are organism-scoped** in the schema (`MediaRecipe → target_organisms[] → growth_metrics[] → nutrient_overrides[]`), NOT top-level. The graph reflects this: the override node hangs off the organism, not the medium.
+- **`role_curie` is out-of-vocabulary** — dashed stroke visually flags that the value isn't in one of the three facet enums (CHEBI/METPO/ENVO/GO/PATO/NCIT role terms).
+- **Roll-up doesn't render individual recipes** — it's a 2-mode aggregate (ingredient nodes + role-value nodes, edges weighted by co-occurrence count). Practical for spotting the top-N most-common facet coverage patterns once data lands.
+
+## Anti-patterns
+
+- Don't render for a recipe with 0 ingredients — you'll get a bare `MEDIUM` node plus the style block. Not useful. The renderer emits it anyway (no null-check), but batch users should filter empty output.
+- Don't try to render the full 15,878-recipe corpus in a single roll-up without `--limit` first — the intermediate `Counter` state is fine, but the .mmd output ceiling is ~200 nodes / 300 edges before mermaid.js chokes in-browser. The renderer caps the roll-up at the top 60 `(ingredient, facet, value)` triples by frequency; adjust in code if a curator wants more.
+- Don't commit rendered SVG/PNG to git — the .mmd source is the canonical artifact; renderers are consumer-side.
+- Don't add graphviz support unless a specific need arises — the repo has no graphviz dep and mermaid is sufficient for realistic recipe sizes.
+
+## Related skills
+
+- `.claude/skills/audit-schema-gaps/SKILL.md` — check what facet slots exist / are populated before rendering.
+- `.claude/skills/review-recipes/skill.md` — the recipe-review workflow that consumes these graphs during curator review.
+- `.claude/skills/deep-research-medium/skill.md` — feeds role assignments this skill visualizes (Step 7b lane).
+
+## Related scripts
+
+- `scripts/backfill_ingredient_roles.py` (#95) — the mechanistic lane that populates the slots this skill visualizes.
+- `scripts/audit_missing_roles.py` (#95) — which ingredients lack the facet assignments a graph would show.
+- `src/culturemech/export/kgx_export.py` — flat biolink:role qualifier; this skill is the per-facet complement.
+- `src/culturemech/render_media_pages.py` — HTML page renderer; this skill's `.mmd` can be embedded there.
+- `culturebotai-claw/src/kg_microbe_browser/graph.py` — sibling `build_ingredient_composition_graph` renderer this skill's node styling mirrors.
+
+## Reference artifacts
+
+Committed alongside the skill (`reports/media_role_graphs/`):
+
+- **`ym.mmd`** — small recipe (6 ingredients, no organisms). Baseline: medium ↔ ingredient edges only, no facet role data yet.
+- **`chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.mmd`** — medium recipe with rich `target_organisms:` evidence. Shows solution layer + organism nodes. `--include-notes` on this recipe surfaces curator role hints as dashed side-nodes.
+- **`nldm_defined_no_iron.mmd`** — 99-ingredient recipe truncated at the 30-ingredient cap. Demonstrates the `...N more` sentinel behavior.
+
+Regenerate any of these via:
+
+```bash
+uv run python scripts/render_media_role_graph.py \
+  --target data/normalized_yaml/<subdir>/<recipe>.yaml
+```
+
+## Testing
+
+`tests/test_render_media_role_graph.py` — 21 tests covering:
+
+- Node-id / label sanitization
+- CHEBI-id extraction preference order
+- Empty / small / faceted / dedup / role_curie / organisms / community_role / nutrient_overrides / solutions / max-ingredients cap / notes / style block
+- Rollup empty-state + aggregation
+- CLI: requires target-or-yaml-dir, stdout mode, batch mode file emission
+
+Run: `uv run pytest tests/test_render_media_role_graph.py -v`
+
+## One-liner runbook
+
+```bash
+# render one, view in mermaid.live:
+uv run python scripts/render_media_role_graph.py --target <path> --stdout | pbcopy
+
+# render batch:
+uv run python scripts/render_media_role_graph.py \
+  --yaml-dir data/normalized_yaml/bacterial --limit 50
+
+# rollup (once #95 or #7b populates faceted roles):
+uv run python scripts/render_media_role_graph.py \
+  --yaml-dir data/normalized_yaml --mode rollup
+```

--- a/reports/media_role_graphs/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.mmd
+++ b/reports/media_role_graphs/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.mmd
@@ -1,0 +1,107 @@
+flowchart LR
+MEDIUM["`**chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733**`"]:::medium
+ing_ATCC_Medium_1490["`ATCC Medium 1490\n(ing:ATCC Medium 1490)`"]:::ingredient
+MEDIUM --> ing_ATCC_Medium_1490
+CHEBI_16526["`Carbon dioxide gas\n(CHEBI:16526)`"]:::ingredient
+MEDIUM --> CHEBI_16526
+note_CHEBI_16526["`_Properties: ガス_`"]:::note
+CHEBI_16526 -.-> note_CHEBI_16526
+CHEBI_17997["`Nitrogen gas\n(CHEBI:17997)`"]:::ingredient
+MEDIUM --> CHEBI_17997
+note_CHEBI_17997["`_Properties: ガス_`"]:::note
+CHEBI_17997 -.-> note_CHEBI_17997
+CHEBI_18276["`Hydrogen gas\n(CHEBI:18276)`"]:::ingredient
+MEDIUM --> CHEBI_18276
+note_CHEBI_18276["`_Properties: Gas_`"]:::note
+CHEBI_18276 -.-> note_CHEBI_18276
+CHEBI_15377["`Distilled water\n(CHEBI:15377)`"]:::ingredient
+MEDIUM --> CHEBI_15377
+note_CHEBI_15377["`_Role: Solvating media; Properties: Inorganic compound, Defined component, Simple component_`"]:::note
+CHEBI_15377 -.-> note_CHEBI_15377
+ing_N_NaOH["`N NaOH\n(ing:N NaOH)`"]:::ingredient
+MEDIUM --> ing_N_NaOH
+note_ing_N_NaOH["`_Properties: Defined component, Inorganic compound, Solution [Merged 2 duplicates: 25.0,..._`"]:::note
+ing_N_NaOH -.-> note_ing_N_NaOH
+ing_Ground_beef__fat_free_["`Ground beef (fat-free)\n(ing:Ground beef (fat-free))`"]:::ingredient
+MEDIUM --> ing_Ground_beef__fat_free_
+note_ing_Ground_beef__fat_free_["`_Properties: Undefined component_`"]:::note
+ing_Ground_beef__fat_free_ -.-> note_ing_Ground_beef__fat_free_
+ing_0_025__Resazurin["`0.025% Resazurin\n(ing:0.025% Resazurin)`"]:::ingredient
+MEDIUM --> ing_0_025__Resazurin
+note_ing_0_025__Resazurin["`_Role: pH dependent redox indicator; Properties: Defined component, Solution_`"]:::note
+ing_0_025__Resazurin -.-> note_ing_0_025__Resazurin
+ing_Yeast_extract["`Yeast extract\n(ing:Yeast extract)`"]:::ingredient
+MEDIUM --> ing_Yeast_extract
+note_ing_Yeast_extract["`_Role: Nutrient source; Properties: Undefined component_`"]:::note
+ing_Yeast_extract -.-> note_ing_Yeast_extract
+CHEBI_131527["`K2HPO4\n(CHEBI:131527)`"]:::ingredient
+MEDIUM --> CHEBI_131527
+note_CHEBI_131527["`_Role: Buffer; Properties: Inorganic compound, Simple component, Defined component_`"]:::note
+CHEBI_131527 -.-> note_CHEBI_131527
+CHEBI_2509["`Agar\n(CHEBI:2509)`"]:::ingredient
+MEDIUM --> CHEBI_2509
+note_CHEBI_2509["`_Role: Solidifying component_`"]:::note
+CHEBI_2509 -.-> note_CHEBI_2509
+ing_Trypticase_Peptone__BD_211921_["`Trypticase Peptone (BD 211921)\n(ing:Trypticase Peptone (BD 211921))`"]:::ingredient
+MEDIUM --> ing_Trypticase_Peptone__BD_211921_
+note_ing_Trypticase_Peptone__BD_211921_["`_Properties: Undefined component_`"]:::note
+ing_Trypticase_Peptone__BD_211921_ -.-> note_ing_Trypticase_Peptone__BD_211921_
+ing_L_Cysteine___HCl["`L-Cysteine . HCl\n(ing:L-Cysteine . HCl)`"]:::ingredient
+MEDIUM --> ing_L_Cysteine___HCl
+note_ing_L_Cysteine___HCl["`_Properties: Organic compound, Simple component, Defined component_`"]:::note
+ing_L_Cysteine___HCl -.-> note_ing_L_Cysteine___HCl
+ing_95__Ethanol["`95% Ethanol\n(ing:95% Ethanol)`"]:::ingredient
+MEDIUM --> ing_95__Ethanol
+note_ing_95__Ethanol["`_Role: Solvating media; Properties: Defined component, Organic compound, Simple component_`"]:::note
+ing_95__Ethanol -.-> note_ing_95__Ethanol
+CHEBI_18067["`Vitamin K1\n(CHEBI:18067)`"]:::ingredient
+MEDIUM --> CHEBI_18067
+note_CHEBI_18067["`_Role: Vitamin; Properties: Defined component, Simple component, Organic compound_`"]:::note
+CHEBI_18067 -.-> note_CHEBI_18067
+ing_Distilled_water_to["`Distilled water to\n(ing:Distilled water to)`"]:::ingredient
+MEDIUM --> ing_Distilled_water_to
+note_ing_Distilled_water_to["`_Role: Solvating media; Properties: Inorganic compound, Defined component, Simple component_`"]:::note
+ing_Distilled_water_to -.-> note_ing_Distilled_water_to
+CHEBI_50385["`Hemin\n(CHEBI:50385)`"]:::ingredient
+MEDIUM --> CHEBI_50385
+note_CHEBI_50385["`_Role: Growth factor; Properties: Simple component, Organic compound, Defined component_`"]:::note
+CHEBI_50385 -.-> note_CHEBI_50385
+ing_DI_Water["`DI Water\n(ing:DI Water)`"]:::ingredient
+MEDIUM --> ing_DI_Water
+note_ing_DI_Water["`_Role: Solvating media; Properties: Inorganic compound, Simple component, Defined component_`"]:::note
+ing_DI_Water -.-> note_ing_DI_Water
+CHEBI_18012["`Fumaric Acid\n(CHEBI:18012)`"]:::ingredient
+MEDIUM --> CHEBI_18012
+note_CHEBI_18012["`_Role: Carbon source; Properties: Organic compound, Defind medium, Simple component_`"]:::note
+CHEBI_18012 -.-> note_CHEBI_18012
+CHEBI_62965["`Sodium Formate\n(CHEBI:62965)`"]:::ingredient
+MEDIUM --> CHEBI_62965
+note_CHEBI_62965["`_Properties: Defined component, Simple component, Inorganic compound_`"]:::note
+CHEBI_62965 -.-> note_CHEBI_62965
+org_Bacteroides_ureolyticus["`Bacteroides ureolyticus\n(org:Bacteroides ureolyticus)`"]:::organism
+MEDIUM ==> org_Bacteroides_ureolyticus
+NCBITaxon_823["`Parabacteroides distasonis\n(NCBITaxon:823)`"]:::organism
+MEDIUM ==> NCBITaxon_823
+NCBITaxon_851["`Fusobacterium nucleatum\n(NCBITaxon:851)`"]:::organism
+MEDIUM ==> NCBITaxon_851
+NCBITaxon_28114["`Porphyromonas levii\n(NCBITaxon:28114)`"]:::organism
+MEDIUM ==> NCBITaxon_28114
+NCBITaxon_28125["`Prevotella bivia\n(NCBITaxon:28125)`"]:::organism
+MEDIUM ==> NCBITaxon_28125
+NCBITaxon_47770["`Lactobacillus crispatus\n(NCBITaxon:47770)`"]:::organism
+MEDIUM ==> NCBITaxon_47770
+NCBITaxon_859["`Fusobacterium necrophorum\n(NCBITaxon:859)`"]:::organism
+MEDIUM ==> NCBITaxon_859
+
+classDef nutritional_roles stroke:#2ca02c,stroke-width:2px,color:#2ca02c
+classDef physicochemical_roles stroke:#1f77b4,stroke-width:2px,color:#1f77b4
+classDef cellular_metabolic_roles stroke:#d62728,stroke-width:2px,color:#d62728
+classDef medium fill:#f5f5f5,stroke:#333,stroke-width:2px,font-weight:bold
+classDef ingredient fill:#fff,stroke:#666,color:#333
+classDef solution fill:#e6f2ff,stroke:#3366aa,color:#000
+classDef organism fill:#fff2e6,stroke:#cc6600,color:#000,font-weight:bold
+classDef community_role fill:#e6ffe6,stroke:#009900,color:#005500
+classDef nutrient_override fill:#f0e6ff,stroke:#7733aa,color:#330066
+classDef role_curie stroke-dasharray:5 5
+classDef truncated fill:#fee,stroke:#c33,color:#833
+classDef note fill:#fefee0,stroke:#cca,color:#663,font-style:italic

--- a/reports/media_role_graphs/nldm_defined_no_iron.mmd
+++ b/reports/media_role_graphs/nldm_defined_no_iron.mmd
@@ -1,0 +1,65 @@
+flowchart LR
+MEDIUM["`**nldm_defined_no_iron**`"]:::medium
+CHEBI_31206["`Ammonium Chloride\n(CHEBI:31206)`"]:::ingredient
+MEDIUM --> CHEBI_31206
+CHEBI_32588["`Potassium Chloride\n(CHEBI:32588)`"]:::ingredient
+MEDIUM --> CHEBI_32588
+CHEBI_31795["`Magnesium sulfate heptahydrate\n(CHEBI:31795)`"]:::ingredient
+MEDIUM --> CHEBI_31795
+CHEBI_86158["`Calcium chloride dihydrate\n(CHEBI:86158)`"]:::ingredient
+MEDIUM --> CHEBI_86158
+CHEBI_64755["`EDTA\n(CHEBI:64755)`"]:::ingredient
+MEDIUM --> CHEBI_64755
+CHEBI_86463["`Magnesium Sulfate Heptahydrate\n(CHEBI:86463)`"]:::ingredient
+MEDIUM --> CHEBI_86463
+CHEBI_86364["`Manganese (II) sulfate monohydrate\n(CHEBI:86364)`"]:::ingredient
+MEDIUM --> CHEBI_86364
+CHEBI_26710["`Sodium Chloride\n(CHEBI:26710)`"]:::ingredient
+MEDIUM --> CHEBI_26710
+CHEBI_75836["`Iron (II) sulfate heptahydrate\n(CHEBI:75836)`"]:::ingredient
+MEDIUM --> CHEBI_75836
+CHEBI_86214["`Cobalt(II) nitrate hexahydrate\n(CHEBI:86214)`"]:::ingredient
+MEDIUM --> CHEBI_86214
+MEDIUM --> CHEBI_86158
+CHEBI_32312["`Zinc sulfate heptahydrate\n(CHEBI:32312)`"]:::ingredient
+MEDIUM --> CHEBI_32312
+CHEBI_31440["`Copper (II) sulfate pentahydrate\n(CHEBI:31440)`"]:::ingredient
+MEDIUM --> CHEBI_31440
+CHEBI_86465["`Aluminum potassium sulfate dodecahydrate\n(CHEBI:86465)`"]:::ingredient
+MEDIUM --> CHEBI_86465
+CHEBI_33118["`Boric Acid\n(CHEBI:33118)`"]:::ingredient
+MEDIUM --> CHEBI_33118
+CHEBI_75213["`Sodium Molybdate Dihydrate\n(CHEBI:75213)`"]:::ingredient
+MEDIUM --> CHEBI_75213
+CHEBI_131361["`Sodium selenite pentahydrate\n(CHEBI:131361)`"]:::ingredient
+MEDIUM --> CHEBI_131361
+CHEBI_63939["`Sodium tungstate dihydrate\n(CHEBI:63939)`"]:::ingredient
+MEDIUM --> CHEBI_63939
+CHEBI_53542["`Nickel (II) chloride hexahydrate\n(CHEBI:53542)`"]:::ingredient
+MEDIUM --> CHEBI_53542
+MEDIUM --> CHEBI_64755
+MEDIUM --> CHEBI_86463
+MEDIUM --> CHEBI_86364
+MEDIUM --> CHEBI_26710
+MEDIUM --> CHEBI_86214
+MEDIUM --> CHEBI_86158
+MEDIUM --> CHEBI_32312
+MEDIUM --> CHEBI_31440
+MEDIUM --> CHEBI_86465
+MEDIUM --> CHEBI_33118
+MEDIUM --> CHEBI_75213
+MORE["`...69 more ingredients (cap: 30)`"]:::truncated
+MEDIUM --> MORE
+
+classDef nutritional_roles stroke:#2ca02c,stroke-width:2px,color:#2ca02c
+classDef physicochemical_roles stroke:#1f77b4,stroke-width:2px,color:#1f77b4
+classDef cellular_metabolic_roles stroke:#d62728,stroke-width:2px,color:#d62728
+classDef medium fill:#f5f5f5,stroke:#333,stroke-width:2px,font-weight:bold
+classDef ingredient fill:#fff,stroke:#666,color:#333
+classDef solution fill:#e6f2ff,stroke:#3366aa,color:#000
+classDef organism fill:#fff2e6,stroke:#cc6600,color:#000,font-weight:bold
+classDef community_role fill:#e6ffe6,stroke:#009900,color:#005500
+classDef nutrient_override fill:#f0e6ff,stroke:#7733aa,color:#330066
+classDef role_curie stroke-dasharray:5 5
+classDef truncated fill:#fee,stroke:#c33,color:#833
+classDef note fill:#fefee0,stroke:#cca,color:#663,font-style:italic

--- a/reports/media_role_graphs/ym.mmd
+++ b/reports/media_role_graphs/ym.mmd
@@ -1,0 +1,27 @@
+flowchart LR
+MEDIUM["`**ym**`"]:::medium
+FOODON_03315426["`Yeast Extract\n(FOODON:03315426)`"]:::ingredient
+MEDIUM --> FOODON_03315426
+CHEBI_16899["`D-Mannitol\n(CHEBI:16899)`"]:::ingredient
+MEDIUM --> CHEBI_16899
+CHEBI_131527["`Potassium phosphate dibasic\n(CHEBI:131527)`"]:::ingredient
+MEDIUM --> CHEBI_131527
+CHEBI_32599["`Magnesium sulfate\n(CHEBI:32599)`"]:::ingredient
+MEDIUM --> CHEBI_32599
+CHEBI_26710["`Sodium Chloride\n(CHEBI:26710)`"]:::ingredient
+MEDIUM --> CHEBI_26710
+CHEBI_3311["`Calcium carbonate\n(CHEBI:3311)`"]:::ingredient
+MEDIUM --> CHEBI_3311
+
+classDef nutritional_roles stroke:#2ca02c,stroke-width:2px,color:#2ca02c
+classDef physicochemical_roles stroke:#1f77b4,stroke-width:2px,color:#1f77b4
+classDef cellular_metabolic_roles stroke:#d62728,stroke-width:2px,color:#d62728
+classDef medium fill:#f5f5f5,stroke:#333,stroke-width:2px,font-weight:bold
+classDef ingredient fill:#fff,stroke:#666,color:#333
+classDef solution fill:#e6f2ff,stroke:#3366aa,color:#000
+classDef organism fill:#fff2e6,stroke:#cc6600,color:#000,font-weight:bold
+classDef community_role fill:#e6ffe6,stroke:#009900,color:#005500
+classDef nutrient_override fill:#f0e6ff,stroke:#7733aa,color:#330066
+classDef role_curie stroke-dasharray:5 5
+classDef truncated fill:#fee,stroke:#c33,color:#833
+classDef note fill:#fefee0,stroke:#cca,color:#663,font-style:italic

--- a/scripts/render_media_role_graph.py
+++ b/scripts/render_media_role_graph.py
@@ -1,0 +1,426 @@
+"""Render a MediaRecipe (or corpus roll-up) as a mermaid role-relationship graph.
+
+Walks a `MediaRecipe` YAML and emits a mermaid flowchart of the ingredient
+↔ role relationships that landed via PRs #93 / #94 / #95 / #98 / #99, plus
+the pre-existing medium ↔ solution / medium ↔ organism / organism ↔
+community-role edges. Complementary to `src/culturemech/export/kgx_export.py`
+(which flattens roles into a single biolink qualifier): this script keeps
+each of the three facets on its own colored edge and dedupes role-value
+nodes across ingredients so a curator can see recurring facet coverage.
+
+Three modes:
+  - **single**: one recipe → one .mmd (default when `--target` is given).
+  - **batch**: many recipes → one .mmd per recipe (`--yaml-dir` + `--limit`).
+  - **roll-up**: aggregate (ingredient, facet, role) frequencies across the
+    corpus → one summary .mmd showing which faceted roles co-occur.
+
+Node budget: capped at `--max-ingredients` (default 30, matching the
+`build_ingredient_composition_graph` sentinel in the sibling
+`culturebotai-claw/src/kg_microbe_browser/graph.py`). Beyond the cap the
+graph emits a `...N more` sentinel node.
+
+Output convention (invented — no prior `.mmd` files in this repo):
+  reports/media_role_graphs/<slug>.mmd     (single or batch)
+  reports/media_role_graphs/_rollup.mmd    (corpus roll-up)
+
+Reference walk mirrors `src/culturemech/export/kgx_export.transform()`:
+ingredients → solutions[.composition] → target_organisms → variants.
+Extends beyond kgx_export.py by:
+  1. Preserving each of the three facet slots as distinct edges.
+  2. Emitting `role_curie` escape-hatch values.
+  3. Following `target_organisms[].community_role` (renamed in #92).
+  4. Following `target_organisms[].growth_metrics[].nutrient_overrides[]`
+     (post-#94 range: NutritionalRoleEnum).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+FACET_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+# Facet display metadata — labels shown on edges + hex colors for edge styling.
+FACET_STYLE = {
+    "nutritional_roles":       {"label": "nut",  "color": "#2ca02c"},  # green
+    "physicochemical_roles":   {"label": "phys", "color": "#1f77b4"},  # blue
+    "cellular_metabolic_roles":{"label": "cell", "color": "#d62728"},  # red
+}
+
+# CHEBI id lives at any of these paths on an ingredient dict, matching the
+# audit_missing_roles.py / backfill_ingredient_roles.py preference order.
+CHEBI_ID_PATHS = (
+    ("term", "id"),
+    ("chebi_term", "id"),
+    ("mediaingredientmech_chebi_term", "id"),
+)
+
+
+def _sanitize_id(s: str) -> str:
+    """Mermaid node ids must be [A-Za-z0-9_].
+
+    Sanitizer matches `culturebotai-claw/src/kg_microbe_browser/graph.py::_id`.
+    """
+    return re.sub(r"[^A-Za-z0-9_]", "_", s)
+
+
+def _label(s: str, max_len: int = 70) -> str:
+    """Sanitize a label for a mermaid node.
+
+    Matches `culturebotai-claw/src/kg_microbe_browser/graph.py::_label`:
+    collapse newlines, replace `"` with `'`, trim to max_len.
+    """
+    if s is None:
+        return ""
+    s = str(s).replace("\n", " ").replace('"', "'").strip()
+    if len(s) > max_len:
+        s = s[: max_len - 3] + "..."
+    return s
+
+
+def _get_nested(record: dict, path: tuple[str, ...]) -> Optional[str]:
+    current: object = record
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current if isinstance(current, str) else None
+
+
+def ingredient_chebi_id(ing: dict) -> Optional[str]:
+    for path in CHEBI_ID_PATHS:
+        value = _get_nested(ing, path)
+        if value and value.startswith("CHEBI:"):
+            return value
+    return None
+
+
+def ingredient_display_id(ing: dict) -> str:
+    """Return a graph-node id for an ingredient. Prefers CHEBI, then any term id, then preferred_term."""
+    chebi = ingredient_chebi_id(ing)
+    if chebi:
+        return chebi
+    for path in [("term", "id"), ("chebi_term", "id"), ("mediaingredientmech_chebi_term", "id")]:
+        v = _get_nested(ing, path)
+        if v:
+            return v
+    pt = (ing.get("preferred_term") or "").strip()
+    return f"ing:{pt}" if pt else "ing:unnamed"
+
+
+def _emit_style(lines: list[str]) -> None:
+    """Emit mermaid classDef color rules for each facet."""
+    lines.append("")
+    for slot, style in FACET_STYLE.items():
+        lines.append(f"classDef {slot} stroke:{style['color']},stroke-width:2px,color:{style['color']}")
+
+
+def _iter_recipe_ingredients(recipe: dict) -> Iterator[tuple[str, dict, str]]:
+    """Yield (source, ingredient_dict, parent_id) for each ingredient in the recipe.
+
+    `source` is one of:
+      - "direct"  — ingredient sits in MediaRecipe.ingredients[]
+      - "solution:<solution_id>" — ingredient sits under a SolutionDescriptor.composition[]
+
+    `parent_id` is the graph-node id of the medium (for direct) or the
+    solution (for composition).
+    """
+    for ing in (recipe.get("ingredients") or []):
+        if isinstance(ing, dict):
+            yield "direct", ing, "MEDIUM"
+    for sol in (recipe.get("solutions") or []):
+        if not isinstance(sol, dict):
+            continue
+        sol_id = _get_nested(sol, ("term", "id")) or f"sol:{(sol.get('preferred_term') or '').strip()}"
+        for ing in (sol.get("composition") or []):
+            if isinstance(ing, dict):
+                yield f"solution:{sol_id}", ing, sol_id
+
+
+def render_single_recipe(
+    recipe_path: Path,
+    max_ingredients: int = 30,
+    include_notes: bool = False,
+) -> str:
+    """Render one MediaRecipe as a mermaid flowchart source string.
+
+    Returns the .mmd source (no ```mermaid fence). Empty recipe → empty string.
+    """
+    try:
+        doc = yaml.safe_load(recipe_path.read_text())
+    except Exception as exc:
+        logger.warning("failed to parse %s: %s", recipe_path, exc)
+        return ""
+    if not isinstance(doc, dict):
+        return ""
+
+    medium_label = (doc.get("preferred_term") or recipe_path.stem).strip()
+    medium_id = _get_nested(doc, ("media_term", "term", "id")) or f"media:{recipe_path.stem}"
+
+    lines: list[str] = ["flowchart LR"]
+    lines.append(f'MEDIUM["`**{_label(medium_label)}**`"]:::medium')
+
+    ingredients_seen = 0
+    dropped_ingredient_count = 0
+    ingredient_nodes: set[str] = set()
+    role_value_nodes: dict[tuple[str, str], str] = {}  # (facet, value) → node_id
+    solution_nodes: set[str] = set()
+
+    # --- ingredients (direct + solution.composition) ---
+    for source, ing, parent_id in _iter_recipe_ingredients(doc):
+        if ingredients_seen >= max_ingredients:
+            dropped_ingredient_count += 1
+            continue
+        ingredients_seen += 1
+
+        ing_id = ingredient_display_id(ing)
+        node_id = _sanitize_id(ing_id)
+        term = (ing.get("preferred_term") or "").strip()
+        label = _label(f"{term}\\n({ing_id})" if term else ing_id)
+
+        if node_id not in ingredient_nodes:
+            ingredient_nodes.add(node_id)
+            lines.append(f'{node_id}["`{label}`"]:::ingredient')
+
+        if source == "direct":
+            lines.append(f"MEDIUM --> {node_id}")
+        else:
+            sol_id = source.split(":", 1)[1]
+            sol_node = _sanitize_id(sol_id)
+            if sol_node not in solution_nodes:
+                solution_nodes.add(sol_node)
+                lines.append(f'{sol_node}(["`{_label(sol_id)}`"]):::solution')
+                lines.append(f"MEDIUM -.-> {sol_node}")
+            lines.append(f"{sol_node} --> {node_id}")
+
+        # facet role edges — one per (facet, value)
+        for slot in FACET_SLOTS:
+            for value in (ing.get(slot) or []):
+                key = (slot, value)
+                if key not in role_value_nodes:
+                    role_value_nodes[key] = _sanitize_id(f"role_{slot}_{value}")
+                    role_id = role_value_nodes[key]
+                    facet_short = FACET_STYLE[slot]["label"]
+                    lines.append(f'{role_id}(("`{value}\\n[{facet_short}]`")):::{slot}')
+                role_id = role_value_nodes[key]
+                lines.append(f"{node_id} --|{FACET_STYLE[slot]['label']}|--> {role_id}")
+
+        # role_curie escape-hatch — separate node style
+        for curie in (ing.get("role_curie") or []):
+            key = ("role_curie", curie)
+            if key not in role_value_nodes:
+                role_value_nodes[key] = _sanitize_id(f"role_curie_{curie}")
+                lines.append(f'{role_value_nodes[key]}(("`{curie}\\n[curie]`")):::role_curie')
+            lines.append(f"{node_id} --|curie|--> {role_value_nodes[key]}")
+
+        if include_notes and ing.get("notes"):
+            note_id = f"note_{node_id}"
+            lines.append(f'{note_id}["`_{_label(ing["notes"], 90)}_`"]:::note')
+            lines.append(f"{node_id} -.-> {note_id}")
+
+    if dropped_ingredient_count:
+        lines.append(
+            f'MORE["`...{dropped_ingredient_count} more ingredients (cap: {max_ingredients})`"]:::truncated'
+        )
+        lines.append(f"MEDIUM --> MORE")
+
+    # --- target organisms ---
+    for org in (doc.get("target_organisms") or []):
+        if not isinstance(org, dict):
+            continue
+        org_id = _get_nested(org, ("term", "id")) or f"org:{(org.get('preferred_term') or '').strip()}"
+        org_node = _sanitize_id(org_id)
+        org_label = _label(f"{(org.get('preferred_term') or '').strip()}\\n({org_id})")
+        lines.append(f'{org_node}["`{org_label}`"]:::organism')
+        lines.append(f"MEDIUM ==> {org_node}")
+
+        for value in (org.get("community_role") or []):
+            key = ("community_organism_role", value)
+            if key not in role_value_nodes:
+                role_value_nodes[key] = _sanitize_id(f"cor_{value}")
+                lines.append(f'{role_value_nodes[key]}(("`{value}\\n[org-role]`")):::community_role')
+            lines.append(f"{org_node} --|community-role|--> {role_value_nodes[key]}")
+
+        # nutrient_overrides live on growth_metrics
+        for gm in (org.get("growth_metrics") or []):
+            if not isinstance(gm, dict):
+                continue
+            for override in (gm.get("nutrient_overrides") or []):
+                if not isinstance(override, dict):
+                    continue
+                src = (override.get("source") or "").strip()
+                role = (override.get("role") or "").strip()
+                sole = " (sole)" if override.get("is_sole_source") else ""
+                node_id = _sanitize_id(f"override_{org_id}_{role}_{src}")
+                lines.append(f'{node_id}["`{_label(src)}{sole}\\n[NutOverride: {role}]`"]:::nutrient_override')
+                lines.append(f"{org_node} --|nut-override|--> {node_id}")
+
+    _emit_style(lines)
+    lines.append("classDef medium fill:#f5f5f5,stroke:#333,stroke-width:2px,font-weight:bold")
+    lines.append("classDef ingredient fill:#fff,stroke:#666,color:#333")
+    lines.append("classDef solution fill:#e6f2ff,stroke:#3366aa,color:#000")
+    lines.append("classDef organism fill:#fff2e6,stroke:#cc6600,color:#000,font-weight:bold")
+    lines.append("classDef community_role fill:#e6ffe6,stroke:#009900,color:#005500")
+    lines.append("classDef nutrient_override fill:#f0e6ff,stroke:#7733aa,color:#330066")
+    lines.append("classDef role_curie stroke-dasharray:5 5")
+    lines.append("classDef truncated fill:#fee,stroke:#c33,color:#833")
+    lines.append("classDef note fill:#fefee0,stroke:#cca,color:#663,font-style:italic")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_rollup(yaml_root: Path, limit: Optional[int] = None) -> str:
+    """Render a cross-corpus roll-up: which (facet, role) pairs co-occur on which CHEBI ids.
+
+    Each edge weight = number of recipes / ingredients where that pairing appears.
+    Currently near-empty because the corpus has no populated facet slots yet
+    (see audit_missing_roles.py output). Included so once #128 / Step 7b
+    populates the slots, this graph immediately becomes useful.
+    """
+    counts: Counter[tuple[str, str, str]] = Counter()  # (chebi_id, facet, value)
+    ingredient_labels: dict[str, str] = {}
+    files_scanned = 0
+    for path in sorted(yaml_root.rglob("*.yaml")):
+        if limit is not None and files_scanned >= limit:
+            break
+        files_scanned += 1
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except Exception:
+            continue
+        if not isinstance(doc, dict):
+            continue
+        for _src, ing, _parent in _iter_recipe_ingredients(doc):
+            chebi = ingredient_chebi_id(ing) or ""
+            if not chebi:
+                continue
+            ingredient_labels.setdefault(chebi, (ing.get("preferred_term") or "").strip() or chebi)
+            for slot in FACET_SLOTS:
+                for value in (ing.get(slot) or []):
+                    counts[(chebi, slot, value)] += 1
+
+    lines = ["flowchart LR", f'HEADER["`**Corpus role roll-up**\\n{files_scanned} recipes scanned`"]:::header']
+
+    if not counts:
+        lines.append('EMPTY["`_(No faceted role assignments found yet. Run #95 backfill or Step 7b literature lane to populate.)_`"]:::empty')
+        lines.append("HEADER --> EMPTY")
+        lines.append("")
+        lines.append("classDef header fill:#f5f5f5,stroke:#333,font-weight:bold")
+        lines.append("classDef empty fill:#fee,stroke:#c33,color:#833,font-style:italic")
+        return "\n".join(lines) + "\n"
+
+    role_value_nodes: dict[tuple[str, str], str] = {}
+    ing_nodes: set[str] = set()
+    for (chebi, slot, value), n in counts.most_common(60):
+        ing_node = _sanitize_id(chebi)
+        if ing_node not in ing_nodes:
+            ing_nodes.add(ing_node)
+            lines.append(f'{ing_node}["`{_label(ingredient_labels[chebi])}\\n({chebi})`"]:::ingredient')
+        key = (slot, value)
+        if key not in role_value_nodes:
+            role_value_nodes[key] = _sanitize_id(f"role_{slot}_{value}")
+            facet_short = FACET_STYLE[slot]["label"]
+            lines.append(f'{role_value_nodes[key]}(("`{value}\\n[{facet_short}]`")):::{slot}')
+        lines.append(f"{ing_node} --|{FACET_STYLE[slot]['label']}: {n}|--> {role_value_nodes[key]}")
+
+    _emit_style(lines)
+    lines.append("classDef header fill:#f5f5f5,stroke:#333,font-weight:bold")
+    lines.append("classDef ingredient fill:#fff,stroke:#666,color:#333")
+    return "\n".join(lines) + "\n"
+
+
+def _slug_for(path: Path) -> str:
+    return path.stem
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--target", type=Path, help="Path to a single MediaRecipe YAML.")
+    group.add_argument("--yaml-dir", type=Path, help="Root of the normalized-YAML corpus (for batch or roll-up).")
+    parser.add_argument(
+        "--mode",
+        choices=("single", "batch", "rollup"),
+        default=None,
+        help="Explicit mode. Defaults: single if --target, batch if --yaml-dir.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=Path("reports/media_role_graphs"),
+                        help="Where to write .mmd files.")
+    parser.add_argument("--max-ingredients", type=int, default=30,
+                        help="Cap on ingredients per single/batch graph (default 30).")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Batch/rollup only: cap total recipes processed.")
+    parser.add_argument("--include-notes", action="store_true",
+                        help="Attach curator `notes:` free-text as dashed side-nodes on each ingredient.")
+    parser.add_argument("--stdout", action="store_true",
+                        help="Emit to stdout instead of writing .mmd files.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(message)s")
+
+    if args.target is None and args.yaml_dir is None:
+        parser.error("one of --target or --yaml-dir is required")
+
+    mode = args.mode
+    if mode is None:
+        mode = "single" if args.target is not None else "batch"
+
+    if mode == "single":
+        if args.target is None:
+            parser.error("--mode single requires --target")
+        mmd = render_single_recipe(args.target, args.max_ingredients, args.include_notes)
+        if args.stdout:
+            print(mmd)
+        else:
+            args.out_dir.mkdir(parents=True, exist_ok=True)
+            out = args.out_dir / f"{_slug_for(args.target)}.mmd"
+            out.write_text(mmd)
+            print(f"wrote {out}", file=sys.stderr)
+        return 0
+
+    if mode == "batch":
+        if args.yaml_dir is None:
+            parser.error("--mode batch requires --yaml-dir")
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        n = 0
+        for path in sorted(args.yaml_dir.rglob("*.yaml")):
+            if args.limit is not None and n >= args.limit:
+                break
+            mmd = render_single_recipe(path, args.max_ingredients, args.include_notes)
+            if not mmd.strip():
+                continue
+            out = args.out_dir / f"{_slug_for(path)}.mmd"
+            out.write_text(mmd)
+            n += 1
+        print(f"wrote {n} .mmd files to {args.out_dir}", file=sys.stderr)
+        return 0
+
+    if mode == "rollup":
+        if args.yaml_dir is None:
+            parser.error("--mode rollup requires --yaml-dir")
+        mmd = render_rollup(args.yaml_dir, args.limit)
+        if args.stdout:
+            print(mmd)
+        else:
+            args.out_dir.mkdir(parents=True, exist_ok=True)
+            out = args.out_dir / "_rollup.mmd"
+            out.write_text(mmd)
+            print(f"wrote {out}", file=sys.stderr)
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_render_media_role_graph.py
+++ b/tests/test_render_media_role_graph.py
@@ -1,0 +1,315 @@
+"""Tests for scripts/render_media_role_graph.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "render_media_role_graph.py"
+_SPEC = importlib.util.spec_from_file_location("_render_media_role_graph", _SCRIPT_PATH)
+_render = importlib.util.module_from_spec(_SPEC)
+sys.modules["_render_media_role_graph"] = _render
+_SPEC.loader.exec_module(_render)  # type: ignore[union-attr]
+
+
+# ---------------- helpers ----------------
+
+
+def _write(tmp_path: Path, doc: dict) -> Path:
+    path = tmp_path / "recipe.yaml"
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+# ---------------- unit helpers ----------------
+
+
+def test_sanitize_id_strips_non_alphanum():
+    assert _render._sanitize_id("CHEBI:12345") == "CHEBI_12345"
+    assert _render._sanitize_id("mediadive.compound:5") == "mediadive_compound_5"
+    assert _render._sanitize_id("has spaces & symbols!") == "has_spaces___symbols_"
+
+
+def test_label_trims_and_collapses():
+    assert _render._label("normal") == "normal"
+    assert _render._label('with "quotes"\nand newlines') == "with 'quotes' and newlines"
+    long = "x" * 100
+    got = _render._label(long, max_len=20)
+    assert got.endswith("...") and len(got) == 20
+
+
+def test_ingredient_chebi_id_prefers_primary_term():
+    ing = {"term": {"id": "CHEBI:17234"}, "chebi_term": {"id": "CHEBI:99999"}}
+    assert _render.ingredient_chebi_id(ing) == "CHEBI:17234"
+
+
+def test_ingredient_chebi_id_falls_back_to_chebi_term():
+    ing = {"term": {"id": "mediadive.compound:5"}, "chebi_term": {"id": "CHEBI:17234"}}
+    assert _render.ingredient_chebi_id(ing) == "CHEBI:17234"
+
+
+def test_ingredient_display_id_prefers_chebi_then_any_term():
+    assert _render.ingredient_display_id({"term": {"id": "CHEBI:17234"}}) == "CHEBI:17234"
+    assert _render.ingredient_display_id({"term": {"id": "mediadive.compound:5"}}) == "mediadive.compound:5"
+    assert _render.ingredient_display_id({"preferred_term": "Distilled water"}) == "ing:Distilled water"
+
+
+# ---------------- single-recipe rendering ----------------
+
+
+def test_single_recipe_empty_recipe_returns_bare_header(tmp_path):
+    recipe = _write(tmp_path, {"preferred_term": "Empty medium", "ingredients": []})
+    mmd = _render.render_single_recipe(recipe)
+    assert mmd.startswith("flowchart LR")
+    assert 'MEDIUM["`**Empty medium**`"]:::medium' in mmd
+    # No ingredient nodes, no role edges.
+    assert "-->" not in mmd or mmd.count("-->") == 0
+    # Style block always emitted.
+    assert "classDef medium" in mmd
+
+
+def test_single_recipe_emits_medium_to_ingredient_edges(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Small medium",
+        "ingredients": [
+            {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}},
+            {"preferred_term": "Sodium chloride", "term": {"id": "CHEBI:26710"}},
+        ],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    assert "MEDIUM --> CHEBI_17234" in mmd
+    assert "MEDIUM --> CHEBI_26710" in mmd
+    assert "Glucose" in mmd and "Sodium chloride" in mmd
+
+
+def test_single_recipe_emits_all_three_facet_edges(tmp_path):
+    """An ingredient with values in all three facet slots produces one edge per facet."""
+    recipe = _write(tmp_path, {
+        "preferred_term": "Faceted medium",
+        "ingredients": [{
+            "preferred_term": "L-cysteine",
+            "term": {"id": "CHEBI:17561"},
+            "nutritional_roles": ["AMINO_ACID_SOURCE", "SULFUR_SOURCE"],
+            "physicochemical_roles": ["REDUCING_AGENT"],
+            "cellular_metabolic_roles": ["SUBSTRATE"],
+        }],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    # Facet-value nodes present.
+    assert "AMINO_ACID_SOURCE" in mmd
+    assert "SULFUR_SOURCE" in mmd
+    assert "REDUCING_AGENT" in mmd
+    assert "SUBSTRATE" in mmd
+    # Each facet has its own edge label.
+    assert "|nut|" in mmd  # from FACET_STYLE
+    assert "|phys|" in mmd
+    assert "|cell|" in mmd
+
+
+def test_single_recipe_role_value_nodes_dedup_across_ingredients(tmp_path):
+    """Two ingredients sharing a facet value should point at the SAME role-value node."""
+    recipe = _write(tmp_path, {
+        "preferred_term": "Dedup medium",
+        "ingredients": [
+            {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"},
+             "nutritional_roles": ["CARBON_SOURCE", "ENERGY_SOURCE"]},
+            {"preferred_term": "Methanol", "term": {"id": "CHEBI:17790"},
+             "nutritional_roles": ["CARBON_SOURCE", "ENERGY_SOURCE"]},
+        ],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    # Node declaration for CARBON_SOURCE / ENERGY_SOURCE should appear exactly once each.
+    assert mmd.count("CARBON_SOURCE\\n[nut]") == 1  # (both an occurrence and a label appearance)
+    assert mmd.count("ENERGY_SOURCE\\n[nut]") == 1
+    # Both ingredients edge to the same role nodes → 4 edges total for the 2×2 facet values.
+    assert mmd.count("|nut|--> role_nutritional_roles_CARBON_SOURCE") == 2
+    assert mmd.count("|nut|--> role_nutritional_roles_ENERGY_SOURCE") == 2
+
+
+def test_single_recipe_role_curie_escape_hatch(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Curie medium",
+        "ingredients": [{
+            "preferred_term": "Something", "term": {"id": "CHEBI:99999"},
+            "role_curie": ["CHEBI:50906", "METPO:2000006"],
+        }],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    assert "|curie|" in mmd
+    assert "CHEBI:50906" in mmd
+    assert "METPO:2000006" in mmd
+    assert ":::role_curie" in mmd
+
+
+def test_single_recipe_target_organisms_and_community_roles(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Community medium",
+        "ingredients": [{"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}}],
+        "target_organisms": [{
+            "preferred_term": "E. coli",
+            "term": {"id": "NCBITaxon:562"},
+            "community_role": ["PRIMARY_DEGRADER"],
+        }],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    assert "NCBITaxon_562" in mmd
+    assert "MEDIUM ==> NCBITaxon_562" in mmd
+    assert "PRIMARY_DEGRADER" in mmd
+    assert "|community-role|--> cor_PRIMARY_DEGRADER" in mmd
+
+
+def test_single_recipe_nutrient_overrides(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Override medium",
+        "ingredients": [],
+        "target_organisms": [{
+            "preferred_term": "Test org",
+            "term": {"id": "NCBITaxon:1"},
+            "growth_metrics": [{
+                "nutrient_overrides": [
+                    {"role": "CARBON_SOURCE", "source": "succinate", "is_sole_source": True},
+                ],
+            }],
+        }],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    assert "|nut-override|" in mmd
+    assert "succinate (sole)" in mmd
+    assert "[NutOverride: CARBON_SOURCE]" in mmd
+
+
+def test_single_recipe_solutions_produce_solution_layer(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Solution medium",
+        "ingredients": [],
+        "solutions": [{
+            "preferred_term": "Vitamin mix",
+            "term": {"id": "mediadive.solution:2227"},
+            "composition": [
+                {"preferred_term": "Biotin", "term": {"id": "CHEBI:15956"}},
+                {"preferred_term": "Folic acid", "term": {"id": "CHEBI:27470"}},
+            ],
+        }],
+    })
+    mmd = _render.render_single_recipe(recipe)
+    # Solution node styling.
+    assert ":::solution" in mmd
+    assert "MEDIUM -.-> mediadive_solution_2227" in mmd
+    # Composition ingredients under the solution.
+    assert "mediadive_solution_2227 --> CHEBI_15956" in mmd
+    assert "mediadive_solution_2227 --> CHEBI_27470" in mmd
+
+
+def test_single_recipe_max_ingredients_cap_emits_sentinel(tmp_path):
+    ingredients = [
+        {"preferred_term": f"ing_{i}", "term": {"id": f"CHEBI:{100 + i}"}}
+        for i in range(50)
+    ]
+    recipe = _write(tmp_path, {"preferred_term": "Big medium", "ingredients": ingredients})
+    mmd = _render.render_single_recipe(recipe, max_ingredients=10)
+    # 10 ingredients rendered, 40 truncated.
+    assert mmd.count(":::ingredient") == 10
+    assert '...40 more ingredients (cap: 10)' in mmd
+    assert ":::truncated" in mmd
+
+
+def test_single_recipe_include_notes_flag(tmp_path):
+    recipe = _write(tmp_path, {
+        "preferred_term": "Noted medium",
+        "ingredients": [{
+            "preferred_term": "X", "term": {"id": "CHEBI:1"},
+            "notes": "Role: Carbon source; From upstream MediaDive record 5",
+        }],
+    })
+    without = _render.render_single_recipe(recipe, include_notes=False)
+    assert "Role: Carbon source" not in without
+    with_notes = _render.render_single_recipe(recipe, include_notes=True)
+    assert "Role: Carbon source" in with_notes
+    assert ":::note" in with_notes
+
+
+def test_single_recipe_style_block_always_emitted(tmp_path):
+    recipe = _write(tmp_path, {"preferred_term": "S", "ingredients": []})
+    mmd = _render.render_single_recipe(recipe)
+    for slot in ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles"):
+        assert f"classDef {slot}" in mmd
+
+
+# ---------------- roll-up ----------------
+
+
+def test_rollup_greenfield_corpus_reports_no_roles(tmp_path):
+    """A corpus with no faceted role values renders an empty-state message, not a crash."""
+    (tmp_path / "recipe.yaml").write_text(yaml.safe_dump({
+        "preferred_term": "R",
+        "ingredients": [
+            {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}},
+        ],
+    }))
+    mmd = _render.render_rollup(tmp_path)
+    assert "Corpus role roll-up" in mmd
+    assert "No faceted role assignments found yet" in mmd
+
+
+def test_rollup_aggregates_across_recipes(tmp_path):
+    """Two recipes sharing CARBON_SOURCE on glucose → count == 2."""
+    (tmp_path / "r1.yaml").write_text(yaml.safe_dump({
+        "preferred_term": "R1",
+        "ingredients": [{
+            "preferred_term": "Glucose", "term": {"id": "CHEBI:17234"},
+            "nutritional_roles": ["CARBON_SOURCE"],
+        }],
+    }))
+    (tmp_path / "r2.yaml").write_text(yaml.safe_dump({
+        "preferred_term": "R2",
+        "ingredients": [{
+            "preferred_term": "Glucose", "term": {"id": "CHEBI:17234"},
+            "nutritional_roles": ["CARBON_SOURCE"],
+        }],
+    }))
+    mmd = _render.render_rollup(tmp_path)
+    assert "CHEBI:17234" in mmd
+    assert "CARBON_SOURCE" in mmd
+    # Weight-on-edge shows count.
+    assert "nut: 2" in mmd
+
+
+# ---------------- CLI smoke ----------------
+
+
+def test_cli_requires_target_or_yaml_dir(capsys):
+    with pytest.raises(SystemExit) as exc:
+        _render.main([])
+    assert exc.value.code == 2
+
+
+def test_cli_single_stdout(tmp_path, capsys):
+    recipe_yaml = _write(tmp_path, {
+        "preferred_term": "CLI medium",
+        "ingredients": [{"preferred_term": "X", "term": {"id": "CHEBI:1"}}],
+    })
+    rc = _render.main(["--target", str(recipe_yaml), "--stdout"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "flowchart LR" in captured.out
+    assert "CLI medium" in captured.out
+
+
+def test_cli_batch_writes_files(tmp_path, capsys):
+    (tmp_path / "a.yaml").write_text(yaml.safe_dump({
+        "preferred_term": "A", "ingredients": [{"preferred_term": "x", "term": {"id": "CHEBI:1"}}],
+    }))
+    (tmp_path / "b.yaml").write_text(yaml.safe_dump({
+        "preferred_term": "B", "ingredients": [{"preferred_term": "y", "term": {"id": "CHEBI:2"}}],
+    }))
+    out_dir = tmp_path / "out"
+    rc = _render.main(["--yaml-dir", str(tmp_path), "--out-dir", str(out_dir), "--mode", "batch"])
+    assert rc == 0
+    assert (out_dir / "a.mmd").exists()
+    assert (out_dir / "b.mmd").exists()


### PR DESCRIPTION
## Summary

New visualization skill that renders a `MediaRecipe` (or corpus roll-up) as a **mermaid** flowchart of the ingredient ↔ facet-role structure the three-facet migration (#93 / #94 / #95 / #98 / #99) put in place. Complementary to `src/culturemech/export/kgx_export.py` which flattens the three facets into a single `biolink:role` qualifier — this skill keeps each facet on its own color-coded edge and dedupes shared role values so recurring patterns pop visually.

## Three modes

- **single** — one recipe → one `.mmd` (default when `--target` is given).
- **batch** — many recipes → one `.mmd` per recipe.
- **rollup** — cross-corpus `(chebi_id, facet, role_value)` frequency aggregation → one summary `.mmd`.

## What lands

| File | Purpose |
| ---- | ------- |
| `scripts/render_media_role_graph.py` (401 lines) | CLI + rendering; walk mirrors `kgx_export.transform()` and extends beyond it by preserving facet edges, `role_curie`, `community_role`, and `nutrient_overrides` (organism-scoped per schema). |
| `tests/test_render_media_role_graph.py` (21 tests, all pass) | Covers sanitizer helpers, per-facet edge emission, node dedup, `role_curie`, community-org role, nutrient overrides via `growth_metrics`, solution composition layer, max-ingredients cap sentinel, notes side-nodes, rollup empty/aggregate, CLI. |
| `.claude/skills/render-media-role-graph/SKILL.md` | Progressive-disclosure runbook. Frontmatter matches `generate-ingredient-umap` / `deep-research-medium`. Sections: Overview, When to Use, Inputs, Workflow (single/batch/rollup), Output structure, Node & edge conventions, Design notes, Anti-patterns, Related skills, Reference artifacts, Testing. |
| `reports/media_role_graphs/{ym,chopped_meat_...,nldm_defined_no_iron}.mmd` | Three reference artifacts across small / medium-with-organisms / ingredient-cap-truncated shapes. |

## Design highlights

- **Facet color coding** (matches matplotlib tab10): 🟢 `nutritional_roles` · 🔵 `physicochemical_roles` · 🔴 `cellular_metabolic_roles` · 🟣 `nutrient_overrides` · 🌿 `community_organism_role`.
- **Role-value dedup**: two ingredients sharing `SULFUR_SOURCE` both point at the same node — spotting recurring facet coverage becomes trivial.
- **Solutions as a middle layer**: `MEDIUM -.-> solution --> composition_ingredient` (dashed edge for the medium→solution link).
- **`nutrient_overrides` are organism-scoped** per the schema (`target_organisms[].growth_metrics[].nutrient_overrides[]`), NOT top-level on `MediaRecipe`. Graph reflects this exactly.
- **Ingredient count cap** = 30 (matches the sentinel in `culturebotai-claw/src/kg_microbe_browser/graph.py`). Beyond the cap: `...N more` sentinel node with `:::truncated` styling.
- **Standalone `.mmd` output** — no Jinja / no HTML wrapping. Consumers render in-browser (mermaid.js supports source directly) or via `mmdc` for static SVG/PNG.

## Corpus reality-check

Today (2026-07-21) the corpus is **greenfield for faceted role slots** — the `audit_missing_roles.py` output from #95 shows 143,651 MIM-mapped ingredients missing all three facet slots. So most single-recipe renders today show only the medium ↔ ingredient scaffold. Once **#128** (retire flat MIM enum) and **#7b** (Edison literature backfill) populate slots, the graphs immediately become richer without any script changes.

## Test plan

- [x] `uv run pytest tests/test_render_media_role_graph.py -v` — 21 passed
- [x] Smoke-rendered 3 reference artifacts (small ym, mid chopped_meat, cap-triggering nldm_defined_no_iron) — all render cleanly, sentinel node fires on nldm at 30/99 ingredients.
- [x] Rollup smoke-tested on `--limit 100` — correctly reports greenfield empty-state (no crashes on all-null facet slots).
- [ ] CI green
- [ ] Follow-up: wire a `just render-media-role-graph <target>` recipe into `project.justfile` under `[group('Visualization')]` — deferred so recipe surface can be reviewed with real usage first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)