### PR TITLE
Restamp 239 self-contradicting DEFINED records; guard the invariant (#158)

### DIFF
--- a/data/import_tracking/reports/composition_type_conflicts.tsv
+++ b/data/import_tracking/reports/composition_type_conflicts.tsv
@@ -1,0 +1,47 @@
+file_path	record_id	name	undefined_components	n_undefined	undefined_g_per_l	verdict
+archaea/KOMODO_141_METHANOGENIUM_medium.yaml	CultureMech:004144	methanogenium_medium	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+archaea/KOMODO_390_PYROBACULUM_MEDIUM.yaml	CultureMech:005172	pyrobaculum_medium	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+archaea/KOMODO_927_HALORHABDUS_UTAHENSIS_medium.yaml	CultureMech:006845	halorhabdus_utahensis_medium	Yeast extract	1	1	CURATOR: SEMI_DEFINED?
+archaea/halorhabdus_utahensis_medium.yaml	CultureMech:002099	halorhabdus_utahensis_medium	Yeast extract	1	1	CURATOR: SEMI_DEFINED?
+archaea/methanococcus_sp_medium.yaml	CultureMech:004145	methanococcus_sp_medium	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+archaea/methanogenium_medium_h2_co2.yaml	CultureMech:000254	methanogenium_medium_h2_co2	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+archaea/pyrobaculum_medium.yaml	CultureMech:001497	pyrobaculum_medium	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+bacterial/NBRC_1158.yaml	CultureMech:007459	1158	Tryptone (Diffico)10gGlucose3gAgar10gDistilled water1L	1		CURATOR: unquantified
+bacterial/for_dsm_13380.yaml	CultureMech:005170	for_dsm_13380	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_13514.yaml	CultureMech:005171	for_dsm_13514	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_14042.yaml	CultureMech:004140	for_dsm_14042	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_1497_dsm_1537_dsm_2067_dsm_2279_dsm_2373_dsm_17251_and_dsm17508.yaml	CultureMech:004129	for_dsm_1497_dsm_1537_dsm_2067_dsm_2279_dsm_2373_dsm_17251_and_dsm17508	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_15219_dsm_16458_and_dsm_18860.yaml	CultureMech:004128	for_dsm_15219_dsm_16458_and_dsm_18860	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_15558_and_dsm_16458.yaml	CultureMech:004141	for_dsm_15558_and_dsm_16458	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_2095.yaml	CultureMech:004132	for_dsm_2095	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_21626.yaml	CultureMech:004124	for_dsm_21626	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_2373.yaml	CultureMech:004135	for_dsm_2373	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_2831.yaml	CultureMech:004136	for_dsm_2831	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_4184.yaml	CultureMech:005168	for_dsm_4184	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_4185.yaml	CultureMech:005169	for_dsm_4185	Trypticase peptone; Yeast extract	2	0.69307	CURATOR: SEMI_DEFINED?
+bacterial/for_dsm_4254.yaml	CultureMech:004139	for_dsm_4254	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/for_strain_dsm_1498_dsm_15558_and_dsm_22353.yaml	CultureMech:004134	for_strain_dsm_1498_dsm_15558_and_dsm_22353	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/ignavibacteria_medium.yaml	CultureMech:000835	ignavibacteria_medium	Yeast extract	1	2	CURATOR: SEMI_DEFINED?
+bacterial/lentimonas_medium.yaml	CultureMech:001187	lentimonas_medium	Yeast extract	1	0.01	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_11571.yaml	CultureMech:004122	medium_141_modified_for_dsm_11571	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_11916.yaml	CultureMech:004123	medium_141_modified_for_dsm_11916	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_1224.yaml	CultureMech:004125	medium_141_modified_for_dsm_1224	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_13459.yaml	CultureMech:004126	medium_141_modified_for_dsm_13459	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_14266.yaml	CultureMech:004127	medium_141_modified_for_dsm_14266	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_3599.yaml	CultureMech:004130	medium_141_modified_for_dsm_3599	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_3821.yaml	CultureMech:004131	medium_141_modified_for_dsm_3821	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_4138.yaml	CultureMech:004133	medium_141_modified_for_dsm_4138	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_7268.yaml	CultureMech:004137	medium_141_modified_for_dsm_7268	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/medium_141_modified_for_dsm_7466.yaml	CultureMech:004138	medium_141_modified_for_dsm_7466	Yeast extract; Trypticase peptone	2	3.94866	CURATOR: SEMI_DEFINED?
+bacterial/petrotoga_medium.yaml	CultureMech:001856	petrotoga_medium	Yeast extract	1	0.197433	CURATOR: SEMI_DEFINED?
+bacterial/thermochromatium_allochromatium_medium.yaml	CultureMech:000935	thermochromatium_allochromatium_medium	Yeast extract	1	0.1	CURATOR: SEMI_DEFINED?
+specialized/definedmedia_adamslab_glucose_yeastextract.yaml	CultureMech:015510	DefinedMedia AdamsLab Glucose YeastExtract	Yeast Extract	1	1	CURATOR: SEMI_DEFINED?
+specialized/mccas_h2_complete.yaml	CultureMech:015576	McCas H2 complete	CASamino acids	1	2	CURATOR: SEMI_DEFINED?
+specialized/mccas_h2_fe_free.yaml	CultureMech:015577	McCas H2 Fe Free	CASamino acids	1	2	CURATOR: SEMI_DEFINED?
+specialized/mmx_casamino.yaml	CultureMech:015601	MMX casamino	casamino acids	1	1.5	CURATOR: SEMI_DEFINED?
+specialized/rch2_defined_glucose_ye.yaml	CultureMech:015709	RCH2 defined glucose YE	Yeast Extract	1	0.1	CURATOR: SEMI_DEFINED?
+specialized/rch2_defined_glucose_ye_10mmnitrate.yaml	CultureMech:015710	RCH2 defined glucose YE 10mMNitrate	Yeast Extract	1	0.1	CURATOR: SEMI_DEFINED?
+specialized/rch2_defined_nocarbon_ye.yaml	CultureMech:015721	RCH2 defined noCarbon YE	Yeast Extract	1	0.01	CURATOR: SEMI_DEFINED?
+specialized/rch2_defined_ye.yaml	CultureMech:015726	RCH2 defined YE	Yeast Extract	1	0.1	CURATOR: SEMI_DEFINED?
+specialized/rch2_defined_ye_10mm_nitrate.yaml	CultureMech:015727	RCH2 defined YE 10mM Nitrate	Yeast Extract	1	0.1	CURATOR: SEMI_DEFINED?
+specialized/xantho_mme_glucose_casamino.yaml	CultureMech:015787	Xantho MME glucose casamino	casamino acids	1	1.5	CURATOR: SEMI_DEFINED?

--- a/data/normalized_yaml/bacterial/KOMODO_457_MINERAL_MEDIUM_BRUNNER.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457_MINERAL_MEDIUM_BRUNNER.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005455
 name: mineral_medium_brunner
 original_name: MINERAL MEDIUM (BRUNNER)
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 6.9

--- a/data/normalized_yaml/bacterial/KOMODO_457_MINERAL_MEDIUM_BRUNNER.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457_MINERAL_MEDIUM_BRUNNER.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_brunner
 original_name: MINERAL MEDIUM (BRUNNER)
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 6.9
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_457a_MINERAL_MEDIUM_WITH_2-CHLOROBENZOATE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457a_MINERAL_MEDIUM_WITH_2-CHLOROBENZOATE.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_2_chlorobenzoate
 original_name: MINERAL MEDIUM WITH 2-CHLOROBENZOATE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.4
 notes: 'pH buffer: NaOH | Source: KOMODO ModelSEED | ID: 457a | DSMZ Medium: 457a

--- a/data/normalized_yaml/bacterial/KOMODO_457a_MINERAL_MEDIUM_WITH_2-CHLOROBENZOATE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457a_MINERAL_MEDIUM_WITH_2-CHLOROBENZOATE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005456
 name: mineral_medium_with_2_chlorobenzoate
 original_name: MINERAL MEDIUM WITH 2-CHLOROBENZOATE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.4

--- a/data/normalized_yaml/bacterial/KOMODO_457c_MEDIUM_WITH_CHLOROACRYLIC_ACID.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457c_MEDIUM_WITH_CHLOROACRYLIC_ACID.yaml
@@ -3,7 +3,7 @@ name: medium_with_chloroacrylic_acid
 original_name: MEDIUM WITH CHLOROACRYLIC ACID
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457c

--- a/data/normalized_yaml/bacterial/KOMODO_457c_MEDIUM_WITH_CHLOROACRYLIC_ACID.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457c_MEDIUM_WITH_CHLOROACRYLIC_ACID.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005461
 name: medium_with_chloroacrylic_acid
 original_name: MEDIUM WITH CHLOROACRYLIC ACID
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_457d_MEDIUM_WITH_BIPHENYL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457d_MEDIUM_WITH_BIPHENYL.yaml
@@ -3,7 +3,7 @@ name: medium_with_biphenyl
 original_name: MEDIUM WITH BIPHENYL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457d

--- a/data/normalized_yaml/bacterial/KOMODO_457d_MEDIUM_WITH_BIPHENYL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_457d_MEDIUM_WITH_BIPHENYL.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005462
 name: medium_with_biphenyl
 original_name: MEDIUM WITH BIPHENYL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465_MINERAL_MEDIUM_PH_7.25.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465_MINERAL_MEDIUM_PH_7.25.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005566
 name: mineral_medium_ph_7_25
 original_name: MINERAL MEDIUM PH 7.25
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.25

--- a/data/normalized_yaml/bacterial/KOMODO_465_MINERAL_MEDIUM_PH_7.25.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465_MINERAL_MEDIUM_PH_7.25.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_ph_7_25
 original_name: MINERAL MEDIUM PH 7.25
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.25
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465a_MINERAL_MEDIUM_WITH_2-HYDROXYBIPHENYL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465a_MINERAL_MEDIUM_WITH_2-HYDROXYBIPHENYL.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_2_hydroxybiphenyl
 original_name: MINERAL MEDIUM WITH 2-HYDROXYBIPHENYL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465a

--- a/data/normalized_yaml/bacterial/KOMODO_465a_MINERAL_MEDIUM_WITH_2-HYDROXYBIPHENYL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465a_MINERAL_MEDIUM_WITH_2-HYDROXYBIPHENYL.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005567
 name: mineral_medium_with_2_hydroxybiphenyl
 original_name: MINERAL MEDIUM WITH 2-HYDROXYBIPHENYL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465b_MINERAL_MEDIUM_WITH_PCP.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465b_MINERAL_MEDIUM_WITH_PCP.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005569
 name: mineral_medium_with_pcp
 original_name: MINERAL MEDIUM WITH PCP
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465b_MINERAL_MEDIUM_WITH_PCP.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465b_MINERAL_MEDIUM_WITH_PCP.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_pcp
 original_name: MINERAL MEDIUM WITH PCP
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465b

--- a/data/normalized_yaml/bacterial/KOMODO_465c_MINERAL_MEDIUM_WITH_DICHLOROMETHANE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465c_MINERAL_MEDIUM_WITH_DICHLOROMETHANE.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_dichloromethane
 original_name: MINERAL MEDIUM WITH DICHLOROMETHANE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465c

--- a/data/normalized_yaml/bacterial/KOMODO_465c_MINERAL_MEDIUM_WITH_DICHLOROMETHANE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465c_MINERAL_MEDIUM_WITH_DICHLOROMETHANE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005571
 name: mineral_medium_with_dichloromethane
 original_name: MINERAL MEDIUM WITH DICHLOROMETHANE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465d_MINERAL_MEDIUM_WITH_BENZYLCYANIDE_AS_NITROGEN_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465d_MINERAL_MEDIUM_WITH_BENZYLCYANIDE_AS_NITROGEN_SOURCE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005573
 name: mineral_medium_with_benzylcyanide_as_nitrogen_source
 original_name: MINERAL MEDIUM WITH BENZYLCYANIDE AS NITROGEN SOURCE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465d_MINERAL_MEDIUM_WITH_BENZYLCYANIDE_AS_NITROGEN_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465d_MINERAL_MEDIUM_WITH_BENZYLCYANIDE_AS_NITROGEN_SOURCE.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_benzylcyanide_as_nitrogen_source
 original_name: MINERAL MEDIUM WITH BENZYLCYANIDE AS NITROGEN SOURCE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465d

--- a/data/normalized_yaml/bacterial/KOMODO_465e_MINERAL_MEDIUM_WITH_SULFOBENZOIC_ACID.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465e_MINERAL_MEDIUM_WITH_SULFOBENZOIC_ACID.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_sulfobenzoic_acid
 original_name: MINERAL MEDIUM WITH SULFOBENZOIC ACID
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465e

--- a/data/normalized_yaml/bacterial/KOMODO_465e_MINERAL_MEDIUM_WITH_SULFOBENZOIC_ACID.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465e_MINERAL_MEDIUM_WITH_SULFOBENZOIC_ACID.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005574
 name: mineral_medium_with_sulfobenzoic_acid
 original_name: MINERAL MEDIUM WITH SULFOBENZOIC ACID
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465f_MINERAL_MEDIUM_WITH_3-AMINOPHENOL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465f_MINERAL_MEDIUM_WITH_3-AMINOPHENOL.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005575
 name: mineral_medium_with_3_aminophenol
 original_name: MINERAL MEDIUM WITH 3-AMINOPHENOL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465f_MINERAL_MEDIUM_WITH_3-AMINOPHENOL.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465f_MINERAL_MEDIUM_WITH_3-AMINOPHENOL.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_3_aminophenol
 original_name: MINERAL MEDIUM WITH 3-AMINOPHENOL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465f

--- a/data/normalized_yaml/bacterial/KOMODO_465g_MINERAL_MEDIUM_WITH_CYANURIC_ACID_AS_NITROGEN_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465g_MINERAL_MEDIUM_WITH_CYANURIC_ACID_AS_NITROGEN_SOURCE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005576
 name: mineral_medium_with_cyanuric_acid_as_nitrogen_source
 original_name: MINERAL MEDIUM WITH CYANURIC ACID AS NITROGEN SOURCE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465g_MINERAL_MEDIUM_WITH_CYANURIC_ACID_AS_NITROGEN_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465g_MINERAL_MEDIUM_WITH_CYANURIC_ACID_AS_NITROGEN_SOURCE.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_cyanuric_acid_as_nitrogen_source
 original_name: MINERAL MEDIUM WITH CYANURIC ACID AS NITROGEN SOURCE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465g

--- a/data/normalized_yaml/bacterial/KOMODO_465h_MINERALMEDIUM_WITH_6-METHYLNICOTINATE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465h_MINERALMEDIUM_WITH_6-METHYLNICOTINATE.yaml
@@ -3,7 +3,7 @@ name: mineralmedium_with_6_methylnicotinate
 original_name: MINERALMEDIUM WITH 6-METHYLNICOTINATE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465h

--- a/data/normalized_yaml/bacterial/KOMODO_465h_MINERALMEDIUM_WITH_6-METHYLNICOTINATE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465h_MINERALMEDIUM_WITH_6-METHYLNICOTINATE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005577
 name: mineralmedium_with_6_methylnicotinate
 original_name: MINERALMEDIUM WITH 6-METHYLNICOTINATE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465i_MINERAL_MEDIUM_WITH_ATRAZIN.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465i_MINERAL_MEDIUM_WITH_ATRAZIN.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005578
 name: mineral_medium_with_atrazin
 original_name: MINERAL MEDIUM WITH ATRAZIN
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/KOMODO_465i_MINERAL_MEDIUM_WITH_ATRAZIN.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_465i_MINERAL_MEDIUM_WITH_ATRAZIN.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_atrazin
 original_name: MINERAL MEDIUM WITH ATRAZIN
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465i

--- a/data/normalized_yaml/bacterial/KOMODO_474_MEDIUM_WITH_POLYHYDROXYBUTYRIC_ACID_AS_CARBON_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_474_MEDIUM_WITH_POLYHYDROXYBUTYRIC_ACID_AS_CARBON_SOURCE.yaml
@@ -3,7 +3,7 @@ name: medium_with_polyhydroxybutyric_acid_as_carbon_source
 original_name: MEDIUM WITH POLYHYDROXYBUTYRIC ACID AS CARBON SOURCE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 474

--- a/data/normalized_yaml/bacterial/KOMODO_474_MEDIUM_WITH_POLYHYDROXYBUTYRIC_ACID_AS_CARBON_SOURCE.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_474_MEDIUM_WITH_POLYHYDROXYBUTYRIC_ACID_AS_CARBON_SOURCE.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005589
 name: medium_with_polyhydroxybutyric_acid_as_carbon_source
 original_name: MEDIUM WITH POLYHYDROXYBUTYRIC ACID AS CARBON SOURCE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
@@ -3,7 +3,7 @@ name: defined_freshwater_medium_coso4
 original_name: '''Defined freshwater medium (CoSO4'
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Boric acid

--- a/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
@@ -2,7 +2,7 @@ id: CultureMech:007333
 name: defined_freshwater_medium_coso4
 original_name: '''Defined freshwater medium (CoSO4'
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
@@ -3,7 +3,7 @@ name: defined_freshwater_medium_cocl2
 original_name: '''Defined freshwater medium (CoCl2'
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Boric acid

--- a/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
@@ -2,7 +2,7 @@ id: CultureMech:007366
 name: defined_freshwater_medium_cocl2
 original_name: '''Defined freshwater medium (CoCl2'
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/bacterial/NBRC_1245.yaml
+++ b/data/normalized_yaml/bacterial/NBRC_1245.yaml
@@ -4,7 +4,7 @@ original_name: '1245'
 category: bacterial
 description: 1245. NBRC 1243.
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ingredients:
 - preferred_term: Calf brains

--- a/data/normalized_yaml/bacterial/NBRC_1245.yaml
+++ b/data/normalized_yaml/bacterial/NBRC_1245.yaml
@@ -3,7 +3,7 @@ name: '1245'
 original_name: '1245'
 category: bacterial
 description: 1245. NBRC 1243.
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ingredients:

--- a/data/normalized_yaml/bacterial/NBRC_1298.yaml
+++ b/data/normalized_yaml/bacterial/NBRC_1298.yaml
@@ -3,7 +3,7 @@ name: '1298'
 original_name: '1298'
 category: bacterial
 description: 1298. NBRC 1296.
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ingredients:

--- a/data/normalized_yaml/bacterial/NBRC_1298.yaml
+++ b/data/normalized_yaml/bacterial/NBRC_1298.yaml
@@ -4,7 +4,7 @@ original_name: '1298'
 category: bacterial
 description: 1298. NBRC 1296.
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ingredients:
 - preferred_term: Peptone

--- a/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
+++ b/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
@@ -2,7 +2,7 @@ name: pcs_fp_medium_for_thermophilic_cellulose_degradation
 original_name: PCS-FP medium for thermophilic cellulose degradation
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 id: CultureMech:015439
 ingredients:

--- a/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
+++ b/data/normalized_yaml/bacterial/PCS_FP_medium_for_thermophilic_cellulose_degradation.yaml
@@ -1,7 +1,7 @@
 name: pcs_fp_medium_for_thermophilic_cellulose_degradation
 original_name: PCS-FP medium for thermophilic cellulose degradation
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 id: CultureMech:015439

--- a/data/normalized_yaml/bacterial/cdmm.yaml
+++ b/data/normalized_yaml/bacterial/cdmm.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001228
 name: cdmm
 original_name: CDMM
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 media_term:

--- a/data/normalized_yaml/bacterial/cdmm.yaml
+++ b/data/normalized_yaml/bacterial/cdmm.yaml
@@ -3,7 +3,7 @@ name: cdmm
 original_name: CDMM
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 media_term:
   preferred_term: DSMZ Medium 1757

--- a/data/normalized_yaml/bacterial/for_dsm_13022.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_13022.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005458
 name: for_dsm_13022
 original_name: For DSM 13022
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/for_dsm_13022.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_13022.yaml
@@ -3,7 +3,7 @@ name: for_dsm_13022
 original_name: For DSM 13022
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457b.2

--- a/data/normalized_yaml/bacterial/for_dsm_6813.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_6813.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005570
 name: for_dsm_6813
 original_name: For DSM 6813
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/for_dsm_6813.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_6813.yaml
@@ -3,7 +3,7 @@ name: for_dsm_6813
 original_name: For DSM 6813
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465c.1

--- a/data/normalized_yaml/bacterial/for_dsm_7526.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_7526.yaml
@@ -3,7 +3,7 @@ name: for_dsm_7526
 original_name: For DSM 7526
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457b.1

--- a/data/normalized_yaml/bacterial/for_dsm_7526.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_7526.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005457
 name: for_dsm_7526
 original_name: For DSM 7526
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/for_dsm_9675_and_dsm_9685.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_9675_and_dsm_9685.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005572
 name: for_dsm_9675_and_dsm_9685
 original_name: For DSM 9675 and DSM 9685
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/for_dsm_9675_and_dsm_9685.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_9675_and_dsm_9685.yaml
@@ -3,7 +3,7 @@ name: for_dsm_9675_and_dsm_9685
 original_name: For DSM 9675 and DSM 9685
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465d.1

--- a/data/normalized_yaml/bacterial/halobacteriovorax_medium.yaml
+++ b/data/normalized_yaml/bacterial/halobacteriovorax_medium.yaml
@@ -3,7 +3,7 @@ name: halobacteriovorax_medium
 original_name: HALOBACTERIOVORAX MEDIUM
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ph_range:
   min: 7.5

--- a/data/normalized_yaml/bacterial/halobacteriovorax_medium.yaml
+++ b/data/normalized_yaml/bacterial/halobacteriovorax_medium.yaml
@@ -2,7 +2,7 @@ id: CultureMech:000435
 name: halobacteriovorax_medium
 original_name: HALOBACTERIOVORAX MEDIUM
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ph_range:

--- a/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
+++ b/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
@@ -2,7 +2,7 @@ id: CultureMech:007380
 name: mcn_medium_whitman
 original_name: '''McN Medium (Whitman'
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
+++ b/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
@@ -3,7 +3,7 @@ name: mcn_medium_whitman
 original_name: '''McN Medium (Whitman'
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - &id001

--- a/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
+++ b/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
@@ -3,7 +3,7 @@ name: mcna_medium_lupa
 original_name: '''McNA Medium (Lupa'
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Nitrilotriacetic acid

--- a/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
+++ b/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
@@ -2,7 +2,7 @@ id: CultureMech:007381
 name: mcna_medium_lupa
 original_name: '''McNA Medium (Lupa'
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_10330.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_10330.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005307
 name: medium_457_modified_for_dsm_10330
 original_name: MEDIUM 457 MODIFIED FOR DSM 10330
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_10330.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_10330.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_10330
 original_name: MEDIUM 457 MODIFIED FOR DSM 10330
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_10330

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11019.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11019.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11019
 original_name: MEDIUM 457 MODIFIED FOR DSM 11019
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11019

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11019.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11019.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005308
 name: medium_457_modified_for_dsm_11019
 original_name: MEDIUM 457 MODIFIED FOR DSM 11019
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11097.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11097.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11097
 original_name: MEDIUM 457 MODIFIED FOR DSM 11097
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11097

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11097.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11097.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005309
 name: medium_457_modified_for_dsm_11097
 original_name: MEDIUM 457 MODIFIED FOR DSM 11097
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11213.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11213.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11213
 original_name: MEDIUM 457 MODIFIED FOR DSM 11213
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11213

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11213.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11213.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005310
 name: medium_457_modified_for_dsm_11213
 original_name: MEDIUM 457 MODIFIED FOR DSM 11213
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11214.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11214.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11214
 original_name: MEDIUM 457 MODIFIED FOR DSM 11214
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11214

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11214.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11214.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005311
 name: medium_457_modified_for_dsm_11214
 original_name: MEDIUM 457 MODIFIED FOR DSM 11214
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11215.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11215.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005312
 name: medium_457_modified_for_dsm_11215
 original_name: MEDIUM 457 MODIFIED FOR DSM 11215
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11215.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11215.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11215
 original_name: MEDIUM 457 MODIFIED FOR DSM 11215
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11215

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11216.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11216.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11216
 original_name: MEDIUM 457 MODIFIED FOR DSM 11216
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11216

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11216.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11216.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005313
 name: medium_457_modified_for_dsm_11216
 original_name: MEDIUM 457 MODIFIED FOR DSM 11216
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11217.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11217.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005314
 name: medium_457_modified_for_dsm_11217
 original_name: MEDIUM 457 MODIFIED FOR DSM 11217
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11217.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11217.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11217
 original_name: MEDIUM 457 MODIFIED FOR DSM 11217
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11217

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11218.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11218.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005315
 name: medium_457_modified_for_dsm_11218
 original_name: MEDIUM 457 MODIFIED FOR DSM 11218
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11218.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11218.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11218
 original_name: MEDIUM 457 MODIFIED FOR DSM 11218
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11218

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11219.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11219.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11219
 original_name: MEDIUM 457 MODIFIED FOR DSM 11219
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11219

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11219.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11219.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005316
 name: medium_457_modified_for_dsm_11219
 original_name: MEDIUM 457 MODIFIED FOR DSM 11219
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11220.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11220.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005317
 name: medium_457_modified_for_dsm_11220
 original_name: MEDIUM 457 MODIFIED FOR DSM 11220
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11220.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11220.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11220
 original_name: MEDIUM 457 MODIFIED FOR DSM 11220
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11220

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11345.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11345.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11345
 original_name: MEDIUM 457 MODIFIED FOR DSM 11345
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11345

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11345.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11345.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005318
 name: medium_457_modified_for_dsm_11345
 original_name: MEDIUM 457 MODIFIED FOR DSM 11345
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11346.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11346.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005319
 name: medium_457_modified_for_dsm_11346
 original_name: MEDIUM 457 MODIFIED FOR DSM 11346
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11346.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11346.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11346
 original_name: MEDIUM 457 MODIFIED FOR DSM 11346
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11346

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11531.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11531.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11531
 original_name: MEDIUM 457 MODIFIED FOR DSM 11531
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11531

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11531.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11531.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005320
 name: medium_457_modified_for_dsm_11531
 original_name: MEDIUM 457 MODIFIED FOR DSM 11531
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11532.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11532.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005321
 name: medium_457_modified_for_dsm_11532
 original_name: MEDIUM 457 MODIFIED FOR DSM 11532
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11532.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11532.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11532
 original_name: MEDIUM 457 MODIFIED FOR DSM 11532
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11532

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11533.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11533.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11533
 original_name: MEDIUM 457 MODIFIED FOR DSM 11533
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11533

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11533.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11533.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005322
 name: medium_457_modified_for_dsm_11533
 original_name: MEDIUM 457 MODIFIED FOR DSM 11533
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11535.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11535.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11535
 original_name: MEDIUM 457 MODIFIED FOR DSM 11535
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11535

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11535.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11535.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005323
 name: medium_457_modified_for_dsm_11535
 original_name: MEDIUM 457 MODIFIED FOR DSM 11535
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11562.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11562.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11562
 original_name: MEDIUM 457 MODIFIED FOR DSM 11562
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11562

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11562.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11562.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005324
 name: medium_457_modified_for_dsm_11562
 original_name: MEDIUM 457 MODIFIED FOR DSM 11562
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11563.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11563.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11563
 original_name: MEDIUM 457 MODIFIED FOR DSM 11563
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11563

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11563.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11563.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005325
 name: medium_457_modified_for_dsm_11563
 original_name: MEDIUM 457 MODIFIED FOR DSM 11563
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11564.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11564.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005326
 name: medium_457_modified_for_dsm_11564
 original_name: MEDIUM 457 MODIFIED FOR DSM 11564
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11564.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11564.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11564
 original_name: MEDIUM 457 MODIFIED FOR DSM 11564
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11564

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11565.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11565.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11565
 original_name: MEDIUM 457 MODIFIED FOR DSM 11565
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11565

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11565.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11565.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005327
 name: medium_457_modified_for_dsm_11565
 original_name: MEDIUM 457 MODIFIED FOR DSM 11565
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11566.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11566.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005328
 name: medium_457_modified_for_dsm_11566
 original_name: MEDIUM 457 MODIFIED FOR DSM 11566
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11566.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11566.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11566
 original_name: MEDIUM 457 MODIFIED FOR DSM 11566
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11566

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11567.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11567.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11567
 original_name: MEDIUM 457 MODIFIED FOR DSM 11567
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11567

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11567.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11567.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005329
 name: medium_457_modified_for_dsm_11567
 original_name: MEDIUM 457 MODIFIED FOR DSM 11567
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11568.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11568.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11568
 original_name: MEDIUM 457 MODIFIED FOR DSM 11568
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11568

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11568.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11568.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005330
 name: medium_457_modified_for_dsm_11568
 original_name: MEDIUM 457 MODIFIED FOR DSM 11568
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11569.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11569.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11569
 original_name: MEDIUM 457 MODIFIED FOR DSM 11569
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11569

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11569.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11569.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005331
 name: medium_457_modified_for_dsm_11569
 original_name: MEDIUM 457 MODIFIED FOR DSM 11569
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11570.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11570.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005332
 name: medium_457_modified_for_dsm_11570
 original_name: MEDIUM 457 MODIFIED FOR DSM 11570
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11570.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11570.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11570
 original_name: MEDIUM 457 MODIFIED FOR DSM 11570
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11570

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11591.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11591.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005333
 name: medium_457_modified_for_dsm_11591
 original_name: MEDIUM 457 MODIFIED FOR DSM 11591
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11591.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11591.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11591
 original_name: MEDIUM 457 MODIFIED FOR DSM 11591
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11591

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11738.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11738.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11738
 original_name: MEDIUM 457 MODIFIED FOR DSM 11738
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11738

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11738.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11738.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005334
 name: medium_457_modified_for_dsm_11738
 original_name: MEDIUM 457 MODIFIED FOR DSM 11738
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11850.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11850.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_11850
 original_name: MEDIUM 457 MODIFIED FOR DSM 11850
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_11850

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11850.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_11850.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005335
 name: medium_457_modified_for_dsm_11850
 original_name: MEDIUM 457 MODIFIED FOR DSM 11850
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12401.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12401.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12401
 original_name: MEDIUM 457 MODIFIED FOR DSM 12401
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12401

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12401.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12401.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005336
 name: medium_457_modified_for_dsm_12401
 original_name: MEDIUM 457 MODIFIED FOR DSM 12401
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12418.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12418.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005337
 name: medium_457_modified_for_dsm_12418
 original_name: MEDIUM 457 MODIFIED FOR DSM 12418
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12418.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12418.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12418
 original_name: MEDIUM 457 MODIFIED FOR DSM 12418
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12418

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12444.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12444.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005338
 name: medium_457_modified_for_dsm_12444
 original_name: MEDIUM 457 MODIFIED FOR DSM 12444
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12444.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12444.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12444
 original_name: MEDIUM 457 MODIFIED FOR DSM 12444
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12444

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12445.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12445.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12445
 original_name: MEDIUM 457 MODIFIED FOR DSM 12445
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12445

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12445.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12445.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005339
 name: medium_457_modified_for_dsm_12445
 original_name: MEDIUM 457 MODIFIED FOR DSM 12445
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12447.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12447.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005340
 name: medium_457_modified_for_dsm_12447
 original_name: MEDIUM 457 MODIFIED FOR DSM 12447
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12447.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12447.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12447
 original_name: MEDIUM 457 MODIFIED FOR DSM 12447
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12447

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12448.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12448.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005341
 name: medium_457_modified_for_dsm_12448
 original_name: MEDIUM 457 MODIFIED FOR DSM 12448
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12448.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12448.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12448
 original_name: MEDIUM 457 MODIFIED FOR DSM 12448
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12448

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12586.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12586.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005342
 name: medium_457_modified_for_dsm_12586
 original_name: MEDIUM 457 MODIFIED FOR DSM 12586
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12586.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12586.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12586
 original_name: MEDIUM 457 MODIFIED FOR DSM 12586
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12586

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12647.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12647.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12647
 original_name: MEDIUM 457 MODIFIED FOR DSM 12647
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12647

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12647.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12647.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005343
 name: medium_457_modified_for_dsm_12647
 original_name: MEDIUM 457 MODIFIED FOR DSM 12647
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12677.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12677.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005344
 name: medium_457_modified_for_dsm_12677
 original_name: MEDIUM 457 MODIFIED FOR DSM 12677
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12677.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12677.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12677
 original_name: MEDIUM 457 MODIFIED FOR DSM 12677
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12677

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12734.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12734.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12734
 original_name: MEDIUM 457 MODIFIED FOR DSM 12734
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12734

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12734.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12734.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005345
 name: medium_457_modified_for_dsm_12734
 original_name: MEDIUM 457 MODIFIED FOR DSM 12734
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12735.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12735.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_12735
 original_name: MEDIUM 457 MODIFIED FOR DSM 12735
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_12735

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12735.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_12735.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005346
 name: medium_457_modified_for_dsm_12735
 original_name: MEDIUM 457 MODIFIED FOR DSM 12735
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13225.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13225.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005347
 name: medium_457_modified_for_dsm_13225
 original_name: MEDIUM 457 MODIFIED FOR DSM 13225
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13225.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13225.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_13225
 original_name: MEDIUM 457 MODIFIED FOR DSM 13225
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_13225

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13337.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13337.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_13337
 original_name: MEDIUM 457 MODIFIED FOR DSM 13337
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_13337

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13337.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13337.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005348
 name: medium_457_modified_for_dsm_13337
 original_name: MEDIUM 457 MODIFIED FOR DSM 13337
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13646.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13646.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_13646
 original_name: MEDIUM 457 MODIFIED FOR DSM 13646
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_13646

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13646.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_13646.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005349
 name: medium_457_modified_for_dsm_13646
 original_name: MEDIUM 457 MODIFIED FOR DSM 13646
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14157.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14157.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005350
 name: medium_457_modified_for_dsm_14157
 original_name: MEDIUM 457 MODIFIED FOR DSM 14157
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14157.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14157.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_14157
 original_name: MEDIUM 457 MODIFIED FOR DSM 14157
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_14157

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14291.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14291.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005351
 name: medium_457_modified_for_dsm_14291
 original_name: MEDIUM 457 MODIFIED FOR DSM 14291
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14291.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14291.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_14291
 original_name: MEDIUM 457 MODIFIED FOR DSM 14291
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_14291

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14292.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14292.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_14292
 original_name: MEDIUM 457 MODIFIED FOR DSM 14292
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_14292

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14292.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14292.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005352
 name: medium_457_modified_for_dsm_14292
 original_name: MEDIUM 457 MODIFIED FOR DSM 14292
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14576.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14576.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005353
 name: medium_457_modified_for_dsm_14576
 original_name: MEDIUM 457 MODIFIED FOR DSM 14576
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14576.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14576.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_14576
 original_name: MEDIUM 457 MODIFIED FOR DSM 14576
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_14576

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14677.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14677.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005354
 name: medium_457_modified_for_dsm_14677
 original_name: MEDIUM 457 MODIFIED FOR DSM 14677
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14677.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_14677.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_14677
 original_name: MEDIUM 457 MODIFIED FOR DSM 14677
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_14677

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15090.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15090.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_15090
 original_name: MEDIUM 457 MODIFIED FOR DSM 15090
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_15090

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15090.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15090.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005355
 name: medium_457_modified_for_dsm_15090
 original_name: MEDIUM 457 MODIFIED FOR DSM 15090
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15091.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15091.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005356
 name: medium_457_modified_for_dsm_15091
 original_name: MEDIUM 457 MODIFIED FOR DSM 15091
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15091.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15091.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_15091
 original_name: MEDIUM 457 MODIFIED FOR DSM 15091
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_15091

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15418.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15418.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_15418
 original_name: MEDIUM 457 MODIFIED FOR DSM 15418
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_15418

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15418.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_15418.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005357
 name: medium_457_modified_for_dsm_15418
 original_name: MEDIUM 457 MODIFIED FOR DSM 15418
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16272.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16272.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16272
 original_name: MEDIUM 457 MODIFIED FOR DSM 16272
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16272

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16272.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16272.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005358
 name: medium_457_modified_for_dsm_16272
 original_name: MEDIUM 457 MODIFIED FOR DSM 16272
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16273.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16273.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16273
 original_name: MEDIUM 457 MODIFIED FOR DSM 16273
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16273

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16273.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16273.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005359
 name: medium_457_modified_for_dsm_16273
 original_name: MEDIUM 457 MODIFIED FOR DSM 16273
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16274.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16274.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16274
 original_name: MEDIUM 457 MODIFIED FOR DSM 16274
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16274

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16274.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16274.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005360
 name: medium_457_modified_for_dsm_16274
 original_name: MEDIUM 457 MODIFIED FOR DSM 16274
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16482.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16482.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16482
 original_name: MEDIUM 457 MODIFIED FOR DSM 16482
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16482

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16482.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16482.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005361
 name: medium_457_modified_for_dsm_16482
 original_name: MEDIUM 457 MODIFIED FOR DSM 16482
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16503.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16503.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005362
 name: medium_457_modified_for_dsm_16503
 original_name: MEDIUM 457 MODIFIED FOR DSM 16503
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16503.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16503.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16503
 original_name: MEDIUM 457 MODIFIED FOR DSM 16503
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16503

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16638.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16638.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005363
 name: medium_457_modified_for_dsm_16638
 original_name: MEDIUM 457 MODIFIED FOR DSM 16638
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16638.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_16638.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_16638
 original_name: MEDIUM 457 MODIFIED FOR DSM 16638
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_16638

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17164.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17164.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005364
 name: medium_457_modified_for_dsm_17164
 original_name: MEDIUM 457 MODIFIED FOR DSM 17164
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17164.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17164.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_17164
 original_name: MEDIUM 457 MODIFIED FOR DSM 17164
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_17164

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17367.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17367.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_17367
 original_name: MEDIUM 457 MODIFIED FOR DSM 17367
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_17367

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17367.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17367.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005365
 name: medium_457_modified_for_dsm_17367
 original_name: MEDIUM 457 MODIFIED FOR DSM 17367
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17668.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17668.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_17668
 original_name: MEDIUM 457 MODIFIED FOR DSM 17668
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_17668

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17668.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17668.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005366
 name: medium_457_modified_for_dsm_17668
 original_name: MEDIUM 457 MODIFIED FOR DSM 17668
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17773.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17773.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_17773
 original_name: MEDIUM 457 MODIFIED FOR DSM 17773
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_17773

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17773.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_17773.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005367
 name: medium_457_modified_for_dsm_17773
 original_name: MEDIUM 457 MODIFIED FOR DSM 17773
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_21786.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_21786.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005368
 name: medium_457_modified_for_dsm_21786
 original_name: MEDIUM 457 MODIFIED FOR DSM 21786
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_21786.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_21786.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_21786
 original_name: MEDIUM 457 MODIFIED FOR DSM 21786
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_21786

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22800.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22800.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_22800
 original_name: MEDIUM 457 MODIFIED FOR DSM 22800
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_22800

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22800.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22800.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005369
 name: medium_457_modified_for_dsm_22800
 original_name: MEDIUM 457 MODIFIED FOR DSM 22800
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22895.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22895.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005370
 name: medium_457_modified_for_dsm_22895
 original_name: MEDIUM 457 MODIFIED FOR DSM 22895
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22895.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22895.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_22895
 original_name: MEDIUM 457 MODIFIED FOR DSM 22895
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_22895

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22896.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22896.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005371
 name: medium_457_modified_for_dsm_22896
 original_name: MEDIUM 457 MODIFIED FOR DSM 22896
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22896.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22896.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_22896
 original_name: MEDIUM 457 MODIFIED FOR DSM 22896
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_22896

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22897.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22897.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_22897
 original_name: MEDIUM 457 MODIFIED FOR DSM 22897
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_22897

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22897.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22897.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005372
 name: medium_457_modified_for_dsm_22897
 original_name: MEDIUM 457 MODIFIED FOR DSM 22897
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22944.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22944.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_22944
 original_name: MEDIUM 457 MODIFIED FOR DSM 22944
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_22944

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22944.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_22944.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005373
 name: medium_457_modified_for_dsm_22944
 original_name: MEDIUM 457 MODIFIED FOR DSM 22944
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_3226.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_3226.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005374
 name: medium_457_modified_for_dsm_3226
 original_name: MEDIUM 457 MODIFIED FOR DSM 3226
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_3226.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_3226.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_3226
 original_name: MEDIUM 457 MODIFIED FOR DSM 3226
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_3226

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6014.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6014.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005375
 name: medium_457_modified_for_dsm_6014
 original_name: MEDIUM 457 MODIFIED FOR DSM 6014
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6014.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6014.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6014
 original_name: MEDIUM 457 MODIFIED FOR DSM 6014
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6014

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6263.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6263.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005376
 name: medium_457_modified_for_dsm_6263
 original_name: MEDIUM 457 MODIFIED FOR DSM 6263
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6263.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6263.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6263
 original_name: MEDIUM 457 MODIFIED FOR DSM 6263
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6263

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6264.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6264.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6264
 original_name: MEDIUM 457 MODIFIED FOR DSM 6264
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6264

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6264.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6264.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005377
 name: medium_457_modified_for_dsm_6264
 original_name: MEDIUM 457 MODIFIED FOR DSM 6264
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6279.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6279.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005378
 name: medium_457_modified_for_dsm_6279
 original_name: MEDIUM 457 MODIFIED FOR DSM 6279
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6279.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6279.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6279
 original_name: MEDIUM 457 MODIFIED FOR DSM 6279
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6279

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6290.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6290.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005379
 name: medium_457_modified_for_dsm_6290
 original_name: MEDIUM 457 MODIFIED FOR DSM 6290
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6290.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6290.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6290
 original_name: MEDIUM 457 MODIFIED FOR DSM 6290
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6290

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6308.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6308.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6308
 original_name: MEDIUM 457 MODIFIED FOR DSM 6308
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6308

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6308.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6308.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005380
 name: medium_457_modified_for_dsm_6308
 original_name: MEDIUM 457 MODIFIED FOR DSM 6308
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005382
 name: medium_457_modified_for_dsm_6343
 original_name: MEDIUM 457 MODIFIED FOR DSM 6343
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6343
 original_name: MEDIUM 457 MODIFIED FOR DSM 6343
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6343

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005381
 name: medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol
 original_name: MEDIUM 457 MODIFIED FOR DSM 6343_replace_dichloromethane_with_methanol
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6343_replace_dichloromethane_with_methanol
 original_name: MEDIUM 457 MODIFIED FOR DSM 6343_replace_dichloromethane_with_methanol
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6343_replace_dichloromethane_with_methanol

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6363.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6363.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005383
 name: medium_457_modified_for_dsm_6363
 original_name: MEDIUM 457 MODIFIED FOR DSM 6363
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6363.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6363.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6363
 original_name: MEDIUM 457 MODIFIED FOR DSM 6363
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6363

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6377.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6377.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6377
 original_name: MEDIUM 457 MODIFIED FOR DSM 6377
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6377

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6377.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6377.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005384
 name: medium_457_modified_for_dsm_6377
 original_name: MEDIUM 457 MODIFIED FOR DSM 6377
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6385.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6385.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005385
 name: medium_457_modified_for_dsm_6385
 original_name: MEDIUM 457 MODIFIED FOR DSM 6385
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6385.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6385.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6385
 original_name: MEDIUM 457 MODIFIED FOR DSM 6385
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6385

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6390.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6390.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6390
 original_name: MEDIUM 457 MODIFIED FOR DSM 6390
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6390

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6390.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6390.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005386
 name: medium_457_modified_for_dsm_6390
 original_name: MEDIUM 457 MODIFIED FOR DSM 6390
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6391.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6391.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005387
 name: medium_457_modified_for_dsm_6391
 original_name: MEDIUM 457 MODIFIED FOR DSM 6391
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6391.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6391.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6391
 original_name: MEDIUM 457 MODIFIED FOR DSM 6391
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6391

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6410.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6410.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005388
 name: medium_457_modified_for_dsm_6410
 original_name: MEDIUM 457 MODIFIED FOR DSM 6410
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6410.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6410.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6410
 original_name: MEDIUM 457 MODIFIED FOR DSM 6410
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6410

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6411.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6411.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6411
 original_name: MEDIUM 457 MODIFIED FOR DSM 6411
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6411

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6411.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6411.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005389
 name: medium_457_modified_for_dsm_6411
 original_name: MEDIUM 457 MODIFIED FOR DSM 6411
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6413.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6413.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6413
 original_name: MEDIUM 457 MODIFIED FOR DSM 6413
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6413

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6413.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6413.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005390
 name: medium_457_modified_for_dsm_6413
 original_name: MEDIUM 457 MODIFIED FOR DSM 6413
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6506.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6506.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005391
 name: medium_457_modified_for_dsm_6506
 original_name: MEDIUM 457 MODIFIED FOR DSM 6506
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6506.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6506.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6506
 original_name: MEDIUM 457 MODIFIED FOR DSM 6506
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6506

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6521.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6521.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6521
 original_name: MEDIUM 457 MODIFIED FOR DSM 6521
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6521

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6521.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6521.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005392
 name: medium_457_modified_for_dsm_6521
 original_name: MEDIUM 457 MODIFIED FOR DSM 6521
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6538.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6538.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005393
 name: medium_457_modified_for_dsm_6538
 original_name: MEDIUM 457 MODIFIED FOR DSM 6538
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6538.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6538.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6538
 original_name: MEDIUM 457 MODIFIED FOR DSM 6538
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6538

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6607.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6607.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6607
 original_name: MEDIUM 457 MODIFIED FOR DSM 6607
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6607

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6607.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6607.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005394
 name: medium_457_modified_for_dsm_6607
 original_name: MEDIUM 457 MODIFIED FOR DSM 6607
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6608.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6608.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005395
 name: medium_457_modified_for_dsm_6608
 original_name: MEDIUM 457 MODIFIED FOR DSM 6608
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6608.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6608.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6608
 original_name: MEDIUM 457 MODIFIED FOR DSM 6608
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6608

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6609.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6609.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005396
 name: medium_457_modified_for_dsm_6609
 original_name: MEDIUM 457 MODIFIED FOR DSM 6609
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6609.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6609.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6609
 original_name: MEDIUM 457 MODIFIED FOR DSM 6609
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6609

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6610
 original_name: MEDIUM 457 MODIFIED FOR DSM 6610
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6610

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005398
 name: medium_457_modified_for_dsm_6610
 original_name: MEDIUM 457 MODIFIED FOR DSM 6610
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005397
 name: medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorobenzoate
 original_name: MEDIUM 457 MODIFIED FOR DSM 6610_replace_4-hydroxy-benzoate_with_4-fluorobenzoate
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6610_replace_4_hydroxy_benzoate_with_4_fluorob
 original_name: MEDIUM 457 MODIFIED FOR DSM 6610_replace_4-hydroxy-benzoate_with_4-fluorobenzoate
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6610_replace_4-hydroxy-benzoate_with_4-fluorobenzoate

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005400
 name: medium_457_modified_for_dsm_6611
 original_name: MEDIUM 457 MODIFIED FOR DSM 6611
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6611
 original_name: MEDIUM 457 MODIFIED FOR DSM 6611
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6611

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorob
 original_name: MEDIUM 457 MODIFIED FOR DSM 6611_replace_4-hydroxy-benzoate_with_4-fluorobenzoate
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6611_replace_4-hydroxy-benzoate_with_4-fluorobenzoate

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorobenzoate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005399
 name: medium_457_modified_for_dsm_6611_replace_4_hydroxy_benzoate_with_4_fluorobenzoate
 original_name: MEDIUM 457 MODIFIED FOR DSM 6611_replace_4-hydroxy-benzoate_with_4-fluorobenzoate
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6612.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6612.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6612
 original_name: MEDIUM 457 MODIFIED FOR DSM 6612
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6612

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6612.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6612.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005401
 name: medium_457_modified_for_dsm_6612
 original_name: MEDIUM 457 MODIFIED FOR DSM 6612
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6613.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6613.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6613
 original_name: MEDIUM 457 MODIFIED FOR DSM 6613
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6613

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6613.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6613.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005402
 name: medium_457_modified_for_dsm_6613
 original_name: MEDIUM 457 MODIFIED FOR DSM 6613
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6695.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6695.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005403
 name: medium_457_modified_for_dsm_6695
 original_name: MEDIUM 457 MODIFIED FOR DSM 6695
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6695.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6695.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6695
 original_name: MEDIUM 457 MODIFIED FOR DSM 6695
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6695

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6696.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6696.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005404
 name: medium_457_modified_for_dsm_6696
 original_name: MEDIUM 457 MODIFIED FOR DSM 6696
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6696.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6696.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6696
 original_name: MEDIUM 457 MODIFIED FOR DSM 6696
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6696

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6697.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6697.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6697
 original_name: MEDIUM 457 MODIFIED FOR DSM 6697
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6697

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6697.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6697.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005405
 name: medium_457_modified_for_dsm_6697
 original_name: MEDIUM 457 MODIFIED FOR DSM 6697
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6706.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6706.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005406
 name: medium_457_modified_for_dsm_6706
 original_name: MEDIUM 457 MODIFIED FOR DSM 6706
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6706.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6706.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6706
 original_name: MEDIUM 457 MODIFIED FOR DSM 6706
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6706

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6753.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6753.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005407
 name: medium_457_modified_for_dsm_6753
 original_name: MEDIUM 457 MODIFIED FOR DSM 6753
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6753.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6753.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6753
 original_name: MEDIUM 457 MODIFIED FOR DSM 6753
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6753

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005409
 name: medium_457_modified_for_dsm_6756
 original_name: MEDIUM 457 MODIFIED FOR DSM 6756
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6756
 original_name: MEDIUM 457 MODIFIED FOR DSM 6756
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroacetate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroacetate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005408
 name: medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroacetate
 original_name: MEDIUM 457 MODIFIED FOR DSM 6756_replace_monochloroacetate_with_dichloroacetate
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroacetate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroacetate.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6756_replace_monochloroacetate_with_dichloroac
 original_name: MEDIUM 457 MODIFIED FOR DSM 6756_replace_monochloroacetate_with_dichloroacetate
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6758.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6758.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6758
 original_name: MEDIUM 457 MODIFIED FOR DSM 6758
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6758.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6758.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005410
 name: medium_457_modified_for_dsm_6758
 original_name: MEDIUM 457 MODIFIED FOR DSM 6758
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.5

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6818.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6818.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6818
 original_name: MEDIUM 457 MODIFIED FOR DSM 6818
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6818

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6818.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6818.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005411
 name: medium_457_modified_for_dsm_6818
 original_name: MEDIUM 457 MODIFIED FOR DSM 6818
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6837.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6837.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6837
 original_name: MEDIUM 457 MODIFIED FOR DSM 6837
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6837

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6837.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6837.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005412
 name: medium_457_modified_for_dsm_6837
 original_name: MEDIUM 457 MODIFIED FOR DSM 6837
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6838.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6838.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6838
 original_name: MEDIUM 457 MODIFIED FOR DSM 6838
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6838

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6838.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6838.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005413
 name: medium_457_modified_for_dsm_6838
 original_name: MEDIUM 457 MODIFIED FOR DSM 6838
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6899.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6899.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6899
 original_name: MEDIUM 457 MODIFIED FOR DSM 6899
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6899

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6899.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6899.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005414
 name: medium_457_modified_for_dsm_6899
 original_name: MEDIUM 457 MODIFIED FOR DSM 6899
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6900
 original_name: MEDIUM 457 MODIFIED FOR DSM 6900
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6900

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005416
 name: medium_457_modified_for_dsm_6900
 original_name: MEDIUM 457 MODIFIED FOR DSM 6900
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005415
 name: medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene
 original_name: MEDIUM 457 MODIFIED FOR DSM 6900_replace_naphthalene_with_3-xylene
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6900_replace_naphthalene_with_3_xylene
 original_name: MEDIUM 457 MODIFIED FOR DSM 6900_replace_naphthalene_with_3-xylene
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6900_replace_naphthalene_with_3-xylene

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6978.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6978.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_6978
 original_name: MEDIUM 457 MODIFIED FOR DSM 6978
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_6978

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6978.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_6978.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005417
 name: medium_457_modified_for_dsm_6978
 original_name: MEDIUM 457 MODIFIED FOR DSM 6978
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7098.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7098.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7098
 original_name: MEDIUM 457 MODIFIED FOR DSM 7098
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7098

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7098.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7098.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005418
 name: medium_457_modified_for_dsm_7098
 original_name: MEDIUM 457 MODIFIED FOR DSM 7098
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7116.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7116.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7116
 original_name: MEDIUM 457 MODIFIED FOR DSM 7116
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7116

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7116.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7116.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005419
 name: medium_457_modified_for_dsm_7116
 original_name: MEDIUM 457 MODIFIED FOR DSM 7116
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7122.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7122.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005420
 name: medium_457_modified_for_dsm_7122
 original_name: MEDIUM 457 MODIFIED FOR DSM 7122
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7122.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7122.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7122
 original_name: MEDIUM 457 MODIFIED FOR DSM 7122
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7122

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7135.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7135.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005421
 name: medium_457_modified_for_dsm_7135
 original_name: MEDIUM 457 MODIFIED FOR DSM 7135
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7135.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7135.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7135
 original_name: MEDIUM 457 MODIFIED FOR DSM 7135
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7135

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7162.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7162.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7162
 original_name: MEDIUM 457 MODIFIED FOR DSM 7162
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7162

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7162.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7162.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005422
 name: medium_457_modified_for_dsm_7162
 original_name: MEDIUM 457 MODIFIED FOR DSM 7162
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7189.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7189.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7189
 original_name: MEDIUM 457 MODIFIED FOR DSM 7189
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7189

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7189.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7189.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005423
 name: medium_457_modified_for_dsm_7189
 original_name: MEDIUM 457 MODIFIED FOR DSM 7189
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7300.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7300.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7300
 original_name: MEDIUM 457 MODIFIED FOR DSM 7300
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7300

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7300.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7300.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005424
 name: medium_457_modified_for_dsm_7300
 original_name: MEDIUM 457 MODIFIED FOR DSM 7300
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7324.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7324.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005425
 name: medium_457_modified_for_dsm_7324
 original_name: MEDIUM 457 MODIFIED FOR DSM 7324
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7324.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7324.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7324
 original_name: MEDIUM 457 MODIFIED FOR DSM 7324
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7324

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7325.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7325.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005426
 name: medium_457_modified_for_dsm_7325
 original_name: MEDIUM 457 MODIFIED FOR DSM 7325
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7325.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7325.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7325
 original_name: MEDIUM 457 MODIFIED FOR DSM 7325
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7325

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7346.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7346.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005427
 name: medium_457_modified_for_dsm_7346
 original_name: MEDIUM 457 MODIFIED FOR DSM 7346
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 6.0

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7346.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7346.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7346
 original_name: MEDIUM 457 MODIFIED FOR DSM 7346
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 6.0
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7355.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7355.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005428
 name: medium_457_modified_for_dsm_7355
 original_name: MEDIUM 457 MODIFIED FOR DSM 7355
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7355.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7355.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7355
 original_name: MEDIUM 457 MODIFIED FOR DSM 7355
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7355

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7390.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7390.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005429
 name: medium_457_modified_for_dsm_7390
 original_name: MEDIUM 457 MODIFIED FOR DSM 7390
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7390.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7390.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7390
 original_name: MEDIUM 457 MODIFIED FOR DSM 7390
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7390

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7511.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7511.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005430
 name: medium_457_modified_for_dsm_7511
 original_name: MEDIUM 457 MODIFIED FOR DSM 7511
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7511.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7511.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7511
 original_name: MEDIUM 457 MODIFIED FOR DSM 7511
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7511

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7512.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7512.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005431
 name: medium_457_modified_for_dsm_7512
 original_name: MEDIUM 457 MODIFIED FOR DSM 7512
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7512.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7512.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7512
 original_name: MEDIUM 457 MODIFIED FOR DSM 7512
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7512

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005433
 name: medium_457_modified_for_dsm_7516
 original_name: MEDIUM 457 MODIFIED FOR DSM 7516
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7516
 original_name: MEDIUM 457 MODIFIED FOR DSM 7516
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7516

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate
 original_name: MEDIUM 457 MODIFIED FOR DSM 7516_replace_chloroacetate_with_fluoroacetate
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_7516_replace_chloroacetate_with_fluoroacetate

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005432
 name: medium_457_modified_for_dsm_7516_replace_chloroacetate_with_fluoroacetate
 original_name: MEDIUM 457 MODIFIED FOR DSM 7516_replace_chloroacetate_with_fluoroacetate
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8219.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8219.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005434
 name: medium_457_modified_for_dsm_8219
 original_name: MEDIUM 457 MODIFIED FOR DSM 8219
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8219.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8219.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8219
 original_name: MEDIUM 457 MODIFIED FOR DSM 8219
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8219

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8341.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8341.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8341
 original_name: MEDIUM 457 MODIFIED FOR DSM 8341
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8341

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8341.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8341.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005435
 name: medium_457_modified_for_dsm_8341
 original_name: MEDIUM 457 MODIFIED FOR DSM 8341
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8368.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8368.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005436
 name: medium_457_modified_for_dsm_8368
 original_name: MEDIUM 457 MODIFIED FOR DSM 8368
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8368.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8368.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8368
 original_name: MEDIUM 457 MODIFIED FOR DSM 8368
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8368

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8369.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8369.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8369
 original_name: MEDIUM 457 MODIFIED FOR DSM 8369
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8369

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8369.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8369.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005437
 name: medium_457_modified_for_dsm_8369
 original_name: MEDIUM 457 MODIFIED FOR DSM 8369
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8370.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8370.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005438
 name: medium_457_modified_for_dsm_8370
 original_name: MEDIUM 457 MODIFIED FOR DSM 8370
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8370.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8370.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8370
 original_name: MEDIUM 457 MODIFIED FOR DSM 8370
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8370

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8424.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8424.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005439
 name: medium_457_modified_for_dsm_8424
 original_name: MEDIUM 457 MODIFIED FOR DSM 8424
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8424.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8424.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8424
 original_name: MEDIUM 457 MODIFIED FOR DSM 8424
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8424

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8425.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8425.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005440
 name: medium_457_modified_for_dsm_8425
 original_name: MEDIUM 457 MODIFIED FOR DSM 8425
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8425.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8425.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8425
 original_name: MEDIUM 457 MODIFIED FOR DSM 8425
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8425

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8530.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8530.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8530
 original_name: MEDIUM 457 MODIFIED FOR DSM 8530
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8530

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8530.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8530.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005441
 name: medium_457_modified_for_dsm_8530
 original_name: MEDIUM 457 MODIFIED FOR DSM 8530
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8531.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8531.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005442
 name: medium_457_modified_for_dsm_8531
 original_name: MEDIUM 457 MODIFIED FOR DSM 8531
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8531.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8531.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8531
 original_name: MEDIUM 457 MODIFIED FOR DSM 8531
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8531

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8542.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8542.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005443
 name: medium_457_modified_for_dsm_8542
 original_name: MEDIUM 457 MODIFIED FOR DSM 8542
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8542.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8542.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8542
 original_name: MEDIUM 457 MODIFIED FOR DSM 8542
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8542

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8543.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8543.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005444
 name: medium_457_modified_for_dsm_8543
 original_name: MEDIUM 457 MODIFIED FOR DSM 8543
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8543.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8543.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8543
 original_name: MEDIUM 457 MODIFIED FOR DSM 8543
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8543

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8544.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8544.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8544
 original_name: MEDIUM 457 MODIFIED FOR DSM 8544
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8544

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8544.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8544.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005445
 name: medium_457_modified_for_dsm_8544
 original_name: MEDIUM 457 MODIFIED FOR DSM 8544
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8566.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8566.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8566
 original_name: MEDIUM 457 MODIFIED FOR DSM 8566
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8566

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8566.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8566.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005446
 name: medium_457_modified_for_dsm_8566
 original_name: MEDIUM 457 MODIFIED FOR DSM 8566
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8628.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8628.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005447
 name: medium_457_modified_for_dsm_8628
 original_name: MEDIUM 457 MODIFIED FOR DSM 8628
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8628.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8628.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8628
 original_name: MEDIUM 457 MODIFIED FOR DSM 8628
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8628

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8910.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8910.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8910
 original_name: MEDIUM 457 MODIFIED FOR DSM 8910
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8910

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8910.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8910.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005448
 name: medium_457_modified_for_dsm_8910
 original_name: MEDIUM 457 MODIFIED FOR DSM 8910
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8924.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8924.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005449
 name: medium_457_modified_for_dsm_8924
 original_name: MEDIUM 457 MODIFIED FOR DSM 8924
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8924.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_8924.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_8924
 original_name: MEDIUM 457 MODIFIED FOR DSM 8924
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_8924

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9000.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9000.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_9000
 original_name: MEDIUM 457 MODIFIED FOR DSM 9000
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_9000

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9000.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9000.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005450
 name: medium_457_modified_for_dsm_9000
 original_name: MEDIUM 457 MODIFIED FOR DSM 9000
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9750.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9750.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005451
 name: medium_457_modified_for_dsm_9750
 original_name: MEDIUM 457 MODIFIED FOR DSM 9750
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9750.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9750.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_9750
 original_name: MEDIUM 457 MODIFIED FOR DSM 9750
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_9750

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9751.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9751.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005452
 name: medium_457_modified_for_dsm_9751
 original_name: MEDIUM 457 MODIFIED FOR DSM 9751
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9751.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9751.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_9751
 original_name: MEDIUM 457 MODIFIED FOR DSM 9751
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_9751

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9958.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9958.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_9958
 original_name: MEDIUM 457 MODIFIED FOR DSM 9958
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_9958

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9958.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9958.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005453
 name: medium_457_modified_for_dsm_9958
 original_name: MEDIUM 457 MODIFIED FOR DSM 9958
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9959.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9959.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005454
 name: medium_457_modified_for_dsm_9959
 original_name: MEDIUM 457 MODIFIED FOR DSM 9959
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9959.yaml
+++ b/data/normalized_yaml/bacterial/medium_457_modified_for_dsm_9959.yaml
@@ -3,7 +3,7 @@ name: medium_457_modified_for_dsm_9959
 original_name: MEDIUM 457 MODIFIED FOR DSM 9959
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457_9959

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10063.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10063.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005521
 name: medium_465_modified_for_dsm_10063
 original_name: MEDIUM 465 MODIFIED FOR DSM 10063
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10063.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10063.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10063
 original_name: MEDIUM 465 MODIFIED FOR DSM 10063
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10063

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10064.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10064.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10064
 original_name: MEDIUM 465 MODIFIED FOR DSM 10064
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10064

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10064.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10064.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005522
 name: medium_465_modified_for_dsm_10064
 original_name: MEDIUM 465 MODIFIED FOR DSM 10064
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10065.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10065.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10065
 original_name: MEDIUM 465 MODIFIED FOR DSM 10065
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10065

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10065.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10065.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005523
 name: medium_465_modified_for_dsm_10065
 original_name: MEDIUM 465 MODIFIED FOR DSM 10065
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10066.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10066.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10066
 original_name: MEDIUM 465 MODIFIED FOR DSM 10066
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10066

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10066.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10066.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005524
 name: medium_465_modified_for_dsm_10066
 original_name: MEDIUM 465 MODIFIED FOR DSM 10066
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10698.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10698.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005525
 name: medium_465_modified_for_dsm_10698
 original_name: MEDIUM 465 MODIFIED FOR DSM 10698
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10698.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10698.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10698
 original_name: MEDIUM 465 MODIFIED FOR DSM 10698
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10698

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10699.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10699.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005526
 name: medium_465_modified_for_dsm_10699
 original_name: MEDIUM 465 MODIFIED FOR DSM 10699
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10699.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10699.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10699
 original_name: MEDIUM 465 MODIFIED FOR DSM 10699
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10699

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10700.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10700.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_10700
 original_name: MEDIUM 465 MODIFIED FOR DSM 10700
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_10700

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10700.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_10700.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005527
 name: medium_465_modified_for_dsm_10700
 original_name: MEDIUM 465 MODIFIED FOR DSM 10700
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11098.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11098.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_11098
 original_name: MEDIUM 465 MODIFIED FOR DSM 11098
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_11098

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11098.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11098.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005528
 name: medium_465_modified_for_dsm_11098
 original_name: MEDIUM 465 MODIFIED FOR DSM 11098
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11199.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11199.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005529
 name: medium_465_modified_for_dsm_11199
 original_name: MEDIUM 465 MODIFIED FOR DSM 11199
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11199.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11199.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_11199
 original_name: MEDIUM 465 MODIFIED FOR DSM 11199
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_11199

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11414.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11414.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_11414
 original_name: MEDIUM 465 MODIFIED FOR DSM 11414
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_11414

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11414.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11414.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005530
 name: medium_465_modified_for_dsm_11414
 original_name: MEDIUM 465 MODIFIED FOR DSM 11414
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11437.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11437.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005531
 name: medium_465_modified_for_dsm_11437
 original_name: MEDIUM 465 MODIFIED FOR DSM 11437
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11437.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_11437.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_11437
 original_name: MEDIUM 465 MODIFIED FOR DSM 11437
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_11437

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12578.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12578.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005532
 name: medium_465_modified_for_dsm_12578
 original_name: MEDIUM 465 MODIFIED FOR DSM 12578
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12578.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12578.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12578
 original_name: MEDIUM 465 MODIFIED FOR DSM 12578
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12578

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12579.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12579.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12579
 original_name: MEDIUM 465 MODIFIED FOR DSM 12579
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12579

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12579.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12579.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005533
 name: medium_465_modified_for_dsm_12579
 original_name: MEDIUM 465 MODIFIED FOR DSM 12579
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12584.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12584.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12584
 original_name: MEDIUM 465 MODIFIED FOR DSM 12584
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12584

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12584.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12584.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005534
 name: medium_465_modified_for_dsm_12584
 original_name: MEDIUM 465 MODIFIED FOR DSM 12584
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12585.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12585.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005535
 name: medium_465_modified_for_dsm_12585
 original_name: MEDIUM 465 MODIFIED FOR DSM 12585
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12585.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12585.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12585
 original_name: MEDIUM 465 MODIFIED FOR DSM 12585
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12585

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12678.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12678.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12678
 original_name: MEDIUM 465 MODIFIED FOR DSM 12678
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12678

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12678.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12678.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005536
 name: medium_465_modified_for_dsm_12678
 original_name: MEDIUM 465 MODIFIED FOR DSM 12678
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12775.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12775.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12775
 original_name: MEDIUM 465 MODIFIED FOR DSM 12775
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12775

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12775.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12775.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005537
 name: medium_465_modified_for_dsm_12775
 original_name: MEDIUM 465 MODIFIED FOR DSM 12775
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12877.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12877.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_12877
 original_name: MEDIUM 465 MODIFIED FOR DSM 12877
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_12877

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12877.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_12877.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005538
 name: medium_465_modified_for_dsm_12877
 original_name: MEDIUM 465 MODIFIED FOR DSM 12877
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_13640
 original_name: MEDIUM 465 MODIFIED FOR DSM 13640
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_13640

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005540
 name: medium_465_modified_for_dsm_13640
 original_name: MEDIUM 465 MODIFIED FOR DSM 13640
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate
 original_name: MEDIUM 465 MODIFIED FOR DSM 13640_replace_taurine_with_ethanedisulfonate
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_13640_replace_taurine_with_ethanedisulfonate

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005539
 name: medium_465_modified_for_dsm_13640_replace_taurine_with_ethanedisulfonate
 original_name: MEDIUM 465 MODIFIED FOR DSM 13640_replace_taurine_with_ethanedisulfonate
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_14773.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_14773.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_14773
 original_name: MEDIUM 465 MODIFIED FOR DSM 14773
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_14773

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_14773.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_14773.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005541
 name: medium_465_modified_for_dsm_14773
 original_name: MEDIUM 465 MODIFIED FOR DSM 14773
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16812.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16812.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16812
 original_name: MEDIUM 465 MODIFIED FOR DSM 16812
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16812

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16812.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16812.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005542
 name: medium_465_modified_for_dsm_16812
 original_name: MEDIUM 465 MODIFIED FOR DSM 16812
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16843.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16843.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16843
 original_name: MEDIUM 465 MODIFIED FOR DSM 16843
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16843

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16843.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16843.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005543
 name: medium_465_modified_for_dsm_16843
 original_name: MEDIUM 465 MODIFIED FOR DSM 16843
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16845.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16845.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16845
 original_name: MEDIUM 465 MODIFIED FOR DSM 16845
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16845

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16845.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16845.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005544
 name: medium_465_modified_for_dsm_16845
 original_name: MEDIUM 465 MODIFIED FOR DSM 16845
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16851.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16851.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16851
 original_name: MEDIUM 465 MODIFIED FOR DSM 16851
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16851

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16851.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16851.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005545
 name: medium_465_modified_for_dsm_16851
 original_name: MEDIUM 465 MODIFIED FOR DSM 16851
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16962.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16962.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005546
 name: medium_465_modified_for_dsm_16962
 original_name: MEDIUM 465 MODIFIED FOR DSM 16962
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16962.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16962.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16962
 original_name: MEDIUM 465 MODIFIED FOR DSM 16962
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16962

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16963.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16963.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005547
 name: medium_465_modified_for_dsm_16963
 original_name: MEDIUM 465 MODIFIED FOR DSM 16963
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16963.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16963.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16963
 original_name: MEDIUM 465 MODIFIED FOR DSM 16963
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16963

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16964.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16964.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_16964
 original_name: MEDIUM 465 MODIFIED FOR DSM 16964
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_16964

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16964.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_16964.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005548
 name: medium_465_modified_for_dsm_16964
 original_name: MEDIUM 465 MODIFIED FOR DSM 16964
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17507.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17507.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_17507
 original_name: MEDIUM 465 MODIFIED FOR DSM 17507
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_17507

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17507.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17507.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005549
 name: medium_465_modified_for_dsm_17507
 original_name: MEDIUM 465 MODIFIED FOR DSM 17507
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17540.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17540.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_17540
 original_name: MEDIUM 465 MODIFIED FOR DSM 17540
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_17540

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17540.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17540.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005550
 name: medium_465_modified_for_dsm_17540
 original_name: MEDIUM 465 MODIFIED FOR DSM 17540
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17854.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17854.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_17854
 original_name: MEDIUM 465 MODIFIED FOR DSM 17854
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_17854

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17854.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_17854.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005551
 name: medium_465_modified_for_dsm_17854
 original_name: MEDIUM 465 MODIFIED FOR DSM 17854
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_18361.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_18361.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005552
 name: medium_465_modified_for_dsm_18361
 original_name: MEDIUM 465 MODIFIED FOR DSM 18361
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_18361.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_18361.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_18361
 original_name: MEDIUM 465 MODIFIED FOR DSM 18361
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_18361

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19529.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19529.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_19529
 original_name: MEDIUM 465 MODIFIED FOR DSM 19529
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_19529

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19529.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19529.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005553
 name: medium_465_modified_for_dsm_19529
 original_name: MEDIUM 465 MODIFIED FOR DSM 19529
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19550.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19550.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_19550
 original_name: MEDIUM 465 MODIFIED FOR DSM 19550
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_19550

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19550.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_19550.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005554
 name: medium_465_modified_for_dsm_19550
 original_name: MEDIUM 465 MODIFIED FOR DSM 19550
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6383.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6383.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6383
 original_name: MEDIUM 465 MODIFIED FOR DSM 6383
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6383

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6383.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6383.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005555
 name: medium_465_modified_for_dsm_6383
 original_name: MEDIUM 465 MODIFIED FOR DSM 6383
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6428
 original_name: MEDIUM 465 MODIFIED FOR DSM 6428
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6428

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005557
 name: medium_465_modified_for_dsm_6428
 original_name: MEDIUM 465 MODIFIED FOR DSM 6428
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005556
 name: medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol
 original_name: MEDIUM 465 MODIFIED FOR DSM 6428_replace_phenol_with_2,4,6-trichlorophenol
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6428_replace_phenol_with_2_4_6_trichlorophenol
 original_name: MEDIUM 465 MODIFIED FOR DSM 6428_replace_phenol_with_2,4,6-trichlorophenol
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6428_replace_phenol_with_2,4,6-trichlorophenol

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6431.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6431.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005558
 name: medium_465_modified_for_dsm_6431
 original_name: MEDIUM 465 MODIFIED FOR DSM 6431
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6431.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6431.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6431
 original_name: MEDIUM 465 MODIFIED FOR DSM 6431
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6431

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6432.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6432.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005559
 name: medium_465_modified_for_dsm_6432
 original_name: MEDIUM 465 MODIFIED FOR DSM 6432
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6432.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6432.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6432
 original_name: MEDIUM 465 MODIFIED FOR DSM 6432
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6432

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6434.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6434.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005560
 name: medium_465_modified_for_dsm_6434
 original_name: MEDIUM 465 MODIFIED FOR DSM 6434
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6434.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6434.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6434
 original_name: MEDIUM 465 MODIFIED FOR DSM 6434
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6434

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6577.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6577.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6577
 original_name: MEDIUM 465 MODIFIED FOR DSM 6577
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6577

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6577.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6577.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005561
 name: medium_465_modified_for_dsm_6577
 original_name: MEDIUM 465 MODIFIED FOR DSM 6577
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6708.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6708.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005562
 name: medium_465_modified_for_dsm_6708
 original_name: MEDIUM 465 MODIFIED FOR DSM 6708
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6708.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6708.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6708
 original_name: MEDIUM 465 MODIFIED FOR DSM 6708
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6708

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6985.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6985.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005563
 name: medium_465_modified_for_dsm_6985
 original_name: MEDIUM 465 MODIFIED FOR DSM 6985
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6985.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6985.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6985
 original_name: MEDIUM 465 MODIFIED FOR DSM 6985
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6985

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6986.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6986.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_6986
 original_name: MEDIUM 465 MODIFIED FOR DSM 6986
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_6986

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6986.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_6986.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005564
 name: medium_465_modified_for_dsm_6986
 original_name: MEDIUM 465 MODIFIED FOR DSM 6986
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_7005.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_7005.yaml
@@ -3,7 +3,7 @@ name: medium_465_modified_for_dsm_7005
 original_name: MEDIUM 465 MODIFIED FOR DSM 7005
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465_7005

--- a/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_7005.yaml
+++ b/data/normalized_yaml/bacterial/medium_465_modified_for_dsm_7005.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005565
 name: medium_465_modified_for_dsm_7005
 original_name: MEDIUM 465 MODIFIED FOR DSM 7005
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465b_modified_for_dsm_6824.yaml
+++ b/data/normalized_yaml/bacterial/medium_465b_modified_for_dsm_6824.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005568
 name: medium_465b_modified_for_dsm_6824
 original_name: MEDIUM 465b MODIFIED FOR DSM 6824
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_465b_modified_for_dsm_6824.yaml
+++ b/data/normalized_yaml/bacterial/medium_465b_modified_for_dsm_6824.yaml
@@ -3,7 +3,7 @@ name: medium_465b_modified_for_dsm_6824
 original_name: MEDIUM 465b MODIFIED FOR DSM 6824
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 465b_6824

--- a/data/normalized_yaml/bacterial/medium_with_biphenyl.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_biphenyl.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001571
 name: medium_with_biphenyl
 original_name: MEDIUM WITH BIPHENYL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_with_biphenyl.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_biphenyl.yaml
@@ -3,7 +3,7 @@ name: medium_with_biphenyl
 original_name: MEDIUM WITH BIPHENYL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 457d

--- a/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid.yaml
@@ -3,7 +3,7 @@ name: medium_with_chloroacrylic_acid
 original_name: MEDIUM WITH CHLOROACRYLIC ACID
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 457c

--- a/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001570
 name: medium_with_chloroacrylic_acid
 original_name: MEDIUM WITH CHLOROACRYLIC ACID
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005460
 name: medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose
 original_name: MEDIUM WITH CHLOROACRYLIC ACID_replace_3-chloroacrylic acid_with_Glucose
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose.yaml
@@ -3,7 +3,7 @@ name: medium_with_chloroacrylic_acid_replace_3_chloroacrylic_acid_with_glucose
 original_name: MEDIUM WITH CHLOROACRYLIC ACID_replace_3-chloroacrylic acid_with_Glucose
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457c_replace_3-chloroacrylic acid_with_Glucose

--- a/data/normalized_yaml/bacterial/medium_with_fluoranthene_or_phenanthrene.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_fluoranthene_or_phenanthrene.yaml
@@ -3,7 +3,7 @@ name: medium_with_fluoranthene_or_phenanthrene
 original_name: MEDIUM WITH FLUORANTHENE OR PHENANTHRENE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: KOMODO Medium 457b

--- a/data/normalized_yaml/bacterial/medium_with_fluoranthene_or_phenanthrene.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_fluoranthene_or_phenanthrene.yaml
@@ -2,7 +2,7 @@ id: CultureMech:005459
 name: medium_with_fluoranthene_or_phenanthrene
 original_name: MEDIUM WITH FLUORANTHENE OR PHENANTHRENE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_with_polyhydroxybutyric_acid_as_carbon_source.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_polyhydroxybutyric_acid_as_carbon_source.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001603
 name: medium_with_polyhydroxybutyric_acid_as_carbon_source
 original_name: MEDIUM WITH POLYHYDROXYBUTYRIC ACID AS CARBON SOURCE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/medium_with_polyhydroxybutyric_acid_as_carbon_source.yaml
+++ b/data/normalized_yaml/bacterial/medium_with_polyhydroxybutyric_acid_as_carbon_source.yaml
@@ -3,7 +3,7 @@ name: medium_with_polyhydroxybutyric_acid_as_carbon_source
 original_name: MEDIUM WITH POLYHYDROXYBUTYRIC ACID AS CARBON SOURCE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 474

--- a/data/normalized_yaml/bacterial/mineral_medium_with_2_chlorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_2_chlorobenzoate.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_2_chlorobenzoate
 original_name: MINERAL MEDIUM WITH 2-CHLOROBENZOATE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.4
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_2_chlorobenzoate.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_2_chlorobenzoate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001568
 name: mineral_medium_with_2_chlorobenzoate
 original_name: MINERAL MEDIUM WITH 2-CHLOROBENZOATE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 ph_value: 7.4

--- a/data/normalized_yaml/bacterial/mineral_medium_with_2_hydroxybiphenyl.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_2_hydroxybiphenyl.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001586
 name: mineral_medium_with_2_hydroxybiphenyl
 original_name: MINERAL MEDIUM WITH 2-HYDROXYBIPHENYL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_2_hydroxybiphenyl.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_2_hydroxybiphenyl.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_2_hydroxybiphenyl
 original_name: MINERAL MEDIUM WITH 2-HYDROXYBIPHENYL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465a

--- a/data/normalized_yaml/bacterial/mineral_medium_with_3_aminophenol.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_3_aminophenol.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_3_aminophenol
 original_name: MINERAL MEDIUM WITH 3-AMINOPHENOL
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465f

--- a/data/normalized_yaml/bacterial/mineral_medium_with_3_aminophenol.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_3_aminophenol.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001591
 name: mineral_medium_with_3_aminophenol
 original_name: MINERAL MEDIUM WITH 3-AMINOPHENOL
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_atrazin.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_atrazin.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_atrazin
 original_name: MINERAL MEDIUM WITH ATRAZIN
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465i

--- a/data/normalized_yaml/bacterial/mineral_medium_with_atrazin.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_atrazin.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001594
 name: mineral_medium_with_atrazin
 original_name: MINERAL MEDIUM WITH ATRAZIN
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_dibenzofuran.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_dibenzofuran.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_dibenzofuran
 original_name: MINERAL MEDIUM WITH DIBENZOFURAN
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 457e

--- a/data/normalized_yaml/bacterial/mineral_medium_with_dibenzofuran.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_dibenzofuran.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001572
 name: mineral_medium_with_dibenzofuran
 original_name: MINERAL MEDIUM WITH DIBENZOFURAN
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_pcp.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_pcp.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001587
 name: mineral_medium_with_pcp
 original_name: MINERAL MEDIUM WITH PCP
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineral_medium_with_pcp.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_pcp.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_pcp
 original_name: MINERAL MEDIUM WITH PCP
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465b

--- a/data/normalized_yaml/bacterial/mineral_medium_with_sulfobenzoic_acid.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_sulfobenzoic_acid.yaml
@@ -3,7 +3,7 @@ name: mineral_medium_with_sulfobenzoic_acid
 original_name: MINERAL MEDIUM WITH SULFOBENZOIC ACID
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465e

--- a/data/normalized_yaml/bacterial/mineral_medium_with_sulfobenzoic_acid.yaml
+++ b/data/normalized_yaml/bacterial/mineral_medium_with_sulfobenzoic_acid.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001590
 name: mineral_medium_with_sulfobenzoic_acid
 original_name: MINERAL MEDIUM WITH SULFOBENZOIC ACID
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineralmedium_with_6_methylnicotinate.yaml
+++ b/data/normalized_yaml/bacterial/mineralmedium_with_6_methylnicotinate.yaml
@@ -2,7 +2,7 @@ id: CultureMech:001593
 name: mineralmedium_with_6_methylnicotinate
 original_name: MINERALMEDIUM WITH 6-METHYLNICOTINATE
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:

--- a/data/normalized_yaml/bacterial/mineralmedium_with_6_methylnicotinate.yaml
+++ b/data/normalized_yaml/bacterial/mineralmedium_with_6_methylnicotinate.yaml
@@ -3,7 +3,7 @@ name: mineralmedium_with_6_methylnicotinate
 original_name: MINERALMEDIUM WITH 6-METHYLNICOTINATE
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: SOLID_AGAR
 media_term:
   preferred_term: DSMZ Medium 465h

--- a/data/normalized_yaml/bacterial/td3_medium.yaml
+++ b/data/normalized_yaml/bacterial/td3_medium.yaml
@@ -3,7 +3,7 @@ name: td3_medium
 original_name: TD3 MEDIUM
 category: bacterial
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ph_value: 7.5
 media_term:

--- a/data/normalized_yaml/bacterial/td3_medium.yaml
+++ b/data/normalized_yaml/bacterial/td3_medium.yaml
@@ -2,7 +2,7 @@ id: CultureMech:002753
 name: td3_medium
 original_name: TD3 MEDIUM
 category: bacterial
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ph_value: 7.5

--- a/data/normalized_yaml/specialized/caac.yaml
+++ b/data/normalized_yaml/specialized/caac.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:015500
 name: CAAc
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/specialized/caac.yaml
+++ b/data/normalized_yaml/specialized/caac.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:015500
 name: CAAc
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Na2HPO4

--- a/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum.yaml
+++ b/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:015732
 name: RPMI with Fetal bovine serum
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Glycine

--- a/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum.yaml
+++ b/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:015732
 name: RPMI with Fetal bovine serum
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum_conditioned.yaml
+++ b/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum_conditioned.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:015733
 name: RPMI with Fetal bovine serum Conditioned
 medium_type: DEFINED
-composition_type: DEFINED
+composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:
 - preferred_term: Glycine

--- a/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum_conditioned.yaml
+++ b/data/normalized_yaml/specialized/rpmi_with_fetal_bovine_serum_conditioned.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:015733
 name: RPMI with Fetal bovine serum Conditioned
-medium_type: DEFINED
+medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID
 ingredients:

--- a/project.justfile
+++ b/project.justfile
@@ -111,6 +111,15 @@ enrich-edison-response *args="":
 prioritize-deep-research-candidates *args="":
     uv run --extra dev python scripts/prioritize_deep_research_candidates.py {{args}}
 
+# Find records whose composition_type contradicts their own ingredient list (#158):
+# `DEFINED` asserted while listing yeast extract, peptone, tryptone etc. Reports by
+# default; `--apply` restamps only records carrying >= 5 g/L of undefined material,
+# where SEMI_DEFINED's "a small amount" cannot apply. Writes:
+#   data/import_tracking/reports/composition_type_conflicts.tsv
+[group('QC')]
+audit-composition-type *args="":
+    uv run --extra dev python scripts/audit_composition_type.py {{args}}
+
 # Triage recipes that share a filename across category directories (#116).
 # Classifies each collision IDENTICAL / EQUIVALENT / DIFFERENT so the manual
 # curation pass is tractable. Read-only — moves, renames and deletes are

--- a/scripts/audit_composition_type.py
+++ b/scripts/audit_composition_type.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Find records whose composition_type contradicts their own ingredient list (#158).
+
+`MediumCompositionTypeEnum.DEFINED` means "every component and its exact quantity
+is known". 285 records assert it while listing yeast extract, peptone, tryptone
+or similar — components that are chemically undefined by definition.
+
+The error predates #148: the migration faithfully mapped `medium_type: DEFINED`
+onto `composition_type: DEFINED` and invented nothing. What changed is that the
+new slot's description states plainly what DEFINED means, which makes the
+contradiction checkable.
+
+## Only one direction is decidable
+
+Detection rests on a finite list of undefined-component names, and that asymmetry
+matters:
+
+  * A record containing "yeast extract" **cannot** be DEFINED. Presence is proof.
+  * A record containing none of these names is **not thereby** defined — the list
+    is not exhaustive, and an unrecognised extract simply is not matched.
+
+So this script only ever reports and repairs the DEFINED direction. The 1,894
+UNDEFINED records with no recognised undefined component are NOT evidence of
+mislabelling and are deliberately left alone; confirming those needs per-record
+curation, not a word list.
+
+## Choosing between UNDEFINED and SEMI_DEFINED
+
+`SEMI_DEFINED` is "predominantly defined ... supplemented with a small amount of
+one or more undefined components". That is a quantitative claim, so the total
+undefined mass decides it, and the corpus splits cleanly:
+
+    >= 5 g/L   239 records    unambiguously UNDEFINED
+    1-5 g/L     31
+    0.5-1 g/L    6
+    < 0.5 g/L    8            plausibly SEMI_DEFINED
+    unmeasured   1
+
+`--apply` restamps only records at or above `--undefined-threshold` (default
+5 g/L), where no reasonable reading calls 5 g/L of peptone "a small amount". The
+remainder are reported for a curator: whether a 1-5 g/L supplement is SEMI_DEFINED
+is a judgement about the medium, not something a threshold settles.
+
+Usage::
+
+    just audit-composition-type              # report
+    just audit-composition-type --apply      # restamp the unambiguous ones
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "composition_type_conflicts.tsv"
+DEFAULT_THRESHOLD = 5.0
+
+# Chemically undefined components: biological extracts and enzymatic digests whose
+# exact composition is not known. Matched on `preferred_term`, which is where the
+# corpus carries the human-readable name.
+UNDEFINED_COMPONENT = re.compile(
+    r"\b(yeast extract|peptone|tryptone|trypticase|casamino|casein hydrolysate|"
+    r"beef extract|meat extract|malt extract|liver extract|proteose|soytone|"
+    r"brain[- ]heart|tryptic soy|rumen fluid|blood|serum)\b",
+    re.I,
+)
+
+
+def _display(path: Path) -> str:
+    """Show `path` relative to the repo when possible, else absolute.
+
+    `Path.relative_to` raises when the target is outside REPO — which a caller
+    passing --out to a scratch directory will hit. Crashing on the way to
+    printing a filename would abort the run before --apply did anything.
+    """
+    try:
+        return str(path.relative_to(REPO))
+    except ValueError:
+        return str(path)
+
+
+def undefined_components(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        ing for ing in doc.get("ingredients") or []
+        if isinstance(ing, dict)
+        and UNDEFINED_COMPONENT.search(str(ing.get("preferred_term") or ""))
+    ]
+
+
+def undefined_mass(ingredients: list[dict[str, Any]]) -> float | None:
+    """Total g/L of the undefined components, or None if any is unquantified.
+
+    None rather than a partial sum: a record with an unmeasured extract cannot be
+    placed against a mass threshold, and guessing low would silently restamp it.
+    """
+    total = 0.0
+    for ing in ingredients:
+        conc = ing.get("concentration") or {}
+        if str(conc.get("unit")) != "G_PER_L":
+            return None
+        try:
+            total += float(conc.get("value"))
+        except (TypeError, ValueError):
+            return None
+    return total
+
+
+def audit(normalized: Path = NORMALIZED) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        if str(doc.get("composition_type")) != "DEFINED":
+            continue
+        hits = undefined_components(doc)
+        if not hits:
+            continue
+        mass = undefined_mass(hits)
+        rows.append({
+            "file_path": str(path.relative_to(normalized)),
+            "record_id": str(doc.get("id") or ""),
+            "name": str(doc.get("name") or ""),
+            "undefined_components": "; ".join(
+                str(i.get("preferred_term")) for i in hits),
+            "n_undefined": str(len(hits)),
+            "undefined_g_per_l": "" if mass is None else f"{mass:g}",
+            "_path": path,
+            "_mass": mass,
+        })
+    return rows
+
+
+def restamp(path: Path, new_value: str) -> bool:
+    """Rewrite the composition_type line in place, leaving all other lines byte-identical."""
+    text = path.read_text()
+    updated, n = re.subn(r"^composition_type:.*$", f"composition_type: {new_value}",
+                         text, count=1, flags=re.M)
+    if n:
+        path.write_text(updated)
+    return bool(n)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--undefined-threshold", type=float, default=DEFAULT_THRESHOLD,
+                    help="g/L of undefined components at or above which UNDEFINED is "
+                         "unambiguous (default: 5.0)")
+    ap.add_argument("--apply", action="store_true",
+                    help="restamp records at or above the threshold to UNDEFINED")
+    args = ap.parse_args(argv)
+
+    rows = audit(args.normalized_dir)
+    clear = [r for r in rows if r["_mass"] is not None and r["_mass"] >= args.undefined_threshold]
+    borderline = [r for r in rows if r["_mass"] is not None and r["_mass"] < args.undefined_threshold]
+    unmeasured = [r for r in rows if r["_mass"] is None]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
+            "file_path", "record_id", "name", "undefined_components",
+            "n_undefined", "undefined_g_per_l", "verdict"])
+        w.writeheader()
+        for r in rows:
+            verdict = ("UNDEFINED" if r in clear
+                       else "CURATOR: SEMI_DEFINED?" if r in borderline
+                       else "CURATOR: unquantified")
+            w.writerow({k: v for k, v in r.items() if not k.startswith("_")} | {"verdict": verdict})
+
+    print(f"DEFINED records containing an undefined component: {len(rows)}")
+    print(f"  >= {args.undefined_threshold:g} g/L — unambiguously UNDEFINED : {len(clear)}")
+    print(f"  <  {args.undefined_threshold:g} g/L — curator call (SEMI_DEFINED?): {len(borderline)}")
+    print(f"  unquantified undefined component            : {len(unmeasured)}")
+    print(f"\nWrote {_display(args.out)}")
+
+    if not args.apply:
+        print("\nReport only. Re-run with --apply to restamp the unambiguous ones.")
+        return 0
+
+    changed = sum(restamp(r["_path"], "UNDEFINED") for r in clear)
+    print(f"\nRestamped {changed} record(s) DEFINED -> UNDEFINED.")
+    print(f"Left {len(borderline) + len(unmeasured)} for curation — see the report.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_composition_type.py
+++ b/tests/test_composition_type.py
@@ -1,0 +1,134 @@
+"""Guard that composition_type does not contradict the ingredient list (#158).
+
+`MediumCompositionTypeEnum.DEFINED` means "every component and its exact quantity
+is known". 285 records asserted it while listing yeast extract, peptone or
+tryptone — chemically undefined by definition.
+
+Only one direction is testable, and the asymmetry is the whole design:
+
+  * containing "yeast extract" **proves** a record is not DEFINED.
+  * containing none of the recognised names proves **nothing** — the list is
+    finite, and an unrecognised extract simply is not matched.
+
+So the corpus assertion below is one-directional. The 1,894 UNDEFINED records with
+no recognised undefined component are not evidence of anything and are not
+asserted on.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def act():
+    return _load("audit_composition_type")
+
+
+def _ing(name, value=None, unit="G_PER_L"):
+    d = {"preferred_term": name}
+    if value is not None:
+        d["concentration"] = {"value": value, "unit": unit}
+    return d
+
+
+# --- component detection --------------------------------------------------
+
+
+@pytest.mark.parametrize("name", [
+    "Yeast extract", "yeast extract", "Peptone", "Tryptone", "Casamino acids",
+    "Beef extract", "Meat extract", "Malt extract", "Proteose peptone",
+    "Brain-heart infusion", "Casein hydrolysate", "Soytone", "Trypticase peptone",
+])
+def test_undefined_components_are_detected(act, name):
+    assert act.undefined_components({"ingredients": [_ing(name, "5")]}), name
+
+
+@pytest.mark.parametrize("name", [
+    "Glucose", "NaCl", "Agar", "MgSO4 x 7 H2O", "Distilled water",
+    "Ammonium sulfate", "Sodium molybdate",
+])
+def test_defined_chemicals_are_not_flagged(act, name):
+    """False positives here would restamp correctly-DEFINED media."""
+    assert not act.undefined_components({"ingredients": [_ing(name, "5")]})
+
+
+def test_malformed_ingredients_do_not_crash(act):
+    doc = {"ingredients": [_ing("Yeast extract", "5"), "not-a-dict", None]}
+    assert len(act.undefined_components(doc)) == 1
+
+
+# --- mass, which decides UNDEFINED vs SEMI_DEFINED ------------------------
+
+
+def test_mass_sums_the_undefined_components(act):
+    ings = [_ing("Peptone", "5"), _ing("Yeast extract", "3")]
+    assert act.undefined_mass(ings) == 8.0
+
+
+def test_unquantified_component_yields_none_not_a_partial_sum(act):
+    """Guessing low here would silently restamp a record on incomplete data."""
+    ings = [_ing("Peptone", "5"), _ing("Yeast extract")]
+    assert act.undefined_mass(ings) is None
+
+
+def test_non_gpl_unit_yields_none(act):
+    assert act.undefined_mass([_ing("Yeast extract", "500", "MG_PER_L")]) is None
+
+
+def test_unparseable_value_yields_none(act):
+    assert act.undefined_mass([_ing("Yeast extract", "trace")]) is None
+
+
+# --- restamp is surgical --------------------------------------------------
+
+
+def test_restamp_changes_only_the_composition_type_line(act, tmp_path):
+    p = tmp_path / "r.yaml"
+    p.write_text("id: CultureMech:1\ncomposition_type: DEFINED\nname: x\n"
+                 "notes: 'mentions composition_type: DEFINED in prose'\n")
+    assert act.restamp(p, "UNDEFINED")
+    lines = p.read_text().splitlines()
+    assert lines[1] == "composition_type: UNDEFINED"
+    assert lines[3].endswith("in prose'"), "prose mentioning the slot must be untouched"
+
+
+def test_restamp_reports_false_when_slot_absent(act, tmp_path):
+    p = tmp_path / "r.yaml"
+    p.write_text("id: CultureMech:1\nname: x\n")
+    assert act.restamp(p, "UNDEFINED") is False
+
+
+# --- the corpus -----------------------------------------------------------
+
+
+def test_no_defined_record_carries_a_bulk_undefined_component(act):
+    """One-directional by design — see the module docstring.
+
+    The threshold matches the repair: at >= 5 g/L, no reading of SEMI_DEFINED's
+    "a small amount" applies, so DEFINED is unambiguously wrong.
+    """
+    offenders = [
+        (r["file_path"], r["undefined_g_per_l"])
+        for r in act.audit()
+        if r["_mass"] is not None and r["_mass"] >= act.DEFAULT_THRESHOLD
+    ]
+    assert not offenders, (
+        f"{len(offenders)} record(s) assert composition_type: DEFINED while carrying "
+        f">= {act.DEFAULT_THRESHOLD:g} g/L of chemically undefined components "
+        f"(e.g. {offenders[:3]}) — run `just audit-composition-type --apply`"
+    )

--- a/tests/test_composition_type.py
+++ b/tests/test_composition_type.py
@@ -132,3 +132,38 @@ def test_no_defined_record_carries_a_bulk_undefined_component(act):
         f">= {act.DEFAULT_THRESHOLD:g} g/L of chemically undefined components "
         f"(e.g. {offenders[:3]}) — run `just audit-composition-type --apply`"
     )
+
+
+def test_medium_type_and_composition_type_do_not_contradict():
+    """The deprecated slot must not disagree with the live one (#165).
+
+    `medium_type` is deprecated and #154 removed its last reader, but it is still
+    present on 11,092 records and still schema-valid, so a reader could pick it
+    up. Restamping only `composition_type` in #164 broke this invariant on 239
+    records — 0 disagreements before, 239 after — which is how this test came to
+    exist.
+
+    Mapping is the schema's own: `composition_type: UNDEFINED` "replaces the
+    deprecated MediumTypeEnum value COMPLEX".
+
+    Dropping `medium_type` from the corpus entirely is the better long-term fix
+    and is tracked in #165; this only holds the line until then.
+    """
+    import yaml as _yaml
+    from record_kinds import is_solution_record
+
+    expect = {"COMPLEX": "UNDEFINED", "DEFINED": "DEFINED"}
+    bad = []
+    for path in (REPO_ROOT / "data" / "normalized_yaml").rglob("*.yaml"):
+        doc = _yaml.safe_load(path.read_text(errors="replace"))
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        mt, ct = doc.get("medium_type"), doc.get("composition_type")
+        if mt is None or ct is None:
+            continue
+        if expect.get(str(mt), str(mt)) != str(ct):
+            bad.append(f"{path.name}: medium_type={mt} composition_type={ct}")
+    assert not bad, (
+        f"{len(bad)} record(s) have a deprecated medium_type contradicting "
+        f"composition_type (e.g. {bad[:3]}) — see #165"
+    )


### PR DESCRIPTION
## The contradiction

`MediumCompositionTypeEnum.DEFINED` means *"every component and its exact quantity is known"*. **285 records** assert it while listing yeast extract, peptone, tryptone or meat extract — chemically undefined by definition.

Verified independently before acting. My count is 285 against the issue's 284; the difference is that I exclude stock-solution records via `record_kinds.is_solution_record`.

## Only one direction is decidable — this shapes everything

Detection rests on a finite list of component names:

- containing "yeast extract" **proves** a record is not DEFINED
- containing none of the listed names proves **nothing** — the list is not exhaustive, and an unrecognised extract simply isn't matched

So the **1,894 UNDEFINED records with no recognised undefined component are not treated as mislabelled** and are untouched. Confirming those needs per-record curation, not a word list. The audit, the repair and the corpus test are all one-directional for this reason.

## UNDEFINED vs SEMI_DEFINED is quantitative

`SEMI_DEFINED` is *"predominantly defined … supplemented with a small amount"*. Total undefined mass splits the corpus cleanly:

| undefined mass | n | action |
|---|--:|---|
| **≥ 5 g/L** | **239** | **restamped → UNDEFINED** |
| 1–5 g/L | 31 | left for curation |
| 0.5–1 g/L | 6 | left for curation |
| < 0.5 g/L | 8 | plausibly SEMI_DEFINED |
| unquantified | 1 | left for curation |

5 g/L of peptone is not "a small amount" under any reading. Whether a 1–5 g/L supplement is `SEMI_DEFINED` is a judgement about the medium, so the remaining **46** are in the report with a per-record verdict column rather than guessed at.

## The canary caught a real bug

Before touching 239 records I ran one end to end, and it **crashed**: `args.out.relative_to(REPO)` raises when `--out` points outside the repo, aborting before `--apply` did anything. Fixed with the `_display()` fallback this repo already uses elsewhere, then **re-canaried rather than fixing and fanning out in the same step**.

The second canary verified *side effects*, not the exit code: slot changed, every other line byte-identical, record still validates, report on disk and non-empty.

## Verification

- 28 new tests, including that `restamp()` leaves prose mentioning `composition_type: DEFINED` untouched
- Corpus assertion fails if any record is reverted — verified by reverting one
- `validate-strict data/normalized_yaml/bacterial` — 14,305 files, 0 errors
- Suite: 831 passed, 2 skipped

**Does not close #158** — 46 records remain for curation, and the UNDEFINED direction is deliberately unexamined.

Review follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)