### PR TITLE
Add apply_ingredient_roles + research-ingredient-roles skill + docs

### DIFF
--- a/.claude/skills/research-ingredient-roles/SKILL.md
+++ b/.claude/skills/research-ingredient-roles/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: research-ingredient-roles
+description: Run the Step 7b Edison + DRC literature backfill lane end-to-end for ingredient role facets (nutritional / physicochemical / cellular-metabolic). Prioritize gaps, dispatch Edison, extract structured YAML, apply to both MIM ingredient records (rich, evidence-bearing) and CultureMech recipes (scalar tokens per descriptor).
+version: 1.0.0
+tags: [edison, deep-research, ingredients, roles, facets, literature]
+author: CultureMech Team
+created: 2026-07-21
+category: enrichment
+requires_database: false
+requires_internet: true
+---
+
+# research-ingredient-roles
+
+## Overview
+
+Orchestrates the **literature lane** of Step 7b — the cross-repo pipeline that
+fills the three ingredient role facets from primary literature via Edison
+(PaperQA3) or the deep-research-client fallback. Complements the **mechanistic
+lane** (Step 7: `scripts/backfill_ingredient_roles.py`, driven by CHEBI
+`has_role` axioms via OAK).
+
+The two lanes write into the SAME per-facet assignment classes but with
+different confidence tiers — mechanistic lands `confidence: "chebi-axiom"`
+automatically; literature lands `confidence: 0.85-0.95` with cited
+DOIs/PMIDs. When they disagree, primary literature wins and a curator review
+item opens.
+
+## When to Use
+
+| Scenario | Action |
+| -------- | ------ |
+| Top-of-corpus gap analysis: "which ingredients lack role facets and would benefit most from Edison spend?" | Step 1 (prioritize) alone |
+| Full run against top-N: propose + verify + apply | Steps 1-5 |
+| Post-mechanistic-backfill fill-in: only ingredients CHEBI didn't cover | Step 1 with default penalty on has_role axiom presence |
+| Re-apply an already-extracted batch to a fresh checkout | Steps 4-5 only |
+
+**Not for**: identity mapping (that's the existing `deep-research-ingredient` skill in MIM) or role assignments derivable from CHEBI axioms (Step 7 mechanistic).
+
+## Runbook
+
+### 1. Prioritize (CultureMech)
+
+```
+just prioritize-role-research-candidates --top 25
+# → data/import_tracking/reports/role_research_priority.json (batch-ready)
+```
+
+Score = `(# empty facets) × log10(1 + occurrences) × mapped-mult × chebi-mult`.
+Records with an existing Edison role-research meta yaml are excluded. The
+output JSON is the exact batch shape MIM's `research_ingredient_edison.py
+--batch` expects.
+
+**Curator triage step:** open the top-25 and drop obvious skips (distilled
+water, plain HCl/NaOH — structural entries where role research isn't
+scientifically meaningful). Write a trimmed `role_research_priority_top10.json`.
+
+### 2. Dispatch Edison (MIM)
+
+```
+cd ../MediaIngredientMech
+just research-ingredient-roles-edison-batch \
+  ../CultureMech/data/import_tracking/reports/role_research_priority_top10.json \
+  --dry-run                                    # sanity — prints plan without spending credits
+# then:
+just research-ingredient-roles-edison-batch \
+  ../CultureMech/data/import_tracking/reports/role_research_priority_top10.json
+# → research/ingredients/roles/*-edison-literature.{md,-meta.yaml,-citations.md,...}
+```
+
+Uses the role-research template
+(`templates/ingredient_role_research.md`) that asks Edison for the three
+facets, cited primary evidence per role, organism-conditional caveats, and
+a machine-readable fenced YAML block.
+
+DRC fallback (deferred as a future MIM PR):
+
+```
+# just research-ingredient-roles ... --provider falcon
+```
+
+### 3. Extract to dual batch JSON (CultureMech)
+
+```
+just extract-roles-from-edison ../MediaIngredientMech/research/ingredients/roles
+# → data/import_tracking/reports/edison_role_batch_mim.json  (rich, for MIM applier)
+# → data/import_tracking/reports/edison_role_batch_cm.json   (scalar, for CM applier)
+```
+
+Robustness: the LAST `role_research:` fenced block wins (template's own
+example is in an earlier fence). String-shorthand entries (`- SULFUR_SOURCE`)
+are upgraded to dict form. Citations sidecar is cross-referenced to fill in
+`reference_text:` when the model reported only a DOI/PMID.
+
+### 4. Apply to MIM ingredient records (rich)
+
+```
+cd ../MediaIngredientMech
+just apply-role-research-results \
+  ../CultureMech/data/import_tracking/reports/edison_role_batch_mim.json \
+  --curator edison-deep-research \
+  --dry-run
+# then:
+just apply-role-research-results \
+  ../CultureMech/data/import_tracking/reports/edison_role_batch_mim.json \
+  --curator edison-deep-research
+```
+
+Writes full `RoleAssignment` records with per-citation `RoleCitation` evidence,
+per-facet never-overwrite guard, curator-history event with `changes:` naming
+the facets touched.
+
+### 5. Apply to CultureMech recipes (scalar tokens)
+
+```
+just apply-ingredient-roles \
+  data/import_tracking/reports/edison_role_batch_cm.json \
+  --dry-run
+# then:
+just apply-ingredient-roles \
+  data/import_tracking/reports/edison_role_batch_cm.json
+```
+
+Walks every recipe under `data/normalized_yaml/`, matches ingredient
+descriptors by CHEBI id (prefers `mediaingredientmech_chebi_term.id`, falls
+back to `term.id`), and populates the three facet slots on descriptors that
+don't already carry them. Never overwrites curator assignments. Adds a
+curation-history event per changed recipe.
+
+### 6. Verify
+
+```
+just validate-strict src/culturemech/schema/culturemech.yaml
+just test tests/test_apply_ingredient_roles.py
+# Optional visualization spot-check on a touched recipe:
+just render-media-role-graph data/normalized_yaml/bacterial/<recipe>.yaml
+```
+
+## Merge Policy (Two Evidence Lanes)
+
+Both lanes write into the same per-facet assignment classes. Merge order:
+
+1. **Mechanistic first** (Step 7, `chebi-axiom` confidence, fast/cheap/deterministic).
+2. **Literature second** (Step 7b, `literature-*` confidence, DOI/PMID cited).
+3. **On agreement**: literature assignment reinforces mechanistic — same facet-role tuple, evidence list is unioned, confidence lifts to literature tier.
+4. **On disagreement**: literature-cited primary evidence beats ChEBI hierarchy inference. Curator review item opens (never silently overwritten).
+
+The extractor detects overlap by facet+role tuple. `apply_role_research_results.py`
+and `apply_ingredient_roles.py` both enforce the "never mutate a populated slot"
+guard, so the merge decision happens BEFORE the applier — either at extraction
+time or in a curator's manual review pass.
+
+## Related Scripts
+
+- `scripts/prioritize_role_research_candidates.py` — this skill's step 1
+- `scripts/extract_roles_from_edison.py` — step 3
+- `scripts/apply_ingredient_roles.py` — step 5
+- MIM `scripts/research_ingredient_roles_edison.py` — step 2
+- MIM `scripts/apply_role_research_results.py` — step 4
+- MIM `templates/ingredient_role_research.md` — the Edison template
+- Step 7 mechanistic backfill: `scripts/backfill_ingredient_roles.py`
+
+## Related Skills
+
+- `render-media-role-graph` — visualize what roles a recipe carries after apply
+- `deep-research-ingredient` (in MIM) — identity mapping (upstream of this skill)
+- `audit-schema-gaps` — post-apply verification that schema constraints hold

--- a/docs/EDISON_REVIEW_WORKFLOW.md
+++ b/docs/EDISON_REVIEW_WORKFLOW.md
@@ -434,6 +434,26 @@ Prioritize authoritative microbiology sources and culture collection databases.
 3. Provide more context (organism type, source database)
 4. Review individual literature for each medium
 
+## Role Research (Step 7b Literature Lane)
+
+This document describes the manual per-recipe review workflow. For **ingredient
+role facets** (nutritional / physicochemical / cellular-metabolic), Step 7b of
+the ingredient-roles migration adds a fully SDK-driven pipeline that
+supersedes the browser-based workflow for role assignments:
+
+- `just prioritize-role-research-candidates` — rank MIM ingredients by facet-gap × occurrence
+- MIM `just research-ingredient-roles-edison-batch` — dispatch Edison against the top-N
+- `just extract-roles-from-edison` — parse the fenced YAML block into dual applier batches
+- MIM `just apply-role-research-results` — write rich per-facet RoleAssignments to MIM
+- `just apply-ingredient-roles` — populate scalar facet tokens on CultureMech recipe descriptors
+
+See the runbook in `.claude/skills/research-ingredient-roles/SKILL.md` for the
+full sequence, dry-run flags, and the mechanistic-vs-literature merge policy.
+
+Use the manual workflow below for **medium-level** enrichment (descriptions,
+pH values, target organisms, ingredient identity mapping) that the SDK pipeline
+does not cover.
+
 ## Next Steps
 
 1. **Review quality report**: `data/import_tracking/reports/quality_analysis.md`

--- a/project.justfile
+++ b/project.justfile
@@ -125,6 +125,14 @@ prioritize-role-research-candidates *args="":
 extract-roles-from-edison inputs="../MediaIngredientMech/research/ingredients/roles" *args="":
     uv run --extra dev python scripts/extract_roles_from_edison.py {{inputs}} {{args}}
 
+# Apply the scalar-projection role batch (from `extract-roles-from-edison --out-cm`)
+# across every recipe under data/normalized_yaml/. Fills empty facet slots on
+# ingredient descriptors whose CHEBI id matches a batch proposal; never overwrites
+# curator assignments. Adds a curation-history event per changed recipe.
+[group('Research')]
+apply-ingredient-roles batch *args="":
+    uv run --extra dev python scripts/apply_ingredient_roles.py {{batch}} {{args}}
+
 [group('Research')]
 research-organism-recipe-edison target organism *args="":
     uv run --extra dev python scripts/research_organism_recipe_edison.py \

--- a/scripts/apply_ingredient_roles.py
+++ b/scripts/apply_ingredient_roles.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Apply Step 7b Edison-derived ingredient role tokens across CultureMech recipes.
+
+Consumes the scalar-projection batch JSON produced by
+`extract_roles_from_edison.py --out-cm`:
+
+  {"proposals": [
+    {"ingredient_identifier": "CHEBI:17561",
+     "ingredient_slug": "L-cysteine",
+     "source_run": "L-cysteine-edison-literature",
+     "roles": {
+       "nutritional_roles": ["AMINO_ACID_SOURCE", "SULFUR_SOURCE"],
+       "physicochemical_roles": ["REDUCING_AGENT"],
+       "cellular_metabolic_roles": ["SUBSTRATE"]}},
+    ...]}
+
+Walks every recipe under `data/normalized_yaml/**/*.yaml`, and for every
+ingredient descriptor whose CHEBI identity matches a batch proposal, fills
+in the three facet slots on the descriptor. Never overwrites — a slot
+already populated on the descriptor is left alone (curator wins).
+
+Complements MIM's `apply_role_research_results.py` (rich shape, evidence
+carried through). Evidence and citations are the source-of-truth on the
+MIM record; CultureMech carries only the scalar tokens per descriptor.
+
+The two appliers should be run against the SAME extractor output (which
+is why `extract_roles_from_edison.py` emits both `--out-mim` and `--out-cm`
+in a single pass).
+
+Usage:
+
+    just apply-ingredient-roles data/import_tracking/reports/edison_role_batch_cm.json --dry-run
+    just apply-ingredient-roles data/import_tracking/reports/edison_role_batch_cm.json
+
+    # Direct CLI:
+    uv run python scripts/apply_ingredient_roles.py \\
+      data/import_tracking/reports/edison_role_batch_cm.json \\
+      --yaml-dir data/normalized_yaml/ \\
+      --curator edison-deep-research
+
+Curation history: one event per changed recipe, with `curator=<--curator>`,
+`action=ANNOTATED`, `changes=` listing facet slot names, and a `notes`
+field naming the source Edison run and the ingredient identifiers touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_YAML_DIR = REPO_ROOT / "data" / "normalized_yaml"
+
+FACET_SLOTS = ("nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles")
+
+DEFAULT_CURATOR = "edison-deep-research"
+
+
+def _load_batch(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict) or "proposals" not in data:
+        raise SystemExit(
+            f"Batch file {path} must be a JSON object with a top-level 'proposals' list."
+        )
+    proposals = data["proposals"]
+    if not isinstance(proposals, list):
+        raise SystemExit(f"'proposals' in {path} must be a list, got {type(proposals).__name__}.")
+    return proposals
+
+
+def _index_by_identifier(proposals: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index proposals by ingredient_identifier for O(1) lookup during the walk."""
+    idx: dict[str, dict[str, Any]] = {}
+    for p in proposals:
+        ident = p.get("ingredient_identifier")
+        if not ident:
+            continue
+        if ident in idx:
+            # Merge: prefer the later proposal's roles, but never lose earlier facets.
+            existing = idx[ident].get("roles") or {}
+            new = p.get("roles") or {}
+            merged = dict(existing)
+            for slot, tokens in new.items():
+                merged.setdefault(slot, tokens)
+            p = dict(p, roles=merged)
+        idx[ident] = p
+    return idx
+
+
+def _descriptor_identifier(ing: dict[str, Any]) -> str | None:
+    """Best-effort CHEBI id for an ingredient descriptor in a normalized recipe.
+
+    Prefers `mediaingredientmech_chebi_term.id` (MIM-mapped anchor); falls
+    back to `term.id`. Returns None if neither is a CHEBI curie.
+    """
+    for key in ("mediaingredientmech_chebi_term", "term", "ingredient_term"):
+        term = ing.get(key)
+        if isinstance(term, dict):
+            tid = term.get("id")
+            if isinstance(tid, str) and tid:
+                return tid
+    return None
+
+
+def _apply_to_descriptor(
+    ing: dict[str, Any],
+    proposal: dict[str, Any],
+) -> list[str]:
+    """Set empty facet slots on one descriptor. Returns list of slots changed."""
+    roles = proposal.get("roles") or {}
+    changed: list[str] = []
+    for slot in FACET_SLOTS:
+        tokens = roles.get(slot) or []
+        if not tokens:
+            continue
+        if ing.get(slot):  # never-overwrite guard
+            continue
+        # Dedup tokens preserving order; enum validation is the schema/apply-linter's job.
+        seen: set[str] = set()
+        clean: list[str] = []
+        for t in tokens:
+            if isinstance(t, str) and t and t not in seen:
+                seen.add(t)
+                clean.append(t)
+        if clean:
+            ing[slot] = clean
+            changed.append(slot)
+    return changed
+
+
+def _add_curation_event(
+    recipe: dict[str, Any],
+    curator_name: str,
+    fields_changed: list[str],
+    notes: str,
+) -> None:
+    """Append a curation_history event to the recipe."""
+    history = recipe.setdefault("curation_history", [])
+    history.append({
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "curator": curator_name,
+        "action": "ANNOTATED",
+        "fields_changed": fields_changed,
+        "notes": notes,
+    })
+
+
+def _walk_descriptors(recipe: dict[str, Any]):
+    """Yield every ingredient-descriptor dict inside a recipe (top-level + solutions)."""
+    for ing in recipe.get("ingredients") or []:
+        if isinstance(ing, dict):
+            yield ing
+    for sol in recipe.get("solutions") or []:
+        if not isinstance(sol, dict):
+            continue
+        for ing in sol.get("ingredients") or []:
+            if isinstance(ing, dict):
+                yield ing
+
+
+def apply_to_recipe(
+    recipe: dict[str, Any],
+    proposals_by_id: dict[str, dict[str, Any]],
+    curator_name: str,
+) -> tuple[list[str], list[str]]:
+    """Apply proposals to one recipe. Returns (fields_changed, touched_identifiers)."""
+    fields_changed: set[str] = set()
+    touched: list[str] = []
+    for ing in _walk_descriptors(recipe):
+        ident = _descriptor_identifier(ing)
+        if not ident or ident not in proposals_by_id:
+            continue
+        proposal = proposals_by_id[ident]
+        changed = _apply_to_descriptor(ing, proposal)
+        if changed:
+            fields_changed.update(changed)
+            touched.append(ident)
+    if fields_changed:
+        source_runs = sorted(
+            {proposals_by_id[i].get("source_run") for i in touched
+             if proposals_by_id[i].get("source_run")}
+        )
+        notes = f"Populated {sorted(fields_changed)} for {sorted(set(touched))}; source_run={source_runs}"
+        _add_curation_event(recipe, curator_name, sorted(fields_changed), notes)
+    return sorted(fields_changed), touched
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("batch", type=Path,
+                        help="JSON batch from extract_roles_from_edison.py --out-cm.")
+    parser.add_argument("--yaml-dir", type=Path, default=DEFAULT_YAML_DIR,
+                        help="Root of the normalized recipe YAMLs.")
+    parser.add_argument("--curator", default=DEFAULT_CURATOR,
+                        help="Curator identity written to curation_history events.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report changes without writing files.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Cap the number of recipes actually written (dry-run counts them all).")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.batch.is_file():
+        print(f"Batch file not found: {args.batch}", file=sys.stderr)
+        return 2
+    if not args.yaml_dir.is_dir():
+        print(f"YAML dir not found: {args.yaml_dir}", file=sys.stderr)
+        return 2
+
+    proposals = _load_batch(args.batch)
+    proposals_by_id = _index_by_identifier(proposals)
+    if not proposals_by_id:
+        print("No proposals with an ingredient_identifier; nothing to apply.")
+        return 0
+
+    print(f"Loaded {len(proposals)} proposals ({len(proposals_by_id)} unique identifiers) from {args.batch}")
+    print(f"Walking recipes under {args.yaml_dir}")
+
+    recipes_touched = 0
+    recipes_written = 0
+    identifiers_touched: set[str] = set()
+
+    for yaml_path in sorted(args.yaml_dir.rglob("*.yaml")):
+        try:
+            recipe = yaml.safe_load(yaml_path.read_text())
+        except Exception as exc:
+            if args.verbose:
+                print(f"skip {yaml_path.relative_to(args.yaml_dir)}: parse error: {exc}")
+            continue
+        if not isinstance(recipe, dict):
+            continue
+
+        fields_changed, touched = apply_to_recipe(recipe, proposals_by_id, args.curator)
+        if not fields_changed:
+            continue
+
+        recipes_touched += 1
+        identifiers_touched.update(touched)
+
+        if args.dry_run:
+            if args.verbose:
+                print(f"[DRY] {yaml_path.relative_to(args.yaml_dir)}: {fields_changed} ({len(touched)} ingredients)")
+            continue
+
+        if args.limit is not None and recipes_written >= args.limit:
+            continue
+
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(recipe, f, default_flow_style=False, sort_keys=False,
+                      allow_unicode=True, width=120)
+        recipes_written += 1
+        if args.verbose:
+            print(f"WROTE {yaml_path.relative_to(args.yaml_dir)}: {fields_changed}")
+
+    print()
+    print(f"Recipes touched: {recipes_touched}")
+    print(f"Recipes written: {recipes_written}{' (DRY RUN)' if args.dry_run else ''}")
+    print(f"Distinct ingredient identifiers applied: {len(identifiers_touched)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/apply_ingredient_roles.py
+++ b/scripts/apply_ingredient_roles.py
@@ -41,6 +41,11 @@ Usage:
 Curation history: one event per changed recipe, with `curator=<--curator>`,
 `action=ANNOTATED`, `changes=` listing facet slot names, and a `notes`
 field naming the source Edison run and the ingredient identifiers touched.
+
+Role tokens are NOT re-validated against the facet enums here — that check
+lives in `extract_roles_from_edison.py`. A batch produced with its
+`--no-validate` flag, or hand-edited afterwards, can carry invalid tokens
+into the corpus, where they surface only at `just validate-strict`.
 """
 
 from __future__ import annotations
@@ -74,15 +79,26 @@ def _load_batch(path: Path) -> list[dict[str, Any]]:
     return proposals
 
 
-def _index_by_identifier(proposals: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    """Index proposals by ingredient_identifier for O(1) lookup during the walk."""
+def _index_by_identifier(
+    proposals: list[dict[str, Any]],
+    skipped: list[dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Index proposals by ingredient_identifier for O(1) lookup during the walk.
+
+    A proposal with no `ingredient_identifier` cannot be matched to a descriptor
+    and is dropped; dropped proposals are appended to `skipped` so the caller can
+    report them rather than losing them silently.
+    """
     idx: dict[str, dict[str, Any]] = {}
     for p in proposals:
         ident = p.get("ingredient_identifier")
         if not ident:
+            if skipped is not None:
+                skipped.append(p)
             continue
         if ident in idx:
-            # Merge: prefer the later proposal's roles, but never lose earlier facets.
+            # Merge: first proposal wins per facet; later ones only fill facets
+            # the earlier proposal left empty.
             existing = idx[ident].get("roles") or {}
             new = p.get("roles") or {}
             merged = dict(existing)
@@ -94,10 +110,13 @@ def _index_by_identifier(proposals: list[dict[str, Any]]) -> dict[str, dict[str,
 
 
 def _descriptor_identifier(ing: dict[str, Any]) -> str | None:
-    """Best-effort CHEBI id for an ingredient descriptor in a normalized recipe.
+    """Best-effort ontology id for an ingredient descriptor in a normalized recipe.
 
-    Prefers `mediaingredientmech_chebi_term.id` (MIM-mapped anchor); falls
-    back to `term.id`. Returns None if neither is a CHEBI curie.
+    Prefers `mediaingredientmech_chebi_term.id` (MIM-mapped anchor); falls back to
+    `term.id`, then `ingredient_term.id`. The id is returned as-is whatever its
+    namespace — no CHEBI filter — since matching is by equality against the batch's
+    `ingredient_identifier`, which is itself CHEBI in practice. Returns None only
+    when no descriptor term carries an id at all.
     """
     for key in ("mediaingredientmech_chebi_term", "term", "ingredient_term"):
         term = ing.get(key)
@@ -140,13 +159,19 @@ def _add_curation_event(
     fields_changed: list[str],
     notes: str,
 ) -> None:
-    """Append a curation_history event to the recipe."""
+    """Append a curation_history event to the recipe.
+
+    `CurationEvent` has no `fields_changed` slot — the slot is `changes`, and its
+    range is a plain string, so the facet list is rendered comma-joined. The class
+    is validated closed (`validate-strict` runs linkml-validate with closed=True),
+    so any extra key here fails CI on every recipe this script writes.
+    """
     history = recipe.setdefault("curation_history", [])
     history.append({
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
         "curator": curator_name,
         "action": "ANNOTATED",
-        "fields_changed": fields_changed,
+        "changes": ", ".join(fields_changed),
         "notes": notes,
     })
 
@@ -214,7 +239,14 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     proposals = _load_batch(args.batch)
-    proposals_by_id = _index_by_identifier(proposals)
+    unidentified: list[dict[str, Any]] = []
+    proposals_by_id = _index_by_identifier(proposals, skipped=unidentified)
+    if unidentified:
+        print(f"WARNING: {len(unidentified)} proposal(s) have no `ingredient_identifier` "
+              f"and cannot be matched to a descriptor — they will NOT be applied:")
+        for p in unidentified:
+            print(f"  - slug={p.get('ingredient_slug') or '(none)'} "
+                  f"source_run={p.get('source_run') or '(none)'}")
     if not proposals_by_id:
         print("No proposals with an ingredient_identifier; nothing to apply.")
         return 0

--- a/tests/test_apply_ingredient_roles.py
+++ b/tests/test_apply_ingredient_roles.py
@@ -205,8 +205,43 @@ def test_apply_to_recipe_adds_curation_event_when_changed():
     assert len(events) == 1
     assert events[0]["curator"] == "test-curator"
     assert events[0]["action"] == "ANNOTATED"
-    assert events[0]["fields_changed"] == ["nutritional_roles"]
+    assert events[0]["changes"] == "nutritional_roles"
     assert "L-cysteine-edison-literature" in events[0]["notes"]
+
+
+def test_curation_event_keys_are_all_curation_event_slots():
+    """Every key we emit must be a declared CurationEvent slot.
+
+    `validate-strict` runs linkml-validate with closed=True, so an undeclared key
+    (e.g. the `fields_changed` this script originally wrote) fails CI on every
+    recipe the applier touches — and nothing else in this suite would catch it,
+    since the applier's own tests never validate against the schema.
+    """
+    schema = yaml.safe_load(
+        (Path(__file__).resolve().parent.parent
+         / "src" / "culturemech" / "schema" / "culturemech.yaml").read_text()
+    )
+    allowed = set(schema["classes"]["CurationEvent"]["attributes"])
+    assert "changes" in allowed and "fields_changed" not in allowed  # guards the fixture itself
+
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+    proposals = [_sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])]
+    _ap.apply_to_recipe(recipe, _ap._index_by_identifier(proposals), "test-curator")
+
+    emitted = set(recipe["curation_history"][0])
+    assert emitted <= allowed, f"undeclared CurationEvent key(s): {sorted(emitted - allowed)}"
+
+
+def test_proposals_without_identifier_are_reported_not_silently_dropped():
+    skipped = []
+    proposals = [
+        _sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"]),
+        {"ingredient_slug": "mystery", "source_run": "mystery-edison-literature",
+         "roles": {"nutritional_roles": ["CARBON_SOURCE"]}},  # no ingredient_identifier
+    ]
+    idx = _ap._index_by_identifier(proposals, skipped=skipped)
+    assert set(idx) == {"CHEBI:17561"}
+    assert [p["ingredient_slug"] for p in skipped] == ["mystery"]
 
 
 def test_apply_to_recipe_no_change_no_curation_event():

--- a/tests/test_apply_ingredient_roles.py
+++ b/tests/test_apply_ingredient_roles.py
@@ -1,0 +1,312 @@
+"""Tests for scripts/apply_ingredient_roles.py — Step 7b CultureMech applier."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "apply_ingredient_roles.py"
+
+_SPEC = importlib.util.spec_from_file_location("_apply_roles", _SCRIPT_PATH)
+_ap = importlib.util.module_from_spec(_SPEC)
+sys.modules["_apply_roles"] = _ap
+_SPEC.loader.exec_module(_ap)  # type: ignore[union-attr]
+
+
+# ---------------- helpers ----------------
+
+
+def _sample_proposal(chebi: str, slug: str, **roles) -> dict:
+    return {
+        "ingredient_identifier": chebi,
+        "ingredient_slug": slug,
+        "source_run": f"{slug}-edison-literature",
+        "roles": roles,
+    }
+
+
+def _write_batch(tmp_path: Path, proposals: list[dict]) -> Path:
+    p = tmp_path / "batch.json"
+    p.write_text(json.dumps({"proposals": proposals}))
+    return p
+
+
+def _sample_recipe(*descriptor_terms: tuple[str, str]) -> dict:
+    """Build a minimal recipe with N ingredients keyed by (chebi_id, preferred_term)."""
+    return {
+        "id": "CultureMech:test",
+        "name": "test_recipe",
+        "ingredients": [
+            {
+                "preferred_term": name,
+                "term": {"id": chebi, "label": name},
+                "mediaingredientmech_chebi_term": {"id": chebi, "label": name},
+                "concentration": {"value": "1.0", "unit": "G_PER_L"},
+            }
+            for chebi, name in descriptor_terms
+        ],
+    }
+
+
+# ---------------- _index_by_identifier ----------------
+
+
+def test_index_by_identifier_keys_on_ingredient_identifier():
+    props = [
+        _sample_proposal("CHEBI:1", "a", nutritional_roles=["CARBON_SOURCE"]),
+        _sample_proposal("CHEBI:2", "b", nutritional_roles=["NITROGEN_SOURCE"]),
+    ]
+    idx = _ap._index_by_identifier(props)
+    assert set(idx.keys()) == {"CHEBI:1", "CHEBI:2"}
+
+
+def test_index_by_identifier_drops_proposals_without_identifier():
+    props = [
+        _sample_proposal("CHEBI:1", "a", nutritional_roles=["CARBON_SOURCE"]),
+        {"ingredient_slug": "orphan", "roles": {}},  # no identifier
+    ]
+    idx = _ap._index_by_identifier(props)
+    assert list(idx.keys()) == ["CHEBI:1"]
+
+
+def test_index_by_identifier_merges_duplicate_ids_by_facet_union():
+    """Two proposals for same CHEBI should union their facet contributions."""
+    props = [
+        _sample_proposal("CHEBI:1", "a", nutritional_roles=["CARBON_SOURCE"]),
+        _sample_proposal("CHEBI:1", "a", physicochemical_roles=["BUFFER"]),
+    ]
+    idx = _ap._index_by_identifier(props)
+    roles = idx["CHEBI:1"]["roles"]
+    assert "nutritional_roles" in roles
+    assert "physicochemical_roles" in roles
+
+
+# ---------------- _descriptor_identifier ----------------
+
+
+def test_descriptor_identifier_prefers_mim_chebi_term():
+    ing = {"term": {"id": "CHEBI:1"},
+           "mediaingredientmech_chebi_term": {"id": "CHEBI:2"}}
+    assert _ap._descriptor_identifier(ing) == "CHEBI:2"
+
+
+def test_descriptor_identifier_falls_back_to_term():
+    ing = {"term": {"id": "CHEBI:1"}}
+    assert _ap._descriptor_identifier(ing) == "CHEBI:1"
+
+
+def test_descriptor_identifier_returns_none_when_no_term():
+    assert _ap._descriptor_identifier({"preferred_term": "x"}) is None
+
+
+def test_descriptor_identifier_returns_none_when_ids_missing():
+    ing = {"term": {"label": "x"}}
+    assert _ap._descriptor_identifier(ing) is None
+
+
+# ---------------- _apply_to_descriptor ----------------
+
+
+def test_apply_to_descriptor_sets_empty_facet_slots():
+    ing = {"preferred_term": "L-cysteine", "term": {"id": "CHEBI:17561"}}
+    proposal = _sample_proposal("CHEBI:17561", "L-cysteine",
+                                 nutritional_roles=["AMINO_ACID_SOURCE", "SULFUR_SOURCE"],
+                                 physicochemical_roles=["REDUCING_AGENT"],
+                                 cellular_metabolic_roles=["SUBSTRATE"])
+    changed = _ap._apply_to_descriptor(ing, proposal)
+    assert set(changed) == {"nutritional_roles", "physicochemical_roles", "cellular_metabolic_roles"}
+    assert ing["nutritional_roles"] == ["AMINO_ACID_SOURCE", "SULFUR_SOURCE"]
+    assert ing["physicochemical_roles"] == ["REDUCING_AGENT"]
+    assert ing["cellular_metabolic_roles"] == ["SUBSTRATE"]
+
+
+def test_apply_to_descriptor_never_overwrites_populated_slot():
+    ing = {
+        "preferred_term": "X",
+        "nutritional_roles": ["CARBON_SOURCE"],  # already set by curator
+    }
+    proposal = _sample_proposal("CHEBI:1", "x",
+                                 nutritional_roles=["NITROGEN_SOURCE"],  # would overwrite
+                                 physicochemical_roles=["BUFFER"])       # empty; fills
+    changed = _ap._apply_to_descriptor(ing, proposal)
+    assert changed == ["physicochemical_roles"]
+    # Preserved curator's choice:
+    assert ing["nutritional_roles"] == ["CARBON_SOURCE"]
+    # Filled the empty facet:
+    assert ing["physicochemical_roles"] == ["BUFFER"]
+
+
+def test_apply_to_descriptor_dedups_tokens():
+    ing = {"preferred_term": "X"}
+    proposal = _sample_proposal("CHEBI:1", "x",
+                                 nutritional_roles=["CARBON_SOURCE", "CARBON_SOURCE", "NITROGEN_SOURCE"])
+    _ap._apply_to_descriptor(ing, proposal)
+    assert ing["nutritional_roles"] == ["CARBON_SOURCE", "NITROGEN_SOURCE"]
+
+
+def test_apply_to_descriptor_ignores_empty_role_list():
+    ing = {"preferred_term": "X"}
+    proposal = _sample_proposal("CHEBI:1", "x", nutritional_roles=[])
+    changed = _ap._apply_to_descriptor(ing, proposal)
+    assert changed == []
+    assert "nutritional_roles" not in ing
+
+
+# ---------------- apply_to_recipe ----------------
+
+
+def test_apply_to_recipe_walks_top_level_ingredients():
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"), ("CHEBI:26710", "NaCl"))
+    proposals = [
+        _sample_proposal("CHEBI:17561", "L-cysteine",
+                          nutritional_roles=["SULFUR_SOURCE"]),
+        _sample_proposal("CHEBI:26710", "NaCl",
+                          physicochemical_roles=["OSMOTIC_AGENT"]),
+    ]
+    idx = _ap._index_by_identifier(proposals)
+    fields, touched = _ap.apply_to_recipe(recipe, idx, "test-curator")
+    assert set(fields) == {"nutritional_roles", "physicochemical_roles"}
+    assert set(touched) == {"CHEBI:17561", "CHEBI:26710"}
+    assert recipe["ingredients"][0]["nutritional_roles"] == ["SULFUR_SOURCE"]
+    assert recipe["ingredients"][1]["physicochemical_roles"] == ["OSMOTIC_AGENT"]
+
+
+def test_apply_to_recipe_walks_solution_ingredients():
+    recipe = {
+        "id": "x",
+        "solutions": [{
+            "name": "trace metals",
+            "ingredients": [
+                {"preferred_term": "FeCl3", "term": {"id": "CHEBI:30808"}},
+            ],
+        }],
+    }
+    proposals = [_sample_proposal("CHEBI:30808", "FeCl3", nutritional_roles=["IRON_SOURCE"])]
+    idx = _ap._index_by_identifier(proposals)
+    fields, touched = _ap.apply_to_recipe(recipe, idx, "test-curator")
+    assert fields == ["nutritional_roles"]
+    assert touched == ["CHEBI:30808"]
+    assert recipe["solutions"][0]["ingredients"][0]["nutritional_roles"] == ["IRON_SOURCE"]
+
+
+def test_apply_to_recipe_adds_curation_event_when_changed():
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+    proposals = [_sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])]
+    idx = _ap._index_by_identifier(proposals)
+    _ap.apply_to_recipe(recipe, idx, "test-curator")
+    events = recipe["curation_history"]
+    assert len(events) == 1
+    assert events[0]["curator"] == "test-curator"
+    assert events[0]["action"] == "ANNOTATED"
+    assert events[0]["fields_changed"] == ["nutritional_roles"]
+    assert "L-cysteine-edison-literature" in events[0]["notes"]
+
+
+def test_apply_to_recipe_no_change_no_curation_event():
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+    recipe["ingredients"][0]["nutritional_roles"] = ["CARBON_SOURCE"]  # already populated
+    proposals = [_sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])]
+    idx = _ap._index_by_identifier(proposals)
+    fields, touched = _ap.apply_to_recipe(recipe, idx, "test-curator")
+    assert fields == []
+    assert "curation_history" not in recipe
+
+
+def test_apply_to_recipe_skips_ingredients_without_matching_identifier():
+    recipe = _sample_recipe(("CHEBI:99999", "unknown_thing"))
+    proposals = [_sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])]
+    idx = _ap._index_by_identifier(proposals)
+    fields, touched = _ap.apply_to_recipe(recipe, idx, "test-curator")
+    assert fields == []
+    assert touched == []
+
+
+# ---------------- CLI main ----------------
+
+
+def test_main_dry_run_makes_no_writes(tmp_path):
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+    recipe_path = yaml_dir / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(recipe))
+    original_bytes = recipe_path.read_bytes()
+
+    batch = _write_batch(tmp_path, [
+        _sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])
+    ])
+
+    rc = _ap.main([str(batch), "--yaml-dir", str(yaml_dir), "--dry-run"])
+    assert rc == 0
+    assert recipe_path.read_bytes() == original_bytes
+
+
+def test_main_writes_recipe_and_round_trips(tmp_path):
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+    recipe_path = yaml_dir / "recipe.yaml"
+    recipe_path.write_text(yaml.safe_dump(recipe))
+
+    batch = _write_batch(tmp_path, [
+        _sample_proposal("CHEBI:17561", "L-cysteine",
+                         nutritional_roles=["AMINO_ACID_SOURCE", "SULFUR_SOURCE"],
+                         cellular_metabolic_roles=["SUBSTRATE"])
+    ])
+
+    rc = _ap.main([str(batch), "--yaml-dir", str(yaml_dir), "--curator", "edison-deep-research"])
+    assert rc == 0
+    updated = yaml.safe_load(recipe_path.read_text())
+    ing = updated["ingredients"][0]
+    assert ing["nutritional_roles"] == ["AMINO_ACID_SOURCE", "SULFUR_SOURCE"]
+    assert ing["cellular_metabolic_roles"] == ["SUBSTRATE"]
+    assert updated["curation_history"][0]["curator"] == "edison-deep-research"
+
+
+def test_main_missing_batch_returns_2(tmp_path):
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    rc = _ap.main([str(tmp_path / "missing.json"), "--yaml-dir", str(yaml_dir)])
+    assert rc == 2
+
+
+def test_main_missing_yaml_dir_returns_2(tmp_path):
+    batch = _write_batch(tmp_path, [
+        _sample_proposal("CHEBI:1", "x", nutritional_roles=["CARBON_SOURCE"])
+    ])
+    rc = _ap.main([str(batch), "--yaml-dir", str(tmp_path / "nope")])
+    assert rc == 2
+
+
+def test_main_limit_caps_writes_but_dry_run_counts_all(tmp_path):
+    """--limit only caps writes, dry-run always reports total touched."""
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    for i in range(3):
+        recipe = _sample_recipe(("CHEBI:17561", "L-cysteine"))
+        (yaml_dir / f"r{i}.yaml").write_text(yaml.safe_dump(recipe))
+    batch = _write_batch(tmp_path, [
+        _sample_proposal("CHEBI:17561", "L-cysteine", nutritional_roles=["SULFUR_SOURCE"])
+    ])
+    rc = _ap.main([str(batch), "--yaml-dir", str(yaml_dir), "--limit", "1"])
+    assert rc == 0
+    # Two of three recipes should still have empty nutritional_roles.
+    written = sum(1 for p in yaml_dir.glob("*.yaml")
+                  if yaml.safe_load(p.read_text())["ingredients"][0].get("nutritional_roles"))
+    assert written == 1
+
+
+def test_main_bad_batch_shape_raises_systemexit(tmp_path):
+    batch = tmp_path / "bad.json"
+    batch.write_text(json.dumps({"not_proposals": []}))
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    with pytest.raises(SystemExit, match="'proposals' list"):
+        _ap.main([str(batch), "--yaml-dir", str(yaml_dir)])


### PR DESCRIPTION
## Summary

Step 7b PR5 — final CultureMech-side plumbing for the literature-lane Edison pipeline. Closes the loop: after the extractor (PR4) emits a scalar-projection batch, this PR applies those role tokens onto every recipe descriptor that matches by CHEBI id.

- **`scripts/apply_ingredient_roles.py`** — walks `data/normalized_yaml/**/*.yaml`, matches ingredient descriptors by CHEBI id (prefers `mediaingredientmech_chebi_term.id`, falls back to `term.id`), and populates the three facet slots on descriptors that don't already carry them. Handles both top-level ingredients and solution-nested ingredients. Never overwrites curator assignments. Adds a curation-history event per changed recipe with the facets touched and the source Edison run.
- **`tests/test_apply_ingredient_roles.py`** — 22 passing tests. Coverage: identifier-index dedup/merge/drop, descriptor identifier selection, per-descriptor apply (fill/never-overwrite/dedup/empty-list), recipe-walker (top-level + solutions, curation-event only when changed, ID-mismatch skip), CLI (dry-run leaves bytes unchanged, --limit caps writes, missing batch/dir returns 2, bad shape raises SystemExit).
- **`.claude/skills/research-ingredient-roles/SKILL.md`** — end-to-end 6-step runbook (prioritize → dispatch Edison → extract → apply-MIM → apply-CM → verify), the mechanistic-vs-literature merge policy from Step 7c of the plan, and links to render-media-role-graph for post-apply visualization.
- **`docs/EDISON_REVIEW_WORKFLOW.md`** — role-research section pointing at the new skill; keeps the manual browser workflow for medium-level enrichment the SDK pipeline doesn't cover.
- **`project.justfile`** — `just apply-ingredient-roles <batch> [--dry-run]` recipe.

## The complete Step 7b pipeline

With PRs #103–#106 (MIM #146, MIM #153, CM #105, CM #106) and this PR, the literature-lane is end-to-end runnable:

```
# 1. Prioritize (CM)                → role_research_priority.json
just prioritize-role-research-candidates --top 10

# 2. Dispatch Edison (MIM)          → research/ingredients/roles/*
cd ../MediaIngredientMech && just research-ingredient-roles-edison-batch ../CultureMech/…priority.json

# 3. Extract dual batches (CM)      → edison_role_batch_{mim,cm}.json
just extract-roles-from-edison ../MediaIngredientMech/research/ingredients/roles

# 4. Apply to MIM ingredient records (rich, evidence-bearing)
cd ../MediaIngredientMech && just apply-role-research-results ../CultureMech/…batch_mim.json

# 5. Apply to CM recipes (scalar tokens per descriptor)  ← this PR
just apply-ingredient-roles data/import_tracking/reports/edison_role_batch_cm.json
```

The only remaining piece is PR6 — a real Edison run against the top-10 output, which is curator-triggered (~\$5-20 in credits) and produces the reference-artifact `-edison-literature.md` bundles that let the pipeline dry-run against real data.

## Test plan

- [x] `uv run pytest tests/test_apply_ingredient_roles.py` — 22/22 pass
- [x] Descriptor walker correctly handles both `ingredients:` (top-level) and `solutions[].ingredients:` (nested)
- [x] Never-overwrite guard verified: curator-set `nutritional_roles` on a descriptor is left alone even when a proposal targets that facet; empty facets on the SAME descriptor still get filled
- [x] CultureMech-scalar shape verified against the `IngredientDescriptor` slots added in Step 4 (`nutritional_roles`, `physicochemical_roles`, `cellular_metabolic_roles` — all multivalued enum lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)