### PR TITLE
Make deep-research priority reports reproducible from tracked data (closes #121)

### DIFF
--- a/data/import_tracking/researched_media.json
+++ b/data/import_tracking/researched_media.json
@@ -1,0 +1,355 @@
+{
+  "description": "Media records with a completed (non-dry-run) Edison deep-research run. Tracked so that deep_research_priority*.json are reproducible from git alone (see issue #121). Refresh with `just refresh-researched-manifest`; entries are merged, never dropped, so multiple machines can contribute.",
+  "entries": [
+    {
+      "slug": "TOGO_M1620_Leuconostoc_oenos_Medium",
+      "job": "literature",
+      "task_id": "8d102d3a-72bc-4310-ad6d-8ebc51a33574",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1633_Thermoproteus_neutrophilus_Medium",
+      "job": "literature",
+      "task_id": "1d348fb9-bed7-4ae5-a2d5-dbaa67dbbc96",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1766_Clostridium_thermocellum_Medium_D58_Medium",
+      "job": "literature",
+      "task_id": "ec509e68-490e-4ab4-ae0e-da99c8cf32e9",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1788_Pelobacter_carbinolicus_Medium",
+      "job": "literature",
+      "task_id": "23d82ac8-ed4a-4e4d-92ef-f06f8db48868",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1789_Medium_for_Ectothiorhodospira",
+      "job": "literature",
+      "task_id": "65016cfa-f8f2-4dce-966e-2405ac31a39f",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1791_Pelobacter_acetylenicus_Medium",
+      "job": "literature",
+      "task_id": "5bca6404-1edd-48e0-b409-389dab1f8f27",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1791_Pelobacter_acetylenicus_Medium-organism-pelobacter-acetylenicus",
+      "job": "literature",
+      "task_id": "16086e43-13fa-4b27-8ca9-6f20f66b7dde",
+      "kind": "organism",
+      "media_slug": "TOGO_M1791_Pelobacter_acetylenicus_Medium"
+    },
+    {
+      "slug": "TOGO_M1796_Desulfovibrio_medium",
+      "job": "literature",
+      "task_id": "1be413df-3604-49e8-9f10-73668371039a",
+      "kind": "medium"
+    },
+    {
+      "slug": "TOGO_M1796_Desulfovibrio_medium-organism-desulfovibrio-desulfuricans-essex-6-dsm-642",
+      "job": "literature",
+      "task_id": "fe467609-026b-4557-8228-3f4e09d355b6",
+      "kind": "organism",
+      "media_slug": "TOGO_M1796_Desulfovibrio_medium"
+    },
+    {
+      "slug": "TOGO_M1796_Desulfovibrio_medium-organism-desulfovibrio-vulgaris-hildenborough-dsm-644",
+      "job": "literature",
+      "task_id": "da185bea-78a5-4fa7-82e9-457f3a9f3a59",
+      "kind": "organism",
+      "media_slug": "TOGO_M1796_Desulfovibrio_medium"
+    },
+    {
+      "slug": "TOGO_M1796_Desulfovibrio_medium-organism-desulfovibrio-vulgaris-subsp-vulgaris-atcc-29579",
+      "job": "literature",
+      "task_id": "0d4cc2be-dcc0-4b55-a349-63891cddd618",
+      "kind": "organism",
+      "media_slug": "TOGO_M1796_Desulfovibrio_medium"
+    },
+    {
+      "slug": "TOGO_M1836_Medium_for_strains_JA145_JA193_JA310_JA334_JA415_JA430_JA447_and_JA643",
+      "job": "literature",
+      "task_id": "358754b4-7d84-4191-a46b-4f8d7fb48d5a",
+      "kind": "medium"
+    },
+    {
+      "slug": "archaeoglobus_medium_dsm_399",
+      "job": "literature",
+      "task_id": "b62d20b4-56f6-439b-aacc-4b24ae41ee10",
+      "kind": "medium"
+    },
+    {
+      "slug": "archaeoglobus_medium_dsm_399-organism-archaeoglobus-fulgidus-dsm-4304-vc-16",
+      "job": "literature",
+      "task_id": "199fbc1a-d07e-4b38-809a-27a7fe9900dc",
+      "kind": "organism",
+      "media_slug": "archaeoglobus_medium_dsm_399"
+    },
+    {
+      "slug": "archaeoglobus_medium_dsm_399-organism-archaeoglobus-fulgidus-stl-medium-variant",
+      "job": "literature",
+      "task_id": "b7f11290-9184-4cf8-9d75-de1207086390",
+      "kind": "organism",
+      "media_slug": "archaeoglobus_medium_dsm_399"
+    },
+    {
+      "slug": "bacto_marine_broth_difco_2216_for_dsm_11879",
+      "job": "literature",
+      "task_id": "c8c06263-f605-420c-af7e-7efbf6c056d0",
+      "kind": "medium"
+    },
+    {
+      "slug": "bacto_marine_broth_difco_2216_for_dsm_11879-organism-cellulophaga-algicola-ic166t",
+      "job": "literature",
+      "task_id": "9849501a-253e-4e20-9028-2e493802bf99",
+      "kind": "organism",
+      "media_slug": "bacto_marine_broth_difco_2216_for_dsm_11879"
+    },
+    {
+      "slug": "bacto_marine_broth_difco_2216_for_dsm_11879-organism-rhodothermus-profundi-pri-2902t",
+      "job": "literature",
+      "task_id": "2e3765eb-ccec-4506-8012-bfcfab97723f",
+      "kind": "organism",
+      "media_slug": "bacto_marine_broth_difco_2216_for_dsm_11879"
+    },
+    {
+      "slug": "beijerinckia_medium_lmg_18",
+      "job": "literature",
+      "task_id": "f09bfb0c-f432-473d-9e79-2efb08cb81aa",
+      "kind": "medium"
+    },
+    {
+      "slug": "beijerinckia_medium_lmg_18-organism-beijerinckia-lactocogenes-ntcc-38849",
+      "job": "literature",
+      "task_id": "508d2c0f-5395-4de1-beac-aeae745ac4ac",
+      "kind": "organism",
+      "media_slug": "beijerinckia_medium_lmg_18"
+    },
+    {
+      "slug": "caldicellulosiruptor_medium_for_dsm_10319",
+      "job": "literature",
+      "task_id": "6b70021e-a69d-4ec6-a2b9-0617e8210180",
+      "kind": "medium"
+    },
+    {
+      "slug": "caldicellulosiruptor_medium_for_dsm_10319-organism-caldicellulosiruptor-bescii-dsm-6725",
+      "job": "literature",
+      "task_id": "e3c5a5ed-1419-47d2-a28f-e8662adf20aa",
+      "kind": "organism",
+      "media_slug": "caldicellulosiruptor_medium_for_dsm_10319"
+    },
+    {
+      "slug": "caldicellulosiruptor_medium_for_dsm_10319-organism-thermoanaerobacterium-calidifontis-rx1",
+      "job": "literature",
+      "task_id": "68d3d8d5-a2b2-4d95-9b29-c9de4dc567e6",
+      "kind": "organism",
+      "media_slug": "caldicellulosiruptor_medium_for_dsm_10319"
+    },
+    {
+      "slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733",
+      "job": "literature",
+      "task_id": "d405081b-7c1b-4964-878b-306bf8e58a29",
+      "kind": "medium"
+    },
+    {
+      "slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733-organism-bacteroides-ureolyticus-atcc-33387",
+      "job": "literature",
+      "task_id": "ccb63acc-a0a2-4204-9c78-80b96d54dd04",
+      "kind": "organism",
+      "media_slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733"
+    },
+    {
+      "slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733-organism-fusobacterium-necrophorum-atcc-27852",
+      "job": "literature",
+      "task_id": "7b85f497-1d1a-4e75-84d2-13c7fa85d851",
+      "kind": "organism",
+      "media_slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733"
+    },
+    {
+      "slug": "ignicoccus_medium_for_dsm_18386",
+      "job": "literature",
+      "task_id": "69f6f5e4-5667-4bbe-9141-785dd7561e0e",
+      "kind": "medium"
+    },
+    {
+      "slug": "ignicoccus_medium_for_dsm_18386-organism-ignicoccus-hospitalis-kin4-i-kin4-it-dsm-18386t",
+      "job": "literature",
+      "task_id": "6fc87f89-50ff-4e12-865e-417dbe4f7b41",
+      "kind": "organism",
+      "media_slug": "ignicoccus_medium_for_dsm_18386"
+    },
+    {
+      "slug": "ignicoccus_medium_for_dsm_18386-organism-ignicoccus-islandicus-kol8-dsm-13165t",
+      "job": "literature",
+      "task_id": "8765f36f-d7be-4035-a0a7-bec0335fdd20",
+      "kind": "organism",
+      "media_slug": "ignicoccus_medium_for_dsm_18386"
+    },
+    {
+      "slug": "ignicoccus_medium_for_dsm_18386-organism-ignicoccus-pacificus-lpc33-dsm-13166t",
+      "job": "literature",
+      "task_id": "17761c99-32b3-492b-bae3-5c7fa0ccefc8",
+      "kind": "organism",
+      "media_slug": "ignicoccus_medium_for_dsm_18386"
+    },
+    {
+      "slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397",
+      "job": "literature",
+      "task_id": "2008b204-5b8f-41bd-9523-acfa060c7689",
+      "kind": "medium"
+    },
+    {
+      "slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397-organism-methanospirillum-hungatei-nbrc-100397t-dsm-864t-atcc-27890t-jf-1t",
+      "job": "literature",
+      "task_id": "af1adad4-d7d3-440a-829f-47ff875aff8a",
+      "kind": "organism",
+      "media_slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397"
+    },
+    {
+      "slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397-organism-pelotomaculum-sp-strain-jt",
+      "job": "literature",
+      "task_id": "5ed47abd-1be5-465d-b773-e612684572c7",
+      "kind": "organism",
+      "media_slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397"
+    },
+    {
+      "slug": "medium_for_sulfospirillum_dsm_806",
+      "job": "literature",
+      "task_id": "427ad7fa-79e5-405f-96ab-6cd47e1ff792",
+      "kind": "medium"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162",
+      "job": "literature",
+      "task_id": "7fad3ac2-5763-4ff3-b022-67f8d9d2adc8",
+      "kind": "medium"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-acidianus-brierleyi-dsm-1651-dsm-3772",
+      "job": "literature",
+      "task_id": "f59621d4-bff8-4efd-a990-831e9fe3de10",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-metallosphaera-hakonensis-ho1-1-dsm-7519",
+      "job": "literature",
+      "task_id": "a93372d3-e41f-4edf-9c13-4286361127b5",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-metallosphaera-prunae-ron-12-ii-dsm-10039",
+      "job": "literature",
+      "task_id": "933dc8b5-f4fb-4c15-9c91-af363b0a549f",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-saccharolobus-solfataricus-p2-dsm-1617",
+      "job": "literature",
+      "task_id": "c36e4f68-6a03-4775-bf8c-cf462ec35dd6",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-sulfodiicoccus-acidiphilus-hs-1t-jcm-31740t-inacc-ar79t",
+      "job": "literature",
+      "task_id": "03cbde46-43e9-4604-9e1f-26090c71ab30",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-sulfolobus-acidocaldarius-mw001",
+      "job": "literature",
+      "task_id": "c40e9182-bc76-4249-99c4-414f88963722",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-sulfuracidifex-tepidarius-ic-007-dsm-104736",
+      "job": "literature",
+      "task_id": "81c377c2-8180-40a7-8667-343556745820",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-sulfurisphaera-ohwakuensis-ta-1-dsm-12421",
+      "job": "literature",
+      "task_id": "497fcd9e-c59f-435e-b91d-3d75466d0f40",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_anaerobic_for_dsm_2162-organism-sulfurisphaera-tokodaii-str-7-dsm-16993",
+      "job": "literature",
+      "task_id": "cd4bef65-2778-4a5e-8cd3-75ee93252f47",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_anaerobic_for_dsm_2162"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_5348",
+      "job": "literature",
+      "task_id": "80dd5f14-6352-4b4e-8372-1801807cc616",
+      "kind": "medium"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_5348-organism-metallosphaera-sedula-dsm-5348t-th2",
+      "job": "literature",
+      "task_id": "0295b11b-30c1-4e59-99bc-0f224c584928",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_for_dsm_5348"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_5348-organism-sulfolobus-acidocaldarius-dsm-639",
+      "job": "literature",
+      "task_id": "195e3848-cb8d-40b5-9ac5-666c1365a287",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_for_dsm_5348"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_5348-organism-sulfolobus-metallicus-dsm-6482",
+      "job": "literature",
+      "task_id": "96a4fbf1-b7c8-43e1-9bbc-d0ce3af82764",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_for_dsm_5348"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_9790",
+      "job": "literature",
+      "task_id": "24bed858-1f37-4ef4-aad1-85af2f6bff80",
+      "kind": "medium"
+    },
+    {
+      "slug": "sulfolobus_medium_for_dsm_9790-organism-metallosphaera-sedula-dsm-5348t",
+      "job": "literature",
+      "task_id": "f4595f49-8d19-40dd-8aea-8f2f2556fee4",
+      "kind": "organism",
+      "media_slug": "sulfolobus_medium_for_dsm_9790"
+    },
+    {
+      "slug": "syntrophomonas_medium_for_syntrophospora_cellicola_19j_3",
+      "job": "literature",
+      "task_id": "d64f279d-51cb-446f-8c50-b6bc31a7393c",
+      "kind": "medium"
+    },
+    {
+      "slug": "syntrophomonas_medium_for_syntrophospora_cellicola_19j_3-organism-syntrophomonas-cellicola-19j-3",
+      "job": "literature",
+      "task_id": "c487cb2a-b01e-43f0-856c-5d6af96e1c56",
+      "kind": "organism",
+      "media_slug": "syntrophomonas_medium_for_syntrophospora_cellicola_19j_3"
+    },
+    {
+      "slug": "wilkins_chalgren_anaerobe_broth_n2_co2_for_dsm_15567",
+      "job": "literature",
+      "task_id": "a66b292a-8a02-4991-88c3-74ce1a248373",
+      "kind": "medium"
+    }
+  ]
+}

--- a/project.justfile
+++ b/project.justfile
@@ -99,9 +99,23 @@ enrich-edison-response *args="":
 #   data/import_tracking/reports/deep_research_priority_top100.json (top 100, batch-ready)
 #   data/import_tracking/reports/deep_research_priority.md          (human report)
 # The top-100 JSON is compatible with `research-media-edison-batch`.
+# Already-researched records are excluded via the TRACKED manifest
+# data/import_tracking/researched_media.json — not by scanning the gitignored
+# research/ tree — so the reports are reproducible from git alone (#121).
+# If the manifest is stale, run `just refresh-researched-manifest` FIRST and
+# commit that diff separately, so a report refresh never mixes the two.
 [group('Research')]
 prioritize-deep-research-candidates *args="":
     uv run --extra dev python scripts/prioritize_deep_research_candidates.py {{args}}
+
+# Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
+# into the tracked researched-media manifest. This is the only step that reads
+# untracked research state; review and commit the resulting diff. Entries are
+# merged, never dropped, so several machines can contribute safely.
+#   just refresh-researched-manifest --dry-run   # preview additions
+[group('Research')]
+refresh-researched-manifest *args="":
+    uv run --extra dev python scripts/refresh_researched_manifest.py {{args}}
 
 # Rank MediaIngredientMech ingredients for Step 7b Edison role-research.
 # Cross-repo scan of ../MediaIngredientMech/data/ingredients/**/*.yaml scored by

--- a/scripts/prioritize_deep_research_candidates.py
+++ b/scripts/prioritize_deep_research_candidates.py
@@ -57,8 +57,16 @@ Hard filters (record is dropped before scoring):
 
   - 0 ingredients
   - category == solutions (no organism associations expected)
-  - already-researched: a non-dry-run meta yaml exists in research/media/
-    for this slug (status != 'dry-run', task_id present)
+  - already-researched: the slug appears in the TRACKED manifest
+    data/import_tracking/researched_media.json
+
+Reproducibility (#121): the already-researched filter reads that tracked
+manifest, never the gitignored `research/media/` tree. Scanning the latter made
+the committed reports a function of whoever last ran the script — regenerating
+on another machine reordered the entire top-10, producing a diff that could not
+be told apart from a real data change. The outputs here are now a pure function
+of tracked inputs: the corpus plus the manifest. Refresh the manifest explicitly
+with `just refresh-researched-manifest` and commit that diff separately.
 
 Outputs:
 
@@ -100,8 +108,10 @@ except ImportError:
     _Loader = yaml.SafeLoader  # type: ignore[misc, assignment]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import researched_manifest as rmf  # noqa: E402  -- tracked already-researched set
+
 NORMALIZED_DIR = REPO_ROOT / "data" / "normalized_yaml"
-RESEARCH_DIR = REPO_ROOT / "research" / "media"
 REPORTS_DIR = REPO_ROOT / "data" / "import_tracking" / "reports"
 
 # Categories that may contain real microbial culture media
@@ -135,23 +145,20 @@ def load_yaml(path: Path) -> dict[str, Any] | None:
         return None
 
 
-def has_existing_research(slug: str) -> bool:
-    """True iff a successful (non-dry-run) Edison meta yaml exists for this slug.
+def has_existing_research(slug: str, researched: set[str] | None = None) -> bool:
+    """True iff `slug` has a completed run, per the TRACKED manifest.
 
-    Spending API credits twice on the same record is the failure mode we
-    want to prevent, so a dry-run-only meta does NOT count as "researched".
+    Reads `data/import_tracking/researched_media.json`, never `research/media/`.
+    That directory is gitignored, so scanning it made the generated reports a
+    function of whoever last ran the script — regenerating elsewhere reordered
+    the whole top-10 (#121). Refresh the manifest explicitly with
+    `just refresh-researched-manifest` and commit the diff.
+
+    Pass `researched` to avoid re-reading the manifest per record.
     """
-    if not RESEARCH_DIR.is_dir():
-        return False
-    for meta_path in RESEARCH_DIR.glob(f"{slug}-edison-*-meta.yaml"):
-        meta = load_yaml(meta_path)
-        if not meta:
-            continue
-        status = str(meta.get("status") or "").lower()
-        task_id = str(meta.get("task_id") or "")
-        if status and status != "dry-run" and task_id:
-            return True
-    return False
+    if researched is None:
+        researched = rmf.researched_slugs()
+    return slug in researched
 
 
 def score_ingredients(doc: dict[str, Any]) -> tuple[int, dict[str, Any]]:
@@ -392,8 +399,15 @@ def expected_yield(breakdown: dict[str, Any]) -> str:
     return "; ".join(bits) or "low yield"
 
 
-def collect_records() -> list[dict[str, Any]]:
-    """Walk the corpus and score every candidate record."""
+def collect_records(researched: set[str] | None = None) -> list[dict[str, Any]]:
+    """Walk the corpus and score every candidate record.
+
+    `researched` is the tracked already-researched slug set (empty set = exclude
+    nothing). Resolved once by the caller so the output depends only on inputs
+    passed in — not on whatever happens to be in the local `research/` dir.
+    """
+    if researched is None:
+        researched = rmf.researched_slugs()
     out: list[dict[str, Any]] = []
     for cat in CANDIDATE_CATEGORIES:
         cat_dir = NORMALIZED_DIR / cat
@@ -404,7 +418,7 @@ def collect_records() -> list[dict[str, Any]]:
             if not doc:
                 continue
             slug = yaml_path.stem
-            if has_existing_research(slug):
+            if slug in researched:
                 continue
             scored = score_record(doc, yaml_path)
             if not scored:
@@ -532,10 +546,25 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--top", type=int, default=100,
                     help="How many entries to include in the markdown report and *_top100.json. Default 100.")
     ap.add_argument("--reports-dir", type=Path, default=REPORTS_DIR)
+    ap.add_argument("--researched-manifest", type=Path, default=rmf.DEFAULT_MANIFEST,
+                    help="Tracked manifest of already-researched slugs to exclude. "
+                         "Refresh it with `just refresh-researched-manifest`.")
+    ap.add_argument("--no-exclude-researched", action="store_true",
+                    help="Score every record, including already-researched ones.")
     args = ap.parse_args(argv)
 
+    researched: set[str] = set()
+    if not args.no_exclude_researched:
+        researched = rmf.researched_slugs(args.researched_manifest)
+        if not researched:
+            print(f"Note: no entries in {args.researched_manifest}; excluding nothing. "
+                  f"Run `just refresh-researched-manifest` if local runs exist.",
+                  flush=True)
+
     print(f"Scanning {NORMALIZED_DIR.relative_to(REPO_ROOT)}/ ...", flush=True)
-    entries = collect_records()
+    print(f"Excluding {len(researched)} already-researched record(s) "
+          f"(source: tracked manifest, not research/).", flush=True)
+    entries = collect_records(researched)
     print(f"Scored {len(entries)} candidate records.")
 
     args.reports_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/refresh_researched_manifest.py
+++ b/scripts/refresh_researched_manifest.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Refresh the tracked researched-media manifest from local Edison runs.
+
+This is the one step that crosses from untracked (`research/media/`, gitignored)
+to tracked (`data/import_tracking/researched_media.json`). Run it after a batch
+of deep research, review the diff, commit it. Everything downstream —
+`prioritize_deep_research_candidates.py` in particular — reads only the manifest,
+which is what makes the committed priority reports reproducible (#121).
+
+Entries are MERGED, never replaced: each machine sees only its own
+`research/media/`, so overwriting would silently drop another contributor's
+records. Nothing is ever removed by this script.
+
+Usage::
+
+    just refresh-researched-manifest              # merge local runs in
+    just refresh-researched-manifest --dry-run    # show what would be added
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import researched_manifest as rmf  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--manifest", type=Path, default=rmf.DEFAULT_MANIFEST,
+                    help="Tracked manifest to update.")
+    ap.add_argument("--research-dir", type=Path, default=rmf.DEFAULT_RESEARCH_DIR,
+                    help="Local (gitignored) Edison output directory to scan.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Report what would be added without writing.")
+    args = ap.parse_args(argv)
+
+    existing = rmf.load_manifest(args.manifest)
+    discovered = rmf.scan_research_dir(args.research_dir)
+    merged, added = rmf.merge_entries(existing, discovered)
+
+    print(f"Manifest:     {args.manifest}")
+    print(f"Research dir: {args.research_dir}"
+          f"{'' if args.research_dir.is_dir() else '  (missing — nothing to scan)'}")
+    print(f"Existing entries: {len(existing)}")
+    print(f"Completed runs found locally: {len(discovered)}")
+    print(f"New entries: {len(added)}")
+
+    if added:
+        print()
+        for e in added[:20]:
+            print(f"  + {e['slug']}  ({e['job']})")
+        if len(added) > 20:
+            print(f"  + ... {len(added) - 20} more")
+
+    if args.dry_run:
+        print("\nDRY RUN — nothing written.")
+        return 0
+
+    if not added and existing:
+        print("\nManifest already up to date; not rewriting.")
+        return 0
+
+    rmf.write_manifest(merged, args.manifest)
+    print(f"\nWrote {len(merged)} entries -> {args.manifest}")
+    print("Review the diff and commit it — this is what makes the priority "
+          "reports reproducible for everyone else.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/researched_manifest.py
+++ b/scripts/researched_manifest.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Tracked manifest of media records that have completed Edison deep research.
+
+Why this exists (#121): `research/` is gitignored, so any report that excluded
+"already-researched" records by scanning `research/media/` was a function of
+whoever last ran it. Regenerating on a different machine reordered the top-10
+completely — a diff indistinguishable from "the author had researched more
+locally".
+
+The split:
+
+  - `research/media/*-meta.yaml`  — untracked, machine-local, authoritative for
+    what THIS machine actually ran.
+  - `data/import_tracking/researched_media.json` — tracked, the shared view.
+    The only input the prioritizer is allowed to read.
+
+`refresh_researched_manifest.py` is the one step that crosses from untracked to
+tracked, and it produces a reviewable diff. Everything downstream is then a pure
+function of tracked data.
+
+Manifest shape (sorted by slug, then job, for stable diffs)::
+
+    {
+      "description": "...",
+      "entries": [
+        {"slug": "lb_broth", "job": "literature", "task_id": "abc123"},
+        ...
+      ]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "data" / "import_tracking" / "researched_media.json"
+DEFAULT_RESEARCH_DIR = REPO_ROOT / "research" / "media"
+
+_DESCRIPTION = (
+    "Media records with a completed (non-dry-run) Edison deep-research run. "
+    "Tracked so that deep_research_priority*.json are reproducible from git alone "
+    "(see issue #121). Refresh with `just refresh-researched-manifest`; entries are "
+    "merged, never dropped, so multiple machines can contribute."
+)
+
+
+def _entry_key(entry: dict[str, Any]) -> tuple[str, str]:
+    return (str(entry.get("slug") or ""), str(entry.get("job") or ""))
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> list[dict[str, Any]]:
+    """Return the manifest's entries, or [] when it does not exist.
+
+    A missing manifest means "exclude nothing" rather than an error: the report
+    stays a pure function of tracked data either way, and a fresh checkout with
+    no manifest should still produce a usable ranking.
+    """
+    if not path.is_file():
+        return []
+    try:
+        doc = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    if isinstance(doc, dict):
+        entries = doc.get("entries")
+    elif isinstance(doc, list):
+        entries = doc  # tolerate a bare list
+    else:
+        entries = None
+    if not isinstance(entries, list):
+        return []
+    return [e for e in entries if isinstance(e, dict) and e.get("slug")]
+
+
+def researched_slugs(path: Path = DEFAULT_MANIFEST) -> set[str]:
+    """Media slugs with at least one completed MEDIUM-level run.
+
+    Phase-2 per-organism follow-ups (`kind == "organism"`) are excluded: they
+    research one organism against a medium, which does not mean the medium
+    itself has been researched. Entries written before `kind` existed are
+    treated as medium-level, matching the old behavior.
+    """
+    return {
+        str(e["slug"]) for e in load_manifest(path)
+        if str(e.get("kind") or "medium") == "medium"
+    }
+
+
+def scan_research_dir(research_dir: Path = DEFAULT_RESEARCH_DIR) -> list[dict[str, Any]]:
+    """Read local `*-edison-*-meta.yaml` files into manifest entries.
+
+    This is the ONLY function that reads untracked state. A dry-run meta costs
+    nothing and produced no answer, so it is not a completed run.
+    """
+    if not research_dir.is_dir():
+        return []
+    found: list[dict[str, Any]] = []
+    for meta_path in sorted(research_dir.glob("*-edison-*-meta.yaml")):
+        try:
+            meta = yaml.safe_load(meta_path.read_text()) or {}
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(meta, dict):
+            continue
+        status = str(meta.get("status") or "").lower()
+        task_id = str(meta.get("task_id") or "")
+        if not status or status == "dry-run" or not task_id:
+            continue
+        # `<slug>-edison-<job>-meta.yaml` -> slug, job
+        stem = meta_path.name[: -len("-meta.yaml")]
+        slug_from_name, _, job = stem.rpartition("-edison-")
+        slug = str(meta.get("slug") or slug_from_name)
+        entry: dict[str, Any] = {
+            "slug": slug,
+            "job": job or "unknown",
+            "task_id": task_id,
+        }
+        # Phase-2 per-organism follow-ups are named
+        # `<medium_slug>-organism-<organism>` and carry no `slug:` of their own.
+        # They research ONE organism against a medium, which is not the same as
+        # having researched the medium — so they are tagged and excluded from the
+        # medium-level filter. Recording them anyway keeps the manifest a full
+        # account of what was actually billed.
+        if "-organism-" in slug:
+            entry["kind"] = "organism"
+            entry["media_slug"] = slug.split("-organism-", 1)[0]
+        else:
+            entry["kind"] = "medium"
+        found.append(entry)
+    return found
+
+
+def merge_entries(
+    existing: list[dict[str, Any]],
+    discovered: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Union `discovered` into `existing`, keyed by (slug, job).
+
+    Returns (merged_sorted, newly_added). Union rather than replace: each machine
+    sees only its own `research/media/`, so overwriting would silently delete
+    another contributor's records. Entries are never dropped here — pruning is a
+    deliberate, separate action.
+    """
+    by_key = {_entry_key(e): e for e in existing}
+    added: list[dict[str, Any]] = []
+    for entry in discovered:
+        key = _entry_key(entry)
+        if key not in by_key:
+            by_key[key] = entry
+            added.append(entry)
+    merged = sorted(by_key.values(), key=_entry_key)
+    return merged, added
+
+
+def write_manifest(entries: list[dict[str, Any]], path: Path = DEFAULT_MANIFEST) -> None:
+    """Write the manifest with sorted entries and a trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "description": _DESCRIPTION,
+        "entries": sorted(entries, key=_entry_key),
+    }
+    path.write_text(json.dumps(doc, indent=2) + "\n")

--- a/tests/test_researched_manifest.py
+++ b/tests/test_researched_manifest.py
@@ -1,0 +1,185 @@
+"""Tests for the tracked researched-media manifest (#121).
+
+The property under test is reproducibility: the priority reports must be a pure
+function of TRACKED inputs (the corpus + the manifest), never of the gitignored
+`research/media/` tree. Before this, regenerating on a different machine
+reordered the entire top-10 and the diff was indistinguishable from a real data
+change.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rmf():
+    return _load("researched_manifest")
+
+
+def _write_meta(research_dir: Path, stem: str, *, status: str, task_id: str,
+                slug: str | None = None) -> Path:
+    research_dir.mkdir(parents=True, exist_ok=True)
+    path = research_dir / f"{stem}-meta.yaml"
+    body = f"status: {status}\n"
+    if task_id:
+        body += f"task_id: {task_id}\n"
+    if slug:
+        body += f"slug: {slug}\n"
+    path.write_text(body)
+    return path
+
+
+# --- scan_research_dir ----------------------------------------------------
+
+
+def test_scan_picks_up_completed_runs(rmf, tmp_path):
+    _write_meta(tmp_path, "lb_broth-edison-literature", status="success", task_id="t1")
+    found = rmf.scan_research_dir(tmp_path)
+    assert len(found) == 1
+    assert found[0]["slug"] == "lb_broth"
+    assert found[0]["job"] == "literature"
+    assert found[0]["kind"] == "medium"
+
+
+def test_scan_ignores_dry_runs_and_missing_task_ids(rmf, tmp_path):
+    _write_meta(tmp_path, "a-edison-literature", status="dry-run", task_id="")
+    _write_meta(tmp_path, "b-edison-literature", status="success", task_id="")
+    assert rmf.scan_research_dir(tmp_path) == []
+
+
+def test_scan_tags_phase2_organism_runs(rmf, tmp_path):
+    """A per-organism follow-up is not the same as researching the medium."""
+    _write_meta(tmp_path, "arch_medium-organism-archaeoglobus-fulgidus-edison-literature",
+                status="success", task_id="t2")
+    [entry] = rmf.scan_research_dir(tmp_path)
+    assert entry["kind"] == "organism"
+    assert entry["media_slug"] == "arch_medium"
+
+
+def test_scan_missing_dir_is_empty(rmf, tmp_path):
+    assert rmf.scan_research_dir(tmp_path / "nope") == []
+
+
+def test_scan_survives_corrupt_meta(rmf, tmp_path):
+    (tmp_path / "bad-edison-literature-meta.yaml").write_text("status: [unclosed\n")
+    _write_meta(tmp_path, "good-edison-literature", status="success", task_id="t1")
+    assert [e["slug"] for e in rmf.scan_research_dir(tmp_path)] == ["good"]
+
+
+# --- researched_slugs -----------------------------------------------------
+
+
+def test_researched_slugs_excludes_organism_entries(rmf, tmp_path):
+    """The medium-level filter must not be tripped by a phase-2 run."""
+    manifest = tmp_path / "m.json"
+    rmf.write_manifest([
+        {"slug": "lb_broth", "job": "literature", "task_id": "t1", "kind": "medium"},
+        {"slug": "arch-organism-foo", "job": "literature", "task_id": "t2",
+         "kind": "organism", "media_slug": "arch"},
+    ], manifest)
+    assert rmf.researched_slugs(manifest) == {"lb_broth"}
+
+
+def test_researched_slugs_treats_untagged_entries_as_medium(rmf, tmp_path):
+    """Back-compat: entries written before `kind` existed still filter."""
+    manifest = tmp_path / "m.json"
+    manifest.write_text(json.dumps({"entries": [{"slug": "lb_broth", "job": "literature"}]}))
+    assert rmf.researched_slugs(manifest) == {"lb_broth"}
+
+
+def test_missing_manifest_excludes_nothing(rmf, tmp_path):
+    """A fresh clone with no manifest must still produce a usable ranking."""
+    assert rmf.researched_slugs(tmp_path / "absent.json") == set()
+
+
+def test_corrupt_manifest_excludes_nothing(rmf, tmp_path):
+    manifest = tmp_path / "m.json"
+    manifest.write_text("{not json")
+    assert rmf.researched_slugs(manifest) == set()
+
+
+# --- merge ----------------------------------------------------------------
+
+
+def test_merge_is_a_union_and_never_drops_entries(rmf):
+    """Each machine sees only its own research/; replace would delete others' work."""
+    existing = [{"slug": "from_other_machine", "job": "literature", "task_id": "x", "kind": "medium"}]
+    discovered = [{"slug": "local", "job": "literature", "task_id": "y", "kind": "medium"}]
+    merged, added = rmf.merge_entries(existing, discovered)
+    assert {e["slug"] for e in merged} == {"from_other_machine", "local"}
+    assert [e["slug"] for e in added] == ["local"]
+
+
+def test_merge_is_idempotent(rmf):
+    entries = [{"slug": "a", "job": "literature", "task_id": "t", "kind": "medium"}]
+    merged, added = rmf.merge_entries(entries, entries)
+    assert merged == entries
+    assert added == []
+
+
+def test_merge_distinguishes_jobs_for_the_same_slug(rmf):
+    existing = [{"slug": "a", "job": "literature", "task_id": "t1", "kind": "medium"}]
+    discovered = [{"slug": "a", "job": "literature-high", "task_id": "t2", "kind": "medium"}]
+    merged, added = rmf.merge_entries(existing, discovered)
+    assert len(merged) == 2
+    assert len(added) == 1
+
+
+def test_written_manifest_is_sorted_for_stable_diffs(rmf, tmp_path):
+    manifest = tmp_path / "m.json"
+    rmf.write_manifest([
+        {"slug": "zebra", "job": "literature", "task_id": "t2", "kind": "medium"},
+        {"slug": "alpha", "job": "literature", "task_id": "t1", "kind": "medium"},
+    ], manifest)
+    doc = json.loads(manifest.read_text())
+    assert [e["slug"] for e in doc["entries"]] == ["alpha", "zebra"]
+    assert manifest.read_text().endswith("\n")
+
+
+# --- the actual reproducibility property ----------------------------------
+
+
+def test_prioritizer_output_does_not_depend_on_local_research_dir(tmp_path, monkeypatch):
+    """The whole point of #121.
+
+    `collect_records` must produce the same ranking whether or not a local
+    `research/media/` tree exists. Previously it scanned that tree directly, so
+    the committed reports encoded one machine's state.
+    """
+    pdrc = _load("prioritize_deep_research_candidates")
+
+    manifest = tmp_path / "m.json"
+    manifest.write_text(json.dumps({"entries": [
+        {"slug": "tyl_medium", "job": "literature", "task_id": "t1", "kind": "medium"},
+    ]}))
+    researched = _load("researched_manifest").researched_slugs(manifest)
+
+    first = pdrc.collect_records(researched)
+
+    # Simulate a machine with a completely different local research/ tree by
+    # pointing the module's research dir somewhere populated-but-irrelevant.
+    other = tmp_path / "research_media"
+    _write_meta(other, "thermus_medium-edison-literature", status="success", task_id="zzz")
+    monkeypatch.setattr(pdrc.rmf, "DEFAULT_RESEARCH_DIR", other, raising=False)
+
+    second = pdrc.collect_records(researched)
+
+    assert [e["recipe_name"] for e in first] == [e["recipe_name"] for e in second]
+    assert "tyl_medium" not in {e["recipe_name"] for e in first}


### PR DESCRIPTION
## Problem

`prioritize_deep_research_candidates.py` excluded already-researched records by scanning `research/media/`, which is gitignored. The committed reports were a snapshot of whoever last ran the script.

Demonstrated on the **old** code — same corpus, same commit, only the presence of a local `research/` tree differing:

| | records scored | top-3 |
|---|---|---|
| `research/` present | 15485 | `thermus_medium` ×3 |
| `research/` hidden | 15506 | `medium_for_sulfospirillum_dsm_806`, `wilkins_chalgren…`, `beijerinckia…` |

## Fix

```
research/media/*-meta.yaml            untracked, machine-local
      |  just refresh-researched-manifest      <- the only crossing point
      v
data/import_tracking/researched_media.json     tracked, reviewable
      |
      v
deep_research_priority*.json = f(corpus, manifest)   pure, tracked inputs
```

With the manifest in place the three reports are **byte-identical whether or not `research/` exists at all** — verified by deleting the directory and re-running.

A missing manifest excludes nothing, so a fresh clone still produces a usable ranking.

## Two decisions worth your review

**Merge is a union, never a replace.** Each machine sees only its own `research/`, so overwriting would silently delete another contributor's records. This matters immediately: #121 was filed from a machine with **391** local summaries; this one has **53** completed runs. The manifest committed here holds only what is visible locally, and is expected to grow as others refresh. If you'd rather seed it from the fuller machine first, say so and I'll hold the commit.

**Phase-2 per-organism runs are tagged `kind: organism` and do not satisfy the medium-level filter.** Researching one organism against a medium is not the same as researching the medium. Of the 53 local runs, **21 are medium-level** and drive exclusion; the other 32 are recorded for audit but never match a corpus slug. The naive version would have excluded all 53.

## Deliberately not done

The committed reports are **not** regenerated here — #120 is in flight and changes `category` for 73 records, which feeds the score. Regenerate after it lands; the diff will now be reviewable.

## Test plan

- [x] 14 new tests
- [x] Reproducibility proven end-to-end: reports byte-identical with `research/` deleted
- [x] Mutation check — removing the `kind` filter fails the organism test
- [x] Full suite: 355 passed, with an **identical** set of 27 pre-existing failures/errors — none introduced

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)