### PR TITLE
Report the 25 unparsed NBRC compositions — and deliberately do not auto-repair them (#166)

### DIFF
--- a/data/import_tracking/reports/unparsed_compositions.tsv
+++ b/data/import_tracking/reports/unparsed_compositions.tsv
@@ -1,0 +1,26 @@
+file_path	record_id	verdict	n_recovered	detail	trailing_note
+bacterial/NBRC_1063.yaml	CultureMech:007453	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Tris-HCl buffer.
+bacterial/NBRC_1135.yaml	CultureMech:007458	PROPOSED	4	4 ingredients parsed	*Manufactured by Asahi Breweries, Ltd., Tokyo, Japan. Distributed by Tanabe Seiyaku Co. Ltd., Osaka, Japan.
+bacterial/NBRC_1158.yaml	CultureMech:007459	PROPOSED	4	4 ingredients parsed	
+bacterial/NBRC_116.yaml	CultureMech:007460	PROPOSED	8	8 ingredients parsed	
+bacterial/NBRC_1197.yaml	CultureMech:007463	HOLD: possible truncated formula	15	KH2PO, Na2HPO4·7H2O, MgSO4·7H2O, FeSO4·7H2O, MgO, CaCO, ZnSO4·7H2O, MnSO4·4H2O, CuSO4·5H2O, CoSO4·7H2O, H3BO — a trailing subscript may have been absorbed into the value; both splits round-trip	*Vanillic acid and syringic acid etc.
+bacterial/NBRC_1210.yaml	CultureMech:007464	HOLD: possible truncated formula	9	K2HPO, MgSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.2+/-0.2
+bacterial/NBRC_1287.yaml	CultureMech:007469	PROPOSED	4	4 ingredients parsed	Agar15gpH 7.0Biphenyl crystal is supplied on a lid of petri dish as vapor phase.
+bacterial/NBRC_1379.yaml	CultureMech:007475	HOLD: implausible value	5	Sucrose 500g	
+bacterial/NBRC_14.yaml	CultureMech:007476	PROPOSED	3	3 ingredients parsed	Agar15gpH 8.2*Dilute artificial seawater or natural seawater with distilled water.
+bacterial/NBRC_1401.yaml	CultureMech:007477	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 5.6
+bacterial/NBRC_229.yaml	CultureMech:007479	PROPOSED	5	5 ingredients parsed	Agar20gpH 7.3
+bacterial/NBRC_245.yaml	CultureMech:007480	PROPOSED	5	5 ingredients parsed	Agar (if needed)20gpH 7.6
+bacterial/NBRC_26.yaml	CultureMech:007482	PROPOSED	5	5 ingredients parsed	
+bacterial/NBRC_280.yaml	CultureMech:007484	PROPOSED	4	4 ingredients parsed	Agar20gpH 7.0
+bacterial/NBRC_310.yaml	CultureMech:007486	HOLD: possible truncated formula	9	K2HPO, KH2PO, MgSO4·7H2O, CaCl2·2H2O, FeSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.0
+bacterial/NBRC_355.yaml	CultureMech:007489	HOLD: possible truncated formula	5	MgSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.0*Wako Pure Chemical Ind., Ltd., Osaka, Japan.**Sterilize separately by filtration.
+bacterial/NBRC_367.yaml	CultureMech:007490	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 5.5
+bacterial/NBRC_382.yaml	CultureMech:007491	PROPOSED	5	5 ingredients parsed	Distilled water1LpH 7.0
+bacterial/NBRC_404.yaml	CultureMech:007493	HOLD: possible truncated formula	9	K2HPO, KH2PO, MgSO4·7H2O, CaCO — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 6.7±0.2
+bacterial/NBRC_804.yaml	CultureMech:007494	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 6.5 - 6.8*Wako Pure Chemical Ind., Ltd., Osaka, Japan.
+bacterial/NBRC_869.yaml	CultureMech:007500	PROPOSED	4	4 ingredients parsed	Distilled water200mlpH 7.6*Filtered, aged seawater or artificial seawater (Daigo's Artificial Seawater SP**)**Wako Pure 
+bacterial/NBRC_892.yaml	CultureMech:007502	PROPOSED	4	4 ingredients parsed	Distilled water1LpH 7.1-7.5
+bacterial/NBRC_915.yaml	CultureMech:007504	HOLD: possible truncated formula	9	K2HPO, MgSO4·7H2O, FeSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	
+bacterial/NBRC_948.yaml	CultureMech:007507	PROPOSED	3	3 ingredients parsed	Distilled water1LpH unadjusted*Sterilize separately by filtration.
+bacterial/NBRC_960.yaml	CultureMech:007508	PROPOSED	5	5 ingredients parsed	

--- a/data/import_tracking/reports/unparsed_compositions.tsv
+++ b/data/import_tracking/reports/unparsed_compositions.tsv
@@ -5,22 +5,22 @@ bacterial/NBRC_1158.yaml	CultureMech:007459	PROPOSED	4	4 ingredients parsed
 bacterial/NBRC_116.yaml	CultureMech:007460	PROPOSED	8	8 ingredients parsed	
 bacterial/NBRC_1197.yaml	CultureMech:007463	HOLD: possible truncated formula	15	KH2PO, Na2HPO4·7H2O, MgSO4·7H2O, FeSO4·7H2O, MgO, CaCO, ZnSO4·7H2O, MnSO4·4H2O, CuSO4·5H2O, CoSO4·7H2O, H3BO — a trailing subscript may have been absorbed into the value; both splits round-trip	*Vanillic acid and syringic acid etc.
 bacterial/NBRC_1210.yaml	CultureMech:007464	HOLD: possible truncated formula	9	K2HPO, MgSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.2+/-0.2
-bacterial/NBRC_1287.yaml	CultureMech:007469	PROPOSED	4	4 ingredients parsed	Agar15gpH 7.0Biphenyl crystal is supplied on a lid of petri dish as vapor phase.
+bacterial/NBRC_1287.yaml	CultureMech:007469	HOLD: ingredient remains in the tail	4	4 parsed, but the tail still holds a quantity: 'Agar15gpH 7.0Biphenyl crystal is supplied on a lid of petri '	Agar15gpH 7.0Biphenyl crystal is supplied on a lid of petri dish as vapor phase.
 bacterial/NBRC_1379.yaml	CultureMech:007475	HOLD: implausible value	5	Sucrose 500g	
-bacterial/NBRC_14.yaml	CultureMech:007476	PROPOSED	3	3 ingredients parsed	Agar15gpH 8.2*Dilute artificial seawater or natural seawater with distilled water.
+bacterial/NBRC_14.yaml	CultureMech:007476	HOLD: ingredient remains in the tail	3	3 parsed, but the tail still holds a quantity: 'Agar15gpH 8.2*Dilute artificial seawater or natural seawater'	Agar15gpH 8.2*Dilute artificial seawater or natural seawater with distilled water.
 bacterial/NBRC_1401.yaml	CultureMech:007477	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 5.6
-bacterial/NBRC_229.yaml	CultureMech:007479	PROPOSED	5	5 ingredients parsed	Agar20gpH 7.3
-bacterial/NBRC_245.yaml	CultureMech:007480	PROPOSED	5	5 ingredients parsed	Agar (if needed)20gpH 7.6
+bacterial/NBRC_229.yaml	CultureMech:007479	HOLD: ingredient remains in the tail	5	5 parsed, but the tail still holds a quantity: 'Agar20gpH 7.3'	Agar20gpH 7.3
+bacterial/NBRC_245.yaml	CultureMech:007480	HOLD: ingredient remains in the tail	5	5 parsed, but the tail still holds a quantity: 'Agar (if needed)20gpH 7.6'	Agar (if needed)20gpH 7.6
 bacterial/NBRC_26.yaml	CultureMech:007482	PROPOSED	5	5 ingredients parsed	
-bacterial/NBRC_280.yaml	CultureMech:007484	PROPOSED	4	4 ingredients parsed	Agar20gpH 7.0
+bacterial/NBRC_280.yaml	CultureMech:007484	HOLD: ingredient remains in the tail	4	4 parsed, but the tail still holds a quantity: 'Agar20gpH 7.0'	Agar20gpH 7.0
 bacterial/NBRC_310.yaml	CultureMech:007486	HOLD: possible truncated formula	9	K2HPO, KH2PO, MgSO4·7H2O, CaCl2·2H2O, FeSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.0
 bacterial/NBRC_355.yaml	CultureMech:007489	HOLD: possible truncated formula	5	MgSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 7.0*Wako Pure Chemical Ind., Ltd., Osaka, Japan.**Sterilize separately by filtration.
 bacterial/NBRC_367.yaml	CultureMech:007490	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 5.5
-bacterial/NBRC_382.yaml	CultureMech:007491	PROPOSED	5	5 ingredients parsed	Distilled water1LpH 7.0
+bacterial/NBRC_382.yaml	CultureMech:007491	HOLD: ingredient remains in the tail	5	5 parsed, but the tail still holds a quantity: 'Distilled water1LpH 7.0'	Distilled water1LpH 7.0
 bacterial/NBRC_404.yaml	CultureMech:007493	HOLD: possible truncated formula	9	K2HPO, KH2PO, MgSO4·7H2O, CaCO — a trailing subscript may have been absorbed into the value; both splits round-trip	Distilled water1LpH 6.7±0.2
 bacterial/NBRC_804.yaml	CultureMech:007494	HOLD: parse does not round-trip	0	reassembly differs from the source; the split is ambiguous (e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)	Agar (if needed)15gpH 6.5 - 6.8*Wako Pure Chemical Ind., Ltd., Osaka, Japan.
-bacterial/NBRC_869.yaml	CultureMech:007500	PROPOSED	4	4 ingredients parsed	Distilled water200mlpH 7.6*Filtered, aged seawater or artificial seawater (Daigo's Artificial Seawater SP**)**Wako Pure 
-bacterial/NBRC_892.yaml	CultureMech:007502	PROPOSED	4	4 ingredients parsed	Distilled water1LpH 7.1-7.5
+bacterial/NBRC_869.yaml	CultureMech:007500	HOLD: ingredient remains in the tail	4	4 parsed, but the tail still holds a quantity: 'Distilled water200mlpH 7.6*Filtered, aged seawater or artifi'	Distilled water200mlpH 7.6*Filtered, aged seawater or artificial seawater (Daigo's Artificial Seawater SP**)**Wako Pure 
+bacterial/NBRC_892.yaml	CultureMech:007502	HOLD: ingredient remains in the tail	4	4 parsed, but the tail still holds a quantity: 'Distilled water1LpH 7.1-7.5'	Distilled water1LpH 7.1-7.5
 bacterial/NBRC_915.yaml	CultureMech:007504	HOLD: possible truncated formula	9	K2HPO, MgSO4·7H2O, FeSO4·7H2O — a trailing subscript may have been absorbed into the value; both splits round-trip	
-bacterial/NBRC_948.yaml	CultureMech:007507	PROPOSED	3	3 ingredients parsed	Distilled water1LpH unadjusted*Sterilize separately by filtration.
+bacterial/NBRC_948.yaml	CultureMech:007507	HOLD: ingredient remains in the tail	3	3 parsed, but the tail still holds a quantity: 'Distilled water1LpH unadjusted*Sterilize separately by filtr'	Distilled water1LpH unadjusted*Sterilize separately by filtration.
 bacterial/NBRC_960.yaml	CultureMech:007508	PROPOSED	5	5 ingredients parsed	

--- a/project.justfile
+++ b/project.justfile
@@ -144,6 +144,15 @@ prioritize-deep-research-candidates *args="":
 score-review-need *args="":
     uv run --extra dev python scripts/score_review_need.py {{args}}
 
+# Turn the 25 NBRC records whose composition was crammed into one ingredient name
+# into a structured worklist (#166). REPORT ONLY — it never writes, because a parse
+# can round-trip and still be wrong: "KH2PO40.85g" splits equally well into
+# KH2PO4+0.85g and KH2PO+40.85g. Writes:
+#   data/import_tracking/reports/unparsed_compositions.tsv
+[group('QC')]
+report-unparsed-compositions *args="":
+    uv run --extra dev python scripts/repair_unparsed_compositions.py {{args}}
+
 # Find records whose composition_type contradicts their own ingredient list (#158):
 # `DEFINED` asserted while listing yeast extract, peptone, tryptone etc. Reports by
 # default; `--apply` restamps only records carrying >= 5 g/L of undefined material,

--- a/project.justfile
+++ b/project.justfile
@@ -151,7 +151,7 @@ score-review-need *args="":
 #   data/import_tracking/reports/unparsed_compositions.tsv
 [group('QC')]
 report-unparsed-compositions *args="":
-    uv run --extra dev python scripts/repair_unparsed_compositions.py {{args}}
+    uv run --extra dev python scripts/report_unparsed_compositions.py {{args}}
 
 # Find records whose composition_type contradicts their own ingredient list (#158):
 # `DEFINED` asserted while listing yeast extract, peptone, tryptone etc. Reports by

--- a/scripts/repair_unparsed_compositions.py
+++ b/scripts/repair_unparsed_compositions.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Recover ingredient lists from NBRC records whose composition was never parsed (#166).
+
+25 records under `NBRC_*` carry their entire composition block crammed into the
+first ingredient's `preferred_term`, separators stripped, plus a second empty
+ingredient:
+
+    Tryptone5gYeast extract3gNaCl10gUrea1gDistilled water1LAgar (if needed)15g
+
+The composition is recoverable, so these are not lost records — they are
+unparsed ones. #166 originally reported this as a single record; that was
+measured with a regex whose `\\b` missed the concatenated cases, and it is 25.
+
+## Splitting on the unit, not on digits
+
+Ingredient names contain digits — `Na2HPO4`, `No. 3`, `·7H2O`, `Tween 80` — so
+splitting on numbers is unsafe. The split anchors on a `<number><unit>` pair whose
+unit is followed by an uppercase letter, a bracket, whitespace, or end-of-string,
+which is where the next ingredient name begins.
+
+## Three checks — and they are why this tool does not write
+
+**Round trip.** Reassembling `name + value + unit` for every parsed item, plus the
+unconsumed tail, must reproduce the original string EXACTLY. If it does, the parse
+re-structured the text and invented nothing. This catches `Tween 800.3g` being read
+as `Tween` + `800.3` — the rebuilt string loses the space and the mismatch shows.
+
+**Plausibility.** Round trip is necessary but NOT sufficient: a wrong split can
+also reassemble. `Tween 80` + `0.3g` and `Tween` + `800.3g` both rebuild to the
+same text, and only the second is absurd. So any non-water solid above 100 g/L is
+held back for a human rather than written.
+
+**Truncated formula.** The decisive one, found by applying an earlier version of
+this script and inspecting the result. `KH2PO4` + `0.85g` concatenates to
+`KH2PO40.85g`, which splits equally well into `KH2PO` + `40.85g`. BOTH round-trip,
+and 40.85 g/L sits under the plausibility ceiling — so the first two checks pass a
+parse that writes a non-existent compound at 47x the real concentration. It
+affected 11 of 20 records an earlier run rewrote, across KH2PO4, K2HPO4, CaCO3 and
+H3BO3.
+
+The flag is a formula-shaped name ending in an uppercase letter. It cannot be used
+to auto-CORRECT, only to refuse, because it also matches `MgO`, which is a real
+compound. That asymmetry is the whole argument: the ambiguity is chemical, and
+resolving it needs the NBRC catalogue rather than a heuristic.
+
+So this tool REPORTS and never writes. It turns 25 opaque records into a
+structured worklist — proposed parse, trailing note, and the specific reason each
+held record is ambiguous — for a curator to confirm against the source.
+
+Usage::
+
+    just repair-unparsed-compositions              # report what would change
+    just repair-unparsed-compositions --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "unparsed_compositions.tsv"
+
+_QTY_UNIT = r"\d+(?:\.\d+)?\s*(?:mg|ml|kg|g|l)(?=[A-Z(\[]|\s|$)"
+MANGLED = re.compile(_QTY_UNIT + r".*?" + _QTY_UNIT)
+
+TOKEN = re.compile(
+    r"(?P<name>.+?)(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>mg|ml|kg|mM|g|L|l)"
+    r"(?=[A-Z(\[]|\s|$|\*)")
+
+UNIT_TO_ENUM = {"g": "G_PER_L", "mg": "MG_PER_L", "ml": "ML_PER_L",
+                "mM": "MILLIMOLAR"}
+
+# "Distilled water1L" is the PREPARATION VOLUME the recipe is made up to, not a
+# concentration. Writing it as a per-litre figure invents the exact defect #118
+# documents — water recorded as a solute — and in ML_PER_L, which the
+# concentration-plausibility gate does not even examine (it checks G_PER_L only).
+# So a volume basis is kept as an ingredient without a concentration, and recorded
+# in notes instead.
+VOLUME_BASIS_UNITS = {"l", "L", "kg"}
+
+# A non-water solid above this is almost certainly a bad split, not a recipe.
+IMPLAUSIBLE_G_PER_L = 100.0
+
+# A chemical formula whose trailing subscript has been eaten by the value.
+# "KH2PO4" + "0.85g" concatenates to "KH2PO40.85g", which splits equally well as
+# "KH2PO" + "40.85g" — and BOTH round-trip, so reassembly cannot tell them apart.
+# The giveaway is a formula-shaped name ending in an uppercase letter.
+#
+# This is why the tool does not write. The rule below also flags MgO, which IS a
+# real compound, so it cannot be used to auto-correct either — only to refuse.
+TRUNCATED_FORMULA = re.compile(r"^[A-Z][A-Za-z0-9()·]*[A-Z]$")
+
+
+def is_crammed(name: str) -> bool:
+    return len(name) > 40 and bool(MANGLED.search(name))
+
+
+def parse_composition(text: str) -> tuple[list[tuple[str, str, str]], str]:
+    """Return (items, unconsumed_tail). Items are (name, value, unit) as written."""
+    items: list[tuple[str, str, str]] = []
+    pos = 0
+    for m in TOKEN.finditer(text):
+        items.append((m.group("name").strip(), m.group("value"), m.group("unit")))
+        pos = m.end()
+    return items, text[pos:]
+
+
+def round_trips(text: str, items: list[tuple[str, str, str]], tail: str) -> bool:
+    """The parse must reproduce the source exactly — proof it invented nothing."""
+    return "".join(f"{n}{v}{u}" for n, v, u in items) + tail == text
+
+
+def implausible(items: list[tuple[str, str, str]]) -> list[str]:
+    bad = []
+    for name, value, unit in items:
+        if unit not in ("g", "kg"):
+            continue
+        try:
+            v = float(value)
+        except ValueError:
+            continue
+        if v > IMPLAUSIBLE_G_PER_L and "water" not in name.lower():
+            bad.append(f"{name} {value}{unit}")
+    return bad
+
+
+def assess(doc: dict[str, Any]) -> dict[str, Any] | None:
+    """Classify one record: repairable, or held back with a reason."""
+    ings = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
+    crammed = next((i for i in ings if is_crammed(str(i.get("preferred_term") or ""))), None)
+    if crammed is None:
+        return None
+    text = str(crammed.get("preferred_term"))
+    items, tail = parse_composition(text)
+
+    if not round_trips(text, items, tail):
+        return {"verdict": "HOLD: parse does not round-trip", "items": [], "tail": tail,
+                "detail": "reassembly differs from the source; the split is ambiguous "
+                          "(e.g. 'Tween 800.3g' — is 80 a grade or part of the value?)"}
+    bad = implausible(items)
+    if bad:
+        return {"verdict": "HOLD: implausible value", "items": items, "tail": tail,
+                "detail": "; ".join(bad)}
+    truncated = [n for n, _, _ in items if TRUNCATED_FORMULA.match(n)]
+    if truncated:
+        return {"verdict": "HOLD: possible truncated formula", "items": items, "tail": tail,
+                "detail": f"{', '.join(truncated)} — a trailing subscript may have been "
+                          f"absorbed into the value; both splits round-trip"}
+    return {"verdict": "PROPOSED", "items": items, "tail": tail,
+            "detail": f"{len(items)} ingredients parsed"}
+
+
+def rebuild_ingredients(items: list[tuple[str, str, str]]) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (ingredients, volume_basis_notes)."""
+    out: list[dict[str, Any]] = []
+    basis: list[str] = []
+    for name, value, unit in items:
+        entry: dict[str, Any] = {"preferred_term": name}
+        if unit in VOLUME_BASIS_UNITS:
+            basis.append(f"{name} {value}{unit}")
+        else:
+            enum = UNIT_TO_ENUM.get(unit)
+            if enum:
+                entry["concentration"] = {"value": value, "unit": enum}
+        out.append(entry)
+    return out, basis
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args(argv)
+
+    rows: list[dict[str, str]] = []
+    for path in sorted(args.normalized_dir.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        verdict = assess(doc)
+        if verdict is None:
+            continue
+        rows.append({
+            "file_path": str(path.relative_to(args.normalized_dir)),
+            "record_id": str(doc.get("id") or ""),
+            "verdict": verdict["verdict"],
+            "n_recovered": str(len(verdict["items"])),
+            "detail": verdict["detail"],
+            "trailing_note": verdict["tail"].strip()[:120],
+        })
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
+            "file_path", "record_id", "verdict", "n_recovered", "detail", "trailing_note"])
+        w.writeheader()
+        w.writerows(rows)
+
+    from collections import Counter
+    tally = Counter(r["verdict"].split(":")[0] for r in rows)
+    print(f"Records with an unparsed composition: {len(rows)}")
+    for k, v in tally.most_common():
+        print(f"  {k:8s} {v}")
+    print(f"\nWrote {args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+    print("\nREPORT ONLY — this tool deliberately does not write.")
+    print("A parse can round-trip and still be wrong: 'KH2PO40.85g' splits equally")
+    print("well into KH2PO4 + 0.85g and KH2PO + 40.85g. Applying the second writes")
+    print("a non-existent compound at a 47x concentration. Resolving these needs the")
+    print("NBRC catalogue, not a heuristic.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report_unparsed_compositions.py
+++ b/scripts/report_unparsed_compositions.py
@@ -18,7 +18,7 @@ splitting on numbers is unsafe. The split anchors on a `<number><unit>` pair who
 unit is followed by an uppercase letter, a bracket, whitespace, or end-of-string,
 which is where the next ingredient name begins.
 
-## Three checks — and they are why this tool does not write
+## Four checks — and they are why this tool does not write
 
 **Round trip.** Reassembling `name + value + unit` for every parsed item, plus the
 unconsumed tail, must reproduce the original string EXACTLY. If it does, the parse
@@ -42,6 +42,16 @@ The flag is a formula-shaped name ending in an uppercase letter. It cannot be us
 to auto-CORRECT, only to refuse, because it also matches `MgO`, which is a real
 compound. That asymmetry is the whole argument: the ambiguity is chemical, and
 resolving it needs the NBRC catalogue rather than a heuristic.
+
+**Complete extraction.** Round trip proves the parse invented nothing; it does not
+prove it extracted everything, since `items + tail == text` holds however much is
+left over. Tokenising stops at the last quantity before a `pH` marker, so the final
+ingredient is swept into the tail with it — 9 of 14 records that would otherwise
+read PROPOSED, and the lost ingredient was usually agar (solid vs liquid medium) or
+distilled water (the basis the recipe is relative to). A tail still holding a
+quantity is held back (#192).
+
+Current split: 5 PROPOSED, 20 HOLD.
 
 So this tool REPORTS and never writes. It turns 25 opaque records into a
 structured worklist — proposed parse, trailing note, and the specific reason each
@@ -91,6 +101,13 @@ UNIT_TO_ENUM = {"g": "G_PER_L", "mg": "MG_PER_L", "ml": "ML_PER_L",
 # So a volume basis is kept as an ingredient without a concentration, and recorded
 # in notes instead.
 VOLUME_BASIS_UNITS = {"l", "L", "kg"}
+
+# A quantity still sitting in the unconsumed tail means an ingredient was not
+# extracted (#192). Reuses `_QTY_UNIT` — which uses a LOOKAHEAD, not `\b`,
+# because the tail reads "Agar15gpH 8.2": there is no word boundary between the
+# "g" and the "p", so a `\b` pattern matches nothing and reports the problem
+# does not exist. Measured "0 of 14" that way before spotting it.
+TAIL_HAS_INGREDIENT = re.compile(_QTY_UNIT, re.I)
 
 # A non-water solid above this is almost certainly a bad split, not a recipe.
 IMPLAUSIBLE_G_PER_L = 100.0
@@ -160,6 +177,20 @@ def assess(doc: dict[str, Any]) -> dict[str, Any] | None:
         return {"verdict": "HOLD: possible truncated formula", "items": items, "tail": tail,
                 "detail": f"{', '.join(truncated)} — a trailing subscript may have been "
                           f"absorbed into the value; both splits round-trip"}
+    # Round-trip proves the parse INVENTED nothing. It does not prove the parse
+    # EXTRACTED everything: `items + tail == text` holds however much is left in
+    # the tail. Tokenising stops at the last quantity before a `pH` marker, because
+    # "pH 7.0" is not a quantity — so the final ingredient is swept into the tail
+    # with it. That was 9 of 14 PROPOSED records, and the dropped ingredient was
+    # usually agar (solid vs liquid medium) or distilled water (the solvent basis
+    # the rest of the recipe is relative to) — see #192.
+    #
+    # PROPOSED reads as "safe to apply", so an incomplete parse must not carry it.
+    if TAIL_HAS_INGREDIENT.search(tail):
+        return {"verdict": "HOLD: ingredient remains in the tail", "items": items,
+                "tail": tail,
+                "detail": f"{len(items)} parsed, but the tail still holds a "
+                          f"quantity: {tail[:60]!r}"}
     return {"verdict": "PROPOSED", "items": items, "tail": tail,
             "detail": f"{len(items)} ingredients parsed"}
 

--- a/scripts/report_unparsed_compositions.py
+++ b/scripts/report_unparsed_compositions.py
@@ -47,10 +47,13 @@ So this tool REPORTS and never writes. It turns 25 opaque records into a
 structured worklist — proposed parse, trailing note, and the specific reason each
 held record is ambiguous — for a curator to confirm against the source.
 
+Named `report_` rather than `repair_` on purpose. This tool cannot write, and a
+name promising repair is an invitation to add the write path back — which would
+reintroduce exactly the defect documented above.
+
 Usage::
 
-    just repair-unparsed-compositions              # report what would change
-    just repair-unparsed-compositions --apply
+    just report-unparsed-compositions
 """
 
 from __future__ import annotations

--- a/tests/test_unparsed_compositions.py
+++ b/tests/test_unparsed_compositions.py
@@ -30,7 +30,7 @@ def _load(name: str):
 
 @pytest.fixture(scope="module")
 def ruc():
-    return _load("repair_unparsed_compositions")
+    return _load("report_unparsed_compositions")
 
 
 def test_parses_a_simple_crammed_composition(ruc):
@@ -143,3 +143,25 @@ def test_every_crammed_record_gets_a_verdict(ruc):
             assert verdict["verdict"].startswith(("PROPOSED", "HOLD")), verdict
             assert verdict["detail"], f"{path.name} has no reason recorded"
     assert seen == 25, f"expected 25 crammed records, found {seen}"
+
+
+def test_the_docstring_does_not_advertise_commands_that_do_not_exist(ruc):
+    """#180: the usage block outlived the --apply flag it documented.
+
+    Third instance this week of a docstring describing behaviour the code lacks,
+    so this checks its own module rather than trusting review to catch the next one.
+    """
+    import inspect
+    import re
+    from pathlib import Path
+
+    doc = inspect.getdoc(ruc) or ""
+    justfile = (REPO_ROOT / "project.justfile").read_text()
+
+    for recipe in re.findall(r"just ([a-z][a-z0-9-]+)", doc):
+        assert f"\n{recipe} " in justfile or f"\n{recipe}:" in justfile, (
+            f"docstring references `just {recipe}`, which is not a recipe")
+
+    src = inspect.getsource(ruc)
+    for flag in set(re.findall(r"(--[a-z][a-z-]+)", doc)):
+        assert f'"{flag}"' in src, f"docstring documents {flag}, which the CLI does not define"

--- a/tests/test_unparsed_compositions.py
+++ b/tests/test_unparsed_compositions.py
@@ -127,16 +127,17 @@ def test_the_tool_cannot_write(ruc):
     assert "path.write_text" not in src, "the reporter has regained a write path"
 
 
-def test_every_crammed_record_gets_a_verdict(ruc):
-    """25 opaque records become a structured worklist, each with a reason."""
-    import yaml
-    from record_kinds import is_solution_record
+def test_every_crammed_record_gets_a_verdict(ruc, media_records):
+    """25 opaque records become a structured worklist, each with a reason.
 
+    Uses the session-scoped `media_records` fixture rather than walking the corpus
+    again: this test cost 102s on its own, and five such scans were enough to
+    cancel the pytest job at the 40-minute CI ceiling with every test passing
+    (#189). The fixture also already excludes stock solutions, which this test was
+    re-implementing.
+    """
     seen = 0
-    for path in (REPO_ROOT / "data" / "normalized_yaml").rglob("*.yaml"):
-        doc = yaml.safe_load(path.read_text(errors="replace"))
-        if not isinstance(doc, dict) or is_solution_record(doc):
-            continue
+    for path, doc in media_records:
         verdict = ruc.assess(doc)
         if verdict:
             seen += 1

--- a/tests/test_unparsed_compositions.py
+++ b/tests/test_unparsed_compositions.py
@@ -165,3 +165,51 @@ def test_the_docstring_does_not_advertise_commands_that_do_not_exist(ruc):
     src = inspect.getsource(ruc)
     for flag in set(re.findall(r"(--[a-z][a-z-]+)", doc)):
         assert f'"{flag}"' in src, f"docstring documents {flag}, which the CLI does not define"
+
+
+# --- #192: PROPOSED must mean the whole composition was extracted -----------
+
+
+def _crammed(text):
+    return {"id": "CultureMech:1", "name": "x",
+            "ingredients": [{"preferred_term": text}, {}]}
+
+
+def test_an_ingredient_left_in_the_tail_downgrades_to_hold(ruc):
+    """Tokenising stops at the last quantity before a `pH` marker, sweeping the
+    final ingredient into the tail. That hit 9 of 14 PROPOSED records, and the
+    dropped ingredient was usually agar — solid vs liquid medium — or distilled
+    water, the basis the rest of the recipe is relative to.
+
+    PROPOSED reads as "safe to apply", so an incomplete parse must not carry it.
+    """
+    v = ruc.assess(_crammed("Tryptone5gYeast extract3gNaCl10gAgar15gpH 7.0"))
+    assert v["verdict"].startswith("HOLD"), v
+    assert "tail" in v["verdict"]
+
+
+def test_round_trip_alone_does_not_earn_proposed(ruc):
+    """`items + tail == text` holds however much is left in the tail, so round-trip
+    proves the parse invented nothing — not that it extracted everything. The #166
+    lesson in a second place."""
+    # >40 chars, or is_crammed() declines to look at it at all.
+    text = "Tryptone5gYeast extract3gNaCl10gAgar15gpH 7.0"
+    items, tail = ruc.parse_composition(text)
+    assert ruc.round_trips(text, items, tail), "precondition: this parse round-trips"
+    assert ruc.assess(_crammed(text))["verdict"].startswith("HOLD")
+
+
+def test_a_footnote_tail_without_a_quantity_stays_proposed(ruc):
+    """Only a QUANTITY in the tail means a lost ingredient. NBRC_1135's tail is
+    '*Manufactured by Asahi Breweries...' — a note, not a composition."""
+    v = ruc.assess(_crammed(
+        "Tryptone5gYeast extract3gNaCl10g*Manufactured by Asahi Breweries, Ltd."))
+    assert v["verdict"] == "PROPOSED", v
+
+
+def test_the_tail_check_does_not_rely_on_a_word_boundary(ruc):
+    """The tail reads "Agar15gpH": no word boundary between the "g" and the "p",
+    so a `\\b` pattern matches nothing and reports the defect does not exist. That
+    measured "0 of 14" before it was spotted."""
+    assert ruc.TAIL_HAS_INGREDIENT.search("Agar15gpH 8.2"), \
+        "the tail check regressed to a \\b pattern and now sees nothing"

--- a/tests/test_unparsed_compositions.py
+++ b/tests/test_unparsed_compositions.py
@@ -1,0 +1,145 @@
+"""Tests for recovering NBRC compositions crammed into one ingredient name (#166).
+
+The parse must be provably faithful, because the alternative is inventing
+concentrations. Two independent checks do that, and both are necessary:
+
+  * round trip — reassembly must reproduce the source exactly, so nothing is
+    invented or dropped;
+  * plausibility — a wrong split can ALSO round-trip ("Tween 80" + "0.3g" and
+    "Tween" + "800.3g" rebuild to the same text), so absurd values are held back.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ruc():
+    return _load("repair_unparsed_compositions")
+
+
+def test_parses_a_simple_crammed_composition(ruc):
+    items, tail = ruc.parse_composition("Tryptone5gGlucose3gAgar10g")
+    assert items == [("Tryptone", "5", "g"), ("Glucose", "3", "g"), ("Agar", "10", "g")]
+    assert tail == ""
+
+
+def test_a_truncated_formula_is_refused_not_guessed(ruc):
+    """The failure that made this tool report-only.
+
+    "KH2PO4" + "0.85g" concatenates to "KH2PO40.85g", which splits equally well
+    into "KH2PO" + "40.85g". Both round-trip and 40.85 is under the plausibility
+    ceiling, so the first two checks pass a parse that writes a non-existent
+    compound at 47x the real concentration. An earlier version applied exactly
+    that to 11 records.
+    """
+    verdict = ruc.assess({"ingredients": [
+        {"preferred_term": "Trypticase peptone10gKH2PO40.85gGlucose5gYeast extract3g"}]})
+    assert verdict["verdict"].startswith("HOLD"), verdict
+    assert "truncated formula" in verdict["verdict"]
+
+
+def test_the_truncated_formula_rule_only_refuses_and_never_corrects(ruc):
+    """It also matches MgO, which is a real compound — so it cannot be used to
+    auto-fix, only to hold back. That asymmetry is why a human is needed."""
+    assert ruc.TRUNCATED_FORMULA.match("KH2PO")   # truncated
+    assert ruc.TRUNCATED_FORMULA.match("MgO")     # genuine, same shape
+
+
+def test_hydrate_names_still_parse(ruc):
+    items, _ = ruc.parse_composition("Na2HPO4·7H2O4.9g")
+    assert items == [("Na2HPO4·7H2O", "4.9", "g")]
+
+
+def test_trailing_prose_is_not_treated_as_an_ingredient(ruc):
+    items, tail = ruc.parse_composition("Glucose3gAdjust pH to 7.0 with NaOH.")
+    assert [n for n, _, _ in items] == ["Glucose"]
+    assert "Adjust pH" in tail
+
+
+def test_round_trip_rejects_an_ambiguous_split(ruc):
+    """The Tween 80 case: the parser reads 'Tween' + '800.3', losing the space."""
+    text = "Maltose20gTween 800.3gPeptone6g"
+    items, tail = ruc.parse_composition(text)
+    assert not ruc.round_trips(text, items, tail)
+
+
+def test_round_trip_accepts_a_faithful_parse(ruc):
+    text = "Tryptone5gGlucose3g"
+    items, tail = ruc.parse_composition(text)
+    assert ruc.round_trips(text, items, tail)
+
+
+def test_implausible_values_are_detected(ruc):
+    assert ruc.implausible([("Tween", "800.3", "g")])
+    assert not ruc.implausible([("Glucose", "20", "g")])
+
+
+def test_water_is_exempt_from_the_plausibility_check(ruc):
+    """Water at 1000 g/L is a preparation artefact, not a bad split — a different
+    defect, tracked by the concentration audit rather than held back here."""
+    assert not ruc.implausible([("Distilled water", "1000", "g")])
+
+
+def test_a_litre_volume_basis_never_becomes_a_concentration(ruc):
+    """'Distilled water1L' is the volume the recipe is made up to.
+
+    Writing it as a per-litre figure would invent the #118 defect — water recorded
+    as a solute — and in ML_PER_L, which the concentration gate does not check.
+    """
+    ings, basis = ruc.rebuild_ingredients([("Distilled water", "1", "L")])
+    assert ings == [{"preferred_term": "Distilled water"}], ings
+    assert basis == ["Distilled water 1L"]
+
+
+def test_millilitre_ingredients_keep_their_concentration(ruc):
+    """Seawater 750ml is a genuine proportion, not a volume basis — the unit, not
+    the word 'water', is what distinguishes them."""
+    ings, basis = ruc.rebuild_ingredients([("Seawater", "750", "ml")])
+    assert ings[0]["concentration"] == {"value": "750", "unit": "ML_PER_L"}
+    assert basis == []
+
+
+def test_assess_returns_none_for_a_healthy_record(ruc):
+    assert ruc.assess({"ingredients": [{"preferred_term": "Glucose"}]}) is None
+
+
+def test_the_tool_cannot_write(ruc):
+    """It reports; it must never gain an --apply path without the chemical
+    ambiguity being resolved first."""
+    import inspect
+    src = inspect.getsource(ruc)
+    assert "path.write_text" not in src, "the reporter has regained a write path"
+
+
+def test_every_crammed_record_gets_a_verdict(ruc):
+    """25 opaque records become a structured worklist, each with a reason."""
+    import yaml
+    from record_kinds import is_solution_record
+
+    seen = 0
+    for path in (REPO_ROOT / "data" / "normalized_yaml").rglob("*.yaml"):
+        doc = yaml.safe_load(path.read_text(errors="replace"))
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        verdict = ruc.assess(doc)
+        if verdict:
+            seen += 1
+            assert verdict["verdict"].startswith(("PROPOSED", "HOLD")), verdict
+            assert verdict["detail"], f"{path.name} has no reason recorded"
+    assert seen == 25, f"expected 25 crammed records, found {seen}"

--- a/tests/test_unparsed_compositions.py
+++ b/tests/test_unparsed_compositions.py
@@ -154,7 +154,6 @@ def test_the_docstring_does_not_advertise_commands_that_do_not_exist(ruc):
     """
     import inspect
     import re
-    from pathlib import Path
 
     doc = inspect.getdoc(ruc) or ""
     justfile = (REPO_ROOT / "project.justfile").read_text()


### PR DESCRIPTION
## What these records are

25 `NBRC_*` records carry their entire composition crammed into the first ingredient's `preferred_term`, separators stripped, plus an empty second ingredient:

```
Tryptone5gYeast extract3gNaCl10gUrea1gDistilled water1LAgar (if needed)15g
```

## I tried to repair them mechanically, and the attempt is why this reports instead

Two checks looked sufficient:

- **Round trip** — reassembling `name + value + unit` for every item, plus the tail, must reproduce the source **exactly**. This proves the parse invented nothing, and it caught `Tween 800.3g` being read as `Tween` + `800.3`.
- **Plausibility** — no non-water solid above 100 g/L.

**20 of 25 passed both, were applied, and validated cleanly.** Then I read the output:

```
KH2PO   at 40.85 G_PER_L      <- what I wrote
KH2PO4  at  0.85 G_PER_L      <- the truth
```

`KH2PO4` + `0.85g` concatenates to `KH2PO40.85g`, which splits **equally well** into `KH2PO` + `40.85g`. Both round-trip. 40.85 is under the plausibility ceiling. The parse had written a **non-existent compound at 47× the real concentration**, in **11 of the 20 records** — across KH2PO4, K2HPO4, CaCO3 and H3BO3.

All 20 edits were reverted. **The corpus in this PR is byte-identical to main** — verified.

## Why a third check cannot rescue it

A formula-shaped name ending in an uppercase letter now flags the hazard. But it can only **refuse**, never correct, because it matches `MgO` just as readily — and MgO is a real compound.

That asymmetry is the argument. `CaCO32mg` is not resolvable from the string: it is `CaCO3` + `2mg` or `CaCO` + `32mg`, and only chemistry decides. That needs the NBRC catalogue, not a heuristic.

So the tool reports and **cannot write** — a test asserts no write path exists.

## What it delivers

25 opaque records become a structured worklist: proposed parse, recovered trailing note, and the specific reason each held record is ambiguous. **14 PROPOSED, 11 HOLD.**

## One more defect the attempt surfaced

An early version wrote `Distilled water1L` as `1 ML_PER_L` — inventing the exact defect #118 documents, water recorded as a solute, in a unit the concentration gate does not even check. A volume basis is now carried in notes instead.

`Seawater750ml` is different and legitimate — a proportion, distinguished by the **unit**, not by the word "water".

## Verification

- [x] Corpus byte-identical to main
- [x] 14 tests, including that the tool has no write path and that the truncated-formula rule only refuses
- [x] Every one of the 25 records gets a verdict with a recorded reason
- [x] Suite: 865 passed, 2 skipped

**Does not close #166** — the records still need a curator with the source catalogue.

Review follows in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)