### PR TITLE
Extend drift check to mech_shared.yaml; retire schema-pin + dormant mim-roles-pin

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -829,49 +829,19 @@ report-label-drift:
 # plus the nightly fleet audit here (.github/workflows/vendored-fleet-audit.yml).
 # See culturebotai-claw vendored_sync_action_plan (Phase 2).
 
-# Durability guard for the shared LinkML module (Discussion + Dataset), vendored
-# byte-identical across the Mech repos — see culturebotai-claw#7.
-SHARED_SCHEMA_MODULE := "src/culturemech/schema/mech_shared.yaml"
-[group('QC')]
-verify-schema-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum -c src/culturemech/schema/.mech_shared.sha256
-    else
-        shasum -a 256 -c src/culturemech/schema/.mech_shared.sha256
-    fi
-
-[group('QC')]
-refresh-schema-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    f={{SHARED_SCHEMA_MODULE}}
-    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
-    printf '%s  %s\n' "$h" "$f" > src/culturemech/schema/.mech_shared.sha256
-    echo "re-pinned $f to $h"
-
-# Durability guard for the MIM-authored ingredient role facet enums, vendored
-# byte-identical from CultureBotAI/MediaIngredientMech.
-MIM_ROLES_MODULE := "src/culturemech/schema/mim_roles.yaml"
-[group('QC')]
-verify-mim-roles-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum -c src/culturemech/schema/.mim_roles.sha256
-    else
-        shasum -a 256 -c src/culturemech/schema/.mim_roles.sha256
-    fi
-
-[group('QC')]
-refresh-mim-roles-pin:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    f={{MIM_ROLES_MODULE}}
-    if command -v sha256sum >/dev/null 2>&1; then h=$(sha256sum "$f" | cut -d' ' -f1); else h=$(shasum -a 256 "$f" | cut -d' ' -f1); fi
-    printf '%s  %s\n' "$h" "$f" > src/culturemech/schema/.mim_roles.sha256
-    echo "re-pinned $f to $h"
+# NOTE: the shared LinkML module (mech_shared.yaml) is vendored byte-identical
+# across the Mech repos (package-namespaced path per repo). Its self-generated
+# sha256 pin (verify-/refresh-schema-pin) was retired — same self-referential
+# flaw as the id-label pin. mech_shared.yaml is now covered by the shared-
+# reference drift check (spokes' scripts/check_vendored_sync.sh diffs their
+# src/<pkg>/schema/mech_shared.yaml against this hub's copy) and the nightly
+# vendored-fleet-audit.yml here. Propagation: change it in this hub → sync the
+# spokes → bump their .vendored_canon_ref.
+#
+# The former mim-roles-pin was also retired: mim_roles.yaml is NOT a shared set —
+# it is empty in MIM/CommunityMech/TraitMech (the real role facets live in MIM's
+# src/mediaingredientmech/utils/role_facets.py) and has content only here, so the
+# self-pin guarded a lone, dormant file. Nothing in CI referenced either pin.
 
 [group('QC')]
 validate-all:

--- a/scripts/audit_vendored_fleet.sh
+++ b/scripts/audit_vendored_fleet.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 ORG="CultureBotAI"
 HUB="CultureMech"
 REPOS=(CultureMech MediaIngredientMech CommunityMech TraitMech)
+# Same-path vendored files: identical relative path in every repo.
 FILES=(
   scripts/validate_id_label_correspondence.py
   scripts/chem_formula.py
@@ -18,6 +19,14 @@ FILES=(
   tests/test_id_label_unknown_prefix.py
   tests/test_id_label_plausibility.py
 )
+# Package-namespaced shared files: same bytes, per-repo path
+# src/<lowercased-repo>/<suffix>. Listed by the suffix after src/<pkg>/.
+MAPPED=(
+  schema/mech_shared.yaml
+)
+
+# Lowercase a repo name to its package dir (CultureMech -> culturemech).
+lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
 
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 fail=0
@@ -26,7 +35,6 @@ for f in "${FILES[@]}"; do
   if ! curl -fsSL "$hub_url" -o "$tmp/hub"; then
     echo "ERROR: hub ${HUB} missing ${f}"; fail=1; continue
   fi
-  hubsum="$(shasum -a 256 "$tmp/hub" 2>/dev/null | cut -d' ' -f1 || sha256sum "$tmp/hub" | cut -d' ' -f1)"
   for r in "${REPOS[@]}"; do
     [ "$r" = "$HUB" ] && continue
     url="https://raw.githubusercontent.com/${ORG}/${r}/main/${f}"
@@ -38,4 +46,24 @@ for f in "${FILES[@]}"; do
     fi
   done
 done
-[ "$fail" -eq 0 ] && echo "OK: all ${#FILES[@]} vendored files agree across ${#REPOS[@]} repos" || { echo ""; echo "Fleet drift detected — sync the lagging repo(s) from ${HUB} and bump their .vendored_canon_ref."; exit 1; }
+# Package-namespaced files: resolve the per-repo path from the lowercased name.
+for suf in "${MAPPED[@]}"; do
+  hubf="src/$(lc "$HUB")/${suf}"
+  hub_url="https://raw.githubusercontent.com/${ORG}/${HUB}/main/${hubf}"
+  if ! curl -fsSL "$hub_url" -o "$tmp/hub"; then
+    echo "ERROR: hub ${HUB} missing ${hubf}"; fail=1; continue
+  fi
+  for r in "${REPOS[@]}"; do
+    [ "$r" = "$HUB" ] && continue
+    rf="src/$(lc "$r")/${suf}"
+    url="https://raw.githubusercontent.com/${ORG}/${r}/main/${rf}"
+    if ! curl -fsSL "$url" -o "$tmp/r"; then
+      echo "DRIFT: ${r} missing ${rf} (hub has it)"; fail=1; continue
+    fi
+    if ! cmp -s "$tmp/hub" "$tmp/r"; then
+      echo "DRIFT: ${r}:${rf} differs from hub ${HUB} (main)"; fail=1
+    fi
+  done
+done
+total=$(( ${#FILES[@]} + ${#MAPPED[@]} ))
+[ "$fail" -eq 0 ] && echo "OK: all ${total} vendored files agree across ${#REPOS[@]} repos" || { echo ""; echo "Fleet drift detected — sync the lagging repo(s) from ${HUB} and bump their .vendored_canon_ref."; exit 1; }

--- a/src/culturemech/schema/.mech_shared.sha256
+++ b/src/culturemech/schema/.mech_shared.sha256
@@ -1,1 +1,0 @@
-1a5e21eb2ee9f3584ff6af3a6906b1d442e18c41de405b1bf907c20f44eafa2a  src/culturemech/schema/mech_shared.yaml

--- a/src/culturemech/schema/.mim_roles.sha256
+++ b/src/culturemech/schema/.mim_roles.sha256
@@ -1,1 +1,0 @@
-6a79074a32990090cba3c0ffb7d29c6c3bd115f6bce3d8936d9726796395ad1f  src/culturemech/schema/mim_roles.yaml


### PR DESCRIPTION
Closes the self-referential-pin blind spot for the **remaining** vendored sets, mirroring what was done for the id-label validator.

## mech_shared.yaml → covered by the drift check
The shared LinkML module is byte-identical across all four Mechs (`md5 3cf80648`), package-namespaced (`src/<pkg>/schema/mech_shared.yaml`), but was still guarded only by a self-generated sha256 pin.
- **`audit_vendored_fleet.sh`**: adds a path-mapped pass (per-repo path derived from the lowercased repo name) — the nightly fleet audit now checks **6** files. Verified green locally (`OK: all 6 vendored files agree across 4 repos`).
- Companion spoke PRs extend each `check_vendored_sync.sh` to diff `mech_shared.yaml` against this hub. The pinned ref (`6be694f3`) already carries the correct bytes, so no ref bump is needed.
- Retire `verify-/refresh-schema-pin` + `SHARED_SCHEMA_MODULE`; delete `.mech_shared.sha256`.

## mim-roles-pin → retired (not a shared set)
`mim_roles.yaml` is **empty** in MIM/CommunityMech/TraitMech (`md5 d41d8cd9` = empty file; the real role facets live in MIM's `src/mediaingredientmech/utils/role_facets.py`) and has content only here. The self-pin guarded a lone dormant file, so it's retired outright rather than added to the drift check.

No CI referenced either pin, so no workflow changes here. `schema-pin`/`mim-roles-pin` recipes are gone; `just --summary` confirms all pin recipes removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)