### PR TITLE
Resolve kg-microbe path so its 13 tests actually run — and fix what they caught

### DIFF
--- a/src/culturemech/match/kg_media_matcher.py
+++ b/src/culturemech/match/kg_media_matcher.py
@@ -69,15 +69,28 @@ class KGMediaMatcher:
 
         logger.info(f"Loading KG-Microbe data from {self.mediadive_dir}")
 
-        # Load nodes for medium names and ingredient labels
+        # Load nodes for medium names and ingredient labels.
+        #
+        # Column order is read from the header rather than assumed. The previous
+        # code took `parts[1]`, which is the `category` column — so every medium
+        # "name" was really the biolink category string
+        # ("biolink:GrowthMedium|biolink:ComplexMolecularMixture"). The bug
+        # survived because the only test asserted the result was a non-empty
+        # string, which a category satisfies.
         with open(self.nodes_file) as f:
+            header = f.readline().rstrip('\n').split('\t')
+            try:
+                name_idx = header.index('name')
+            except ValueError:
+                name_idx = 2  # kg-microbe KGX default: id, category, name, ...
+
             for line in f:
-                parts = line.strip().split('\t')
+                parts = line.rstrip('\n').split('\t')
                 if len(parts) < 2:
                     continue
 
                 node_id = parts[0]
-                name = parts[1] if len(parts) > 1 and parts[1] else parts[2] if len(parts) > 2 else ""
+                name = parts[name_idx] if len(parts) > name_idx else ""
 
                 if node_id.startswith('mediadive.medium:'):
                     medium_id = node_id.replace('mediadive.medium:', '')

--- a/tests/test_kg_media_matcher.py
+++ b/tests/test_kg_media_matcher.py
@@ -1,8 +1,43 @@
 """Tests for KG-Microbe media matcher."""
 
+import os
+
 import pytest
 from pathlib import Path
 from culturemech.match import KGMediaMatcher, match_recipe_to_kg_microbe
+
+
+# kg-microbe's checkout layout varies: the repo may sit directly at
+# <workspace>/kg-microbe, or nested one level down at
+# <workspace>/kg-microbe/kg-microbe when the outer directory is a workspace
+# container. Probing beats hard-coding — the previous single hard-coded guess
+# pointed at the container, so these tests silently skipped on a machine that
+# had the data all along.
+def _resolve_kg_microbe_dir() -> Path | None:
+    """First candidate that actually holds the transformed mediadive tables."""
+    env = os.environ.get("KG_MICROBE_DIR")
+    workspace = Path(__file__).resolve().parent.parent.parent.parent
+    candidates = [
+        *( [Path(env)] if env else [] ),
+        workspace / "kg-microbe" / "kg-microbe",
+        workspace / "kg-microbe",
+        Path(__file__).resolve().parent.parent.parent / "kg-microbe",
+    ]
+    for cand in candidates:
+        mediadive = cand / "data" / "transformed" / "mediadive"
+        if (mediadive / "edges.tsv").is_file() and (mediadive / "nodes.tsv").is_file():
+            return cand
+    return None
+
+
+_KG_MICROBE_DIR = _resolve_kg_microbe_dir()
+_SKIP_REASON = (
+    "KG-Microbe mediadive data not found. Looked for "
+    "data/transformed/mediadive/{edges,nodes}.tsv under $KG_MICROBE_DIR and the "
+    "usual checkout layouts. Clone kg-microbe and run its transform, or set "
+    "KG_MICROBE_DIR."
+)
+
 
 
 class TestKGMediaMatcher:
@@ -10,23 +45,10 @@ class TestKGMediaMatcher:
 
     @pytest.fixture
     def kg_microbe_dir(self):
-        """Path to kg-microbe repository."""
-        # Adjust this path based on your local setup
-        kg_dir = Path(__file__).parent.parent.parent.parent / "kg-microbe"
-
-        # KGMediaMatcher needs the TRANSFORMED mediadive tables, not merely the
-        # repo checkout. Guarding on the directory alone let these tests error
-        # with FileNotFoundError on a machine that has the repo but has not run
-        # the transform — which is every CI runner.
-        mediadive = kg_dir / "data" / "transformed" / "mediadive"
-        missing = [f for f in ("edges.tsv", "nodes.tsv") if not (mediadive / f).exists()]
-        if missing:
-            pytest.skip(
-                f"KG-Microbe mediadive data not available at {mediadive} "
-                f"(missing: {', '.join(missing)}). Clone kg-microbe and run its transform."
-            )
-
-        return kg_dir
+        """Path to the kg-microbe checkout holding the transformed mediadive tables."""
+        if _KG_MICROBE_DIR is None:
+            pytest.skip(_SKIP_REASON)
+        return _KG_MICROBE_DIR
 
     @pytest.fixture
     def matcher(self, kg_microbe_dir):
@@ -49,12 +71,17 @@ class TestKGMediaMatcher:
         assert matcher._normalize_ontology_id("UNKNOWN:123") == "UNKNOWN:123"
 
     def test_get_medium_name(self, matcher):
-        """Test retrieving medium names."""
-        # Test known medium
+        """Test retrieving medium names.
+
+        This used to assert only `isinstance(str)` and `len > 0`, which a
+        biolink category string satisfies — and that is exactly what the loader
+        was storing, having read the `category` column instead of `name`. Assert
+        the actual name so the bug cannot come back silently.
+        """
         if '514' in matcher.medium_names:
             name = matcher.get_medium_name('514')
-            assert isinstance(name, str)
-            assert len(name) > 0
+            assert name == "BACTO MARINE BROTH DIFCO 2216"
+            assert not name.startswith("biolink:"), "reading the category column again"
 
         # Test unknown medium
         unknown_name = matcher.get_medium_name('99999999')
@@ -111,27 +138,39 @@ class TestKGMediaMatcher:
         assert only2 == {'CHEBI:1'}
 
     def test_find_matches(self, matcher):
-        """Test finding matches."""
-        # Use ingredients from a known medium if available
+        """Test finding matches.
+
+        Medium ids are NOT uniquely determined by their ingredient set: 514,
+        760, 1173, 1517 and 1753 all share the same 17 ingredients (1173 is
+        literally "MODIFIED MEDIUM 514"). So this asserts every perfect-Jaccard
+        hit really is one, and that 514 is among them — not that it sorts first,
+        which is an arbitrary tie-break.
+        """
         if '514' in matcher.medium_ingredients:
             test_ingredients = matcher.get_medium_ingredients('514')
 
             matches = matcher.find_matches(test_ingredients, min_jaccard=1.0, max_results=5)
 
+            # find_matches yields (medium_id, jaccard, shared, only_a, only_b).
             assert len(matches) > 0
-            # First match should be exact
-            assert matches[0][0] == '514'
-            assert matches[0][1] == 1.0  # Jaccard score
+            assert all(m[1] == 1.0 for m in matches)
+            assert all(matcher.get_medium_ingredients(m[0]) == test_ingredients
+                       for m in matches)
+            assert '514' in {m[0] for m in matches}
 
     def test_find_exact_match(self, matcher):
-        """Test finding exact matches."""
-        # Use ingredients from a known medium if available
+        """Test finding exact matches.
+
+        Returns *an* exact match, not a canonical one — see test_find_matches for
+        why 514's ingredient set maps to five media.
+        """
         if '514' in matcher.medium_ingredients:
             test_ingredients = matcher.get_medium_ingredients('514')
 
             exact_match = matcher.find_exact_match(test_ingredients)
 
-            assert exact_match == '514'
+            assert exact_match is not None
+            assert matcher.get_medium_ingredients(exact_match) == test_ingredients
 
     def test_find_exact_match_no_match(self, matcher):
         """Test finding exact match when none exists."""
@@ -173,22 +212,10 @@ class TestMatchRecipeToKGMicrobe:
 
     @pytest.fixture
     def kg_microbe_dir(self):
-        """Path to kg-microbe repository."""
-        kg_dir = Path(__file__).parent.parent.parent.parent / "kg-microbe"
-
-        # KGMediaMatcher needs the TRANSFORMED mediadive tables, not merely the
-        # repo checkout. Guarding on the directory alone let these tests error
-        # with FileNotFoundError on a machine that has the repo but has not run
-        # the transform — which is every CI runner.
-        mediadive = kg_dir / "data" / "transformed" / "mediadive"
-        missing = [f for f in ("edges.tsv", "nodes.tsv") if not (mediadive / f).exists()]
-        if missing:
-            pytest.skip(
-                f"KG-Microbe mediadive data not available at {mediadive} "
-                f"(missing: {', '.join(missing)}). Clone kg-microbe and run its transform."
-            )
-
-        return kg_dir
+        """Path to the kg-microbe checkout holding the transformed mediadive tables."""
+        if _KG_MICROBE_DIR is None:
+            pytest.skip(_SKIP_REASON)
+        return _KG_MICROBE_DIR
 
     def test_match_recipe_exact(self, kg_microbe_dir, tmp_path):
         """Test matching recipe with exact match."""


### PR DESCRIPTION
## The path bug

`tests/test_kg_media_matcher.py` hard-coded `<workspace>/kg-microbe`. On this machine the repo is nested one level lower at `<workspace>/kg-microbe/kg-microbe`, so the guard I added in #130 skipped **all 13 tests on a machine that had the data all along**.

Replaced with a resolver that probes `$KG_MICROBE_DIR` and the plausible layouts, taking the first that actually holds `data/transformed/mediadive/{edges,nodes}.tsv`. It still skips cleanly with an actionable message when there is none — verified by relocating the test file into a throwaway tree so every candidate misses.

## What running them caught

**A production bug: `get_medium_name` never returned a name.**

The nodes.tsv loader took `parts[1]` — the `category` column. `parts[2]` is `name`. So `medium_names` held `"biolink:GrowthMedium|biolink:ComplexMolecularMixture"` for every medium in the corpus.

It survived because `test_get_medium_name` asserted only `isinstance(str)` and `len > 0`, which a category string satisfies. The loader now reads the column index from the header:

```
medium 88   -> SULFOLOBUS MEDIUM
medium 514  -> BACTO MARINE BROTH DIFCO 2216
medium 1173 -> MODIFIED MEDIUM 514
```

Test tightened to assert the actual name, and to fail if it ever starts with `biolink:` again.

**Two tests assumed medium ids are unique per ingredient set.** They aren't — `514`, `760`, `1173`, `1517`, `1753` all share the same 17 ingredients, and `1173` is literally *"MODIFIED MEDIUM 514"*. So `find_exact_match` returning `1173` for 514's ingredients is **correct**; pinning one arbitrary id was not. They now assert every perfect-Jaccard hit genuinely has the same ingredient set and that `514` is among them, rather than that it sorts first.

Same duplicate-media phenomenon as #127, showing up in a different subsystem.

## Test plan

- [x] 13/13 pass against live kg-microbe data (previously all skipped)
- [x] Skip path verified when no checkout is present
- [x] Full suite: **498 passed, 2 skipped** — was 485 passed, 15 skipped

One self-correction: my first rewrite unpacked `find_matches` results as pairs; it yields 5-tuples `(id, jaccard, shared, only_a, only_b)`. Caught by the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)