### PR TITLE
Add pytest CI gate and repair the 27 tests failing unnoticed (closes #129)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,46 @@
+name: tests
+
+# Deliberately NO `paths:` filter, unlike the data-integrity workflows.
+#
+# Two reasons. First, this repo's tests span scripts/, src/, AND the corpus —
+# tests/test_record_kinds.py asserts against the real data/normalized_yaml/
+# tree, so a data-only PR can legitimately break them. Second, path-filtered
+# gates are how the repo ended up here: validate-strict and chebi-consistency
+# are both scoped to data/normalized_yaml/**, so a pure scripts/ + tests/ PR
+# could land with no checks at all (#129).
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      # `--extra dev` is required: pytest lives in [project.optional-dependencies]
+      # dev, which a plain `uv sync` does not install. The other workflows omit it
+      # because they only invoke runtime deps.
+      - name: Sync dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run test suite
+        run: just test

--- a/project.justfile
+++ b/project.justfile
@@ -1360,7 +1360,7 @@ gen-page file:
 test:
     #!/usr/bin/env bash
     echo "Running test suite..."
-    uv run pytest tests/ -v
+    uv run --extra dev pytest tests/ -v
 
 [group('Test')]
 test-kgx:

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -151,7 +151,7 @@ class TestRecipeFingerprinter:
             'ingredients': []
         }
 
-        with pytest.raises(ValueError, match="no ingredients"):
+        with pytest.raises(ValueError, match="empty ingredients"):
             self.fingerprinter.fingerprint(recipe)
 
     def test_extract_identifier_priority(self):

--- a/tests/test_kg_media_matcher.py
+++ b/tests/test_kg_media_matcher.py
@@ -14,8 +14,17 @@ class TestKGMediaMatcher:
         # Adjust this path based on your local setup
         kg_dir = Path(__file__).parent.parent.parent.parent / "kg-microbe"
 
-        if not kg_dir.exists():
-            pytest.skip(f"KG-Microbe not found at {kg_dir}")
+        # KGMediaMatcher needs the TRANSFORMED mediadive tables, not merely the
+        # repo checkout. Guarding on the directory alone let these tests error
+        # with FileNotFoundError on a machine that has the repo but has not run
+        # the transform — which is every CI runner.
+        mediadive = kg_dir / "data" / "transformed" / "mediadive"
+        missing = [f for f in ("edges.tsv", "nodes.tsv") if not (mediadive / f).exists()]
+        if missing:
+            pytest.skip(
+                f"KG-Microbe mediadive data not available at {mediadive} "
+                f"(missing: {', '.join(missing)}). Clone kg-microbe and run its transform."
+            )
 
         return kg_dir
 
@@ -167,8 +176,17 @@ class TestMatchRecipeToKGMicrobe:
         """Path to kg-microbe repository."""
         kg_dir = Path(__file__).parent.parent.parent.parent / "kg-microbe"
 
-        if not kg_dir.exists():
-            pytest.skip(f"KG-Microbe not found at {kg_dir}")
+        # KGMediaMatcher needs the TRANSFORMED mediadive tables, not merely the
+        # repo checkout. Guarding on the directory alone let these tests error
+        # with FileNotFoundError on a machine that has the repo but has not run
+        # the transform — which is every CI runner.
+        mediadive = kg_dir / "data" / "transformed" / "mediadive"
+        missing = [f for f in ("edges.tsv", "nodes.tsv") if not (mediadive / f).exists()]
+        if missing:
+            pytest.skip(
+                f"KG-Microbe mediadive data not available at {mediadive} "
+                f"(missing: {', '.join(missing)}). Clone kg-microbe and run its transform."
+            )
 
         return kg_dir
 

--- a/tests/test_kg_microbe_integration.py
+++ b/tests/test_kg_microbe_integration.py
@@ -14,6 +14,7 @@ Key query patterns:
 
 import json
 import pytest
+import yaml
 from pathlib import Path
 from culturemech.export.kgx_export import transform
 
@@ -45,17 +46,17 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         # Transform to KGX
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
 
         # Find organism edges
         organism_edges = [
             e for e in edges
-            if e.get("predicate") == "biolink:used_to_culture"
-            and e.get("object") == "NCBITaxon:562"
+            if e.get("predicate") == "METPO:2000517"
+            and e.get("subject") == "NCBITaxon:562"
         ]
 
         assert len(organism_edges) > 0, "Should find E. coli edge"
-        assert organism_edges[0]["object"] == "NCBITaxon:562"
+        assert organism_edges[0]["subject"] == "NCBITaxon:562"
 
     def test_organism_with_strain_designation(self, tmpdir):
         """Test organism with strain designation is queryable."""
@@ -80,10 +81,10 @@ ingredients:
         recipe_file = tmpdir / "k12_recipe.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
         organism_edges = [
             e for e in edges
-            if e.get("predicate") == "biolink:used_to_culture"
+            if e.get("predicate") == "METPO:2000517"
         ]
 
         assert len(organism_edges) > 0
@@ -115,10 +116,10 @@ ingredients:
         recipe_file = tmpdir / "dsm_strain.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
         organism_edges = [
             e for e in edges
-            if "used_to_culture" in e.get("predicate", "")
+            if e.get("predicate") == "METPO:2000517"
         ]
 
         assert len(organism_edges) > 0
@@ -142,8 +143,10 @@ class TestCrossDatabaseIntegration:
         with open(merge_stats_file) as f:
             stats = json.load(f)
 
-        # Check that we have merged groups with multiple sources
-        assert stats.get("total_groups", 0) > 0
+        # Dedup actually collapsed something: fewer outputs than inputs, and
+        # at least one group held more than one recipe.
+        assert stats["input_recipes"] > stats["output_recipes"] > 0
+        assert stats.get("largest_group_size", 0) > 1
 
         # Verify reduction happened (duplicates found)
         input_count = stats.get("input_recipes", 0)
@@ -190,7 +193,7 @@ ingredients:
         recipe_file = tmpdir / "glucose_medium.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
 
         # Find ingredient edges
         glucose_edges = [
@@ -221,7 +224,7 @@ ingredients:
         recipe_file = tmpdir / "nacl_medium.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
         nacl_edges = [
             e for e in edges
             if e.get("object") == "CHEBI:26710"
@@ -255,7 +258,7 @@ ingredients:
         recipe_file = tmpdir / "agar_plate.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
 
         # Physical state should generate an edge
         state_edges = [
@@ -279,7 +282,7 @@ ingredients:
         recipe_file = tmpdir / "ph_medium.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
 
         # pH should be in some edge or property
         assert len(edges) > 0
@@ -307,10 +310,10 @@ ingredients:
         recipe_file = tmpdir / "isolate.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
         organism_edges = [
             e for e in edges
-            if "culture" in e.get("predicate", "")
+            if e.get("predicate") == "METPO:2000517"
         ]
 
         assert len(organism_edges) > 0
@@ -338,10 +341,10 @@ ingredients:
         recipe_file = tmpdir / "community.yaml"
         recipe_file.write(recipe_yaml)
 
-        edges = transform(str(recipe_file))
+        edges = list(transform(yaml.safe_load(recipe_yaml)))
         organism_edges = [
             e for e in edges
-            if "culture" in e.get("predicate", "")
+            if e.get("predicate") == "METPO:2000517"
         ]
 
         # Should have edges for both organisms
@@ -383,7 +386,7 @@ class TestRealDataIntegration:
         # Verify stats structure
         assert "input_recipes" in stats
         assert "output_recipes" in stats
-        assert "duplicate_groups" in stats
+        assert "top_duplicates" in stats
 
         # Verify significant deduplication occurred
         assert stats["input_recipes"] > stats["output_recipes"]

--- a/tests/test_ols_client.py
+++ b/tests/test_ols_client.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import json
 import tempfile
 
+import requests
+
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
@@ -103,10 +105,16 @@ class TestOLSClient(unittest.TestCase):
     @patch('culturemech.ontology.ols_client.requests.get')
     def test_verify_invalid_chebi_id(self, mock_get):
         """Test verification of invalid CHEBI ID."""
-        # Mock 404 response
+        # Mock 404 response. The side effect must be a real
+        # requests.exceptions.HTTPError carrying the response: _make_request
+        # catches HTTPError specifically and inspects e.response.status_code.
+        # A bare Exception() sails straight past that handler, so this test
+        # used to fail against correct production code.
         mock_response = Mock()
         mock_response.status_code = 404
-        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Not Found", response=mock_response
+        )
         mock_get.return_value = mock_response
 
         # Test verification

--- a/tests/test_sssom_generation.py
+++ b/tests/test_sssom_generation.py
@@ -123,7 +123,7 @@ class TestSSSOMGeneration(unittest.TestCase):
 
         # Name with special characters
         curie = create_curie("D-Glucose (anhydrous)")
-        self.assertEqual(curie, "culturemech:D-Glucose_anhydrous_")
+        self.assertEqual(curie, "culturemech:D-Glucose_anhydrous")
 
     def test_validate_sssom_format(self):
         """Test SSSOM format validation."""


### PR DESCRIPTION
## The gap

**No workflow ran pytest.** Six workflows existed — all data-integrity or rendering gates. A PR's green checks said nothing about whether the tests passed. `just test` existed at `project.justfile:1360` and worked; it was simply never invoked.

That is how **27 tests came to be failing on `main`** unnoticed, and how #107 shipped a latent schema bug through a green PR.

## Ordering: fix the suite first

Wiring pytest to a red suite produces a permanently-failing check everyone learns to ignore — worse than no check. So all 27 are repaired here and the gate lands green.

**None were production bugs.** All were tests encoding a contract the code had moved away from, plus one wrong environment guard. Each was diagnosed rather than force-fitted:

| file | n | cause |
|---|---|---|
| `test_kg_microbe_integration.py` | 11 | `transform()` takes a record **dict**; tests passed a file **path**. Plus the organism edge was re-modelled — `biolink:used_to_culture` → `METPO:2000517`, and the direction flipped so the organism is now *subject*. Plus 2 asserting `merge_stats` keys that no longer exist. |
| `test_kg_media_matcher.py` | 13 | Fixture skipped on absence of the kg-microbe **repo**, but the matcher needs the **transformed** tables. On a machine with the repo and no transform — every CI runner — they errored instead of skipping. |
| `test_ols_client.py` | 1 | Mock raised a bare `Exception`, which sails past `except requests.exceptions.HTTPError`. **Production code was correct**; the mock was unrealistic. |
| `test_fingerprint.py` | 1 | Passed `ingredients: []` but matched the message for a *missing* key — the code raises distinct errors for the two cases. |
| `test_sssom_generation.py` | 1 | Expected a trailing underscore that `create_curie` deliberately strips. |

The OLS one is worth a look: it would have been easy to "fix" by loosening the assertion, which would have masked that the mock never exercised the 404 path at all.

## The workflow

**No `paths:` filter, deliberately.** Tests here span `scripts/`, `src/`, *and* the corpus — `test_record_kinds.py` asserts against the real `data/normalized_yaml/` tree, so a data-only PR can legitimately break them. And path-filtered gates are precisely how a `scripts/` + `tests/` PR could previously land with no checks at all.

Runs on `pull_request`, `push` to `main`, and `workflow_dispatch`.

## Result

```
395 passed, 15 skipped, 0 failing
```

The 15 skips are the kg-microbe tests, which now skip cleanly with an actionable message instead of erroring.

## Test plan

- [x] Full suite green locally
- [x] `just test` verified in an isolated CI-equivalent venv (`UV_PROJECT_ENVIRONMENT` + `uv sync --frozen --extra dev`)
- [x] Workflow YAML parsed; uv/just setup steps identical to the existing workflows
- [x] Each of the 27 traced to a specific cause before being changed — no assertion loosened to make a failure disappear

One note: I added `--extra dev` to `just test` on the assumption a plain `uv sync` would omit pytest. It turns out pytest arrives transitively today, so plain sync works by accident — I kept the flag so the gate does not depend on that accident.

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)