### PR TITLE
Skip already-researched records in the Edison runner (closes #117)

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -70,6 +70,9 @@ research-media-edison target *args="":
 # Batch variant: walk a edison_batch.json priority list and research
 # the first N recipes. Default --limit is unset (run all 100); always
 # pass `--limit 5` (or similar) on first runs to bound credit spend.
+# Records with a completed run for the same job are skipped, so `--limit 5`
+# advances 5 FRESH records per invocation rather than re-billing the first
+# five. Pass `--force` to re-submit them anyway.
 [group('Research')]
 research-media-edison-batch batch *args="":
     uv run --extra dev python scripts/research_media_edison.py \

--- a/scripts/research_media_edison.py
+++ b/scripts/research_media_edison.py
@@ -40,6 +40,13 @@ Usage::
     # (including the full rendered query) so you can inspect the
     # prompt that would have been sent without spending credits.
     python scripts/research_media_edison.py --target lb_broth --dry-run
+
+Records that already have a completed (non-dry-run) run for the SAME job are
+skipped by default, so re-running a batch does not re-spend credits; pass
+``--force`` to re-submit anyway. The skip is applied BEFORE ``--start`` /
+``--limit``, which makes those windows count work still to do: repeating
+``--limit 5`` walks forward 5 fresh records at a time instead of resubmitting
+the same first five.
 """
 from __future__ import annotations
 
@@ -153,6 +160,48 @@ def _display_path(path: Path) -> str:
         return str(path.relative_to(REPO_ROOT))
     except ValueError:
         return str(path)
+
+
+def has_existing_research(out_dir: Path, slug: str, job_short: str) -> bool:
+    """True iff a completed (non-dry-run) Edison run already exists for this slug+job.
+
+    Mirrors ``prioritize_deep_research_candidates.has_existing_research`` — a
+    dry-run meta does NOT count, since it cost nothing and produced no answer.
+
+    Scoped to the SAME job rather than any job (the prioritizer's
+    ``{slug}-edison-*`` glob), because ``--job literature-high`` after
+    ``--job literature`` is a deliberately different, more expensive question.
+    Blocking that would be wrong; blocking an identical re-submission is the
+    point.
+    """
+    meta_path = out_dir / f"{slug}-edison-{job_short}-meta.yaml"
+    if not meta_path.is_file():
+        return False
+    try:
+        meta = yaml.safe_load(meta_path.read_text()) or {}
+    except (yaml.YAMLError, OSError):
+        return False
+    if not isinstance(meta, dict):
+        return False
+    status = str(meta.get("status") or "").lower()
+    task_id = str(meta.get("task_id") or "")
+    return bool(status and status != "dry-run" and task_id)
+
+
+def partition_already_researched(
+    targets: list[Path],
+    out_dir: Path,
+    job_short: str,
+) -> tuple[list[Path], list[Path]]:
+    """Split resolved targets into (to_submit, already_done), preserving order."""
+    to_submit: list[Path] = []
+    already: list[Path] = []
+    for path in targets:
+        if has_existing_research(out_dir, slug_for(path), job_short):
+            already.append(path)
+        else:
+            to_submit.append(path)
+    return to_submit, already
 
 
 def run_one(
@@ -270,6 +319,9 @@ def main(argv: list[str] | None = None) -> int:
                     help="When using --batch, skip this many entries before submitting.")
     ap.add_argument("--dry-run", action="store_true",
                     help="Render queries + print plan; do NOT call the API.")
+    ap.add_argument("--force", action="store_true",
+                    help="Re-submit records that already have a completed run for this "
+                         "job, re-spending credits. Default: skip them.")
     args = ap.parse_args(argv)
 
     job = resolve_job(args.job)
@@ -279,9 +331,6 @@ def main(argv: list[str] | None = None) -> int:
         targets = [rm.resolve_media_file(args.target)]
     else:
         candidate_lists = load_batch_targets(args.batch)
-        candidate_lists = candidate_lists[args.start:]
-        if args.limit is not None:
-            candidate_lists = candidate_lists[: args.limit]
         targets = []
         unresolved: list[str] = []
         media_dir = REPO_ROOT / "data" / "normalized_yaml"
@@ -323,13 +372,44 @@ def main(argv: list[str] | None = None) -> int:
         print("No targets to research.", file=sys.stderr)
         return 2
 
+    # Drop already-researched records BEFORE applying --start/--limit, so the
+    # window counts work still to do. Windowing first would make `--limit 5` mean
+    # "the first 5 batch entries" — re-billing any of them already done, and
+    # advancing by fewer than 5 new records per run.
+    job_short = _short_job(job)
+    skipped: list[Path] = []
+    if not args.force:
+        targets, skipped = partition_already_researched(targets, args.out_dir, job_short)
+
+    if args.batch:
+        targets = targets[args.start:]
+        if args.limit is not None:
+            targets = targets[: args.limit]
+
+    if not targets:
+        if skipped:
+            print(f"All {len(skipped)} resolved record(s) already have a completed "
+                  f"{job.name} run; nothing to submit. Use --force to re-run them.")
+            return 0
+        print("No targets to research.", file=sys.stderr)
+        return 2
+
     print(f"Edison job:    {job.name} ({job.value})")
     print(f"Template:      {_display_path(args.template.resolve())}")
     print(f"Output dir:    {_display_path(args.out_dir.resolve())}")
-    print(f"Recipes:       {len(targets)}")
+    print(f"Recipes:       {len(targets)} to submit"
+          + (f", {len(skipped)} skipped (already researched)" if skipped else ""))
+    if args.force:
+        print("Mode:          --force (re-submitting regardless of existing runs)")
     if args.dry_run:
         print("Mode:          DRY RUN (no API calls, no credits spent)")
     print()
+    if skipped:
+        for p in skipped[:5]:
+            print(f"  skip {slug_for(p)} — completed {job_short} run exists")
+        if len(skipped) > 5:
+            print(f"  skip ... {len(skipped) - 5} more")
+        print()
 
     client = None
     if not args.dry_run:
@@ -347,10 +427,11 @@ def main(argv: list[str] | None = None) -> int:
         if client is not None:
             client.close()
 
+    print()
+    print(f"Done. {len(results)} submitted / {len(skipped)} skipped (already researched).")
     if not args.dry_run:
         total_cost = sum(r["cost"] or 0.0 for r in results)
-        print()
-        print(f"Done. {len(results)} recipes researched. Total reported cost: {total_cost:.4f}")
+        print(f"Total reported cost: {total_cost:.4f}")
     return 0
 
 

--- a/tests/test_research_media_edison.py
+++ b/tests/test_research_media_edison.py
@@ -122,3 +122,152 @@ def test_resolve_job_known_aliases(rme):
 def test_resolve_job_unknown_raises(rme):
     with pytest.raises(SystemExit, match="Unknown --job"):
         rme.resolve_job("not-a-real-job")
+
+
+# --- skip-already-done guard (#117) ---------------------------------------
+
+
+def _write_meta(out_dir: Path, slug: str, job_short: str, *, status: str, task_id: str) -> Path:
+    """Write the meta yaml that run_one() would leave behind."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{slug}-edison-{job_short}-meta.yaml"
+    body = f"slug: {slug}\nstatus: {status}\n"
+    if task_id:
+        body += f"task_id: {task_id}\n"
+    path.write_text(body)
+    return path
+
+
+def test_has_existing_research_true_for_completed_run(rme, tmp_path):
+    _write_meta(tmp_path, "lb_broth", "literature", status="success", task_id="abc123")
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature") is True
+
+
+def test_has_existing_research_false_for_dry_run_stub(rme, tmp_path):
+    """A dry run costs nothing and produces no answer — it must not block a real run."""
+    _write_meta(tmp_path, "lb_broth", "literature", status="dry-run", task_id="")
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature") is False
+
+
+def test_has_existing_research_false_without_task_id(rme, tmp_path):
+    """Status set but no task_id means the submission never landed."""
+    _write_meta(tmp_path, "lb_broth", "literature", status="success", task_id="")
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature") is False
+
+
+def test_has_existing_research_is_scoped_to_the_same_job(rme, tmp_path):
+    """`--job literature-high` after `literature` is a different, deeper question."""
+    _write_meta(tmp_path, "lb_broth", "literature", status="success", task_id="abc123")
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature") is True
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature-high") is False
+
+
+def test_has_existing_research_false_when_out_dir_missing(rme, tmp_path):
+    assert rme.has_existing_research(tmp_path / "nope", "lb_broth", "literature") is False
+
+
+def test_has_existing_research_survives_corrupt_meta(rme, tmp_path):
+    """A truncated/corrupt meta must not crash a batch — treat it as not-researched."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lb_broth-edison-literature-meta.yaml").write_text("status: [unclosed\n")
+    assert rme.has_existing_research(tmp_path, "lb_broth", "literature") is False
+
+
+def test_partition_already_researched_preserves_order(rme, tmp_path):
+    data = tmp_path / "data"
+    paths = [_make_recipe(data, f"medium_{i}") for i in range(4)]
+    out_dir = tmp_path / "research"
+    _write_meta(out_dir, "medium_1", "literature", status="success", task_id="t1")
+    _write_meta(out_dir, "medium_3", "literature", status="success", task_id="t3")
+
+    to_submit, already = rme.partition_already_researched(paths, out_dir, "literature")
+    assert [p.stem for p in to_submit] == ["medium_0", "medium_2"]
+    assert [p.stem for p in already] == ["medium_1", "medium_3"]
+
+
+def test_partition_with_no_prior_runs_submits_everything(rme, tmp_path):
+    data = tmp_path / "data"
+    paths = [_make_recipe(data, f"medium_{i}") for i in range(3)]
+    to_submit, already = rme.partition_already_researched(paths, tmp_path / "research", "literature")
+    assert len(to_submit) == 3
+    assert already == []
+
+
+def _batch_of(tmp_path: Path, rel_paths: list[str]) -> Path:
+    batch = tmp_path / "batch.json"
+    batch.write_text(json.dumps(
+        [{"recipe_name": Path(p).stem, "file_path": p} for p in rel_paths]
+    ))
+    return batch
+
+
+# Four real corpus records — main() resolves batch entries against the live
+# data/normalized_yaml/ tree, so these cannot be tmp_path fixtures.
+_REAL = [
+    "bacterial/tyl_medium.yaml",
+    "bacterial/mediadive_4367_SL10_elements.yaml",
+    "bacterial/mediadive_1448_Main_sol_697.yaml",
+    "bacterial/mediadive_3695_Main_sol_J68.yaml",
+]
+
+
+def _submitted_slugs(capsys) -> list[str]:
+    """Slugs the dry run reported it would submit."""
+    out = capsys.readouterr().out
+    return [line.split("] ")[1].split(" -> ")[0].split("/")[-1].removesuffix(".yaml")
+            for line in out.splitlines() if line.startswith("[DRY RUN]")]
+
+
+def test_limit_window_advances_instead_of_resubmitting(rme, tmp_path, capsys):
+    """The #117 property: repeating `--limit 2` must walk forward.
+
+    Before the guard, `--limit 2` always took batch entries 0-1, so a second run
+    re-submitted (re-billed) the same two records and never reached entries 2-3.
+    """
+    out_dir = tmp_path / "research"
+    batch = _batch_of(tmp_path, _REAL)
+    argv = ["--batch", str(batch), "--out-dir", str(out_dir), "--limit", "2", "--dry-run"]
+
+    assert rme.main(argv) == 0
+    first = _submitted_slugs(capsys)
+    assert len(first) == 2
+
+    # Dry runs don't count as researched, so mark them completed as a real run would.
+    for slug in first:
+        _write_meta(out_dir, slug, "literature", status="success", task_id=f"t-{slug}")
+
+    assert rme.main(argv) == 0
+    second = _submitted_slugs(capsys)
+    assert len(second) == 2
+    assert set(first).isdisjoint(second), f"re-submitted {set(first) & set(second)}"
+
+
+def test_force_resubmits_already_researched(rme, tmp_path, capsys):
+    out_dir = tmp_path / "research"
+    batch = _batch_of(tmp_path, _REAL[:2])
+    base = ["--batch", str(batch), "--out-dir", str(out_dir), "--dry-run"]
+
+    assert rme.main(base) == 0
+    done = _submitted_slugs(capsys)
+    for slug in done:
+        _write_meta(out_dir, slug, "literature", status="success", task_id=f"t-{slug}")
+
+    # Default: everything is skipped, exit 0, nothing submitted.
+    assert rme.main(base) == 0
+    assert _submitted_slugs(capsys) == []
+
+    # --force: submitted again.
+    assert rme.main(base + ["--force"]) == 0
+    assert set(_submitted_slugs(capsys)) == set(done)
+
+
+def test_single_target_is_skipped_when_already_researched(rme, tmp_path, capsys):
+    out_dir = tmp_path / "research"
+    argv = ["--target", "tyl_medium", "--out-dir", str(out_dir), "--dry-run"]
+
+    assert rme.main(argv) == 0
+    assert _submitted_slugs(capsys) == ["tyl_medium"]
+
+    _write_meta(out_dir, "tyl_medium", "literature", status="success", task_id="t1")
+    assert rme.main(argv) == 0
+    assert _submitted_slugs(capsys) == []


### PR DESCRIPTION
## Problem

`scripts/research_media_edison.py` called `run_one()` on every resolved target with no existing-run check. Overlapping batch runs re-submitted — and re-billed — records that already had a completed answer, and `--start`/`--limit` windows were not idempotent: repeating `--limit 5` always took batch entries 0–4.

Measured against the current `deep_research_priority_top100.json` and local `research/media/`: **4 of 100 entries would be re-billed by a plain re-run today**, growing as research progresses.

## Fix

- `has_existing_research(out_dir, slug, job_short)` — a completed (non-dry-run, `task_id`-bearing) meta yaml blocks resubmission. Mirrors the helper in `prioritize_deep_research_candidates.py`.
- `--force` re-submits anyway.
- Summary reports `N submitted / M skipped`; skipped slugs are listed so a no-op run explains itself.

Two decisions worth a look:

**Scoped to the same job, not any job.** The prioritizer globs `{slug}-edison-*`; this guard matches `{slug}-edison-{job}` exactly. `--job literature-high` after `--job literature` is a deliberately deeper, more expensive question — blocking it would be wrong.

**The skip runs BEFORE `--start`/`--limit`.** This is the part that actually fixes the reported bug. A guard applied after windowing would still stall: `--limit 5` would take the same first five entries, skip the done ones, and submit fewer than five new records each run. Filtering first makes the window count work still to do.

Applies to `--target` as well as `--batch` — a single re-run re-bills identically.

## Test plan

- [x] 11 new tests (18 total in the file, all pass)
- [x] End-to-end: repeating `--limit 2` submits a disjoint set the second time
- [x] Mutation check — disabling the guard fails 3 of the new tests
- [x] Full suite: 328 passed vs 317 on `main`, with an **identical** set of 27 pre-existing failures/errors — none introduced

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)