### PR TITLE
Add the append-only curation-history layer

### DIFF
--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -1,0 +1,94 @@
+name: Curation history
+
+# Two-part check, deliberately asymmetric (see history/README.md):
+#
+#   * VALIDITY is blocking. A malformed history record fails like any other
+#     validation error.
+#   * PRESENCE is advisory. If a media recipe changes without a matching history
+#     record, this warns in the job summary and passes. A hard gate on provenance
+#     blocks legitimate work at inconvenient moments and trains people to route
+#     around it.
+#
+# Validation uses the VENDORED schema at src/culturemech/schema/history.yaml, so
+# this job has no dependency on the private culturebotai-claw repo. Only the
+# `just new-history` scaffolder needs claw, and that is a dev-time tool.
+
+on:
+  pull_request:
+    paths:
+      - "data/normalized_yaml/**"
+      - "history/**"
+      - "src/culturemech/schema/history.yaml"
+      - ".github/workflows/curation-history.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "data/normalized_yaml/**"
+      - "history/**"
+      - "src/culturemech/schema/history.yaml"
+      - ".github/workflows/curation-history.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: curation-history-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  history:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need the merge base to diff against
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install deps
+        run: uv sync
+
+      - name: Validate history records (blocking)
+        run: |
+          set -euo pipefail
+          if [ ! -d history ] || [ -z "$(find history -name '*.yaml' -print -quit)" ]; then
+            echo "No history records to validate."
+            exit 0
+          fi
+          find history -name '*.yaml' -print0 \
+            | xargs -0 uv run linkml-validate \
+                --schema src/culturemech/schema/history.yaml \
+                --target-class HistoryRecord
+
+      - name: Check for missing history records (advisory)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          base="origin/${{ github.base_ref }}"
+
+          changed_media=$(git diff --name-only "$base"...HEAD -- 'data/normalized_yaml/**/*.yaml' | wc -l | tr -d ' ')
+          new_history=$(git diff --name-only --diff-filter=A "$base"...HEAD -- 'history/**/*.yaml' | wc -l | tr -d ' ')
+
+          {
+            echo "## Curation history"
+            echo
+            echo "- media recipes changed: **$changed_media**"
+            echo "- history records added: **$new_history**"
+            echo
+            if [ "$changed_media" -gt 0 ] && [ "$new_history" -eq 0 ]; then
+              echo "> [!WARNING]"
+              echo "> This PR changes media recipes but adds no history record."
+              echo "> Scaffold one with \`just new-history\` — see \`history/README.md\`."
+              echo ">"
+              echo "> Advisory only; this does not block the build."
+            elif [ "$changed_media" -gt 0 ]; then
+              echo "Provenance recorded for this change."
+            else
+              echo "No media recipes changed; nothing to record."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/history/README.md
+++ b/history/README.md
@@ -1,0 +1,125 @@
+# Curation history
+
+Append-only provenance for curation sessions. One record per session per target,
+written once and **never edited afterwards**. Corrections go in a new record that
+references the old one in its `details`.
+
+```
+history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml
+```
+
+## Why this exists
+
+Nothing else in the repo records *which model, using which tool, changed what,
+why, and under which issue*. Git tells you a commit happened; it does not tell you
+that an ingredient was grounded against a specific CHEBI release, or which
+deep-research provider produced a recipe correction, or that a review deliberately
+changed nothing.
+
+That gap matters more as autonomous agents start doing the changing. See
+`culturebotai-claw/docs/AUTONOMOUS_LOOPS.md`.
+
+## Why the layout looks like that
+
+The directory-per-slug plus unguessable `shortid` is the whole design. Two agents
+curating the same medium concurrently cannot write the same file, so this layer
+has **no merge-conflict surface**. A single shared changelog would conflict on
+every parallel PR; this never does. That matters here more than most places —
+CultureMech carries over 15,000 media records and several agents work it at once.
+
+## Writing a record
+
+Do not hand-write the filename or the timestamp — scaffold it:
+
+```bash
+just new-history --kind record --slug 1_10_r2a_medium \
+  --target-root data/normalized_yaml/bacterial \
+  --event EDIT --outcome changed \
+  --sections ingredients,solutions \
+  --summary "Ground two unmapped ingredients to CHEBI" \
+  --model claude-opus-5 --agent-tool claude-code \
+  --issue https://github.com/CultureBotAI/CultureMech/issues/123 \
+  --details "What was done, what evidence was used, how it was validated."
+```
+
+Omit `--details` and you get a TODO placeholder to edit before committing —
+`just validate-history` **fails** while it is still there, so an unfilled record
+cannot slip through. The command prints the record path as its final stdout line,
+so scripts can capture it.
+
+`--kind record` and `--kind schema` can derive the target path from `--slug` plus
+`--target-root`. Every other kind needs an explicit `--path`, because only those
+two are reliably `.yaml`.
+
+The `--target-root` for a medium is the taxon-group directory the record lives in:
+`data/normalized_yaml/bacterial`, `.../archaea`, `.../fungal`, `.../algae`,
+`.../solutions`, or `.../specialized`.
+
+Then validate and stage:
+
+```bash
+just validate-history history/records/1_10_r2a_medium/<file>.yaml
+git add history/
+```
+
+## The vocabulary
+
+`event`: `CREATE` · `EDIT` · `REVIEW` · `AUDIT` · `GENERAL`
+
+`outcome`: `changed` · `no_change` · `needs_followup` · `blocked`
+
+Outcome is **orthogonal** to event on purpose. A `REVIEW` that found nothing is
+`no_change` — a real result worth recording, because it says something was
+checked. An `EDIT` that hit a wall is `blocked`, and `details` must say what the
+wall was so the next session does not rediscover it.
+
+`kind`: `record` · `schema` · `mapping` · `report` · `infrastructure` · `other`
+(`other` requires an explicit `--path`).
+
+## How strictly this is enforced
+
+Deliberately split:
+
+- **Presence is advisory.** CI warns when a medium under `data/normalized_yaml/`
+  changes without a matching history record. It does not block. A hard gate on
+  provenance blocks legitimate work at inconvenient moments and trains people to
+  route around it.
+- **Validity is not.** If you write a record it must be schema-valid, and
+  `just validate-history` fails like any other validation error.
+
+## Where the schema lives
+
+Two copies, on purpose:
+
+- **Canonical**: `culturebotai-claw/shared/history/history.yaml`, with the
+  scaffolder at `culturebotai-claw/src/kg_microbe_history/`.
+- **Vendored here**: `src/culturemech/schema/history.yaml`, byte-identical.
+
+Check that identity rather than trusting this file — with a claw checkout:
+
+```bash
+diff "${CLAW_SRC:-../culturebotai-claw/src}/../shared/history/history.yaml" \
+     src/culturemech/schema/history.yaml && echo "in sync"
+```
+
+Do not write the md5 into this prose instead. TraitMech's copy of this README did
+exactly that, and the hash went stale one commit later when the schema gained a
+field — which is the argument against a hash in prose at all: nothing recomputes
+it, so it decays into a confident false negative. A runnable command cannot go
+stale.
+
+The vendored copy exists so validation has **no dependency on claw**, which is
+private — a public repo's CI cannot check it out without a token. `just
+validate-history` and the `curation-history` workflow both use the local copy and
+work with no claw checkout at all.
+
+Only `just new-history` needs claw, via `CLAW_SRC` (default:
+`../culturebotai-claw/src`). That is a dev-time scaffolder, and anyone writing
+curation records has claw checked out.
+
+Changing the schema means changing the canonical copy and re-vendoring here — the
+same hub-and-spoke rule as `mech_shared.yaml`. Nothing automated enforces that rule
+for this file yet. CultureMech has no vendored-drift check of its own to append it
+to, and the obvious shortcut does not work: the canonical copy lives in claw, which
+is private, so a tokenless `raw.githubusercontent` fetch cannot reach it. Until
+that is solved, the `diff` above is the check, run by hand.

--- a/history/infrastructure/curation-history/2026-08-01T041511Z-claude-code-470d8e.yaml
+++ b/history/infrastructure/curation-history/2026-08-01T041511Z-claude-code-470d8e.yaml
@@ -1,0 +1,34 @@
+history_version: 1
+target:
+  kind: infrastructure
+  path: src/culturemech/schema/history.yaml
+  slug: curation-history
+session:
+  id: 2026-08-01T041511Z-claude-code-470d8e
+  timestamp: '2026-08-01T04:15:11Z'
+  actors:
+  - type: ai_agent
+    name: claude-code
+    model: claude-opus-5
+    agent_tool: claude-code
+events:
+- type: CREATE
+  outcome: changed
+  sections:
+  - schema
+  - justfile
+  - ci
+  - docs
+  summary: Port the append-only curation-history layer from TraitMech
+  details: 'Ported TraitMech''s curation-history surface into CultureMech: vendored src/culturemech/schema/history.yaml
+    byte-identical from culturebotai-claw/shared/history/history.yaml (md5 3742bc2068b637868c48aba406f6569d,
+    verified against both the canonical copy and TraitMech''s vendored copy); added the new-history
+    and validate-history justfile recipes, with validate-history pointing at the local vendored
+    schema so CI needs no claw checkout; added history/README.md; added .github/workflows/curation-history.yaml
+    with blocking record validation and an advisory missing-record check scoped to data/normalized_yaml/**.
+    Enabling ''set positional-arguments := true'' was required for new-history to preserve
+    multi-word --summary/--details prose; verified beforehand that no recipe in justfile or
+    project.justfile uses $1/$@/$*, so nothing else changes. Verified: just --list recipe
+    count went 211 to 213; a scaffolded record without --details fails validate-history on
+    the schema''s TODO-placeholder pattern; CLAW_SRC=/nonexistent fails loudly with exit 1;
+    empty and nonexistent validate-history targets exit 2. No media records were changed.'

--- a/justfile
+++ b/justfile
@@ -3,6 +3,12 @@
 
 set dotenv-load := true
 
+# Binds recipe arguments to "$@" in shebang recipes so multi-word arguments keep
+# their quoting. Needed by `new-history`, whose --summary/--details are prose;
+# plain `{{args}}` interpolation splits them on whitespace. No existing recipe
+# uses $1/$@, so enabling this changes nothing else.
+set positional-arguments := true
+
 # Shared tooling lives in the culturebotai-claw checkout. Override CLAW_SRC when
 # claw is not the default sibling directory — CI checks it out elsewhere.
 claw_src := env_var_or_default("CLAW_SRC", "../culturebotai-claw/src")
@@ -136,3 +142,53 @@ migrate-medium-type-axes *args:
 gen-discussions-data: (_require-claw "kg_microbe_discussions")
     PYTHONPATH={{claw_src}} uv run python \
       -m kg_microbe_discussions --config conf/discussions_config.yaml --output app/discussions
+
+# ============== Curation history ==============
+
+# Scaffold an append-only curation-history record. See history/README.md. e.g.
+#   just new-history --kind record --slug 1_10_r2a_medium \
+#     --target-root data/normalized_yaml/bacterial \
+#     --event EDIT --outcome changed --sections ingredients \
+#     --summary "Ground two ingredients to CHEBI" \
+#     --details "What was done, what evidence was used, how it was validated."
+new-history *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    claw_src="${CLAW_SRC:-../culturebotai-claw/src}"
+    if [ ! -d "$claw_src/kg_microbe_history" ]; then
+      echo "new-history: kg_microbe_history not found under '$claw_src'." >&2
+      echo "Set CLAW_SRC to the src/ directory of a culturebotai-claw checkout." >&2
+      exit 1
+    fi
+    # "$@" not {{args}} — see `set positional-arguments` at the top of this file.
+    # `uv run python`, not `python3`: bare python3 is whatever the machine puts
+    # first on PATH, which is the same undeclared-interpreter problem that has
+    # bitten other recipes here.
+    PYTHONPATH="$claw_src" uv run python -m kg_microbe_history new "$@"
+
+# Validate one history record, or a directory of them. Uses the VENDORED schema,
+# so this works with no claw checkout — same as CI.
+validate-history target="history":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target="{{target}}"
+    if [ -z "$target" ]; then
+      echo "validate-history: empty target. Pass a record path or a directory." >&2
+      exit 2
+    fi
+    if [ ! -e "$target" ]; then
+      echo "validate-history: '$target' does not exist." >&2
+      exit 2
+    fi
+    if [ -d "$target" ]; then
+      if [ -z "$(find "$target" -name '*.yaml' -print -quit)" ]; then
+        echo "No history records under '$target'."
+        exit 0
+      fi
+      find "$target" -name '*.yaml' -print0 \
+        | xargs -0 uv run linkml-validate \
+            --schema src/culturemech/schema/history.yaml --target-class HistoryRecord
+    else
+      uv run linkml-validate \
+        --schema src/culturemech/schema/history.yaml --target-class HistoryRecord "$target"
+    fi

--- a/src/culturemech/schema/history.yaml
+++ b/src/culturemech/schema/history.yaml
@@ -1,0 +1,265 @@
+id: https://w3id.org/kg-microbe/history
+name: mech_history
+title: Mech curation-history module — append-only provenance records
+description: >-
+  Append-only provenance for curation sessions across the Mech knowledge bases
+  (CultureMech / MIM / CommunityMech / TraitMech). Ported from
+  monarch-initiative/dismech's `history/` layer.
+
+  One record per session per target, written once and never edited. Records live
+  at `history/<kind-dir>/<slug>/<TIMESTAMP>-<actor>-<shortid>.yaml`. The
+  directory-per-slug layout with an unguessable `shortid` is the whole point:
+  concurrent agents curating the same record never write the same file, so the
+  layer has ZERO merge-conflict surface. Compare a single shared CHANGELOG,
+  which conflicts on every parallel PR.
+
+  This answers a question nothing else in the fleet can: which model, using which
+  tool, changed what, why, and under which issue. That matters more as autonomous
+  agents start doing the changing — see culturebotai-claw docs/AUTONOMOUS_LOOPS.md.
+
+  ENFORCEMENT IS DELIBERATELY SPLIT. Presence of a record is *advisory* — CI
+  warns, it does not block, because a hard gate on provenance blocks legitimate
+  work at inconvenient moments and trains people to route around it. But if a
+  record IS written it must be schema-valid, and that check is hard.
+
+  Do not hand-write records or filenames. Scaffold with `just new-history`, which
+  guarantees a schema-valid skeleton and a collision-free name, then edit the
+  `details` field.
+
+license: BSD-3-Clause
+default_range: string
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  mech_history: https://w3id.org/kg-microbe/history/
+
+default_prefix: mech_history
+
+imports:
+  - linkml:types
+
+# ============================== Enums ==============================
+
+enums:
+
+  HistoryTargetKindEnum:
+    description: >-
+      What kind of thing the session acted on. Repo-agnostic: each Mech maps its
+      own record type onto one of these, and `other` exists so a repo never has
+      to invent an enum value to record real work.
+    permissible_values:
+      record:
+        description: >-
+          A knowledge-base record — a CultureMech media recipe, a MIM ingredient,
+          a CommunityMech community, a TraitMech trait.
+      schema:
+        description: A LinkML schema or schema module.
+      mapping:
+        description: A mapping artifact such as an SSSOM file or a grounding table.
+      report:
+        description: A generated report, audit, dashboard, or ranking artifact.
+      infrastructure:
+        description: >-
+          Tooling, CI, justfile recipes, skills — changes to how the repo works
+          rather than to what it knows.
+      other:
+        description: >-
+          Anything not covered above. Requires an explicit path when scaffolding,
+          since the target cannot be derived from a slug.
+
+  HistoryActorTypeEnum:
+    description: Who or what performed the session.
+    permissible_values:
+      human:
+        description: A person working directly.
+      ai_agent:
+        description: >-
+          An LLM-driven agent, whether human-supervised or autonomous. Record the
+          model and the harness in `model` / `agent_tool`.
+      automation:
+        description: >-
+          A deterministic script or scheduled job with no model in the loop —
+          a cron scan, a regeneration step.
+      other:
+        description: Anything else.
+
+  HistoryEventTypeEnum:
+    description: >-
+      What the session did. Kept deliberately small; reach for `outcome` rather
+      than inventing a new type for "tried and failed".
+    permissible_values:
+      GENERAL:
+        description: Unclassified or legacy. Prefer a specific type.
+      CREATE:
+        description: Created a target that did not previously exist.
+      EDIT:
+        description: Modified an existing target.
+      REVIEW:
+        description: >-
+          Reviewed a target. May or may not have produced edits — say which via
+          `outcome`.
+      AUDIT:
+        description: >-
+          Structured inspection, compliance check, or triage across one or many
+          targets.
+
+  HistoryOutcomeEnum:
+    description: >-
+      What actually happened. Orthogonal to event type on purpose: it lets you
+      record a REVIEW that changed nothing (`no_change`) or an EDIT that got
+      stuck (`blocked`) without multiplying event types.
+    permissible_values:
+      changed:
+        description: The target was modified.
+      no_change:
+        description: >-
+          The session ran to completion and deliberately changed nothing. This is
+          a real result, not a non-event — it records that something was checked.
+      needs_followup:
+        description: Partial progress; specific remaining work is named in `details`.
+      blocked:
+        description: >-
+          Could not proceed. `details` must say what blocked it, so the next
+          session does not rediscover the same wall.
+
+# ============================== Classes ==============================
+
+classes:
+
+  HistoryRecord:
+    tree_root: true
+    description: >-
+      One curation session against one target. Append-only: write it once, never
+      edit it. Corrections go in a new record that references the old one in its
+      `details`.
+    attributes:
+      history_version:
+        description: Schema version of this record. Currently always 1.
+        range: integer
+        required: true
+        ifabsent: int(1)
+      target:
+        range: HistoryTarget
+        required: true
+      session:
+        range: HistorySession
+        required: true
+      links:
+        range: HistoryLinks
+        required: false
+      events:
+        description: >-
+          What happened, in order. At least one — a record with no events carries
+          no information.
+        range: HistoryEvent
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryTarget:
+    description: What the session acted on.
+    attributes:
+      kind:
+        range: HistoryTargetKindEnum
+        required: true
+      slug:
+        description: >-
+          Stable identifier for the target within its kind — usually the record
+          filename stem. Also the directory name under `history/<kind-dir>/`.
+        required: false
+      path:
+        description: Repo-relative path to the target.
+        required: true
+
+  HistorySession:
+    description: When the session ran and who ran it.
+    attributes:
+      id:
+        description: >-
+          Stable session identifier. Always equals the record's filename stem, so
+          a record can be located from its id alone.
+        required: true
+      timestamp:
+        description: ISO-8601 UTC start time.
+        required: true
+        pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})$'
+      actors:
+        description: >-
+          Everyone involved. A list even when there is one actor, because
+          human-plus-agent sessions are the common case and retrofitting a list
+          later would break every existing record.
+        range: HistoryActor
+        required: true
+        multivalued: true
+        minimum_cardinality: 1
+        inlined_as_list: true
+
+  HistoryActor:
+    description: A participant in the session.
+    attributes:
+      type:
+        range: HistoryActorTypeEnum
+        required: true
+      name:
+        description: >-
+          Identifier for the actor — a GitHub login for a human, a harness name
+          such as `claude-code` or `codex` for an agent.
+        required: true
+      model:
+        description: >-
+          Model identifier when the actor is an AI agent, e.g. `claude-opus-5`.
+          This is the field that makes the layer worth having; fill it in.
+        required: false
+      agent_tool:
+        description: Harness that ran the model, e.g. `claude-code`, `codex`.
+        required: false
+      agent_version:
+        description: Version of the harness, when known.
+        required: false
+
+  HistoryLinks:
+    description: Pointers to related discussion. All optional.
+    attributes:
+      issues:
+        range: uri
+        multivalued: true
+      prs:
+        range: uri
+        multivalued: true
+      urls:
+        range: uri
+        multivalued: true
+
+  HistoryEvent:
+    description: One thing the session did.
+    attributes:
+      type:
+        range: HistoryEventTypeEnum
+        required: true
+      outcome:
+        range: HistoryOutcomeEnum
+        required: true
+      sections:
+        description: >-
+          Which parts of the target were touched, in the target's own vocabulary
+          (e.g. `composition`, `causal_graphs`, `ontology_mapping`).
+        multivalued: true
+        required: false
+      summary:
+        description: One short line. Shows up in listings; keep it scannable.
+        required: true
+      details:
+        description: >-
+          The substance, and the reason this layer exists. Required, because a
+          record without it is just a timestamp. Write what a colleague picking
+          this up cold would need: what was done, what evidence or provider was
+          used, how it was validated, and anything deliberately left undone.
+
+          The pattern rejects the scaffolder's TODO placeholder. That check lives
+          in the schema rather than only in the CLI so that a repo validating with
+          plain `linkml-validate` against its vendored copy — which is how the
+          spokes do it, to avoid depending on this private repo — catches an
+          unfilled record too.
+        required: true
+        pattern: '^(?!TODO: replace this placeholder)'


### PR DESCRIPTION
Ports the curation-history layer from TraitMech, which has been running it in production. Same four-piece surface, adapted to CultureMech's paths and data layout.

## Why

Nothing here records *which model, using which tool, changed what, why, and under which issue*. Git tells you a commit happened; it does not tell you an ingredient was grounded against a specific CHEBI release, which deep-research provider produced a recipe correction, or that a review deliberately changed nothing. That gap widens as autonomous agents do more of the changing.

The directory-per-slug plus unguessable shortid layout means two agents curating the same medium concurrently cannot write the same file — this layer has **no merge-conflict surface**. That matters more here than in most repos: CultureMech carries over 15,000 media records and several agents work it at once.

## What's in it

- **`src/culturemech/schema/history.yaml`** — vendored byte-identical from claw's canonical `shared/history/history.yaml` (md5 `3742bc2068b637868c48aba406f6569d`, matching both the canonical copy and TraitMech's vendored one). Vendored rather than referenced because claw is private: public CI cannot check it out without a token. `just validate-history` and the workflow both use this local copy and work with no claw checkout at all. Only the `new-history` scaffolder needs claw, and that is a dev-time tool.
- **Two justfile recipes.** `new-history` resolves the scaffolder through `CLAW_SRC` and fails loudly when it is missing — no skip path, since a skip-when-missing check is exactly what lets a job pass while verifying nothing. `validate-history` points at the vendored schema.
- **`history/README.md`** — the vocabulary, the layout rationale, and a runnable `diff` for checking vendored-schema drift (deliberately not an md5 written into prose, which goes stale silently).
- **`.github/workflows/curation-history.yaml`** — deliberately asymmetric. Record **validity is blocking**; the **missing-record presence check is advisory**, warning in the job summary and never failing. A hard gate on provenance blocks legitimate work at inconvenient moments and trains people to route around it. Path filters point at `data/normalized_yaml/**`, the hand-curated surface that `validate-strict` also guards.

## `set positional-arguments := true`

Required for `new-history`: `--summary` and `--details` are prose, and plain `{{args}}` interpolation splits them on whitespace.

I checked before enabling it — **no recipe in `justfile` or `project.justfile` uses `$1`, `$@`, `$2`, or `$*`**, so nothing can regress. Confirmed empirically as well: `just -n` output for the existing `*args` recipes is byte-identical before and after the change.

```
$ just -n migrate-medium-type-axes --apply
uv run --extra dev python scripts/migrate_medium_type_axes.py --apply     # identical pre/post
$ just -n validate-media-recipe 1_10_r2a_medium --out /tmp/x
uv run python scripts/render_media_prompt.py --target 1_10_r2a_medium --out /tmp/x   # identical pre/post
```

## Verification

| Check | Result |
|---|---|
| `just --list` recipe count | 211 → 213, exactly the two additions |
| Vendored schema md5 vs claw canonical | identical |
| Scaffold + validate a real record | `No issues found`, exit 0 |
| Scaffold **without** `--details` | `validate-history` **fails** on the schema's TODO-placeholder pattern, exit 1 |
| Multi-word `--summary` through `just` | survives intact, unsplit |
| `CLAW_SRC=/nonexistent just new-history …` | fails loudly, exit 1 |
| `just validate-history ""` | exit 2 |
| `just validate-history <nonexistent>` | exit 2 |
| Empty history directory | exit 0, "No history records under …" |

The TODO-placeholder failure is the important one — it means an unfilled record cannot slip through.

The one included history record describes this port itself, and no media records were touched.

## Did not translate cleanly

TraitMech's README closes by noting its vendored schema is not on the automated vendored-fleet drift check, tracked in its #191. CultureMech has no vendored-drift check at all to append this to, so the README states the gap and gives the manual `diff` instead of citing an issue number I would have had to invent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)