### PR TITLE
Gate implausible concentrations at the known backlog (#150)

### DIFF
--- a/data/import_tracking/reports/concentration_plausibility.tsv
+++ b/data/import_tracking/reports/concentration_plausibility.tsv
@@ -42,6 +42,12 @@ TRACE_SALT_AS_STOCK	bacterial/8kg_4_medium.yaml	CultureMech:003180	FeCl3 x 6 H2O
 TRACE_SALT_AS_STOCK	bacterial/9k_medium.yaml	CultureMech:003277	FeSO4 x 7 H2O	49.9501	G_PER_L	49.9501 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/CCAP_C18_BG11₀.yaml	CultureMech:000325	H3BO3	2.86	G_PER_L	2.86 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/CCAP_C18_BG11₀.yaml	CultureMech:000325	MnCl2 x 4 H2O	1.81	G_PER_L	1.81 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+TRACE_SALT_AS_STOCK	bacterial/DSMZ_1014_THIOALKALIVIBRIO_HALOPHILUS_MEDIUM.yaml	CultureMech:000243	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+TRACE_SALT_AS_STOCK	bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+INDICATOR_UNIT_SLIP	bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/DSMZ_1170_METHYLONATRUM_MEDIUM.yaml	CultureMech:000612	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/DSMZ_1419_HYPHOMICROBIUM_MEDIUM.yaml	CultureMech:000880	FeSO4 x 7 H2O	1.599	G_PER_L	1.599 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/DSMZ_1419_HYPHOMICROBIUM_MEDIUM.yaml	CultureMech:000880	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -63,7 +69,9 @@ INDICATOR_UNIT_SLIP	bacterial/DSMZ_1828_MWC.yaml	CultureMech:001255	Thiamine HCl
 INDICATOR_UNIT_SLIP	bacterial/DSMZ_1828_MWC.yaml	CultureMech:001255	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/DSMZ_1828_MWC.yaml	CultureMech:001255	Vitamin B12	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/DSMZ_46_PFENNIG_S_MEDIUM_I_WITH_SALT.yaml	CultureMech:001599	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+TRACE_SALT_AS_STOCK	bacterial/DSMZ_470_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000265	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/DSMZ_572_GYE_-_MEDIUM.yaml	CultureMech:001700	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
+TRACE_SALT_AS_STOCK	bacterial/DSMZ_590_DICHOTOMICROBIUM_THERMOHALOPHILUM_MEDIUM.yaml	CultureMech:000274	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/DSMZ_628_MMB_MEDIUM.yaml	CultureMech:001759	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/DSMZ_647a_DESULFUROMONAS_THIOPHILA_MEDIUM.yaml	CultureMech:001786	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/DSMZ_647a_DESULFUROMONAS_THIOPHILA_MEDIUM.yaml	CultureMech:001786	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -88,6 +96,7 @@ TRACE_SALT_AS_STOCK	bacterial/JCM_J1192_GEOTHERMOBACTER_MEDIUM.yaml	CultureMech:
 INDICATOR_UNIT_SLIP	bacterial/JCM_J1203_TREPONEMA_SACCHAROPHILUM_MEDIUM.yaml	CultureMech:002372	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/JCM_J1204_SPOROMUSA_ACIDOVORANS_MEDIUM.yaml	CultureMech:002373	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/JCM_J1204_SPOROMUSA_ACIDOVORANS_MEDIUM.yaml	CultureMech:002373	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+TRACE_SALT_AS_STOCK	bacterial/JCM_J1237_TREPONEMA_THERMOPHILUM_MEDIUM.yaml	CultureMech:000291	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/JCM_J1303_UREAPLASMA_MEDIUM.yaml	CultureMech:002467	Phenol red	200	G_PER_L	200 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/JCM_J1353_GBS_SALTS_MEDIUM_FOR_FERVIDIBACTER.yaml	CultureMech:015836	FeSO4·7H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/JCM_J1353_GBS_SALTS_MEDIUM_FOR_FERVIDIBACTER.yaml	CultureMech:015836	Na2WO4·2H2O	1.65	G_PER_L	1.65 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -116,6 +125,7 @@ TRACE_SALT_AS_STOCK	bacterial/JCM_J370_TEPIDANAEROBACTER_MEDIUM.yaml	CultureMech
 TRACE_SALT_AS_STOCK	bacterial/JCM_J381_TRICHOCOCCUS_MEDIUM.yaml	CultureMech:002738	Na2WO4 x 2 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/JCM_J383_DESULFOBACTERIUM_MEDIUM.yaml	CultureMech:002740	Na2SeO3	3	G_PER_L	3 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/JCM_J383_DESULFOBACTERIUM_MEDIUM.yaml	CultureMech:002740	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+TRACE_SALT_AS_STOCK	bacterial/JCM_J433_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000297	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/JCM_J434_ANAEROLINEA_MEDIUM.yaml	CultureMech:002785	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/JCM_J436_VY_2_AGAR.yaml	CultureMech:002787	Sea water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/JCM_J470_VULCANIBACILLUS_MEDIUM.yaml	CultureMech:002819	FeSO4 x 7 H2O	1.0978474	G_PER_L	1.09785 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -4628,6 +4638,7 @@ TRACE_SALT_AS_STOCK	bacterial/desulfocapsa_sulfexigens_medium.yaml	CultureMech:0
 TRACE_SALT_AS_STOCK	bacterial/desulfocapsa_sulfexigens_medium.yaml	CultureMech:001295	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfocastaena_medium.yaml	CultureMech:001492	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfocastaena_medium.yaml	CultureMech:001492	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+TRACE_SALT_AS_STOCK	bacterial/desulfocella_halophila_medium.yaml	CultureMech:000283	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfocella_medium.yaml	CultureMech:002422	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfofaba_hansenii_medium.yaml	CultureMech:002084	FeCl2 x 4 H2O	53.5	G_PER_L	53.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfofaba_hansenii_medium.yaml	CultureMech:002084	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -8322,6 +8333,7 @@ INDICATOR_UNIT_SLIP	bacterial/petrothermobacter_medium.yaml	CultureMech:008708	F
 INDICATOR_UNIT_SLIP	bacterial/petrothermobacter_medium.yaml	CultureMech:008708	Vitamin B12	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/petrothermobacter_medium.yaml	CultureMech:008708	Riboflavin	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/petrothermobacter_medium.yaml	CultureMech:008708	Nicotinic acid	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/petrotoga_halophila_medium.yaml	CultureMech:000279	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/petrotoga_medium.yaml	CultureMech:001856	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 WATER_AS_VOLUME	bacterial/pfennig_s_medium.yaml	CultureMech:008863	Distilled water	1051.0	G_PER_L	1051 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/pfennig_s_medium.yaml	CultureMech:008863	Na2MoO4.2H2O	18	G_PER_L	18 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -8655,6 +8667,8 @@ TRACE_SALT_AS_STOCK	bacterial/spirochaeta_medium.yaml	CultureMech:003198	FeCl2 x
 TRACE_SALT_AS_STOCK	bacterial/spirochaeta_ri_19_b1_medium.yaml	CultureMech:001643	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/spirochaeta_ri_19_b1_medium.yaml	CultureMech:001643	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/spirochaeta_sp_medium.yaml	CultureMech:000723	Resazurin	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+TRACE_SALT_AS_STOCK	bacterial/spirochaeta_thermophila_medium.yaml	CultureMech:000268	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+INDICATOR_UNIT_SLIP	bacterial/spirochaeta_thermophila_medium.yaml	CultureMech:000268	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/spirochete_thermophile_medium.yaml	CultureMech:005711	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/spirochete_thermophile_medium.yaml	CultureMech:005711	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/spirulina_ogawa_terui_sot_medium.yaml	CultureMech:008795	H3BO3	2.86	G_PER_L	2.86 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -8665,6 +8679,7 @@ TRACE_SALT_AS_STOCK	bacterial/sporobacter_medium.yaml	CultureMech:001849	FeCl2 x
 INDICATOR_UNIT_SLIP	bacterial/sporobacter_medium.yaml	CultureMech:001849	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/sporohalobacter_lortetii_medium.yaml	CultureMech:001420	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/sporolituus_medium.yaml	CultureMech:000695	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+TRACE_SALT_AS_STOCK	bacterial/sporolituus_thermophilus_medium.yaml	CultureMech:000303	FeSO4 x 7 H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/sporomusa_acidovorans_medium.yaml	CultureMech:001412	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/sporomusa_acidovorans_medium.yaml	CultureMech:001412	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/sporomusa_medium.yaml	CultureMech:003076	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -9218,6 +9233,8 @@ TRACE_SALT_AS_STOCK	bacterial/thiobacillus_thyasiris_and_t_halophilus_medium.yam
 TRACE_SALT_AS_STOCK	bacterial/thiobacillus_thyasiris_and_t_halophilus_medium.yaml	CultureMech:005607	MnCl2 x 4 H2O	2.5	G_PER_L	2.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/thiobacillus_thyasiris_and_t_halophilus_medium.yaml	CultureMech:005607	FeSO4 x 7 H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/thiobacter_mj_medium.yaml	CultureMech:000428	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/thiocapsa_halophila_medium.yaml	CultureMech:000272	Vitamin B12	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+TRACE_SALT_AS_STOCK	bacterial/thiocapsa_halophila_medium.yaml	CultureMech:000272	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/thiocapsa_medium.yaml	CultureMech:002993	Vitamin B12	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thiofaba_medium.yaml	CultureMech:000550	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thiogranum_medium.yaml	CultureMech:001047	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -9243,6 +9260,11 @@ INDICATOR_UNIT_SLIP	bacterial/thiohalorhabdus_denitrificans_medium.yaml	CultureM
 INDICATOR_UNIT_SLIP	bacterial/thiohalorhabdus_denitrificans_medium.yaml	CultureMech:000488	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thiohalorhabdus_denitrificans_medium.yaml	CultureMech:000488	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thiohalospira_alkaliphila_medium.yaml	CultureMech:000687	Vitamin B12	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+TRACE_SALT_AS_STOCK	bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
+INDICATOR_UNIT_SLIP	bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
+INDICATOR_UNIT_SLIP	bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/thiomicrorhabdus_medium.yaml	CultureMech:000893	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/thiomicrorhabdus_medium.yaml	CultureMech:000893	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thiomicrorhabdus_medium.yaml	CultureMech:000893	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -9833,7 +9855,6 @@ TRACE_SALT_AS_STOCK	archaea/JCM_J1149_METHANOMASSILIICOCCUS_ALVUS_MEDIUM.yaml	Cu
 TRACE_SALT_AS_STOCK	archaea/JCM_J230_METHANOSARCINA_MEDIUM.yaml	CultureMech:002591	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/JCM_J243_METHANOTHRIX_MEDIUM.yaml	CultureMech:002604	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/JCM_J283_FERROPLASMA_ACIDIPHILUM_MEDIUM.yaml	CultureMech:002641	FeSO4 x 7 H2O	25	G_PER_L	25 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/JCM_J433_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000297	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/JCM_J507_METHANOCELLA_MEDIUM.yaml	CultureMech:002857	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/JCM_J911_METHANOCELLA_CONRADII_MEDIUM.yaml	CultureMech:003260	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/JCM_J911_METHANOCELLA_CONRADII_MEDIUM.yaml	CultureMech:003260	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -10822,11 +10843,9 @@ TRACE_SALT_AS_STOCK	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	FeCl2
 INDICATOR_UNIT_SLIP	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	Thiamine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/conexivisphaera_medium.yaml	CultureMech:001193	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/desulfocella_halophila_medium.yaml	CultureMech:000283	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/desulfurococcus_amylolyticus_medium.yaml	CultureMech:002548	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/desulfurococcus_medium.yaml	CultureMech:001502	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/desulfurococcus_medium.yaml	CultureMech:001502	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/dichotomicrobium_thermohalophilum_medium.yaml	CultureMech:000274	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/ferroglobus_placidus_medium.yaml	CultureMech:001865	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/ferroplasma_acidiphilum_medium.yaml	CultureMech:002032	FeSO4 x 7 H2O	500	G_PER_L	500 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/ferroplasma_acidiphilum_medium.yaml	CultureMech:002032	FeCl3 x 6 H2O	1.93	G_PER_L	1.93 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -11265,9 +11284,7 @@ INDICATOR_UNIT_SLIP	archaea/palaeococcus_medium.yaml	CultureMech:001479	Pyridoxi
 INDICATOR_UNIT_SLIP	archaea/peat_medium_2_for_methanobacteria.yaml	CultureMech:003271	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/peat_medium_2_for_methanobacteria.yaml	CultureMech:003271	FeCl2 x 4 H2O	1.344	G_PER_L	1.344 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/peat_medium_2_for_methanobacteria.yaml	CultureMech:003271	AlK(SO4)2 x 12 H2O	3.446	G_PER_L	3.446 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/petrotoga_halophila_medium.yaml	CultureMech:000279	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/pfennig_ignisphaera_medium.yaml	CultureMech:009692	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/pseudomonas_halophila_medium.yaml	CultureMech:000265	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/pyrobaculum_ferrireducens_medium.yaml	CultureMech:001053	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/pyrobaculum_ferrireducens_medium.yaml	CultureMech:001053	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/pyrococcus_medium_2.yaml	CultureMech:008136	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -11297,9 +11314,6 @@ TRACE_SALT_AS_STOCK	archaea/pyrolobus_medium.yaml	CultureMech:003204	ZnSO4 x 7 H
 TRACE_SALT_AS_STOCK	archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	MnCl2·4H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	Na2B4O7	4.5	G_PER_L	4.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/saccharolobus_mt_4_medium.yaml	CultureMech:001258	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/spirochaeta_thermophila_medium.yaml	CultureMech:000268	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/spirochaeta_thermophila_medium.yaml	CultureMech:000268	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/sporolituus_thermophilus_medium.yaml	CultureMech:000303	FeSO4 x 7 H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	archaea/sulfolobus_medium_anaerobic.yaml	CultureMech:008970	Distilled water	2000.0	G_PER_L	2000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	archaea/sulfolobus_medium_anaerobic.yaml	CultureMech:008970	Na2MoO4 x 2 H2O	3	G_PER_L	3 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/sulfolobus_medium_anaerobic.yaml	CultureMech:008970	MnCl2 x 4 H2O	180	G_PER_L	180 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -11352,20 +11366,6 @@ TRACE_SALT_AS_STOCK	archaea/thermoproteus_tenax_medium_2.yaml	CultureMech:008190
 TRACE_SALT_AS_STOCK	archaea/thermoproteus_tenax_medium_2.yaml	CultureMech:008190	Na2B4O7·10H2O	4.5	G_PER_L	4.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/thermoproteus_uzoniensis_medium.yaml	CultureMech:001609	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/thermosphaera_medium.yaml	CultureMech:001964	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/thioalkalivibrio_halophilus_medium.yaml	CultureMech:000243	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/thiocapsa_halophila_medium.yaml	CultureMech:000272	Vitamin B12	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/thiocapsa_halophila_medium.yaml	CultureMech:000272	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/thiohalophilus_medium.yaml	CultureMech:000244	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/thiohalophilus_medium.yaml	CultureMech:000244	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalophilus_medium.yaml	CultureMech:000244	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalophilus_medium.yaml	CultureMech:000244	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalophilus_medium.yaml	CultureMech:000244	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/treponema_thermophilum_medium.yaml	CultureMech:000291	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/wr_medium_for_methanobacteriaceae.yaml	CultureMech:003152	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	algae/2asw.yaml	CultureMech:000038	Thiamine HCl	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	algae/CCAP_TAP Medium.yaml	CultureMech:000139	ZnSO4 x 7 H2O	22	G_PER_L	22 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below

--- a/data/import_tracking/reports/concentration_plausibility_by_record.tsv
+++ b/data/import_tracking/reports/concentration_plausibility_by_record.tsv
@@ -32,7 +32,6 @@ archaea/JCM_J1149_METHANOMASSILIICOCCUS_ALVUS_MEDIUM.yaml	CultureMech:002322	1	0
 archaea/JCM_J230_METHANOSARCINA_MEDIUM.yaml	CultureMech:002591	1	0	1	0	no	no
 archaea/JCM_J243_METHANOTHRIX_MEDIUM.yaml	CultureMech:002604	1	0	1	0	no	no
 archaea/JCM_J283_FERROPLASMA_ACIDIPHILUM_MEDIUM.yaml	CultureMech:002641	1	0	1	0	no	no
-archaea/JCM_J433_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000297	1	0	1	0	no	no
 archaea/JCM_J507_METHANOCELLA_MEDIUM.yaml	CultureMech:002857	1	0	1	0	no	no
 archaea/JCM_J911_METHANOCELLA_CONRADII_MEDIUM.yaml	CultureMech:003260	4	0	1	3	no	yes
 archaea/KOMODO_1083_ACIDULIPROFUNDUM_medium.yaml	CultureMech:003735	4	0	4	0	no	yes
@@ -282,10 +281,8 @@ archaea/caldivirga_medium.yaml	CultureMech:002043	1	0	0	1	no	no
 archaea/caldococcus_medium.yaml	CultureMech:002864	3	0	3	0	no	yes
 archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	3	0	1	2	no	no
 archaea/conexivisphaera_medium.yaml	CultureMech:001193	1	0	0	1	no	no
-archaea/desulfocella_halophila_medium.yaml	CultureMech:000283	1	0	1	0	no	no
 archaea/desulfurococcus_amylolyticus_medium.yaml	CultureMech:002548	1	0	1	0	no	no
 archaea/desulfurococcus_medium.yaml	CultureMech:001502	2	0	1	1	no	no
-archaea/dichotomicrobium_thermohalophilum_medium.yaml	CultureMech:000274	1	0	1	0	no	no
 archaea/ferroglobus_placidus_medium.yaml	CultureMech:001865	1	0	0	1	no	no
 archaea/ferroplasma_acidiphilum_medium.yaml	CultureMech:002032	2	0	2	0	no	no
 archaea/fervidicoccus_fontis_medium.yaml	CultureMech:003283	1	0	1	0	no	no
@@ -432,9 +429,7 @@ archaea/nitrosotalea_aoa_fresh_water_medium_fw.yaml	CultureMech:001267	1	1	0	0	n
 archaea/norris_ferroplasma_medium.yaml	CultureMech:002877	1	0	1	0	no	no
 archaea/palaeococcus_medium.yaml	CultureMech:001479	1	0	0	1	no	no
 archaea/peat_medium_2_for_methanobacteria.yaml	CultureMech:003271	3	0	2	1	no	no
-archaea/petrotoga_halophila_medium.yaml	CultureMech:000279	1	0	0	1	no	no
 archaea/pfennig_ignisphaera_medium.yaml	CultureMech:009692	1	0	0	1	yes	no
-archaea/pseudomonas_halophila_medium.yaml	CultureMech:000265	1	0	1	0	no	no
 archaea/pyrobaculum_ferrireducens_medium.yaml	CultureMech:001053	2	0	1	1	no	no
 archaea/pyrococcus_medium_2.yaml	CultureMech:008136	2	0	1	1	yes	no
 archaea/pyrodictium_abyssi_medium.yaml	CultureMech:005709	5	0	0	5	no	yes
@@ -444,8 +439,6 @@ archaea/pyrolobus_fumarii_medium.yaml	CultureMech:001932	8	0	4	4	no	yes
 archaea/pyrolobus_medium.yaml	CultureMech:003204	4	0	4	0	no	yes
 archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	2	0	2	0	no	no
 archaea/saccharolobus_mt_4_medium.yaml	CultureMech:001258	1	0	1	0	no	no
-archaea/spirochaeta_thermophila_medium.yaml	CultureMech:000268	2	0	1	1	no	no
-archaea/sporolituus_thermophilus_medium.yaml	CultureMech:000303	1	0	1	0	no	no
 archaea/sulfolobus_medium_anaerobic.yaml	CultureMech:008970	7	1	6	0	yes	no
 archaea/sulfolobus_medium_anaerobic_for_dsm_2162.yaml	CultureMech:009226	7	1	6	0	yes	no
 archaea/sulfolobus_medium_for_dsm_5348.yaml	CultureMech:008908	7	1	6	0	yes	no
@@ -464,11 +457,6 @@ archaea/thermoproteus_tenax_medium.yaml	CultureMech:002558	3	0	3	0	no	yes
 archaea/thermoproteus_tenax_medium_2.yaml	CultureMech:008190	3	0	2	1	no	no
 archaea/thermoproteus_uzoniensis_medium.yaml	CultureMech:001609	1	0	1	0	no	no
 archaea/thermosphaera_medium.yaml	CultureMech:001964	1	0	0	1	no	no
-archaea/thioalkalivibrio_halophilus_medium.yaml	CultureMech:000243	1	0	1	0	no	no
-archaea/thiocapsa_halophila_medium.yaml	CultureMech:000272	2	0	1	1	no	no
-archaea/thiohalophilus_medium.yaml	CultureMech:000244	5	0	1	4	no	yes
-archaea/thiohalospira_halophila_medium.yaml	CultureMech:000245	5	0	1	4	no	yes
-archaea/treponema_thermophilum_medium.yaml	CultureMech:000291	1	0	1	0	no	no
 archaea/wr_medium_for_methanobacteriaceae.yaml	CultureMech:003152	1	0	1	0	no	no
 bacterial/0_01_lb_seawater_medium.yaml	CultureMech:002439	4	1	0	3	no	yes
 bacterial/0_3_x_hyphomicrobium_medium.yaml	CultureMech:002268	3	0	2	1	no	no
@@ -490,6 +478,8 @@ bacterial/7way_8_7_medium.yaml	CultureMech:003179	1	0	1	0	no	no
 bacterial/8kg_4_medium.yaml	CultureMech:003180	1	0	1	0	no	no
 bacterial/9k_medium.yaml	CultureMech:003277	1	0	1	0	no	no
 bacterial/CCAP_C18_BG11₀.yaml	CultureMech:000325	2	0	2	0	no	no
+bacterial/DSMZ_1014_THIOALKALIVIBRIO_HALOPHILUS_MEDIUM.yaml	CultureMech:000243	1	0	1	0	no	no
+bacterial/DSMZ_1058_THIOHALOPHILUS_MEDIUM.yaml	CultureMech:000244	5	0	1	4	no	yes
 bacterial/DSMZ_1170_METHYLONATRUM_MEDIUM.yaml	CultureMech:000612	1	0	0	1	no	no
 bacterial/DSMZ_1419_HYPHOMICROBIUM_MEDIUM.yaml	CultureMech:000880	2	0	2	0	no	no
 bacterial/DSMZ_1593_Cyanobacteria_Medium_BG11.yaml	CultureMech:001070	4	0	3	1	no	yes
@@ -497,7 +487,9 @@ bacterial/DSMZ_1645_Cyanobacteria_Medium_AB-.yaml	CultureMech:001128	3	0	3	0	no	
 bacterial/DSMZ_1753_SEAWATER_MEDIUM.yaml	CultureMech:001226	1	1	0	0	no	no
 bacterial/DSMZ_1828_MWC.yaml	CultureMech:001255	9	0	6	3	no	yes
 bacterial/DSMZ_46_PFENNIG_S_MEDIUM_I_WITH_SALT.yaml	CultureMech:001599	1	0	0	1	no	no
+bacterial/DSMZ_470_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000265	1	0	1	0	no	no
 bacterial/DSMZ_572_GYE_-_MEDIUM.yaml	CultureMech:001700	1	1	0	0	no	no
+bacterial/DSMZ_590_DICHOTOMICROBIUM_THERMOHALOPHILUM_MEDIUM.yaml	CultureMech:000274	1	0	1	0	no	no
 bacterial/DSMZ_628_MMB_MEDIUM.yaml	CultureMech:001759	1	0	1	0	no	no
 bacterial/DSMZ_647a_DESULFUROMONAS_THIOPHILA_MEDIUM.yaml	CultureMech:001786	5	0	1	4	no	yes
 bacterial/DSMZ_668_FLEXIBACTER_MEDIUM.yaml	CultureMech:001809	4	1	3	0	no	yes
@@ -512,6 +504,7 @@ bacterial/JCM_J1104_HYPNOCYCLICUS_MEDIUM.yaml	CultureMech:002282	3	0	1	2	no	no
 bacterial/JCM_J1192_GEOTHERMOBACTER_MEDIUM.yaml	CultureMech:002359	1	0	1	0	no	no
 bacterial/JCM_J1203_TREPONEMA_SACCHAROPHILUM_MEDIUM.yaml	CultureMech:002372	1	0	0	1	no	no
 bacterial/JCM_J1204_SPOROMUSA_ACIDOVORANS_MEDIUM.yaml	CultureMech:002373	2	0	2	0	no	no
+bacterial/JCM_J1237_TREPONEMA_THERMOPHILUM_MEDIUM.yaml	CultureMech:000291	1	0	1	0	no	no
 bacterial/JCM_J1303_UREAPLASMA_MEDIUM.yaml	CultureMech:002467	1	0	0	1	no	no
 bacterial/JCM_J1353_GBS_SALTS_MEDIUM_FOR_FERVIDIBACTER.yaml	CultureMech:015836	2	0	2	0	no	no
 bacterial/JCM_J1357_Marinagarivorans_sp_GE09_medium.yaml	CultureMech:015838	1	0	1	0	no	no
@@ -527,6 +520,7 @@ bacterial/JCM_J330_SPOROTOMACULUM_MEDIUM.yaml	CultureMech:002689	1	0	1	0	no	no
 bacterial/JCM_J370_TEPIDANAEROBACTER_MEDIUM.yaml	CultureMech:002729	1	0	1	0	no	no
 bacterial/JCM_J381_TRICHOCOCCUS_MEDIUM.yaml	CultureMech:002738	1	0	1	0	no	no
 bacterial/JCM_J383_DESULFOBACTERIUM_MEDIUM.yaml	CultureMech:002740	2	0	2	0	no	no
+bacterial/JCM_J433_PSEUDOMONAS_HALOPHILA_MEDIUM.yaml	CultureMech:000297	1	0	1	0	no	no
 bacterial/JCM_J434_ANAEROLINEA_MEDIUM.yaml	CultureMech:002785	1	0	1	0	no	no
 bacterial/JCM_J436_VY_2_AGAR.yaml	CultureMech:002787	1	1	0	0	no	no
 bacterial/JCM_J470_VULCANIBACILLUS_MEDIUM.yaml	CultureMech:002819	4	0	4	0	no	yes
@@ -2023,6 +2017,7 @@ bacterial/desulfobulbus_sp_medium_freshwater.yaml	CultureMech:001288	2	0	1	1	no	
 bacterial/desulfobulbus_sp_medium_freshwater_for_dsm_14880.yaml	CultureMech:009098	20	1	10	9	yes	no
 bacterial/desulfocapsa_sulfexigens_medium.yaml	CultureMech:001295	2	0	2	0	no	no
 bacterial/desulfocastaena_medium.yaml	CultureMech:001492	2	0	1	1	no	no
+bacterial/desulfocella_halophila_medium.yaml	CultureMech:000283	1	0	1	0	no	no
 bacterial/desulfocella_medium.yaml	CultureMech:002422	1	0	1	0	no	no
 bacterial/desulfofaba_hansenii_medium.yaml	CultureMech:002084	2	0	1	1	no	no
 bacterial/desulfofaba_medium.yaml	CultureMech:001287	5	0	1	4	no	yes
@@ -3343,6 +3338,7 @@ bacterial/pes_provasoli_s_enriched_seawater_medium_7_psu_at_25_c.yaml	CultureMec
 bacterial/petc_medium.yaml	CultureMech:009267	15	1	6	8	yes	no
 bacterial/petc_mes_medium.yaml	CultureMech:009617	8	0	1	7	yes	no
 bacterial/petrothermobacter_medium.yaml	CultureMech:008708	18	0	10	8	yes	no
+bacterial/petrotoga_halophila_medium.yaml	CultureMech:000279	1	0	0	1	no	no
 bacterial/petrotoga_medium.yaml	CultureMech:001856	1	0	0	1	no	no
 bacterial/pfennig_s_medium.yaml	CultureMech:008863	6	1	4	1	yes	no
 bacterial/pfennigs_medium.yaml	CultureMech:003027	1	0	1	0	no	no
@@ -3508,11 +3504,13 @@ bacterial/spirochaeta_cellobiosiphila_medium.yaml	CultureMech:000630	4	0	4	0	no	
 bacterial/spirochaeta_medium.yaml	CultureMech:003198	1	0	1	0	no	no
 bacterial/spirochaeta_ri_19_b1_medium.yaml	CultureMech:001643	2	0	1	1	no	no
 bacterial/spirochaeta_sp_medium.yaml	CultureMech:000723	1	0	0	1	no	no
+bacterial/spirochaeta_thermophila_medium.yaml	CultureMech:000268	2	0	1	1	no	no
 bacterial/spirochete_thermophile_medium.yaml	CultureMech:005711	2	0	1	1	no	no
 bacterial/spirulina_ogawa_terui_sot_medium.yaml	CultureMech:008795	4	0	4	0	no	yes
 bacterial/sporobacter_medium.yaml	CultureMech:001849	2	0	1	1	no	no
 bacterial/sporohalobacter_lortetii_medium.yaml	CultureMech:001420	1	0	0	1	no	no
 bacterial/sporolituus_medium.yaml	CultureMech:000695	1	0	1	0	no	no
+bacterial/sporolituus_thermophilus_medium.yaml	CultureMech:000303	1	0	1	0	no	no
 bacterial/sporomusa_acidovorans_medium.yaml	CultureMech:001412	2	0	1	1	no	no
 bacterial/sporomusa_medium.yaml	CultureMech:003076	1	0	1	0	no	no
 bacterial/sporomusa_medium_betaine.yaml	CultureMech:001410	2	0	1	1	no	no
@@ -3710,6 +3708,7 @@ bacterial/thiobacillus_thioparus_ii_medium.yaml	CultureMech:005609	4	0	3	1	no	ye
 bacterial/thiobacillus_thioparus_tk_m_medium.yaml	CultureMech:001614	4	0	3	1	no	yes
 bacterial/thiobacillus_thyasiris_and_t_halophilus_medium.yaml	CultureMech:005607	3	0	3	0	no	yes
 bacterial/thiobacter_mj_medium.yaml	CultureMech:000428	1	0	0	1	no	no
+bacterial/thiocapsa_halophila_medium.yaml	CultureMech:000272	2	0	1	1	no	no
 bacterial/thiocapsa_medium.yaml	CultureMech:002993	1	0	0	1	no	no
 bacterial/thiofaba_medium.yaml	CultureMech:000550	1	0	0	1	no	no
 bacterial/thiogranum_medium.yaml	CultureMech:001047	1	0	0	1	no	no
@@ -3719,6 +3718,7 @@ bacterial/thiohalomonas_denitrificans_medium.yaml	CultureMech:000489	5	0	1	4	no	
 bacterial/thiohalophilus_medium.yaml	CultureMech:003641	5	0	1	4	no	yes
 bacterial/thiohalorhabdus_denitrificans_medium.yaml	CultureMech:000488	5	0	1	4	no	yes
 bacterial/thiohalospira_alkaliphila_medium.yaml	CultureMech:000687	1	0	0	1	no	no
+bacterial/thiohalospira_halophila_medium.yaml	CultureMech:000245	5	0	1	4	no	yes
 bacterial/thiomicrorhabdus_medium.yaml	CultureMech:000893	5	0	1	4	no	yes
 bacterial/thiomicrospira_pelophila_medium.yaml	CultureMech:000892	9	0	5	4	no	yes
 bacterial/thiomicrospira_psychrophila_medium.yaml	CultureMech:004156	9	0	5	4	no	yes

--- a/project.justfile
+++ b/project.justfile
@@ -141,7 +141,8 @@ audit-filename-collisions *args="":
 # records are repaired; raising it to make a run pass defeats the point.
 [group('QC')]
 audit-concentration-plausibility *args="":
-    uv run --extra dev python scripts/audit_concentration_plausibility.py {{args}}
+    uv run --extra dev python scripts/audit_concentration_plausibility.py \
+        --max-allowed 11540 {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/project.justfile
+++ b/project.justfile
@@ -134,6 +134,11 @@ audit-filename-collisions *args="":
 #   data/import_tracking/reports/concentration_plausibility.tsv            (per row)
 #   data/import_tracking/reports/concentration_plausibility_by_record.tsv  (per record,
 #     with a `flattened_cocktail` flag marking the actionable subset)
+# Baseline history (#150): 11,540 rows across 3,914 records at the time the gate
+# was added — the backlog #135's audit found and #118 never repaired. The gate
+# blocks NEW implausible concentrations without demanding the backlog be cleared
+# first, the same convention as `check-chebi-grounding`. LOWER the baseline as
+# records are repaired; raising it to make a run pass defeats the point.
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py {{args}}

--- a/scripts/audit_concentration_plausibility.py
+++ b/scripts/audit_concentration_plausibility.py
@@ -237,6 +237,11 @@ def main(argv: list[str] | None = None) -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
     ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--max-allowed", type=int, default=None,
+                    help="Exit non-zero when flagged rows exceed this baseline. Gates "
+                         "NEW defects without blocking on the existing backlog — the "
+                         "same convention as `check-chebi-grounding`. Lower it as the "
+                         "backlog is repaired; never raise it to make a run pass.")
     args = ap.parse_args(argv)
 
     rows = audit(args.normalized_dir)
@@ -277,6 +282,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Wrote {summary_path.relative_to(REPO_ROOT)}")
     print("\nRead-only. Repairing the trace-element case means nesting the cocktail "
           "under a stock `solution` object with an addition volume — per-record curation.")
+
+    if args.max_allowed is not None and len(rows) > args.max_allowed:
+        print(f"\nFAIL: {len(rows)} implausible concentration rows > baseline "
+              f"{args.max_allowed}. A new import or edit has introduced rows beyond the "
+              f"known backlog; see the report for which records.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -186,3 +186,42 @@ def test_stock_solution_records_are_excluded(corpus_findings):
     for file_path in sorted({r["file_path"] for r in corpus_findings})[:400]:
         doc = _yaml.safe_load((normalized / file_path).read_text())
         assert not is_solution_record(doc), f"solution record flagged: {file_path}"
+
+
+CONCENTRATION_BACKLOG_BASELINE = 11_540
+
+
+def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings):
+    """Gate NEW implausible concentrations without blocking on the backlog (#150).
+
+    #135 shipped the audit; the repair never happened, so 11,540 rows across
+    3,914 records are known-bad today. A guard demanding zero would fail
+    immediately and be switched off — the #129 lesson about wiring a gate to a red
+    suite. So this baselines at the current count, exactly as
+    `check-chebi-grounding --max-allowed 101` does for grounding.
+
+    LOWER this number as records are repaired. Raising it to make a run pass is
+    the one move that defeats the purpose: it would let a fresh import land the
+    same defect shape that #118 documented and #135 measured.
+    """
+    assert len(corpus_findings) <= CONCENTRATION_BACKLOG_BASELINE, (
+        f"{len(corpus_findings)} implausible concentration rows exceeds the baseline "
+        f"{CONCENTRATION_BACKLOG_BASELINE}. Something new introduced rows beyond the "
+        f"known backlog — see data/import_tracking/reports/concentration_plausibility.tsv. "
+        f"Do NOT raise the baseline to make this pass."
+    )
+
+
+def test_the_baseline_is_not_far_above_reality(corpus_findings):
+    """A baseline left far above the real count silently stops gating.
+
+    If the backlog is repaired but the number here is not lowered, this test keeps
+    passing while permitting thousands of new defects. Fails once the gap exceeds
+    10%, prompting the baseline to be tightened.
+    """
+    actual = len(corpus_findings)
+    slack = CONCENTRATION_BACKLOG_BASELINE - actual
+    assert slack <= CONCENTRATION_BACKLOG_BASELINE * 0.10, (
+        f"baseline {CONCENTRATION_BACKLOG_BASELINE} is {slack} above the actual "
+        f"{actual}; lower it to {actual} so the gate keeps biting"
+    )

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -225,3 +225,25 @@ def test_the_baseline_is_not_far_above_reality(corpus_findings):
         f"baseline {CONCENTRATION_BACKLOG_BASELINE} is {slack} above the actual "
         f"{actual}; lower it to {actual} so the gate keeps biting"
     )
+
+
+def test_justfile_baseline_matches_the_test_baseline():
+    """Two hardcoded copies of a number that is meant to change is a drift bug (#170).
+
+    The baseline lives in `project.justfile` (so `just
+    audit-concentration-plausibility` gates outside pytest) and here (so CI gates
+    without invoking just). Both must be lowered together as the backlog is
+    repaired. Miss one and either the gate stops biting or local runs fail while
+    CI passes — the same drift class as #144 and #157, which is why this asserts
+    rather than trusts.
+    """
+    import re
+
+    justfile = (REPO_ROOT / "project.justfile").read_text()
+    block = justfile.split("audit-concentration-plausibility", 1)[1][:400]
+    match = re.search(r"--max-allowed\s+(\d+)", block)
+    assert match, "the recipe no longer passes --max-allowed; it has stopped gating"
+    assert int(match.group(1)) == CONCENTRATION_BACKLOG_BASELINE, (
+        f"project.justfile gates at {match.group(1)} but this file baselines at "
+        f"{CONCENTRATION_BACKLOG_BASELINE}; lower both together"
+    )


### PR DESCRIPTION
## Scope: one of the issue's three parts, chosen because the issue says so

#150 lists three pieces of work and names the third — a validator stopping new imports reintroducing the defect — as *"arguably the highest-leverage: without it the corpus repair is a one-off sweep that decays."* This does that piece only.

## Baselined, not zeroed

The corpus holds **11,540 implausible rows across 3,914 records**, unchanged since #135 measured them. A guard demanding zero would fail on every run and be switched off within a day — the #129 lesson about wiring a gate to a red suite.

So it baselines at the current count, the convention `check-chebi-grounding --max-allowed 101` already established in this repo: **new defects fail, the known backlog does not block**.

## Guarded in both directions

A baseline gate fails two ways, and only one is obvious:

| failure | guard |
|---|---|
| count **above** baseline — something new landed | `test_implausible_row_count_does_not_exceed_the_known_backlog` |
| baseline **far above** reality — backlog repaired, number never lowered, so the gate silently permits thousands of new defects while still passing | `test_the_baseline_is_not_far_above_reality` (fails past a 10% gap) |

Verified both bite: baseline `11_000` fails the first, `99_999` fails the second.

`--max-allowed` on the script mirrors `audit_chebi_consistency.py` so the same gate can run outside pytest. The tests reuse the existing module-scoped `corpus_findings` fixture, so this adds **no extra corpus walk**.

## Incidental: 12 stale paths in the committed reports

Refreshed both reports. The finding-set is byte-identical — 11,540 rows before and after, same records, ingredients and values — but **12 `file_path`s still said `archaea/`** for records moved to `bacterial/` by #137 and #143. Verified path-only by comparing the finding-sets keyed on (record_id, ingredient, value, finding). The #145 pattern again.

## Explicitly not done

**Items 1 and 2 of the issue.** Nesting the 579 flattened cocktails under stock `solution` objects is structural per-record surgery; the 3,335 non-cocktail records need per-value judgment. Neither is a sweep to make unilaterally on scientific data.

**#150 stays open** — this stops the decay, it does not repair the corpus.

## Verification

- [x] Gate passes at 11,540, fails at 11,539 with exit 1 and an actionable message
- [x] Both test directions mutation-tested
- [x] Report delta proven path-only, not a change in findings
- [x] Suite: 837 passed, 2 skipped

Review follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)