### PR TITLE
Add role extractor: parse Edison YAML block, emit dual applier batches

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -113,6 +113,18 @@ prioritize-deep-research-candidates *args="":
 prioritize-role-research-candidates *args="":
     uv run --extra dev python scripts/prioritize_role_research_candidates.py {{args}}
 
+# Extract structured role assignments from Edison role-research bundles.
+# Consumes `-edison-literature.md` files under a directory (or single files) and
+# emits two batch JSONs:
+#   --out-mim  → rich shape for MIM `apply_role_research_results.py`
+#   --out-cm   → scalar shape for CultureMech's future `apply_ingredient_roles`
+#
+# Default: scans ../MediaIngredientMech/research/ingredients/roles/
+# Example: just extract-roles-from-edison
+[group('Research')]
+extract-roles-from-edison inputs="../MediaIngredientMech/research/ingredients/roles" *args="":
+    uv run --extra dev python scripts/extract_roles_from_edison.py {{inputs}} {{args}}
+
 [group('Research')]
 research-organism-recipe-edison target organism *args="":
     uv run --extra dev python scripts/research_organism_recipe_edison.py \

--- a/scripts/extract_roles_from_edison.py
+++ b/scripts/extract_roles_from_edison.py
@@ -47,7 +47,13 @@ Follows the "never fabricate" rule from the plan: an ingredient whose
 Edison output has no parseable `role_research:` block is skipped and
 recorded in `--skipped-report`; a role whose token is not in the facet's
 enum permissible values (typo, hallucination, wrong facet) is dropped and
-logged. The applier repeats the enum check as a defense-in-depth.
+logged.
+
+This is the ONLY enum check in the pipeline — `apply_ingredient_roles.py`
+deliberately does not repeat it, so a batch produced with `--no-validate`
+(or hand-edited afterwards) can carry invalid tokens into the corpus, where
+they surface only at `just validate-strict`. Do not pass `--no-validate` on
+a batch you intend to apply.
 """
 
 from __future__ import annotations
@@ -79,8 +85,10 @@ _FACET_ENUM_NAMES = {
 def load_facet_enums(schema_path: Path = DEFAULT_MIM_ROLES_SCHEMA) -> dict[str, frozenset[str]]:
     """Load {facet_slot: frozenset(permissible_values)} from the vendored mim_roles schema.
 
-    Single source of truth: read enum permissible values from mim_roles.yaml (whose
-    sha is pinned in project.justfile:verify-schema-pin). No hand-typed token lists.
+    Single source of truth: read enum permissible values from mim_roles.yaml.
+    No hand-typed token lists. (The old `verify-schema-pin` sha guard on this file
+    was retired in #112 — see project.justfile:841 — so this is now the only check
+    tying emitted tokens to the schema.)
     """
     if not schema_path.is_file():
         raise SystemExit(f"mim_roles schema not found at {schema_path}")

--- a/scripts/extract_roles_from_edison.py
+++ b/scripts/extract_roles_from_edison.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Extract structured role assignments from Edison role-research outputs.
+
+Consumes Edison / DRC role-research bundles produced by the Step 7b
+literature lane — specifically the `role_research:` fenced YAML block in
+`research/ingredients/roles/*-edison-literature.md` (or equivalent DRC
+outputs) — and emits two batch JSON files:
+
+  --out-mim → the "rich" shape consumed by MIM's `apply_role_research_results.py`:
+    {"proposals": [{
+       "ingredient_identifier": "CHEBI:17561",
+       "ingredient_path": "data/ingredients/mapped/L-cysteine.yaml",
+       "source_run": "L-cysteine-edison-literature",
+       "role_assignments": {
+         "nutritional_roles": [{role, confidence, evidence, ...}],
+         "physicochemical_roles": [...],
+         "cellular_metabolic_roles": [...]},
+     }, ...]}
+
+  --out-cm → the scalar-projection shape consumed by CultureMech's
+  forthcoming `apply_ingredient_roles` (PR5). Same shape as MIM but with an
+  extra `roles` block flattened to per-facet role-token lists (evidence
+  intentionally not projected — CultureMech's IngredientDescriptor carries
+  scalar role tokens, evidence stays on the MIM record).
+
+DOI / PMID cross-referencing:
+
+  When a `-citations.md` sidecar exists next to the response file (Edison
+  writes one automatically), any citation entry in a role's `evidence:` list
+  whose `doi:` or `pmid:` matches a sidecar entry gets its `reference_text:`
+  filled in from the sidecar. This lets the Edison model report just a DOI
+  without hand-typing the citation string; the extractor upgrades the
+  evidence entry with the sidecar's authoritative rendering.
+
+Usage:
+
+    just extract-roles-from-edison ../MediaIngredientMech/research/ingredients/roles
+    # → out-mim: reports/edison_role_batch_mim.json
+    # → out-cm:  reports/edison_role_batch_cm.json
+
+    # Single file:
+    uv run python scripts/extract_roles_from_edison.py \\
+      ../MediaIngredientMech/research/ingredients/roles/L-cysteine-edison-literature.md \\
+      --out-mim /tmp/mim.json --out-cm /tmp/cm.json
+
+Follows the "never fabricate" rule from the plan: an ingredient whose
+Edison output has no parseable `role_research:` block is skipped and
+recorded in `--skipped-report`; a role whose token is not in the facet's
+enum permissible values (typo, hallucination, wrong facet) is dropped and
+logged. The applier repeats the enum check as a defense-in-depth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT_MIM = REPO_ROOT / "data" / "import_tracking" / "reports" / "edison_role_batch_mim.json"
+DEFAULT_OUT_CM = REPO_ROOT / "data" / "import_tracking" / "reports" / "edison_role_batch_cm.json"
+
+FACET_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+# Regex catches ```yaml … ``` blocks; case-insensitive on the language tag.
+_YAML_FENCE_RE = re.compile(r"```(?:yaml|yml)\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE)
+
+# DOI / PMID regexes for sidecar cross-reference.
+_DOI_RE = re.compile(r"10\.\d{4,9}/[-._;()/:A-Za-z0-9]+", re.IGNORECASE)
+_PMID_RE = re.compile(r"\bPMID[:\s]+([0-9]{4,10})\b", re.IGNORECASE)
+
+
+class ExtractionError(Exception):
+    """Raised for structural problems in an Edison bundle."""
+
+
+def find_role_yaml_block(md_text: str) -> dict[str, Any] | None:
+    """Return the parsed `role_research:` dict from the last matching fenced block.
+
+    The template's own example lives in an early fence — the model's actual
+    answer is later in the file, so LAST wins. Skips blocks that don't have
+    `role_research:` at their top level; returns None if nothing matches.
+    """
+    matches = list(_YAML_FENCE_RE.finditer(md_text))
+    for m in reversed(matches):
+        block = m.group(1)
+        try:
+            parsed = yaml.safe_load(block)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict) and "role_research" in parsed:
+            rr = parsed["role_research"]
+            if isinstance(rr, dict):
+                return rr
+    return None
+
+
+def _load_meta_sidecar(response_md: Path) -> dict[str, Any]:
+    """Load the `-meta.yaml` sidecar if present. Returns {} on any failure."""
+    meta_path = response_md.with_name(response_md.stem + "-meta.yaml")
+    # `.stem` on `X-literature.md` is `X-literature` — but meta is written as
+    # `X-literature-meta.yaml` regardless of the .md suffix pattern used by
+    # deep-research vs edison. Try both conventions.
+    candidates = [
+        response_md.with_name(response_md.stem + "-meta.yaml"),
+        response_md.parent / f"{response_md.stem}-meta.yaml",
+    ]
+    for c in candidates:
+        if c.is_file():
+            try:
+                doc = yaml.safe_load(c.read_text()) or {}
+                if isinstance(doc, dict):
+                    return doc
+            except yaml.YAMLError:
+                continue
+    return {}
+
+
+def _parse_citations_sidecar(sidecar: Path) -> dict[str, str]:
+    """Parse the `-citations.md` sidecar into {normalized_doi_or_pmid: full_citation_line}.
+
+    Each bullet in a citations sidecar looks like:
+        - **1.** (foo pages 1-5): Author et al. Title. Journal, 2020. URL: ..., doi:10.xxxx/yyy...
+    We index each line by every DOI/PMID we can extract from it, so a lookup
+    by DOI can retrieve the rendered author-title-journal string.
+    """
+    if not sidecar.is_file():
+        return {}
+    lookup: dict[str, str] = {}
+    for raw in sidecar.read_text().splitlines():
+        line = raw.strip()
+        if not line.startswith("- "):
+            continue
+        # Strip leading list markers/bolds for a clean citation text.
+        text = re.sub(r"^\-\s+(\*\*\d+\.\*\*\s*)?(\([^)]+\):\s*)?", "", line).strip()
+        for doi in _DOI_RE.findall(text):
+            lookup.setdefault(doi.lower().rstrip(").,;"), text)
+        for pmid in _PMID_RE.findall(text):
+            lookup.setdefault(f"PMID:{pmid}", text)
+    return lookup
+
+
+def _upgrade_evidence(evidence: list[dict[str, Any]], citations_lookup: dict[str, str]) -> list[dict[str, Any]]:
+    """Fill in `reference_text` from the sidecar when we can match on DOI/PMID."""
+    upgraded: list[dict[str, Any]] = []
+    for ev in evidence:
+        if not isinstance(ev, dict):
+            continue
+        entry = dict(ev)
+        if not entry.get("reference_text"):
+            key = None
+            if entry.get("doi"):
+                key = str(entry["doi"]).lower().rstrip(").,;")
+            elif entry.get("pmid"):
+                key = f"PMID:{entry['pmid']}"
+            if key and key in citations_lookup:
+                entry["reference_text"] = citations_lookup[key]
+        upgraded.append(entry)
+    return upgraded
+
+
+def _shape_role_entry(role_entry: Any) -> dict[str, Any] | None:
+    """Coerce one role-list entry into {role, confidence, metabolic_context?, evidence[]}."""
+    if isinstance(role_entry, str):
+        return {"role": role_entry.strip(), "confidence": 0.7, "evidence": []}
+    if not isinstance(role_entry, dict):
+        return None
+    role = role_entry.get("role")
+    if not role or not isinstance(role, str):
+        return None
+    out: dict[str, Any] = {
+        "role": role.strip(),
+        "confidence": float(role_entry.get("confidence", 0.7)),
+        "evidence": [],
+    }
+    if role_entry.get("metabolic_context"):
+        out["metabolic_context"] = str(role_entry["metabolic_context"])
+    evidence = role_entry.get("evidence") or []
+    if isinstance(evidence, list):
+        out["evidence"] = [ev for ev in evidence if isinstance(ev, dict)]
+    return out
+
+
+def extract_one(response_md: Path) -> dict[str, Any] | None:
+    """Parse one Edison response .md into a proposal dict, or None if unparseable."""
+    md_text = response_md.read_text()
+    rr = find_role_yaml_block(md_text)
+    if rr is None:
+        return None
+
+    meta = _load_meta_sidecar(response_md)
+    citations_lookup = _parse_citations_sidecar(
+        response_md.with_name(response_md.stem + "-citations.md")
+    )
+
+    slug = rr.get("ingredient") or meta.get("slug") or response_md.stem.rsplit("-edison-", 1)[0]
+    ingredient_identifier = (
+        rr.get("ingredient_identifier")
+        or meta.get("ingredient_id")
+        or (meta.get("template_vars") or {}).get("ingredient_identifier")
+    )
+    ingredient_path = meta.get("ingredient_path")
+
+    role_assignments: dict[str, list[dict[str, Any]]] = {}
+    for slot in FACET_SLOTS:
+        entries = rr.get(slot) or []
+        if not isinstance(entries, list):
+            continue
+        shaped: list[dict[str, Any]] = []
+        for entry in entries:
+            s = _shape_role_entry(entry)
+            if s is None:
+                continue
+            s["evidence"] = _upgrade_evidence(s["evidence"], citations_lookup)
+            # metabolic_context is only schema-legal on cellular_metabolic; drop elsewhere.
+            if slot != "cellular_metabolic_roles":
+                s.pop("metabolic_context", None)
+            shaped.append(s)
+        if shaped:
+            role_assignments[slot] = shaped
+
+    if not role_assignments:
+        return None
+
+    proposal: dict[str, Any] = {
+        "ingredient_slug": slug,
+        "source_run": response_md.stem,
+        "role_assignments": role_assignments,
+    }
+    if ingredient_identifier:
+        proposal["ingredient_identifier"] = ingredient_identifier
+    if ingredient_path:
+        proposal["ingredient_path"] = ingredient_path
+    if rr.get("warnings"):
+        proposal["warnings"] = list(rr["warnings"]) if isinstance(rr["warnings"], list) else [str(rr["warnings"])]
+    return proposal
+
+
+def _to_cm_shape(mim_proposal: dict[str, Any]) -> dict[str, Any]:
+    """Project a rich MIM proposal to the scalar CultureMech shape."""
+    ra = mim_proposal.get("role_assignments") or {}
+    roles: dict[str, list[str]] = {}
+    for slot in FACET_SLOTS:
+        tokens = [entry.get("role") for entry in ra.get(slot, []) if entry.get("role")]
+        if tokens:
+            roles[slot] = tokens
+    cm: dict[str, Any] = {
+        "ingredient_slug": mim_proposal.get("ingredient_slug"),
+        "source_run": mim_proposal.get("source_run"),
+        "roles": roles,
+    }
+    if mim_proposal.get("ingredient_identifier"):
+        cm["ingredient_identifier"] = mim_proposal["ingredient_identifier"]
+    return cm
+
+
+def discover_inputs(inputs: list[Path]) -> list[Path]:
+    """Expand any directory in `inputs` to all *-edison-literature.md files inside."""
+    out: list[Path] = []
+    for p in inputs:
+        if p.is_dir():
+            out.extend(sorted(p.glob("*-edison-literature.md")))
+            out.extend(sorted(p.glob("*-deep-research-*.md")))
+        elif p.is_file():
+            out.append(p)
+    # Dedup while preserving order.
+    seen: set[Path] = set()
+    uniq: list[Path] = []
+    for p in out:
+        if p not in seen:
+            seen.add(p)
+            uniq.append(p)
+    return uniq
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("inputs", type=Path, nargs="+",
+                        help="One or more files or directories of *-edison-literature.md outputs.")
+    parser.add_argument("--out-mim", type=Path, default=DEFAULT_OUT_MIM,
+                        help="Output path for the rich MIM applier batch.")
+    parser.add_argument("--out-cm", type=Path, default=DEFAULT_OUT_CM,
+                        help="Output path for the scalar CultureMech applier batch.")
+    parser.add_argument("--skipped-report", type=Path, default=None,
+                        help="Optional path to write a report of files skipped with reasons.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    input_files = discover_inputs(args.inputs)
+    if not input_files:
+        print("No input files found. Pass a file or directory.", file=sys.stderr)
+        return 2
+
+    proposals: list[dict[str, Any]] = []
+    skipped: list[tuple[Path, str]] = []
+    for f in input_files:
+        try:
+            proposal = extract_one(f)
+        except Exception as exc:
+            skipped.append((f, f"error: {exc}"))
+            continue
+        if proposal is None:
+            skipped.append((f, "no `role_research:` fenced YAML block found"))
+            continue
+        proposals.append(proposal)
+        if args.verbose:
+            print(f"OK  {f.name}  → {sum(len(v) for v in proposal['role_assignments'].values())} roles")
+
+    args.out_mim.parent.mkdir(parents=True, exist_ok=True)
+    args.out_cm.parent.mkdir(parents=True, exist_ok=True)
+    args.out_mim.write_text(json.dumps({"proposals": proposals}, indent=2))
+    args.out_cm.write_text(json.dumps({"proposals": [_to_cm_shape(p) for p in proposals]}, indent=2))
+
+    if args.skipped_report and skipped:
+        lines = ["# Skipped Edison role-research files\n"]
+        for f, reason in skipped:
+            lines.append(f"- `{f}` — {reason}")
+        args.skipped_report.write_text("\n".join(lines))
+
+    print(f"Scanned {len(input_files)} input file(s)")
+    print(f"Parsed {len(proposals)} proposal(s) → {args.out_mim}")
+    print(f"                             → {args.out_cm}")
+    if skipped:
+        print(f"Skipped {len(skipped)} file(s){' (see report)' if args.skipped_report else ''}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/extract_roles_from_edison.py
+++ b/scripts/extract_roles_from_edison.py
@@ -64,8 +64,35 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OUT_MIM = REPO_ROOT / "data" / "import_tracking" / "reports" / "edison_role_batch_mim.json"
 DEFAULT_OUT_CM = REPO_ROOT / "data" / "import_tracking" / "reports" / "edison_role_batch_cm.json"
+DEFAULT_MIM_ROLES_SCHEMA = REPO_ROOT / "src" / "culturemech" / "schema" / "mim_roles.yaml"
 
 FACET_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+# Map facet slot name → enum class name in mim_roles.yaml.
+_FACET_ENUM_NAMES = {
+    "nutritional_roles": "NutritionalRoleEnum",
+    "physicochemical_roles": "PhysicochemicalRoleEnum",
+    "cellular_metabolic_roles": "CellularMetabolicRoleEnum",
+}
+
+
+def load_facet_enums(schema_path: Path = DEFAULT_MIM_ROLES_SCHEMA) -> dict[str, frozenset[str]]:
+    """Load {facet_slot: frozenset(permissible_values)} from the vendored mim_roles schema.
+
+    Single source of truth: read enum permissible values from mim_roles.yaml (whose
+    sha is pinned in project.justfile:verify-schema-pin). No hand-typed token lists.
+    """
+    if not schema_path.is_file():
+        raise SystemExit(f"mim_roles schema not found at {schema_path}")
+    doc = yaml.safe_load(schema_path.read_text()) or {}
+    enums = (doc.get("enums") or {}) if isinstance(doc, dict) else {}
+    result: dict[str, frozenset[str]] = {}
+    for slot, enum_name in _FACET_ENUM_NAMES.items():
+        pv = ((enums.get(enum_name) or {}).get("permissible_values") or {})
+        if not isinstance(pv, dict) or not pv:
+            raise SystemExit(f"{enum_name}.permissible_values missing or empty in {schema_path}")
+        result[slot] = frozenset(pv.keys())
+    return result
 
 # Regex catches ```yaml … ``` blocks; case-insensitive on the language tag.
 _YAML_FENCE_RE = re.compile(r"```(?:yaml|yml)\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE)
@@ -186,8 +213,31 @@ def _shape_role_entry(role_entry: Any) -> dict[str, Any] | None:
     return out
 
 
-def extract_one(response_md: Path) -> dict[str, Any] | None:
-    """Parse one Edison response .md into a proposal dict, or None if unparseable."""
+def _mim_relative_source_run(response_md: Path, mim_repo: Path | None) -> str:
+    """Return the MIM-repo-relative path of the response file if inside `mim_repo`;
+    otherwise return just the filename stem (backwards-compatible fallback)."""
+    if mim_repo is not None:
+        try:
+            return str(response_md.resolve().relative_to(mim_repo.resolve()))
+        except ValueError:
+            pass
+    return response_md.stem
+
+
+def extract_one(
+    response_md: Path,
+    valid_tokens: dict[str, frozenset[str]] | None = None,
+    mim_repo: Path | None = None,
+    validation_errors: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Parse one Edison response .md into a proposal dict, or None if unparseable.
+
+    When `valid_tokens` is provided (a `{facet: frozenset(...)}` map from
+    `load_facet_enums()`), each role token is validated against its facet's
+    permissible values. Invalid or wrong-facet tokens are DROPPED from the
+    proposal and appended to `validation_errors` (if given) as
+    `{source_file, facet, role, reason, correct_facet?}` records.
+    """
     md_text = response_md.read_text()
     rr = find_role_yaml_block(md_text)
     if rr is None:
@@ -216,6 +266,31 @@ def extract_one(response_md: Path) -> dict[str, Any] | None:
             s = _shape_role_entry(entry)
             if s is None:
                 continue
+            token = s["role"]
+
+            # Token validation against the facet's enum permissible values.
+            if valid_tokens is not None:
+                if token in valid_tokens[slot]:
+                    pass  # canonical, keep
+                else:
+                    # Check whether it belongs to a DIFFERENT facet (misfiling).
+                    other_facet = next(
+                        (other for other, allowed in valid_tokens.items()
+                         if other != slot and token in allowed),
+                        None,
+                    )
+                    if validation_errors is not None:
+                        record: dict[str, Any] = {
+                            "source_file": str(response_md),
+                            "facet": slot,
+                            "role": token,
+                            "reason": "wrong_facet" if other_facet else "unknown_token",
+                        }
+                        if other_facet:
+                            record["correct_facet"] = other_facet
+                        validation_errors.append(record)
+                    continue  # drop the entry either way
+
             s["evidence"] = _upgrade_evidence(s["evidence"], citations_lookup)
             # metabolic_context is only schema-legal on cellular_metabolic; drop elsewhere.
             if slot != "cellular_metabolic_roles":
@@ -229,15 +304,16 @@ def extract_one(response_md: Path) -> dict[str, Any] | None:
 
     proposal: dict[str, Any] = {
         "ingredient_slug": slug,
-        "source_run": response_md.stem,
+        "source_run": _mim_relative_source_run(response_md, mim_repo),
         "role_assignments": role_assignments,
     }
     if ingredient_identifier:
         proposal["ingredient_identifier"] = ingredient_identifier
     if ingredient_path:
         proposal["ingredient_path"] = ingredient_path
-    if rr.get("warnings"):
-        proposal["warnings"] = list(rr["warnings"]) if isinstance(rr["warnings"], list) else [str(rr["warnings"])]
+    # `warnings:` from the YAML block are human-only per the applier contract —
+    # they never appear in the emitted batch. If a --warnings-report is passed
+    # at the CLI layer, warnings are surfaced there instead.
     return proposal
 
 
@@ -278,6 +354,17 @@ def discover_inputs(inputs: list[Path]) -> list[Path]:
     return uniq
 
 
+def _collect_warnings(response_md: Path) -> list[str]:
+    """Return the human-only `warnings:` list from a response.md, if any."""
+    rr = find_role_yaml_block(response_md.read_text())
+    if not isinstance(rr, dict):
+        return []
+    w = rr.get("warnings") or []
+    if isinstance(w, list):
+        return [str(x) for x in w]
+    return [str(w)]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("inputs", type=Path, nargs="+",
@@ -286,8 +373,19 @@ def main(argv: list[str] | None = None) -> int:
                         help="Output path for the rich MIM applier batch.")
     parser.add_argument("--out-cm", type=Path, default=DEFAULT_OUT_CM,
                         help="Output path for the scalar CultureMech applier batch.")
+    parser.add_argument("--mim-repo", type=Path, default=REPO_ROOT.parent / "MediaIngredientMech",
+                        help="MediaIngredientMech checkout root. Used to render `source_run` as a "
+                             "MIM-repo-relative path per the applier contract.")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_MIM_ROLES_SCHEMA,
+                        help="mim_roles.yaml with the three facet enums (source of truth for token validation).")
+    parser.add_argument("--no-validate", action="store_true",
+                        help="Skip token-vs-enum validation. Emits every role token unchanged. "
+                             "Default: validate; drop invalid tokens; surface them in --validation-report.")
     parser.add_argument("--skipped-report", type=Path, default=None,
                         help="Optional path to write a report of files skipped with reasons.")
+    parser.add_argument("--validation-report", type=Path, default=None,
+                        help="Optional path to write invalid/wrong-facet token records "
+                             "and the human-only `warnings:` blocks that never enter the batch.")
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args(argv)
 
@@ -296,18 +394,29 @@ def main(argv: list[str] | None = None) -> int:
         print("No input files found. Pass a file or directory.", file=sys.stderr)
         return 2
 
+    valid_tokens = None if args.no_validate else load_facet_enums(args.schema)
+    mim_repo = args.mim_repo if args.mim_repo.is_dir() else None
+
     proposals: list[dict[str, Any]] = []
     skipped: list[tuple[Path, str]] = []
+    validation_errors: list[dict[str, Any]] = []
+    warnings_by_file: dict[str, list[str]] = {}
+
     for f in input_files:
         try:
-            proposal = extract_one(f)
+            proposal = extract_one(f, valid_tokens=valid_tokens, mim_repo=mim_repo,
+                                   validation_errors=validation_errors)
         except Exception as exc:
             skipped.append((f, f"error: {exc}"))
             continue
         if proposal is None:
-            skipped.append((f, "no `role_research:` fenced YAML block found"))
+            skipped.append((f, "no `role_research:` fenced YAML block or no valid role tokens"))
             continue
         proposals.append(proposal)
+        # Collect human-only warnings for the validation report (never enter the batch).
+        ws = _collect_warnings(f)
+        if ws:
+            warnings_by_file[str(f)] = ws
         if args.verbose:
             print(f"OK  {f.name}  → {sum(len(v) for v in proposal['role_assignments'].values())} roles")
 
@@ -322,11 +431,30 @@ def main(argv: list[str] | None = None) -> int:
             lines.append(f"- `{f}` — {reason}")
         args.skipped_report.write_text("\n".join(lines))
 
+    if args.validation_report and (validation_errors or warnings_by_file):
+        lines = ["# Extraction validation report\n"]
+        if validation_errors:
+            lines.append(f"## Rejected role tokens ({len(validation_errors)})\n")
+            for err in validation_errors:
+                corr = f" — belongs in `{err['correct_facet']}`" if err.get("correct_facet") else ""
+                lines.append(f"- `{err['role']}` in `{err['facet']}` ({err['reason']}){corr}")
+                lines.append(f"    source: `{err['source_file']}`")
+        if warnings_by_file:
+            lines.append(f"\n## Curator warnings ({sum(len(v) for v in warnings_by_file.values())})\n")
+            for fpath, ws in warnings_by_file.items():
+                lines.append(f"### `{fpath}`")
+                for w in ws:
+                    lines.append(f"- {w}")
+        args.validation_report.write_text("\n".join(lines))
+
     print(f"Scanned {len(input_files)} input file(s)")
     print(f"Parsed {len(proposals)} proposal(s) → {args.out_mim}")
     print(f"                             → {args.out_cm}")
     if skipped:
         print(f"Skipped {len(skipped)} file(s){' (see report)' if args.skipped_report else ''}")
+    if validation_errors:
+        print(f"Rejected {len(validation_errors)} role token(s)"
+              f"{' (see validation report)' if args.validation_report else ''}")
     return 0
 
 

--- a/tests/test_extract_roles_from_edison.py
+++ b/tests/test_extract_roles_from_edison.py
@@ -207,6 +207,7 @@ def test_extract_one_full_bundle(tmp_path):
     assert proposal["ingredient_slug"] == "L-cysteine"
     assert proposal["ingredient_identifier"] == "CHEBI:17561"
     assert proposal["ingredient_path"] == "data/ingredients/mapped/L-cysteine.yaml"
+    # Without --mim-repo, source_run falls back to the file's stem.
     assert proposal["source_run"] == "L-cysteine-edison-literature"
 
     ra = proposal["role_assignments"]
@@ -228,7 +229,8 @@ def test_extract_one_full_bundle(tmp_path):
     assert cm[0]["role"] == "SUBSTRATE"
     assert cm[0]["metabolic_context"] == "assimilatory sulfate reduction"
 
-    assert proposal["warnings"] == ["Do not confuse with cystine."]
+    # Warnings are human-only per the applier contract — never in the batch.
+    assert "warnings" not in proposal
 
 
 def test_extract_one_returns_none_when_no_yaml_block(tmp_path):
@@ -397,3 +399,196 @@ def test_main_records_skipped_files(tmp_path):
     assert rc == 0
     assert "no `role_research:` fenced YAML block" in skipped.read_text()
     assert json.loads(out_mim.read_text())["proposals"] == []
+
+
+# ---------------- load_facet_enums ----------------
+
+
+def test_load_facet_enums_reads_permissible_values(tmp_path):
+    """Verify the schema loader parses the three enum permissible-value sets."""
+    schema = tmp_path / "mim_roles.yaml"
+    schema.write_text(yaml.safe_dump({
+        "enums": {
+            "NutritionalRoleEnum": {"permissible_values": {
+                "CARBON_SOURCE": {}, "NITROGEN_SOURCE": {}}},
+            "PhysicochemicalRoleEnum": {"permissible_values": {
+                "BUFFER": {}, "REDUCING_AGENT": {}}},
+            "CellularMetabolicRoleEnum": {"permissible_values": {
+                "SUBSTRATE": {}, "COFACTOR": {}}},
+        }
+    }))
+    enums = _ext.load_facet_enums(schema)
+    assert enums["nutritional_roles"] == frozenset({"CARBON_SOURCE", "NITROGEN_SOURCE"})
+    assert enums["physicochemical_roles"] == frozenset({"BUFFER", "REDUCING_AGENT"})
+    assert enums["cellular_metabolic_roles"] == frozenset({"SUBSTRATE", "COFACTOR"})
+
+
+def test_load_facet_enums_raises_on_missing_schema(tmp_path):
+    with pytest.raises(SystemExit, match="mim_roles schema not found"):
+        _ext.load_facet_enums(tmp_path / "does_not_exist.yaml")
+
+
+def test_load_facet_enums_raises_on_missing_enum(tmp_path):
+    schema = tmp_path / "mim_roles.yaml"
+    schema.write_text(yaml.safe_dump({"enums": {"NutritionalRoleEnum": {"permissible_values": {"X": {}}}}}))
+    with pytest.raises(SystemExit, match="PhysicochemicalRoleEnum.permissible_values missing"):
+        _ext.load_facet_enums(schema)
+
+
+def test_load_facet_enums_reads_real_shipped_schema():
+    """Sanity-check that the actual vendored schema loads and contains expected tokens."""
+    enums = _ext.load_facet_enums()  # uses DEFAULT_MIM_ROLES_SCHEMA
+    assert "CARBON_SOURCE" in enums["nutritional_roles"]
+    assert "SULFUR_SOURCE" in enums["nutritional_roles"]
+    assert "BUFFER" in enums["physicochemical_roles"]
+    assert "REDUCING_AGENT" in enums["physicochemical_roles"]
+    assert "SUBSTRATE" in enums["cellular_metabolic_roles"]
+    assert "ELECTRON_DONOR" in enums["cellular_metabolic_roles"]
+
+
+# ---------------- extract_one with token validation ----------------
+
+
+_VALID_TOKENS_FIXTURE = {
+    "nutritional_roles": frozenset({"CARBON_SOURCE", "SULFUR_SOURCE", "AMINO_ACID_SOURCE"}),
+    "physicochemical_roles": frozenset({"BUFFER", "REDUCING_AGENT"}),
+    "cellular_metabolic_roles": frozenset({"SUBSTRATE", "COFACTOR"}),
+}
+
+
+def test_extract_one_drops_unknown_tokens_and_records_them(tmp_path):
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - role: CARBON_SOURCE   # valid
+            - role: FROBNICATOR     # bogus — should be dropped and reported
+          physicochemical_roles:
+            - role: BUFFER          # valid
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    errors: list = []
+    proposal = _ext.extract_one(md, valid_tokens=_VALID_TOKENS_FIXTURE,
+                                 validation_errors=errors)
+    nut = proposal["role_assignments"]["nutritional_roles"]
+    assert [r["role"] for r in nut] == ["CARBON_SOURCE"]
+    assert len(errors) == 1
+    assert errors[0]["role"] == "FROBNICATOR"
+    assert errors[0]["reason"] == "unknown_token"
+    assert errors[0]["facet"] == "nutritional_roles"
+    assert "source_file" in errors[0]
+
+
+def test_extract_one_drops_wrong_facet_tokens_and_flags_correct_facet(tmp_path):
+    """A valid PhysicochemicalRoleEnum token filed under nutritional_roles is misfiled."""
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - role: BUFFER   # this is a Physicochemical value; wrong facet
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    errors: list = []
+    proposal = _ext.extract_one(md, valid_tokens=_VALID_TOKENS_FIXTURE,
+                                 validation_errors=errors)
+    # Proposal becomes None because after dropping, no valid roles remain.
+    assert proposal is None
+    assert len(errors) == 1
+    assert errors[0]["reason"] == "wrong_facet"
+    assert errors[0]["role"] == "BUFFER"
+    assert errors[0]["facet"] == "nutritional_roles"
+    assert errors[0]["correct_facet"] == "physicochemical_roles"
+
+
+def test_extract_one_no_validation_when_valid_tokens_is_none(tmp_path):
+    """Without a token whitelist, extractor is permissive (backwards compat)."""
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - role: FROBNICATOR
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    proposal = _ext.extract_one(md, valid_tokens=None)
+    assert proposal["role_assignments"]["nutritional_roles"][0]["role"] == "FROBNICATOR"
+
+
+def test_extract_one_source_run_is_mim_relative_when_repo_given(tmp_path):
+    """With --mim-repo pointing at the containing dir, source_run becomes MIM-relative."""
+    mim = tmp_path / "MIM"
+    roles_dir = mim / "research" / "ingredients" / "roles"
+    roles_dir.mkdir(parents=True)
+    body = "```yaml\nrole_research:\n  ingredient: X\n  nutritional_roles: [{role: CARBON_SOURCE}]\n```"
+    md = _write_bundle(roles_dir, "X", body)
+    proposal = _ext.extract_one(md, valid_tokens=_VALID_TOKENS_FIXTURE, mim_repo=mim)
+    assert proposal["source_run"] == "research/ingredients/roles/X-edison-literature.md"
+
+
+def test_extract_one_source_run_falls_back_when_file_outside_mim_repo(tmp_path):
+    """File that isn't inside --mim-repo falls back to stem — never crashes."""
+    mim = tmp_path / "MIM"
+    mim.mkdir()
+    md = _write_bundle(tmp_path, "X",
+                       "```yaml\nrole_research:\n  ingredient: X\n  nutritional_roles: [{role: CARBON_SOURCE}]\n```")
+    proposal = _ext.extract_one(md, valid_tokens=_VALID_TOKENS_FIXTURE, mim_repo=mim)
+    assert proposal["source_run"] == "X-edison-literature"
+
+
+# ---------------- main() with validation ----------------
+
+
+def test_main_validation_report_records_dropped_tokens_and_warnings(tmp_path):
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - role: CARBON_SOURCE
+            - role: BOGUS_TOKEN
+          warnings:
+            - "Curator note: needs review of concentration ranges"
+        ```
+        """)
+    _write_bundle(tmp_path, "X", body)
+    schema = tmp_path / "mim_roles.yaml"
+    schema.write_text(yaml.safe_dump({"enums": {
+        "NutritionalRoleEnum": {"permissible_values": {"CARBON_SOURCE": {}}},
+        "PhysicochemicalRoleEnum": {"permissible_values": {"BUFFER": {}}},
+        "CellularMetabolicRoleEnum": {"permissible_values": {"SUBSTRATE": {}}},
+    }}))
+    out_mim = tmp_path / "mim.json"
+    out_cm = tmp_path / "cm.json"
+    report = tmp_path / "validation.md"
+    rc = _ext.main([str(tmp_path), "--out-mim", str(out_mim), "--out-cm", str(out_cm),
+                    "--schema", str(schema), "--validation-report", str(report)])
+    assert rc == 0
+    # Batch shipped with only the valid token.
+    p = json.loads(out_mim.read_text())["proposals"][0]
+    assert [r["role"] for r in p["role_assignments"]["nutritional_roles"]] == ["CARBON_SOURCE"]
+    # Batch is silent on warnings (contract).
+    assert "warnings" not in p
+    # But the validation report captured both.
+    report_text = report.read_text()
+    assert "BOGUS_TOKEN" in report_text
+    assert "unknown_token" in report_text
+    assert "needs review of concentration ranges" in report_text
+
+
+def test_main_no_validate_flag_disables_token_check(tmp_path):
+    """--no-validate lets any token through (backwards-compat safety valve)."""
+    body = ("```yaml\nrole_research:\n  ingredient: X\n"
+            "  nutritional_roles: [{role: NOT_A_REAL_TOKEN}]\n```")
+    _write_bundle(tmp_path, "X", body)
+    out_mim = tmp_path / "mim.json"
+    out_cm = tmp_path / "cm.json"
+    rc = _ext.main([str(tmp_path), "--out-mim", str(out_mim), "--out-cm", str(out_cm),
+                    "--no-validate"])
+    assert rc == 0
+    p = json.loads(out_mim.read_text())["proposals"][0]
+    assert p["role_assignments"]["nutritional_roles"][0]["role"] == "NOT_A_REAL_TOKEN"

--- a/tests/test_extract_roles_from_edison.py
+++ b/tests/test_extract_roles_from_edison.py
@@ -1,0 +1,399 @@
+"""Tests for scripts/extract_roles_from_edison.py — Step 7b role extractor."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "extract_roles_from_edison.py"
+
+_SPEC = importlib.util.spec_from_file_location("_extract_roles", _SCRIPT_PATH)
+_ext = importlib.util.module_from_spec(_SPEC)
+sys.modules["_extract_roles"] = _ext
+_SPEC.loader.exec_module(_ext)  # type: ignore[union-attr]
+
+
+_MODEL_YAML_ANSWER = textwrap.dedent("""\
+    Some prose from the model here...
+
+    ```yaml
+    role_research:
+      ingredient: L-cysteine
+      ingredient_identifier: CHEBI:17561
+      nutritional_roles:
+        - role: SULFUR_SOURCE
+          confidence: 0.95
+          evidence:
+            - reference_type: PEER_REVIEWED_PUBLICATION
+              doi: 10.1128/jb.00456-20
+              reference_text: "Smith et al. 2020, J. Bacteriol."
+        - role: AMINO_ACID_SOURCE
+          confidence: 0.9
+          evidence: []
+      physicochemical_roles:
+        - role: REDUCING_AGENT
+          confidence: 0.85
+          metabolic_context: "in anaerobic media"
+          evidence:
+            - reference_type: PEER_REVIEWED_PUBLICATION
+              doi: 10.5555/xyz.2019
+      cellular_metabolic_roles:
+        - role: SUBSTRATE
+          confidence: 0.9
+          metabolic_context: "assimilatory sulfate reduction"
+          evidence: []
+      warnings:
+        - "Do not confuse with cystine."
+    ```
+
+    (End of report.)
+    """)
+
+
+def _write_bundle(tmp_path: Path, slug: str, body_md: str, meta: dict | None = None,
+                  citations_text: str | None = None) -> Path:
+    """Write a complete Edison bundle under `tmp_path` and return the .md path."""
+    md = tmp_path / f"{slug}-edison-literature.md"
+    md.write_text(body_md)
+    if meta is not None:
+        (tmp_path / f"{slug}-edison-literature-meta.yaml").write_text(yaml.safe_dump(meta))
+    if citations_text is not None:
+        (tmp_path / f"{slug}-edison-literature-citations.md").write_text(citations_text)
+    return md
+
+
+# ---------------- find_role_yaml_block ----------------
+
+
+def test_find_role_yaml_block_finds_last_matching_fence():
+    """Template's own example is in an early fence; the model's answer must win."""
+    text = textwrap.dedent("""\
+        Template example:
+        ```yaml
+        role_research:
+          ingredient: EXAMPLE
+        ```
+
+        Model's actual answer:
+        ```yaml
+        role_research:
+          ingredient: L-cysteine
+          nutritional_roles:
+            - role: SULFUR_SOURCE
+        ```
+        """)
+    rr = _ext.find_role_yaml_block(text)
+    assert rr["ingredient"] == "L-cysteine"
+
+
+def test_find_role_yaml_block_returns_none_when_absent():
+    text = "no yaml here.\n\nJust prose."
+    assert _ext.find_role_yaml_block(text) is None
+
+
+def test_find_role_yaml_block_skips_non_role_yaml_fences():
+    """Other ```yaml``` blocks in the doc don't confuse the finder."""
+    text = textwrap.dedent("""\
+        Some other yaml:
+        ```yaml
+        unrelated: data
+        ```
+        The real answer:
+        ```yaml
+        role_research:
+          ingredient: X
+        ```
+        """)
+    rr = _ext.find_role_yaml_block(text)
+    assert rr["ingredient"] == "X"
+
+
+def test_find_role_yaml_block_tolerates_yml_tag():
+    text = "```yml\nrole_research:\n  ingredient: X\n```"
+    rr = _ext.find_role_yaml_block(text)
+    assert rr["ingredient"] == "X"
+
+
+def test_find_role_yaml_block_skips_malformed_yaml():
+    """A malformed yaml fence shouldn't block a later valid one."""
+    text = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: LATER
+        ```
+        ```yaml
+        role_research: [malformed:: yaml
+        ```
+        """)
+    # Note: reversed iteration means malformed is tried first, then falls back to good one.
+    rr = _ext.find_role_yaml_block(text)
+    assert rr["ingredient"] == "LATER"
+
+
+# ---------------- _parse_citations_sidecar ----------------
+
+
+def test_parse_citations_sidecar_indexes_by_doi(tmp_path):
+    sidecar = tmp_path / "cite.md"
+    sidecar.write_text(textwrap.dedent("""\
+        # Citations
+
+        - **1.** (smith2020) Smith et al. 2020, J. Bacteriol. doi:10.1128/jb.00456-20
+        - **2.** (jones2019) Jones et al. 2019, Nature. doi:10.5555/xyz.2019
+        """))
+    lookup = _ext._parse_citations_sidecar(sidecar)
+    assert "10.1128/jb.00456-20" in lookup
+    assert "10.5555/xyz.2019" in lookup
+    assert "Smith et al" in lookup["10.1128/jb.00456-20"]
+
+
+def test_parse_citations_sidecar_indexes_pmid(tmp_path):
+    sidecar = tmp_path / "cite.md"
+    sidecar.write_text("- **1.** (foo) PMID: 12345678. Old paper.")
+    lookup = _ext._parse_citations_sidecar(sidecar)
+    assert "PMID:12345678" in lookup
+
+
+def test_parse_citations_sidecar_missing_file_returns_empty(tmp_path):
+    assert _ext._parse_citations_sidecar(tmp_path / "nonexistent.md") == {}
+
+
+# ---------------- _upgrade_evidence ----------------
+
+
+def test_upgrade_evidence_fills_reference_text_by_doi():
+    lookup = {"10.1128/jb.00456-20": "Smith et al. 2020, J. Bacteriol. doi:10.1128/jb.00456-20"}
+    evidence = [{"doi": "10.1128/jb.00456-20", "reference_type": "PEER_REVIEWED_PUBLICATION"}]
+    up = _ext._upgrade_evidence(evidence, lookup)
+    assert "Smith et al" in up[0]["reference_text"]
+
+
+def test_upgrade_evidence_preserves_existing_reference_text():
+    lookup = {"10.1128/jb.00456-20": "Sidecar version"}
+    evidence = [{"doi": "10.1128/jb.00456-20", "reference_text": "Curator's version"}]
+    up = _ext._upgrade_evidence(evidence, lookup)
+    assert up[0]["reference_text"] == "Curator's version"  # never overwrite
+
+
+def test_upgrade_evidence_leaves_untouched_when_no_match():
+    evidence = [{"doi": "10.9999/unknown", "reference_type": "X"}]
+    up = _ext._upgrade_evidence(evidence, {})
+    assert up[0].get("reference_text") is None
+
+
+# ---------------- extract_one end-to-end ----------------
+
+
+def test_extract_one_full_bundle(tmp_path):
+    md = _write_bundle(
+        tmp_path, "L-cysteine", _MODEL_YAML_ANSWER,
+        meta={"slug": "L-cysteine", "ingredient_path": "data/ingredients/mapped/L-cysteine.yaml",
+              "ingredient_id": "CHEBI:17561"},
+        citations_text=textwrap.dedent("""\
+            - **1.** (smith2020) Smith et al. 2020, J. Bacteriol. doi:10.1128/jb.00456-20
+            - **2.** (jones2019) Jones et al. 2019, Nature. doi:10.5555/xyz.2019
+            """),
+    )
+    proposal = _ext.extract_one(md)
+    assert proposal is not None
+    assert proposal["ingredient_slug"] == "L-cysteine"
+    assert proposal["ingredient_identifier"] == "CHEBI:17561"
+    assert proposal["ingredient_path"] == "data/ingredients/mapped/L-cysteine.yaml"
+    assert proposal["source_run"] == "L-cysteine-edison-literature"
+
+    ra = proposal["role_assignments"]
+    # Nutritional: 2 roles.
+    nut_tokens = [r["role"] for r in ra["nutritional_roles"]]
+    assert set(nut_tokens) == {"SULFUR_SOURCE", "AMINO_ACID_SOURCE"}
+    # Sulfur got its reference_text filled in from citations sidecar.
+    sulfur = next(r for r in ra["nutritional_roles"] if r["role"] == "SULFUR_SOURCE")
+    assert "Smith et al" in sulfur["evidence"][0]["reference_text"]
+
+    # Physicochem: 1 role, metabolic_context DROPPED (schema-illegal on non-cellular facet).
+    phys = ra["physicochemical_roles"]
+    assert len(phys) == 1
+    assert phys[0]["role"] == "REDUCING_AGENT"
+    assert "metabolic_context" not in phys[0]
+
+    # Cellular metabolic: 1 role, metabolic_context PRESERVED.
+    cm = ra["cellular_metabolic_roles"]
+    assert cm[0]["role"] == "SUBSTRATE"
+    assert cm[0]["metabolic_context"] == "assimilatory sulfate reduction"
+
+    assert proposal["warnings"] == ["Do not confuse with cystine."]
+
+
+def test_extract_one_returns_none_when_no_yaml_block(tmp_path):
+    md = _write_bundle(tmp_path, "unmapped_slug", "Model said no useful roles.")
+    assert _ext.extract_one(md) is None
+
+
+def test_extract_one_returns_none_when_all_facets_empty(tmp_path):
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles: []
+          physicochemical_roles: []
+          cellular_metabolic_roles: []
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    assert _ext.extract_one(md) is None
+
+
+def test_extract_one_falls_back_to_meta_slug(tmp_path):
+    """If the YAML block omits `ingredient:` fall back to meta.slug."""
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          nutritional_roles:
+            - role: CARBON_SOURCE
+        ```
+        """)
+    md = _write_bundle(tmp_path, "some_slug", body,
+                       meta={"slug": "some_slug", "ingredient_id": "CHEBI:99999"})
+    proposal = _ext.extract_one(md)
+    assert proposal["ingredient_slug"] == "some_slug"
+    assert proposal["ingredient_identifier"] == "CHEBI:99999"
+
+
+def test_extract_one_coerces_string_shorthand(tmp_path):
+    """Model can emit shorthand `- SULFUR_SOURCE` — extractor upgrades to dict form."""
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - CARBON_SOURCE
+            - {role: NITROGEN_SOURCE, confidence: 0.9}
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    proposal = _ext.extract_one(md)
+    nut = proposal["role_assignments"]["nutritional_roles"]
+    assert [r["role"] for r in nut] == ["CARBON_SOURCE", "NITROGEN_SOURCE"]
+    # Shorthand entry got default confidence 0.7.
+    assert nut[0]["confidence"] == 0.7
+    assert nut[1]["confidence"] == 0.9
+
+
+def test_extract_one_drops_entries_without_role(tmp_path):
+    body = textwrap.dedent("""\
+        ```yaml
+        role_research:
+          ingredient: X
+          nutritional_roles:
+            - confidence: 0.9   # no role key — drop
+            - role: CARBON_SOURCE
+        ```
+        """)
+    md = _write_bundle(tmp_path, "X", body)
+    proposal = _ext.extract_one(md)
+    nut = proposal["role_assignments"]["nutritional_roles"]
+    assert [r["role"] for r in nut] == ["CARBON_SOURCE"]
+
+
+# ---------------- _to_cm_shape ----------------
+
+
+def test_to_cm_shape_flattens_to_scalar_tokens():
+    mim = {
+        "ingredient_slug": "X",
+        "ingredient_identifier": "CHEBI:1",
+        "source_run": "X-edison-literature",
+        "role_assignments": {
+            "nutritional_roles": [
+                {"role": "SULFUR_SOURCE", "confidence": 0.95, "evidence": [{"doi": "..."}]},
+                {"role": "AMINO_ACID_SOURCE", "confidence": 0.9, "evidence": []},
+            ],
+            "physicochemical_roles": [{"role": "REDUCING_AGENT", "confidence": 0.85, "evidence": []}],
+        },
+    }
+    cm = _ext._to_cm_shape(mim)
+    assert cm["ingredient_slug"] == "X"
+    assert cm["ingredient_identifier"] == "CHEBI:1"
+    assert cm["roles"] == {
+        "nutritional_roles": ["SULFUR_SOURCE", "AMINO_ACID_SOURCE"],
+        "physicochemical_roles": ["REDUCING_AGENT"],
+    }
+    # Evidence intentionally not carried through — CultureMech carries scalars only.
+    assert "evidence" not in json.dumps(cm)
+
+
+def test_to_cm_shape_skips_facets_without_roles():
+    mim = {
+        "ingredient_slug": "X",
+        "role_assignments": {"nutritional_roles": [{"role": "CARBON_SOURCE"}]},
+    }
+    cm = _ext._to_cm_shape(mim)
+    assert cm["roles"] == {"nutritional_roles": ["CARBON_SOURCE"]}
+
+
+# ---------------- discover_inputs ----------------
+
+
+def test_discover_inputs_expands_directory(tmp_path):
+    (tmp_path / "a-edison-literature.md").write_text("x")
+    (tmp_path / "b-edison-literature.md").write_text("y")
+    (tmp_path / "c-something-else.md").write_text("z")
+    files = _ext.discover_inputs([tmp_path])
+    names = sorted(f.name for f in files)
+    assert names == ["a-edison-literature.md", "b-edison-literature.md"]
+
+
+def test_discover_inputs_dedups_repeated_paths(tmp_path):
+    p = tmp_path / "x-edison-literature.md"
+    p.write_text("")
+    files = _ext.discover_inputs([p, p, tmp_path])
+    assert len(files) == 1
+
+
+# ---------------- CLI main ----------------
+
+
+def test_main_writes_both_batches(tmp_path):
+    _write_bundle(tmp_path, "L-cysteine", _MODEL_YAML_ANSWER,
+                  meta={"slug": "L-cysteine", "ingredient_id": "CHEBI:17561"})
+    out_mim = tmp_path / "mim.json"
+    out_cm = tmp_path / "cm.json"
+    rc = _ext.main([str(tmp_path), "--out-mim", str(out_mim), "--out-cm", str(out_cm)])
+    assert rc == 0
+    mim_data = json.loads(out_mim.read_text())
+    assert len(mim_data["proposals"]) == 1
+    # MIM batch shape matches PR2 applier's _load_batch expectations.
+    p = mim_data["proposals"][0]
+    assert "ingredient_identifier" in p
+    assert "role_assignments" in p
+    assert "nutritional_roles" in p["role_assignments"]
+    # CM batch has the scalar shape.
+    cm_data = json.loads(out_cm.read_text())
+    cp = cm_data["proposals"][0]
+    assert cp["roles"]["nutritional_roles"] == ["SULFUR_SOURCE", "AMINO_ACID_SOURCE"]
+
+
+def test_main_returns_2_when_no_inputs(tmp_path, capsys):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    rc = _ext.main([str(empty)])
+    assert rc == 2
+
+
+def test_main_records_skipped_files(tmp_path):
+    _write_bundle(tmp_path, "no-roles", "Model said no useful roles.")
+    out_mim = tmp_path / "mim.json"
+    out_cm = tmp_path / "cm.json"
+    skipped = tmp_path / "skipped.md"
+    rc = _ext.main([str(tmp_path), "--out-mim", str(out_mim), "--out-cm", str(out_cm),
+                    "--skipped-report", str(skipped)])
+    assert rc == 0
+    assert "no `role_research:` fenced YAML block" in skipped.read_text()
+    assert json.loads(out_mim.read_text())["proposals"] == []


### PR DESCRIPTION
## Summary

Step 7b PR4 of the ingredient-roles migration. Adds `scripts/extract_roles_from_edison.py`, the parser that consumes `research/ingredients/roles/*-edison-literature.md` bundles (produced by PR1's role-research template) and emits two batch JSONs:

- **`--out-mim`** → rich shape with per-role confidence, metabolic_context, and evidence-citation lists. Feeds MIM's `apply_role_research_results.py` (PR2) directly.
- **`--out-cm`** → scalar-projection shape (facet → role-token list, no evidence). Feeds the forthcoming CultureMech `apply_ingredient_roles` (PR5). CultureMech's IngredientDescriptor carries scalar role tokens; evidence stays on the source-of-truth MIM record.

## Robustness notes

- **LAST fenced YAML block wins.** The template's own example lives in an early fence in the response file (the "Question:" block); the model's actual answer lives later. `find_role_yaml_block` iterates in reverse and picks the last block whose top-level key is `role_research:`.
- **Malformed YAML fences skipped, not fatal.** If the model wrote a broken YAML fence somewhere, the extractor moves on to the next candidate rather than aborting.
- **String shorthand upgraded.** `- SULFUR_SOURCE` becomes `{role: SULFUR_SOURCE, confidence: 0.7, evidence: []}`. The model can use either form.
- **Entries without `role:` dropped.** Guards against half-formed proposals.
- **`metabolic_context` schema legality enforced.** Only the cellular-metabolic facet keeps `metabolic_context`; on nutritional/physicochemical it's dropped silently. The applier repeats the check as defense-in-depth.
- **`-citations.md` sidecar cross-referenced.** Evidence entries with a `doi:` or `pmid:` but no `reference_text:` get their reference text filled in from the sidecar. Existing `reference_text:` never overwritten.
- **Meta sidecar fallback.** If the YAML block omits `ingredient:` / `ingredient_identifier:`, the extractor falls back to the `-meta.yaml` sidecar's `slug` / `ingredient_id`.

## Wiring

`just extract-roles-from-edison` (default target: `../MediaIngredientMech/research/ingredients/roles/`).

## Test plan

- [x] `uv run pytest tests/test_extract_roles_from_edison.py` — 24/24 pass
- [x] Rich MIM batch shape verified against PR2 applier's `_load_batch()` — top-level `proposals[]`, each with `ingredient_identifier` / `ingredient_path` / `source_run` / `role_assignments.{nutritional,physicochemical,cellular_metabolic}_roles[]`
- [x] Scalar CM batch shape verified — `roles.{facet}` is a flat list of tokens; no evidence fields leak through
- [x] Real Edison bundles will be exercised end-to-end in PR6 (curator-triggered run against the top-10 prioritizer output from PR3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)