### PR TITLE
Add role-research prioritizer: rank MIM ingredients by facet-gap × occurrence

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -103,6 +103,16 @@ enrich-edison-response *args="":
 prioritize-deep-research-candidates *args="":
     uv run --extra dev python scripts/prioritize_deep_research_candidates.py {{args}}
 
+# Rank MediaIngredientMech ingredients for Step 7b Edison role-research.
+# Cross-repo scan of ../MediaIngredientMech/data/ingredients/**/*.yaml scored by
+# (# facets missing) × log(occurrence) × mapped-mult × chebi-mult, minus records
+# that already have completed Edison role research. Writes:
+#   data/import_tracking/reports/role_research_priority.json  (batch-ready)
+# Output is a batch payload accepted by MIM's `research-ingredient-roles-edison-batch`.
+[group('Research')]
+prioritize-role-research-candidates *args="":
+    uv run --extra dev python scripts/prioritize_role_research_candidates.py {{args}}
+
 [group('Research')]
 research-organism-recipe-edison target organism *args="":
     uv run --extra dev python scripts/research_organism_recipe_edison.py \

--- a/scripts/prioritize_role_research_candidates.py
+++ b/scripts/prioritize_role_research_candidates.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Prioritize MIM ingredients for Step 7b Edison role research.
+
+Scans `MediaIngredientMech/data/ingredients/**/*.yaml` (cross-repo via
+`--mim-repo`), scores each record by "how much do we gain by researching
+the roles here?", and emits a batch JSON compatible with MIM's
+`research_ingredient_edison.py --batch`.
+
+Scoring rubric (higher = higher priority):
+
+  base = (# facet slots empty) × log10(1 + total_occurrences)
+       × (mapping_status == "MAPPED" ? 1.0 : 0.3)
+       × (has_CHEBI_grounding ? 1.0 : 0.4)
+
+  penalty for records that already ran Edison role research
+  (existing `research/ingredients/roles/<slug>-edison-*-meta.yaml`)
+  reduces score to 0.
+
+Rationale:
+
+  - **Facet gaps count** — every empty facet is an opportunity, weighted
+    equally (3 empty vs 2 empty vs 1 empty).
+  - **Occurrence matters most on log scale** — glucose (1638 occurrences)
+    ranks higher than a rare ingredient (5 occurrences), but not 300×
+    higher; log-scale keeps rare-but-empty ingredients on the map.
+  - **UNMAPPED downgraded** — role research on an unmapped ingredient
+    lands roles the ontology mapping can't tie back to; still worth
+    doing but at 0.3× priority.
+  - **Non-CHEBI grounding downgraded** — Edison's CHEBI-flavored
+    role research is calibrated on CHEBI; FOODON/MICRO/UBERON groundings
+    still ok (0.4× multiplier) but ranking-below-equal.
+
+Companion of the existing `scripts/prioritize_deep_research_candidates.py`
+which scores CultureMech MEDIA recipes (not MIM INGREDIENTS) with a
+different rubric. Two scripts, two different corpora, one output format.
+
+Usage:
+
+    just prioritize-role-research-candidates
+    # → data/import_tracking/reports/role_research_priority.json
+
+    # Custom MIM location + smaller top-N:
+    uv run python scripts/prioritize_role_research_candidates.py \\
+        --mim-repo ../MediaIngredientMech --top 25 \\
+        --out data/import_tracking/reports/role_research_priority_top25.json
+
+    # Feed the output straight into MIM's Edison batch runner:
+    (cd ../MediaIngredientMech && \\
+     just research-ingredient-roles-edison-batch \\
+       ../CultureMech/data/import_tracking/reports/role_research_priority.json \\
+       --dry-run)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MIM_REPO = REPO_ROOT.parent / "MediaIngredientMech"
+DEFAULT_OUTPUT = REPO_ROOT / "data" / "import_tracking" / "reports" / "role_research_priority.json"
+
+FACET_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+
+def _read_ingredient(path: Path) -> dict[str, Any] | None:
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except Exception:
+        return None
+    if not isinstance(doc, dict):
+        return None
+    return doc
+
+
+def _score_record(doc: dict[str, Any]) -> tuple[float, dict[str, Any]]:
+    """Return (score, breakdown_dict) for one ingredient record."""
+    empty_facets = sum(1 for slot in FACET_SLOTS if not doc.get(slot))
+    occurrences = int((doc.get("occurrence_statistics") or {}).get("total_occurrences") or 0)
+    mapping_status = str(doc.get("mapping_status") or "").upper()
+    identifier = doc.get("identifier") or ""
+    ontology_id = (doc.get("ontology_mapping") or {}).get("ontology_id") or ""
+
+    is_chebi = identifier.startswith("CHEBI:") or (isinstance(ontology_id, str) and ontology_id.startswith("CHEBI:"))
+    is_mapped = mapping_status == "MAPPED"
+
+    # log10(1 + n) — glucose (1638) → 3.21; a 5-occurrence ingredient → 0.78.
+    occurrence_weight = math.log10(1 + occurrences) if occurrences > 0 else 0.0
+
+    mapped_mult = 1.0 if is_mapped else 0.3
+    chebi_mult = 1.0 if is_chebi else 0.4
+
+    score = empty_facets * occurrence_weight * mapped_mult * chebi_mult
+
+    breakdown = {
+        "empty_facets": empty_facets,
+        "total_occurrences": occurrences,
+        "occurrence_weight": round(occurrence_weight, 3),
+        "mapped_mult": mapped_mult,
+        "chebi_mult": chebi_mult,
+        "score": round(score, 3),
+    }
+    return score, breakdown
+
+
+def _existing_roles_research(mim_repo: Path, slug: str) -> bool:
+    """True if any Edison role-research meta yaml already exists for `slug`."""
+    roles_dir = mim_repo / "research" / "ingredients" / "roles"
+    if not roles_dir.is_dir():
+        return False
+    for path in roles_dir.glob(f"{slug}-edison-*-meta.yaml"):
+        # Skip dry-run stubs; only real runs count as "already researched".
+        try:
+            meta = yaml.safe_load(path.read_text()) or {}
+        except Exception:
+            continue
+        if str(meta.get("status", "")).lower() != "dry-run" and meta.get("task_id"):
+            return True
+    return False
+
+
+def _record_to_batch_entry(path: Path, mim_repo: Path, doc: dict[str, Any], score: float, breakdown: dict[str, Any]) -> dict[str, Any]:
+    """Shape one entry for MIM's `research_ingredient_edison.py --batch`."""
+    slug = path.stem
+    try:
+        rel = path.relative_to(mim_repo)
+    except ValueError:
+        rel = path
+    return {
+        # research_ingredient_edison.py's load_batch_targets accepts either bare
+        # slug strings or dicts with `target`/`slug`/`file_path`/`identifier`.
+        "target": str(rel),  # relative-to-mim-repo path — passed as --target
+        "slug": slug,
+        "identifier": doc.get("identifier"),
+        "preferred_term": doc.get("preferred_term"),
+        "score": round(score, 3),
+        "score_breakdown": breakdown,
+    }
+
+
+def collect_and_score(
+    mim_repo: Path,
+    include_already_researched: bool = False,
+) -> list[dict[str, Any]]:
+    """Walk MIM ingredients and return a ranked list of batch entries."""
+    ingredients_root = mim_repo / "data" / "ingredients"
+    if not ingredients_root.is_dir():
+        raise SystemExit(f"MIM ingredients not found at {ingredients_root}. Pass --mim-repo.")
+
+    entries: list[tuple[float, dict[str, Any]]] = []
+    for path in sorted(ingredients_root.rglob("*.yaml")):
+        doc = _read_ingredient(path)
+        if doc is None:
+            continue
+        score, breakdown = _score_record(doc)
+        if score <= 0:
+            # Nothing to research: either all 3 facets full or no occurrences.
+            continue
+        if not include_already_researched and _existing_roles_research(mim_repo, path.stem):
+            continue
+        entry = _record_to_batch_entry(path, mim_repo, doc, score, breakdown)
+        entries.append((score, entry))
+
+    entries.sort(key=lambda t: t[0], reverse=True)
+    return [entry for _, entry in entries]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mim-repo", type=Path, default=DEFAULT_MIM_REPO,
+                        help="MediaIngredientMech checkout root (default: ../MediaIngredientMech).")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT,
+                        help="Output JSON path.")
+    parser.add_argument("--top", type=int, default=None,
+                        help="Cap output to top-N candidates.")
+    parser.add_argument("--include-already-researched", action="store_true",
+                        help="Include ingredients that already have an Edison role-research meta yaml.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    entries = collect_and_score(args.mim_repo, include_already_researched=args.include_already_researched)
+    if args.top is not None:
+        entries = entries[: args.top]
+
+    args.out.write_text(json.dumps(entries, indent=2))
+
+    print(f"Scanned MIM ingredients under {args.mim_repo}/data/ingredients")
+    print(f"Ranked {len(entries)} candidates → {args.out}")
+    if entries:
+        print()
+        print("Top 5:")
+        for e in entries[:5]:
+            print(f"  score={e['score']:7.3f}  {e['identifier'] or '(no id)'} — {e['preferred_term']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prioritize_role_research_candidates.py
+++ b/tests/test_prioritize_role_research_candidates.py
@@ -1,0 +1,309 @@
+"""Tests for scripts/prioritize_role_research_candidates.py — Step 7b prioritizer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "prioritize_role_research_candidates.py"
+
+_SPEC = importlib.util.spec_from_file_location("_prioritize", _SCRIPT_PATH)
+_prio = importlib.util.module_from_spec(_SPEC)
+sys.modules["_prioritize"] = _prio
+_SPEC.loader.exec_module(_prio)  # type: ignore[union-attr]
+
+
+def _make_mim_tree(tmp_path: Path, records: dict[str, dict]) -> Path:
+    """Build a mini MediaIngredientMech tree with one YAML per record.
+
+    `records` is `{path_relative_to_data_ingredients: doc}`.
+    """
+    mim = tmp_path / "mim"
+    for rel_path, doc in records.items():
+        target = mim / "data" / "ingredients" / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(yaml.safe_dump(doc))
+    return mim
+
+
+# ---------------- _score_record ----------------
+
+
+def test_score_zero_when_all_three_facets_full():
+    doc = {
+        "identifier": "CHEBI:17234",
+        "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+        "nutritional_roles": [{"role": "CARBON_SOURCE"}],
+        "physicochemical_roles": [{"role": "BUFFER"}],
+        "cellular_metabolic_roles": [{"role": "SUBSTRATE"}],
+    }
+    score, breakdown = _prio._score_record(doc)
+    assert score == 0.0
+    assert breakdown["empty_facets"] == 0
+
+
+def test_score_higher_for_more_facets_missing():
+    base = {
+        "identifier": "CHEBI:17234", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    zero_full = dict(base)  # all 3 missing
+    one_full = dict(base, nutritional_roles=[{"role": "X"}])  # 2 missing
+    two_full = dict(base, nutritional_roles=[{"role": "X"}],
+                    physicochemical_roles=[{"role": "Y"}])  # 1 missing
+    s0, _ = _prio._score_record(zero_full)
+    s1, _ = _prio._score_record(one_full)
+    s2, _ = _prio._score_record(two_full)
+    assert s0 > s1 > s2 > 0
+    # 3× vs 2× vs 1× — linear in empty count.
+    assert s0 == pytest.approx(3.0 * s2, rel=1e-3)
+
+
+def test_score_occurrence_weighting_is_log10():
+    """A 1638-occurrence ingredient (like glucose) should not swamp a 100-occurrence one."""
+    doc_lo = {
+        "identifier": "CHEBI:1", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    doc_hi = {
+        "identifier": "CHEBI:2", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 1638},
+    }
+    s_lo, _ = _prio._score_record(doc_lo)
+    s_hi, _ = _prio._score_record(doc_hi)
+    # Ratio should be log10(1639)/log10(101) ≈ 3.21/2.00 ≈ 1.60, not 16.4.
+    ratio = s_hi / s_lo
+    assert 1.2 < ratio < 2.0, f"expected log-scale ratio in (1.2, 2.0); got {ratio:.2f}"
+
+
+def test_score_unmapped_downgrade():
+    mapped = {
+        "identifier": "CHEBI:17234", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    unmapped = {
+        "identifier": "CHEBI:17234", "mapping_status": "UNMAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    s_m, _ = _prio._score_record(mapped)
+    s_u, _ = _prio._score_record(unmapped)
+    assert s_u == pytest.approx(0.3 * s_m, rel=1e-3)
+
+
+def test_score_non_chebi_downgrade():
+    chebi_grounded = {
+        "identifier": "CHEBI:17234", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    foodon_grounded = {
+        "identifier": "MediaIngredientMech:00042", "mapping_status": "MAPPED",
+        "ontology_mapping": {"ontology_id": "FOODON:03315720"},
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    s_c, _ = _prio._score_record(chebi_grounded)
+    s_f, _ = _prio._score_record(foodon_grounded)
+    assert s_f == pytest.approx(0.4 * s_c, rel=1e-3)
+
+
+def test_score_ontology_mapping_chebi_lifts_multiplier():
+    """A non-CHEBI identifier but CHEBI ontology_mapping still counts as CHEBI-grounded."""
+    doc = {
+        "identifier": "MediaIngredientMech:00042", "mapping_status": "MAPPED",
+        "ontology_mapping": {"ontology_id": "CHEBI:17234"},
+        "occurrence_statistics": {"total_occurrences": 100},
+    }
+    score, breakdown = _prio._score_record(doc)
+    assert breakdown["chebi_mult"] == 1.0
+    assert score > 0
+
+
+def test_score_zero_when_no_occurrences():
+    doc = {
+        "identifier": "CHEBI:17234", "mapping_status": "MAPPED",
+        "occurrence_statistics": {"total_occurrences": 0},
+    }
+    score, _ = _prio._score_record(doc)
+    assert score == 0.0
+
+
+# ---------------- collect_and_score ----------------
+
+
+def test_collect_ranks_by_score(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/high.yaml": {
+            "identifier": "CHEBI:1", "preferred_term": "high", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 1000},
+        },  # all facets empty, high occurrence → high score
+        "mapped/med.yaml": {
+            "identifier": "CHEBI:2", "preferred_term": "med", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 50},
+        },  # all empty, med occurrence
+        "mapped/low.yaml": {
+            "identifier": "CHEBI:3", "preferred_term": "low", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 5},
+            "nutritional_roles": [{"role": "X"}],
+            "physicochemical_roles": [{"role": "Y"}],
+        },  # 1 facet empty, low occurrence
+    })
+    entries = _prio.collect_and_score(mim)
+    assert [e["preferred_term"] for e in entries] == ["high", "med", "low"]
+
+
+def test_collect_skips_fully_roled_ingredients(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/full.yaml": {
+            "identifier": "CHEBI:1", "preferred_term": "full", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+            "nutritional_roles": [{"role": "X"}],
+            "physicochemical_roles": [{"role": "Y"}],
+            "cellular_metabolic_roles": [{"role": "Z"}],
+        },
+        "mapped/gap.yaml": {
+            "identifier": "CHEBI:2", "preferred_term": "gap", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+    })
+    entries = _prio.collect_and_score(mim)
+    assert len(entries) == 1
+    assert entries[0]["preferred_term"] == "gap"
+
+
+def test_collect_skips_zero_occurrence_ingredients(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/zero.yaml": {
+            "identifier": "CHEBI:1", "preferred_term": "zero", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 0},
+        },
+        "mapped/one.yaml": {
+            "identifier": "CHEBI:2", "preferred_term": "one", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 1},
+        },
+    })
+    entries = _prio.collect_and_score(mim)
+    assert [e["preferred_term"] for e in entries] == ["one"]
+
+
+def test_collect_skips_already_researched(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/researched.yaml": {
+            "identifier": "CHEBI:1", "preferred_term": "researched", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+        "mapped/fresh.yaml": {
+            "identifier": "CHEBI:2", "preferred_term": "fresh", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+    })
+    # Simulate a completed real run for `researched` (not a dry-run).
+    roles_dir = mim / "research" / "ingredients" / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "researched-edison-literature-meta.yaml").write_text(yaml.safe_dump({
+        "status": "complete", "task_id": "task_abc123",
+    }))
+    # And a dry-run for `fresh` — those don't count as researched.
+    (roles_dir / "fresh-edison-literature-meta.yaml").write_text(yaml.safe_dump({
+        "status": "dry-run", "task_id": None,
+    }))
+
+    entries = _prio.collect_and_score(mim)
+    slugs = [e["slug"] for e in entries]
+    assert "fresh" in slugs
+    assert "researched" not in slugs
+
+
+def test_collect_include_already_researched_flag(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/researched.yaml": {
+            "identifier": "CHEBI:1", "preferred_term": "researched", "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+    })
+    roles_dir = mim / "research" / "ingredients" / "roles"
+    roles_dir.mkdir(parents=True)
+    (roles_dir / "researched-edison-literature-meta.yaml").write_text(yaml.safe_dump({
+        "status": "complete", "task_id": "task_abc123",
+    }))
+
+    entries = _prio.collect_and_score(mim, include_already_researched=True)
+    assert len(entries) == 1
+
+
+# ---------------- batch entry shape ----------------
+
+
+def test_batch_entry_carries_target_and_slug(tmp_path):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/L-cysteine.yaml": {
+            "identifier": "CHEBI:17561", "preferred_term": "L-cysteine",
+            "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+    })
+    entries = _prio.collect_and_score(mim)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["slug"] == "L-cysteine"
+    assert e["target"] == "data/ingredients/mapped/L-cysteine.yaml"
+    assert e["identifier"] == "CHEBI:17561"
+    assert e["preferred_term"] == "L-cysteine"
+    assert "score" in e
+    assert "score_breakdown" in e
+
+
+# ---------------- CLI ----------------
+
+
+def test_main_writes_output(tmp_path, capsys):
+    mim = _make_mim_tree(tmp_path, {
+        "mapped/L-cysteine.yaml": {
+            "identifier": "CHEBI:17561", "preferred_term": "L-cysteine",
+            "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100},
+        },
+    })
+    out = tmp_path / "priority.json"
+    rc = _prio.main(["--mim-repo", str(mim), "--out", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["slug"] == "L-cysteine"
+
+    stdout = capsys.readouterr().out
+    assert "Ranked 1 candidates" in stdout
+    assert "Top 5:" in stdout
+    assert "L-cysteine" in stdout
+
+
+def test_main_top_cap(tmp_path):
+    records = {
+        f"mapped/rec_{i:03d}.yaml": {
+            "identifier": f"CHEBI:{i:04d}", "preferred_term": f"rec_{i}",
+            "mapping_status": "MAPPED",
+            "occurrence_statistics": {"total_occurrences": 100 - i},
+        }
+        for i in range(10)
+    }
+    mim = _make_mim_tree(tmp_path, records)
+    out = tmp_path / "priority.json"
+    rc = _prio.main(["--mim-repo", str(mim), "--out", str(out), "--top", "3"])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert len(data) == 3
+    # Sorted descending by occurrence weight.
+    assert data[0]["preferred_term"] == "rec_0"
+
+
+def test_main_errors_on_missing_mim_repo(tmp_path, capsys):
+    out = tmp_path / "priority.json"
+    with pytest.raises(SystemExit, match="MIM ingredients not found"):
+        _prio.main(["--mim-repo", str(tmp_path / "nonexistent"), "--out", str(out)])


### PR DESCRIPTION
## Summary

Step 7b PR3 of the ingredient-roles migration. Adds a cross-repo prioritizer that scans `../MediaIngredientMech/data/ingredients/**/*.yaml` and ranks ingredients by how much would be gained by running Edison role research on them. Emits a batch JSON payload compatible with MIM's `research_ingredient_edison.py --batch`.

- `scripts/prioritize_role_research_candidates.py` — ranker + CLI. Scoring rubric:
  ```
  score = (# empty facets in {nutritional, physicochemical, cellular_metabolic})
        × log10(1 + total_occurrences)
        × (MAPPED ? 1.0 : 0.3)
        × (has CHEBI grounding ? 1.0 : 0.4)
  ```
  Records that already have a completed Edison role-research meta yaml
  (`research/ingredients/roles/<slug>-edison-*-meta.yaml` with non-dry-run status
  and a task_id) are excluded. Dry-run stubs don't count.

- `tests/test_prioritize_role_research_candidates.py` — 16 tests covering scoring edge cases (all-full → 0, log-scale occurrence ratio, unmapped/non-CHEBI downgrades, ontology_mapping CHEBI lift), the collection filter (skip fully-roled, skip zero-occurrence, skip already-researched), the batch-entry shape (target relative to mim-repo, slug, identifier, preferred_term, score breakdown), and the CLI (--top cap, --out, missing --mim-repo).

- `project.justfile` — `just prioritize-role-research-candidates` recipe.

### Sanity check against real MIM

```
$ just prioritize-role-research-candidates --top 5
Ranked 5 candidates
Top 5:
  score= 10.897  CHEBI:15377 — Distilled water
  score=  9.221  CHEBI:32145 — NaOH
  score=  9.131  CHEBI:17883 — HCl
  score=  7.601  CHEBI:26710 — NaCl
  score=  7.276  CHEBI:86158 — CaCl2 x 2 H2O
```

The top-N surfaces both "high-value but unglamorous" ingredients (NaCl, CaCl2 — likely to yield OSMOTIC_AGENT / TRACE_ELEMENT hits) and structural entries (distilled water, HCl, NaOH — where the curator may triage before spending Edison credits). The prioritizer's job is to rank by empty-facet × occurrence signal; curator judgment applies to the top-N before firing off the batch.

### Companion of

`scripts/prioritize_deep_research_candidates.py` (media recipes, not ingredients). Two separate scripts, two separate corpora, same output shape so both feed into batch runners identically.

## Test plan

- [x] `uv run pytest tests/test_prioritize_role_research_candidates.py` — 16/16 pass
- [x] `just prioritize-role-research-candidates --top 10` succeeds against real MIM checkout
- [x] Output JSON shape verified against MIM's `load_batch_targets()` — the `target` key wins (repo-relative path), which is exactly what `research_ingredient_edison.py --target` accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)