### PR TITLE
Phase 2: nightly cross-repo vendored-file audit (hub-side guard)

### DIFF
--- a/.github/workflows/vendored-fleet-audit.yml
+++ b/.github/workflows/vendored-fleet-audit.yml
@@ -1,0 +1,21 @@
+name: vendored-fleet-audit
+
+# Nightly cross-repo audit: the per-repo drift check verifies each spoke against
+# the hub, but nothing checks the hub itself or a spoke whose pinned ref lags.
+# This compares all four Mech repos' vendored files on main and fails on any
+# disagreement. Dependency-free (checkout + curl).
+on:
+  schedule:
+    - cron: "17 8 * * *"   # 08:17 UTC daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Audit vendored files across the fleet
+        run: bash scripts/audit_vendored_fleet.sh

--- a/scripts/audit_vendored_fleet.sh
+++ b/scripts/audit_vendored_fleet.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Nightly fleet audit for vendored byte-identical files.
+#
+# The per-repo drift check (scripts/check_vendored_sync.sh in each spoke) verifies
+# a spoke against the canonical hub, but NOTHING checks the hub itself, nor a
+# spoke whose pinned ref lags the hub. This audit closes that gap: it fetches
+# each vendored file from ALL FOUR repos' main branches and compares them,
+# failing if any repo disagrees with the hub. Dependency-free (bash + curl).
+set -euo pipefail
+
+ORG="CultureBotAI"
+HUB="CultureMech"
+REPOS=(CultureMech MediaIngredientMech CommunityMech TraitMech)
+FILES=(
+  scripts/validate_id_label_correspondence.py
+  scripts/chem_formula.py
+  tests/test_id_label_empty_adapter.py
+  tests/test_id_label_unknown_prefix.py
+  tests/test_id_label_plausibility.py
+)
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+fail=0
+for f in "${FILES[@]}"; do
+  hub_url="https://raw.githubusercontent.com/${ORG}/${HUB}/main/${f}"
+  if ! curl -fsSL "$hub_url" -o "$tmp/hub"; then
+    echo "ERROR: hub ${HUB} missing ${f}"; fail=1; continue
+  fi
+  hubsum="$(shasum -a 256 "$tmp/hub" 2>/dev/null | cut -d' ' -f1 || sha256sum "$tmp/hub" | cut -d' ' -f1)"
+  for r in "${REPOS[@]}"; do
+    [ "$r" = "$HUB" ] && continue
+    url="https://raw.githubusercontent.com/${ORG}/${r}/main/${f}"
+    if ! curl -fsSL "$url" -o "$tmp/r"; then
+      echo "DRIFT: ${r} missing ${f} (hub has it)"; fail=1; continue
+    fi
+    if ! cmp -s "$tmp/hub" "$tmp/r"; then
+      echo "DRIFT: ${r}:${f} differs from hub ${HUB} (main)"; fail=1
+    fi
+  done
+done
+[ "$fail" -eq 0 ] && echo "OK: all ${#FILES[@]} vendored files agree across ${#REPOS[@]} repos" || { echo ""; echo "Fleet drift detected — sync the lagging repo(s) from ${HUB} and bump their .vendored_canon_ref."; exit 1; }


### PR DESCRIPTION
Adds the hub-side half of the drift-detection design. The per-repo
`check_vendored_sync.sh` verifies each spoke against this hub, but nothing checks
**this** repo's copies, nor a spoke whose pinned ref lags. This scheduled workflow
compares every vendored file across all four Mech repos' `main` branches and fails
on disagreement.

Dependency-free (checkout + curl), runs daily + `workflow_dispatch`.

Note: it will report drift until the spoke PRs (TraitMech #176, MIM #154,
CommunityMech #238) merge — those carry the `test_id_label_plausibility.py` sync
that is currently only on branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)