### PR TITLE
Edison axis classification: stratified sample, 25-record probe, manifest support (#152)

### DIFF
--- a/data/import_tracking/reports/axis_research_batch.json
+++ b/data/import_tracking/reports/axis_research_batch.json
@@ -6,597 +6,9 @@
     "stratum": "SEMI_DEFINED"
   },
   {
-    "recipe_name": "TOGO_M923_Dethiosulfovibrio_Belb1_Medium",
-    "file_path": "bacterial/TOGO_M923_Dethiosulfovibrio_Belb1_Medium.yaml",
-    "culturemech_id": "CultureMech:010344",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "sd0_medium",
-    "file_path": "bacterial/sd0_medium.yaml",
-    "culturemech_id": "CultureMech:002698",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "for_arhodomonas",
-    "file_path": "bacterial/for_arhodomonas.yaml",
-    "culturemech_id": "CultureMech:006871",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "methanobacterium_medium_ii",
-    "file_path": "archaea/methanobacterium_medium_ii.yaml",
-    "culturemech_id": "CultureMech:003048",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "chthonomonas_medium",
-    "file_path": "bacterial/chthonomonas_medium.yaml",
-    "culturemech_id": "CultureMech:000754",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "for_dsm_17771",
-    "file_path": "bacterial/for_dsm_17771.yaml",
-    "culturemech_id": "CultureMech:006915",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "desulfotomaculum_lam5_medium",
-    "file_path": "bacterial/desulfotomaculum_lam5_medium.yaml",
-    "culturemech_id": "CultureMech:002893",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "artificial_seawater_for_halophiles",
-    "file_path": "bacterial/artificial_seawater_for_halophiles.yaml",
-    "culturemech_id": "CultureMech:009844",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "TOGO_M1041_MPOB_Medium",
-    "file_path": "bacterial/TOGO_M1041_MPOB_Medium.yaml",
-    "culturemech_id": "CultureMech:007557",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "methanolinea_medium",
-    "file_path": "archaea/methanolinea_medium.yaml",
-    "culturemech_id": "CultureMech:002777",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA",
-    "file_path": "bacterial/KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA.yaml",
-    "culturemech_id": "CultureMech:004655",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "TOGO_M1377_Glucose_bicarbonate-Buffered_Medium",
-    "file_path": "bacterial/TOGO_M1377_Glucose_bicarbonate-Buffered_Medium.yaml",
-    "culturemech_id": "CultureMech:007916",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "acidianus_medium_anaerobic",
-    "file_path": "specialized/acidianus_medium_anaerobic.yaml",
-    "culturemech_id": "CultureMech:015354",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "thiorhodococcus_medium",
-    "file_path": "bacterial/thiorhodococcus_medium.yaml",
-    "culturemech_id": "CultureMech:000816",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "for_dsm_17721",
-    "file_path": "bacterial/for_dsm_17721.yaml",
-    "culturemech_id": "CultureMech:003631",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "yem_agar",
-    "file_path": "bacterial/yem_agar.yaml",
-    "culturemech_id": "CultureMech:009635",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "TOGO_M1634_Methanosarcina_Medium",
-    "file_path": "archaea/TOGO_M1634_Methanosarcina_Medium.yaml",
-    "culturemech_id": "CultureMech:008189",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "thermodesulfovibrio_yellowstonii_medium",
-    "file_path": "bacterial/thermodesulfovibrio_yellowstonii_medium.yaml",
-    "culturemech_id": "CultureMech:001883",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "KOMODO_1038_ACIDICALDUS_medium",
-    "file_path": "bacterial/KOMODO_1038_ACIDICALDUS_medium.yaml",
-    "culturemech_id": "CultureMech:003552",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "lactate_bicarbonate_buffered_medium",
-    "file_path": "bacterial/lactate_bicarbonate_buffered_medium.yaml",
-    "culturemech_id": "CultureMech:003203",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "medium_for_strain_mp_01",
-    "file_path": "bacterial/medium_for_strain_mp_01.yaml",
-    "culturemech_id": "CultureMech:010405",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "sdo_medium",
-    "file_path": "bacterial/sdo_medium.yaml",
-    "culturemech_id": "CultureMech:000590",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium",
-    "file_path": "bacterial/TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium.yaml",
-    "culturemech_id": "CultureMech:010082",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "marine_h2_using_methanogen_medium",
-    "file_path": "archaea/marine_h2_using_methanogen_medium.yaml",
-    "culturemech_id": "CultureMech:008267",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "KOMODO_1174_NITRINCOLA_medium",
-    "file_path": "bacterial/KOMODO_1174_NITRINCOLA_medium.yaml",
-    "culturemech_id": "CultureMech:003894",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "methanosalsum_wen5_medium",
-    "file_path": "archaea/methanosalsum_wen5_medium.yaml",
-    "culturemech_id": "CultureMech:001829",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "acidianus_infernus_medium",
-    "file_path": "archaea/acidianus_infernus_medium.yaml",
-    "culturemech_id": "CultureMech:005077",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "marichromatium_bheemlicum_medium",
-    "file_path": "bacterial/marichromatium_bheemlicum_medium.yaml",
-    "culturemech_id": "CultureMech:002881",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "for_dsm_24312",
-    "file_path": "bacterial/for_dsm_24312.yaml",
-    "culturemech_id": "CultureMech:003633",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "succinate_minimal_salts_medium_sms",
-    "file_path": "bacterial/succinate_minimal_salts_medium_sms.yaml",
-    "culturemech_id": "CultureMech:000833",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "nasu_iron_reducer_medium",
-    "file_path": "bacterial/nasu_iron_reducer_medium.yaml",
-    "culturemech_id": "CultureMech:002199",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium",
-    "file_path": "bacterial/KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium.yaml",
-    "culturemech_id": "CultureMech:006400",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "rhodovulum_imhoffii_medium",
-    "file_path": "bacterial/rhodovulum_imhoffii_medium.yaml",
-    "culturemech_id": "CultureMech:002871",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "marine_methanobacterium_medium",
-    "file_path": "archaea/marine_methanobacterium_medium.yaml",
-    "culturemech_id": "CultureMech:007804",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "TOGO_M1275_Vallitalea_70B-A_Medium",
-    "file_path": "bacterial/TOGO_M1275_Vallitalea_70B-A_Medium.yaml",
-    "culturemech_id": "CultureMech:007808",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine",
-    "file_path": "bacterial/acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine.yaml",
-    "culturemech_id": "CultureMech:005622",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "methanospirillum_lacunae_medium",
-    "file_path": "archaea/methanospirillum_lacunae_medium.yaml",
-    "culturemech_id": "CultureMech:000735",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "KOMODO_1360_HIPPEA_JASONIAE_medium",
-    "file_path": "bacterial/KOMODO_1360_HIPPEA_JASONIAE_medium.yaml",
-    "culturemech_id": "CultureMech:004108",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784",
-    "file_path": "bacterial/natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784.yaml",
-    "culturemech_id": "CultureMech:006483",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "norris_ferroplasma_medium",
-    "file_path": "archaea/norris_ferroplasma_medium.yaml",
-    "culturemech_id": "CultureMech:002877",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "geothermobacter_medium",
-    "file_path": "bacterial/geothermobacter_medium.yaml",
-    "culturemech_id": "CultureMech:002163",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "ird_marine_clostrida_medium",
-    "file_path": "specialized/ird_marine_clostrida_medium.yaml",
-    "culturemech_id": "CultureMech:015423",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "for_dsm_19306",
-    "file_path": "bacterial/for_dsm_19306.yaml",
-    "culturemech_id": "CultureMech:006946",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "lca",
-    "file_path": "bacterial/lca.yaml",
-    "culturemech_id": "CultureMech:008306",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "t49_medium",
-    "file_path": "bacterial/t49_medium.yaml",
-    "culturemech_id": "CultureMech:004041",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "rhodomicrobium_medium",
-    "file_path": "bacterial/rhodomicrobium_medium.yaml",
-    "culturemech_id": "CultureMech:008166",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "rhodobium_gokurnum_medium",
-    "file_path": "bacterial/rhodobium_gokurnum_medium.yaml",
-    "culturemech_id": "CultureMech:002867",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "modified_balchs_methanogen_medium_1_b",
-    "file_path": "archaea/modified_balchs_methanogen_medium_1_b.yaml",
-    "culturemech_id": "CultureMech:000304",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
-    "recipe_name": "planctomyces_pyreformis_medium",
-    "file_path": "bacterial/planctomyces_pyreformis_medium.yaml",
-    "culturemech_id": "CultureMech:001009",
-    "stratum": "SEMI_DEFINED"
-  },
-  {
     "recipe_name": "brain_heart_infusion_bhi_broth_containing_c_difficile_supplement_and_0_04_cysteine",
     "file_path": "bacterial/brain_heart_infusion_bhi_broth_containing_c_difficile_supplement_and_0_04_cysteine.yaml",
     "culturemech_id": "CultureMech:009359",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "frey_broth",
-    "file_path": "bacterial/frey_broth.yaml",
-    "culturemech_id": "CultureMech:008822",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "desulfobulbus_sp_medium_freshwater_for_dsm_14880",
-    "file_path": "bacterial/desulfobulbus_sp_medium_freshwater_for_dsm_14880.yaml",
-    "culturemech_id": "CultureMech:009098",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M1875_Thermus_medium",
-    "file_path": "bacterial/TOGO_M1875_Thermus_medium.yaml",
-    "culturemech_id": "CultureMech:008450",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "allen_medium",
-    "file_path": "bacterial/allen_medium.yaml",
-    "culturemech_id": "CultureMech:008820",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium",
-    "file_path": "bacterial/TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium.yaml",
-    "culturemech_id": "CultureMech:008883",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12",
-    "file_path": "bacterial/mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12.yaml",
-    "culturemech_id": "CultureMech:009056",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M3231_Minimal_media",
-    "file_path": "bacterial/TOGO_M3231_Minimal_media.yaml",
-    "culturemech_id": "CultureMech:009671",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2726_Clostridium_medium",
-    "file_path": "bacterial/TOGO_M2726_Clostridium_medium.yaml",
-    "culturemech_id": "CultureMech:009276",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "mag_modified_arabinose_gluconate_medium",
-    "file_path": "bacterial/mag_modified_arabinose_gluconate_medium.yaml",
-    "culturemech_id": "CultureMech:001150",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2228_Friis_medium",
-    "file_path": "bacterial/TOGO_M2228_Friis_medium.yaml",
-    "culturemech_id": "CultureMech:008816",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "anaerobic_freshwater_fwm_medium_for_dsm_15978",
-    "file_path": "bacterial/anaerobic_freshwater_fwm_medium_for_dsm_15978.yaml",
-    "culturemech_id": "CultureMech:009205",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "mineral_medium_jagmann",
-    "file_path": "bacterial/mineral_medium_jagmann.yaml",
-    "culturemech_id": "CultureMech:001199",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_strain_r_1",
-    "file_path": "bacterial/medium_for_strain_r_1.yaml",
-    "culturemech_id": "CultureMech:008433",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "chopped_meat_medium_with_1_glucose",
-    "file_path": "bacterial/chopped_meat_medium_with_1_glucose.yaml",
-    "culturemech_id": "CultureMech:009305",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "formate_medium",
-    "file_path": "bacterial/formate_medium.yaml",
-    "culturemech_id": "CultureMech:009652",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "clostridium_thermocellum_medium_d58_medium",
-    "file_path": "bacterial/clostridium_thermocellum_medium_d58_medium.yaml",
-    "culturemech_id": "CultureMech:008330",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "dsm_135_medium",
-    "file_path": "bacterial/dsm_135_medium.yaml",
-    "culturemech_id": "CultureMech:009613",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "gbs_salts_modified_for_thermocrinis_jamiesonii",
-    "file_path": "bacterial/gbs_salts_modified_for_thermocrinis_jamiesonii.yaml",
-    "culturemech_id": "CultureMech:000953",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M3036_Thiomonas_cuprina_medium",
-    "file_path": "bacterial/TOGO_M3036_Thiomonas_cuprina_medium.yaml",
-    "culturemech_id": "CultureMech:009548",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2692_Alkaline_xylan_medium",
-    "file_path": "bacterial/TOGO_M2692_Alkaline_xylan_medium.yaml",
-    "culturemech_id": "CultureMech:009244",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_strains_ja121_and_ja322",
-    "file_path": "bacterial/medium_for_strains_ja121_and_ja322.yaml",
-    "culturemech_id": "CultureMech:008370",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "minimal_medium_containing_nicotin",
-    "file_path": "bacterial/minimal_medium_containing_nicotin.yaml",
-    "culturemech_id": "CultureMech:009420",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_freshwater_flexibacteria",
-    "file_path": "bacterial/medium_for_freshwater_flexibacteria.yaml",
-    "culturemech_id": "CultureMech:008096",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2576_Modified_chopped_meat_medium",
-    "file_path": "bacterial/TOGO_M2576_Modified_chopped_meat_medium.yaml",
-    "culturemech_id": "CultureMech:009145",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "actinotalea_fermentas_medium",
-    "file_path": "bacterial/actinotalea_fermentas_medium.yaml",
-    "culturemech_id": "CultureMech:008423",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M3199_Defined_minimal_medium",
-    "file_path": "bacterial/TOGO_M3199_Defined_minimal_medium.yaml",
-    "culturemech_id": "CultureMech:009640",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_marine_flexibacteria",
-    "file_path": "bacterial/medium_for_marine_flexibacteria.yaml",
-    "culturemech_id": "CultureMech:008091",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M3228_Defined_medium",
-    "file_path": "bacterial/TOGO_M3228_Defined_medium.yaml",
-    "culturemech_id": "CultureMech:009667",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn",
-    "file_path": "bacterial/leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn.yaml",
-    "culturemech_id": "CultureMech:008670",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "leeming_amp_notman_agar_modified_mlna",
-    "file_path": "bacterial/leeming_amp_notman_agar_modified_mlna.yaml",
-    "culturemech_id": "CultureMech:008353",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2378_Natronobacteria_medium",
-    "file_path": "bacterial/TOGO_M2378_Natronobacteria_medium.yaml",
-    "culturemech_id": "CultureMech:008962",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "enriched_anaerobe_medium",
-    "file_path": "bacterial/enriched_anaerobe_medium.yaml",
-    "culturemech_id": "CultureMech:009304",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "clostridia_growth_medium_cgm",
-    "file_path": "bacterial/clostridia_growth_medium_cgm.yaml",
-    "culturemech_id": "CultureMech:009356",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643",
-    "file_path": "bacterial/medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643.yaml",
-    "culturemech_id": "CultureMech:008408",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "chocolate_agar_polyvitex_pvx",
-    "file_path": "bacterial/chocolate_agar_polyvitex_pvx.yaml",
-    "culturemech_id": "CultureMech:008743",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid",
-    "file_path": "bacterial/basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid.yaml",
-    "culturemech_id": "CultureMech:008825",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "brain_heart_infusion_bhi_broth_oxoid",
-    "file_path": "bacterial/brain_heart_infusion_bhi_broth_oxoid.yaml",
-    "culturemech_id": "CultureMech:008801",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "isosphaera_medium",
-    "file_path": "bacterial/isosphaera_medium.yaml",
-    "culturemech_id": "CultureMech:008891",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "meiothermus_hypogaeus_medium",
-    "file_path": "bacterial/meiothermus_hypogaeus_medium.yaml",
-    "culturemech_id": "CultureMech:000920",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M3200_Defined_minimal_medium",
-    "file_path": "bacterial/TOGO_M3200_Defined_minimal_medium.yaml",
-    "culturemech_id": "CultureMech:009643",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood",
-    "file_path": "bacterial/brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood.yaml",
-    "culturemech_id": "CultureMech:009466",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "desulfovibrio_mv_medium_for_dsm_13257",
-    "file_path": "bacterial/desulfovibrio_mv_medium_for_dsm_13257.yaml",
-    "culturemech_id": "CultureMech:009288",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "alkaline_halophile_medium",
-    "file_path": "bacterial/alkaline_halophile_medium.yaml",
-    "culturemech_id": "CultureMech:008289",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "medium_for_tick_cells_rickettsia",
-    "file_path": "bacterial/medium_for_tick_cells_rickettsia.yaml",
-    "culturemech_id": "CultureMech:001032",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated",
-    "file_path": "bacterial/TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated.yaml",
-    "culturemech_id": "CultureMech:009142",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "TOGO_M2711_Clostridium_Cellulolytic_medium",
-    "file_path": "bacterial/TOGO_M2711_Clostridium_Cellulolytic_medium.yaml",
-    "culturemech_id": "CultureMech:009263",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2",
-    "file_path": "bacterial/columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2.yaml",
-    "culturemech_id": "CultureMech:008843",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "k_101_flexibacter_medium",
-    "file_path": "bacterial/k_101_flexibacter_medium.yaml",
-    "culturemech_id": "CultureMech:009160",
-    "stratum": "DEEP_RESEARCH"
-  },
-  {
-    "recipe_name": "defined_minimal_medium",
-    "file_path": "bacterial/defined_minimal_medium.yaml",
-    "culturemech_id": "CultureMech:009638",
     "stratum": "DEEP_RESEARCH"
   },
   {
@@ -606,304 +18,28 @@
     "stratum": "WELL_KNOWN"
   },
   {
-    "recipe_name": "brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex",
-    "file_path": "bacterial/brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex.yaml",
-    "culturemech_id": "CultureMech:009397",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "lb_rifampicin_medium",
-    "file_path": "bacterial/lb_rifampicin_medium.yaml",
-    "culturemech_id": "CultureMech:008553",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "tryptic_soy_agar_tsa_carl_roth_gmbh_co",
-    "file_path": "bacterial/tryptic_soy_agar_tsa_carl_roth_gmbh_co.yaml",
-    "culturemech_id": "CultureMech:009450",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "nutrient_agar_broth",
-    "file_path": "bacterial/nutrient_agar_broth.yaml",
-    "culturemech_id": "CultureMech:008307",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_5_nacl",
-    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_2_with_5_nacl.yaml",
-    "culturemech_id": "CultureMech:008596",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "1_100_nutrient_agar_no_2",
-    "file_path": "bacterial/1_100_nutrient_agar_no_2.yaml",
-    "culturemech_id": "CultureMech:002131",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "yeast_extract_malt_extract_agar_isp_2",
-    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2.yaml",
-    "culturemech_id": "CultureMech:010528",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "2_malt_extract_agar",
-    "file_path": "bacterial/2_malt_extract_agar.yaml",
-    "culturemech_id": "CultureMech:008671",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "r2a_agar",
-    "file_path": "bacterial/r2a_agar.yaml",
-    "culturemech_id": "CultureMech:002706",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "blood_agar_tsa_with_5_sheep_blood_remel",
-    "file_path": "bacterial/blood_agar_tsa_with_5_sheep_blood_remel.yaml",
-    "culturemech_id": "CultureMech:009339",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M2199_LB_Agar_Broth_Miller",
-    "file_path": "bacterial/TOGO_M2199_LB_Agar_Broth_Miller.yaml",
-    "culturemech_id": "CultureMech:008791",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "JCM_J100_ALKALINE_NUTRIENT_AGAR",
-    "file_path": "bacterial/JCM_J100_ALKALINE_NUTRIENT_AGAR.yaml",
-    "culturemech_id": "CultureMech:002194",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "m9_farmer_et_al",
-    "file_path": "bacterial/m9_farmer_et_al.yaml",
-    "culturemech_id": "CultureMech:007010",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR",
-    "file_path": "bacterial/KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR.yaml",
-    "culturemech_id": "CultureMech:006268",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "sea_water_luria_bertani_medium",
-    "file_path": "bacterial/sea_water_luria_bertani_medium.yaml",
-    "culturemech_id": "CultureMech:001039",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "mueller_hinton_medium",
-    "file_path": "bacterial/mueller_hinton_medium.yaml",
-    "culturemech_id": "CultureMech:009463",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "r2a_with_artificial_soda_salt_lake_water",
-    "file_path": "bacterial/r2a_with_artificial_soda_salt_lake_water.yaml",
-    "culturemech_id": "CultureMech:001197",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M2362_Columbia_Blood_Agar",
-    "file_path": "bacterial/TOGO_M2362_Columbia_Blood_Agar.yaml",
-    "culturemech_id": "CultureMech:008948",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "r2a_agar_with_2_nacl",
-    "file_path": "bacterial/r2a_agar_with_2_nacl.yaml",
-    "culturemech_id": "CultureMech:002325",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "modified_m9_medium",
-    "file_path": "bacterial/modified_m9_medium.yaml",
-    "culturemech_id": "CultureMech:009533",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "nutrient_agar_oxoid_cm3_with_phosphate",
-    "file_path": "bacterial/nutrient_agar_oxoid_cm3_with_phosphate.yaml",
-    "culturemech_id": "CultureMech:001733",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M492_1_2_MRS_1_2_BHI_Agar",
-    "file_path": "bacterial/TOGO_M492_1_2_MRS_1_2_BHI_Agar.yaml",
-    "culturemech_id": "CultureMech:009880",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M18_YM_Agar",
-    "file_path": "bacterial/TOGO_M18_YM_Agar.yaml",
-    "culturemech_id": "CultureMech:008476",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "m9_minimal_media_plus",
-    "file_path": "specialized/m9_minimal_media_plus.yaml",
-    "culturemech_id": "CultureMech:015550",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "brain_heart_infusion_2_nacl",
-    "file_path": "bacterial/brain_heart_infusion_2_nacl.yaml",
-    "culturemech_id": "CultureMech:008546",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar",
-    "file_path": "bacterial/TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar.yaml",
-    "culturemech_id": "CultureMech:008269",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "anaerobic_tryptic_soy_broth_medium",
-    "file_path": "specialized/anaerobic_tryptic_soy_broth_medium.yaml",
-    "culturemech_id": "CultureMech:015369",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "r2a_fumarate_anaerobic",
-    "file_path": "bacterial/r2a_fumarate_anaerobic.yaml",
-    "culturemech_id": "CultureMech:009554",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "malt_extract_agar",
-    "file_path": "fungal/malt_extract_agar.yaml",
-    "culturemech_id": "CultureMech:010520",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "KOMODO_952_1_10_NUTRIENT_AGAR_NO.2",
-    "file_path": "bacterial/KOMODO_952_1_10_NUTRIENT_AGAR_NO.2.yaml",
-    "culturemech_id": "CultureMech:006895",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "brain_heart_infusion_bhi_with_sodium_acetate",
-    "file_path": "bacterial/brain_heart_infusion_bhi_with_sodium_acetate.yaml",
-    "culturemech_id": "CultureMech:009557",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "m9_minimal_medium_with_acetate",
-    "file_path": "bacterial/m9_minimal_medium_with_acetate.yaml",
-    "culturemech_id": "CultureMech:007300",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M2511_brain_heart_infusion_broth",
-    "file_path": "bacterial/TOGO_M2511_brain_heart_infusion_broth.yaml",
-    "culturemech_id": "CultureMech:009083",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M94_Nutrient_Agar_With_25_Soil_Extract",
-    "file_path": "bacterial/TOGO_M94_Nutrient_Agar_With_25_Soil_Extract.yaml",
-    "culturemech_id": "CultureMech:010373",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M2520_R2A_Medium",
-    "file_path": "bacterial/TOGO_M2520_R2A_Medium.yaml",
-    "culturemech_id": "CultureMech:009090",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "czapek_yeast_extract_agar_cya",
-    "file_path": "fungal/czapek_yeast_extract_agar_cya.yaml",
-    "culturemech_id": "CultureMech:010511",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M21_Brain_Heart_Infusion_Agar",
-    "file_path": "bacterial/TOGO_M21_Brain_Heart_Infusion_Agar.yaml",
-    "culturemech_id": "CultureMech:008793",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "brain_heart_infusion_agar_with_soil_extract",
-    "file_path": "bacterial/brain_heart_infusion_agar_with_soil_extract.yaml",
-    "culturemech_id": "CultureMech:002702",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "columbia_blood_agar_containing_10_bovine_blood",
-    "file_path": "bacterial/columbia_blood_agar_containing_10_bovine_blood.yaml",
-    "culturemech_id": "CultureMech:009496",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "luria_bertani_lb_medium_buffered_mops",
-    "file_path": "bacterial/luria_bertani_lb_medium_buffered_mops.yaml",
-    "culturemech_id": "CultureMech:009075",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M16_1_10_Nutrient_Agar_NO._2",
-    "file_path": "bacterial/TOGO_M16_1_10_Nutrient_Agar_NO._2.yaml",
-    "culturemech_id": "CultureMech:008261",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood",
-    "file_path": "bacterial/tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood.yaml",
-    "culturemech_id": "CultureMech:009342",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "bhi_glucose_medium",
-    "file_path": "bacterial/bhi_glucose_medium.yaml",
-    "culturemech_id": "CultureMech:001983",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater",
-    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater.yaml",
-    "culturemech_id": "CultureMech:010536",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "half_strength_nutrient_broth_or_agar",
-    "file_path": "bacterial/half_strength_nutrient_broth_or_agar.yaml",
-    "culturemech_id": "CultureMech:001813",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5",
-    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5.yaml",
-    "culturemech_id": "CultureMech:008390",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood",
-    "file_path": "bacterial/TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood.yaml",
-    "culturemech_id": "CultureMech:010365",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "TOGO_M3116_Nutrient_Agar",
-    "file_path": "bacterial/TOGO_M3116_Nutrient_Agar.yaml",
-    "culturemech_id": "CultureMech:009588",
-    "stratum": "WELL_KNOWN"
-  },
-  {
-    "recipe_name": "lb_luria_bertani_medium",
-    "file_path": "bacterial/lb_luria_bertani_medium.yaml",
-    "culturemech_id": "CultureMech:001486",
-    "stratum": "WELL_KNOWN"
-  },
-  {
     "recipe_name": "anaerobic_sulfolobales_medium",
     "file_path": "archaea/anaerobic_sulfolobales_medium.yaml",
     "culturemech_id": "CultureMech:010119",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M923_Dethiosulfovibrio_Belb1_Medium",
+    "file_path": "bacterial/TOGO_M923_Dethiosulfovibrio_Belb1_Medium.yaml",
+    "culturemech_id": "CultureMech:010344",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "frey_broth",
+    "file_path": "bacterial/frey_broth.yaml",
+    "culturemech_id": "CultureMech:008822",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex",
+    "file_path": "bacterial/brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex.yaml",
+    "culturemech_id": "CultureMech:009397",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "JCM_J1425_SPOROMUSA_MEDIUM_2",
@@ -912,10 +48,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "sd0_medium",
+    "file_path": "bacterial/sd0_medium.yaml",
+    "culturemech_id": "CultureMech:002698",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "desulfobulbus_sp_medium_freshwater_for_dsm_14880",
+    "file_path": "bacterial/desulfobulbus_sp_medium_freshwater_for_dsm_14880.yaml",
+    "culturemech_id": "CultureMech:009098",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "lb_rifampicin_medium",
+    "file_path": "bacterial/lb_rifampicin_medium.yaml",
+    "culturemech_id": "CultureMech:008553",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "desulfoglaeba_medium",
     "file_path": "bacterial/desulfoglaeba_medium.yaml",
     "culturemech_id": "CultureMech:000506",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "for_arhodomonas",
+    "file_path": "bacterial/for_arhodomonas.yaml",
+    "culturemech_id": "CultureMech:006871",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M1875_Thermus_medium",
+    "file_path": "bacterial/TOGO_M1875_Thermus_medium.yaml",
+    "culturemech_id": "CultureMech:008450",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "tryptic_soy_agar_tsa_carl_roth_gmbh_co",
+    "file_path": "bacterial/tryptic_soy_agar_tsa_carl_roth_gmbh_co.yaml",
+    "culturemech_id": "CultureMech:009450",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "rc_medium",
@@ -924,10 +96,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "methanobacterium_medium_ii",
+    "file_path": "archaea/methanobacterium_medium_ii.yaml",
+    "culturemech_id": "CultureMech:003048",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "allen_medium",
+    "file_path": "bacterial/allen_medium.yaml",
+    "culturemech_id": "CultureMech:008820",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "nutrient_agar_broth",
+    "file_path": "bacterial/nutrient_agar_broth.yaml",
+    "culturemech_id": "CultureMech:008307",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "gemmatimonas_medium",
     "file_path": "bacterial/gemmatimonas_medium.yaml",
     "culturemech_id": "CultureMech:001129",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "chthonomonas_medium",
+    "file_path": "bacterial/chthonomonas_medium.yaml",
+    "culturemech_id": "CultureMech:000754",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium",
+    "file_path": "bacterial/TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium.yaml",
+    "culturemech_id": "CultureMech:008883",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_5_nacl",
+    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_2_with_5_nacl.yaml",
+    "culturemech_id": "CultureMech:008596",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "v2_medium",
@@ -936,10 +144,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "for_dsm_17771",
+    "file_path": "bacterial/for_dsm_17771.yaml",
+    "culturemech_id": "CultureMech:006915",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12",
+    "file_path": "bacterial/mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12.yaml",
+    "culturemech_id": "CultureMech:009056",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "1_100_nutrient_agar_no_2",
+    "file_path": "bacterial/1_100_nutrient_agar_no_2.yaml",
+    "culturemech_id": "CultureMech:002131",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "JCM_J54_POTATO-CARROT_AGAR",
     "file_path": "bacterial/JCM_J54_POTATO-CARROT_AGAR.yaml",
     "culturemech_id": "CultureMech:002897",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "desulfotomaculum_lam5_medium",
+    "file_path": "bacterial/desulfotomaculum_lam5_medium.yaml",
+    "culturemech_id": "CultureMech:002893",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M3231_Minimal_media",
+    "file_path": "bacterial/TOGO_M3231_Minimal_media.yaml",
+    "culturemech_id": "CultureMech:009671",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2",
+    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2.yaml",
+    "culturemech_id": "CultureMech:010528",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_651_R_8_A_H_medium",
@@ -948,10 +192,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "artificial_seawater_for_halophiles",
+    "file_path": "bacterial/artificial_seawater_for_halophiles.yaml",
+    "culturemech_id": "CultureMech:009844",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2726_Clostridium_medium",
+    "file_path": "bacterial/TOGO_M2726_Clostridium_medium.yaml",
+    "culturemech_id": "CultureMech:009276",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "2_malt_extract_agar",
+    "file_path": "bacterial/2_malt_extract_agar.yaml",
+    "culturemech_id": "CultureMech:008671",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen",
     "file_path": "specialized/varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen.yaml",
     "culturemech_id": "CultureMech:015780",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M1041_MPOB_Medium",
+    "file_path": "bacterial/TOGO_M1041_MPOB_Medium.yaml",
+    "culturemech_id": "CultureMech:007557",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "mag_modified_arabinose_gluconate_medium",
+    "file_path": "bacterial/mag_modified_arabinose_gluconate_medium.yaml",
+    "culturemech_id": "CultureMech:001150",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "r2a_agar",
+    "file_path": "bacterial/r2a_agar.yaml",
+    "culturemech_id": "CultureMech:002706",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "m17_broth_containing_glucose",
@@ -960,10 +240,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "methanolinea_medium",
+    "file_path": "archaea/methanolinea_medium.yaml",
+    "culturemech_id": "CultureMech:002777",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2228_Friis_medium",
+    "file_path": "bacterial/TOGO_M2228_Friis_medium.yaml",
+    "culturemech_id": "CultureMech:008816",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "blood_agar_tsa_with_5_sheep_blood_remel",
+    "file_path": "bacterial/blood_agar_tsa_with_5_sheep_blood_remel.yaml",
+    "culturemech_id": "CultureMech:009339",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "trace_element_solution_medium_929",
     "file_path": "bacterial/trace_element_solution_medium_929.yaml",
     "culturemech_id": "CultureMech:004330",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA",
+    "file_path": "bacterial/KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA.yaml",
+    "culturemech_id": "CultureMech:004655",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "anaerobic_freshwater_fwm_medium_for_dsm_15978",
+    "file_path": "bacterial/anaerobic_freshwater_fwm_medium_for_dsm_15978.yaml",
+    "culturemech_id": "CultureMech:009205",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2199_LB_Agar_Broth_Miller",
+    "file_path": "bacterial/TOGO_M2199_LB_Agar_Broth_Miller.yaml",
+    "culturemech_id": "CultureMech:008791",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "medium_104_modified_for_dsm_21651",
@@ -972,10 +288,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "TOGO_M1377_Glucose_bicarbonate-Buffered_Medium",
+    "file_path": "bacterial/TOGO_M1377_Glucose_bicarbonate-Buffered_Medium.yaml",
+    "culturemech_id": "CultureMech:007916",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "mineral_medium_jagmann",
+    "file_path": "bacterial/mineral_medium_jagmann.yaml",
+    "culturemech_id": "CultureMech:001199",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "JCM_J100_ALKALINE_NUTRIENT_AGAR",
+    "file_path": "bacterial/JCM_J100_ALKALINE_NUTRIENT_AGAR.yaml",
+    "culturemech_id": "CultureMech:002194",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "th_agar",
     "file_path": "bacterial/th_agar.yaml",
     "culturemech_id": "CultureMech:002731",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "acidianus_medium_anaerobic",
+    "file_path": "specialized/acidianus_medium_anaerobic.yaml",
+    "culturemech_id": "CultureMech:015354",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_strain_r_1",
+    "file_path": "bacterial/medium_for_strain_r_1.yaml",
+    "culturemech_id": "CultureMech:008433",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "m9_farmer_et_al",
+    "file_path": "bacterial/m9_farmer_et_al.yaml",
+    "culturemech_id": "CultureMech:007010",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "NBRC_1021",
@@ -984,10 +336,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "thiorhodococcus_medium",
+    "file_path": "bacterial/thiorhodococcus_medium.yaml",
+    "culturemech_id": "CultureMech:000816",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "chopped_meat_medium_with_1_glucose",
+    "file_path": "bacterial/chopped_meat_medium_with_1_glucose.yaml",
+    "culturemech_id": "CultureMech:009305",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR",
+    "file_path": "bacterial/KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR.yaml",
+    "culturemech_id": "CultureMech:006268",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "KOMODO_492_CLOSTRIDIUM_METHYLPENTOSUM_MEDIUM",
     "file_path": "bacterial/KOMODO_492_CLOSTRIDIUM_METHYLPENTOSUM_MEDIUM.yaml",
     "culturemech_id": "CultureMech:005620",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "for_dsm_17721",
+    "file_path": "bacterial/for_dsm_17721.yaml",
+    "culturemech_id": "CultureMech:003631",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "formate_medium",
+    "file_path": "bacterial/formate_medium.yaml",
+    "culturemech_id": "CultureMech:009652",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "sea_water_luria_bertani_medium",
+    "file_path": "bacterial/sea_water_luria_bertani_medium.yaml",
+    "culturemech_id": "CultureMech:001039",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "trace_elements_solution_medium_1019",
@@ -996,10 +384,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "yem_agar",
+    "file_path": "bacterial/yem_agar.yaml",
+    "culturemech_id": "CultureMech:009635",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "clostridium_thermocellum_medium_d58_medium",
+    "file_path": "bacterial/clostridium_thermocellum_medium_d58_medium.yaml",
+    "culturemech_id": "CultureMech:008330",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "mueller_hinton_medium",
+    "file_path": "bacterial/mueller_hinton_medium.yaml",
+    "culturemech_id": "CultureMech:009463",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "batch_cultivation_medium_for_ta1",
     "file_path": "bacterial/batch_cultivation_medium_for_ta1.yaml",
     "culturemech_id": "CultureMech:007209",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M1634_Methanosarcina_Medium",
+    "file_path": "archaea/TOGO_M1634_Methanosarcina_Medium.yaml",
+    "culturemech_id": "CultureMech:008189",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "dsm_135_medium",
+    "file_path": "bacterial/dsm_135_medium.yaml",
+    "culturemech_id": "CultureMech:009613",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "r2a_with_artificial_soda_salt_lake_water",
+    "file_path": "bacterial/r2a_with_artificial_soda_salt_lake_water.yaml",
+    "culturemech_id": "CultureMech:001197",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_391-1_For_DSM_4254",
@@ -1008,10 +432,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "thermodesulfovibrio_yellowstonii_medium",
+    "file_path": "bacterial/thermodesulfovibrio_yellowstonii_medium.yaml",
+    "culturemech_id": "CultureMech:001883",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "gbs_salts_modified_for_thermocrinis_jamiesonii",
+    "file_path": "bacterial/gbs_salts_modified_for_thermocrinis_jamiesonii.yaml",
+    "culturemech_id": "CultureMech:000953",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2362_Columbia_Blood_Agar",
+    "file_path": "bacterial/TOGO_M2362_Columbia_Blood_Agar.yaml",
+    "culturemech_id": "CultureMech:008948",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "medium_402_modified_for_dsm_18237",
     "file_path": "bacterial/medium_402_modified_for_dsm_18237.yaml",
     "culturemech_id": "CultureMech:005203",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_1038_ACIDICALDUS_medium",
+    "file_path": "bacterial/KOMODO_1038_ACIDICALDUS_medium.yaml",
+    "culturemech_id": "CultureMech:003552",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M3036_Thiomonas_cuprina_medium",
+    "file_path": "bacterial/TOGO_M3036_Thiomonas_cuprina_medium.yaml",
+    "culturemech_id": "CultureMech:009548",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "r2a_agar_with_2_nacl",
+    "file_path": "bacterial/r2a_agar_with_2_nacl.yaml",
+    "culturemech_id": "CultureMech:002325",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_1181_METHYLOCELLA_SILVERSTRIS_MEDIUM",
@@ -1020,10 +480,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "lactate_bicarbonate_buffered_medium",
+    "file_path": "bacterial/lactate_bicarbonate_buffered_medium.yaml",
+    "culturemech_id": "CultureMech:003203",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2692_Alkaline_xylan_medium",
+    "file_path": "bacterial/TOGO_M2692_Alkaline_xylan_medium.yaml",
+    "culturemech_id": "CultureMech:009244",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "modified_m9_medium",
+    "file_path": "bacterial/modified_m9_medium.yaml",
+    "culturemech_id": "CultureMech:009533",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "DSMZ_1405_PYG_MEDIUM_MODIFIED",
     "file_path": "bacterial/DSMZ_1405_PYG_MEDIUM_MODIFIED.yaml",
     "culturemech_id": "CultureMech:000866",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_for_strain_mp_01",
+    "file_path": "bacterial/medium_for_strain_mp_01.yaml",
+    "culturemech_id": "CultureMech:010405",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_strains_ja121_and_ja322",
+    "file_path": "bacterial/medium_for_strains_ja121_and_ja322.yaml",
+    "culturemech_id": "CultureMech:008370",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "nutrient_agar_oxoid_cm3_with_phosphate",
+    "file_path": "bacterial/nutrient_agar_oxoid_cm3_with_phosphate.yaml",
+    "culturemech_id": "CultureMech:001733",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "histidine_salt_schaechter_et_al",
@@ -1032,10 +528,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "sdo_medium",
+    "file_path": "bacterial/sdo_medium.yaml",
+    "culturemech_id": "CultureMech:000590",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "minimal_medium_containing_nicotin",
+    "file_path": "bacterial/minimal_medium_containing_nicotin.yaml",
+    "culturemech_id": "CultureMech:009420",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M492_1_2_MRS_1_2_BHI_Agar",
+    "file_path": "bacterial/TOGO_M492_1_2_MRS_1_2_BHI_Agar.yaml",
+    "culturemech_id": "CultureMech:009880",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "TOGO_M970_Peat_Medium_2_For_Methanobacteria",
     "file_path": "archaea/TOGO_M970_Peat_Medium_2_For_Methanobacteria.yaml",
     "culturemech_id": "CultureMech:010396",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium",
+    "file_path": "bacterial/TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium.yaml",
+    "culturemech_id": "CultureMech:010082",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_freshwater_flexibacteria",
+    "file_path": "bacterial/medium_for_freshwater_flexibacteria.yaml",
+    "culturemech_id": "CultureMech:008096",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M18_YM_Agar",
+    "file_path": "bacterial/TOGO_M18_YM_Agar.yaml",
+    "culturemech_id": "CultureMech:008476",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "medium_830_modified_for_dsm_18704",
@@ -1044,10 +576,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "marine_h2_using_methanogen_medium",
+    "file_path": "archaea/marine_h2_using_methanogen_medium.yaml",
+    "culturemech_id": "CultureMech:008267",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2576_Modified_chopped_meat_medium",
+    "file_path": "bacterial/TOGO_M2576_Modified_chopped_meat_medium.yaml",
+    "culturemech_id": "CultureMech:009145",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "m9_minimal_media_plus",
+    "file_path": "specialized/m9_minimal_media_plus.yaml",
+    "culturemech_id": "CultureMech:015550",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "beijerinckia_medium",
     "file_path": "bacterial/beijerinckia_medium.yaml",
     "culturemech_id": "CultureMech:000556",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_1174_NITRINCOLA_medium",
+    "file_path": "bacterial/KOMODO_1174_NITRINCOLA_medium.yaml",
+    "culturemech_id": "CultureMech:003894",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "actinotalea_fermentas_medium",
+    "file_path": "bacterial/actinotalea_fermentas_medium.yaml",
+    "culturemech_id": "CultureMech:008423",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_2_nacl",
+    "file_path": "bacterial/brain_heart_infusion_2_nacl.yaml",
+    "culturemech_id": "CultureMech:008546",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_726_RHIZOMONAS_SUBERIFACIENS_medium",
@@ -1056,10 +624,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "methanosalsum_wen5_medium",
+    "file_path": "archaea/methanosalsum_wen5_medium.yaml",
+    "culturemech_id": "CultureMech:001829",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M3199_Defined_minimal_medium",
+    "file_path": "bacterial/TOGO_M3199_Defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009640",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar",
+    "file_path": "bacterial/TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar.yaml",
+    "culturemech_id": "CultureMech:008269",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "TOGO_M160_Halobacteria_Medium",
     "file_path": "archaea/TOGO_M160_Halobacteria_Medium.yaml",
     "culturemech_id": "CultureMech:008163",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "acidianus_infernus_medium",
+    "file_path": "archaea/acidianus_infernus_medium.yaml",
+    "culturemech_id": "CultureMech:005077",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_marine_flexibacteria",
+    "file_path": "bacterial/medium_for_marine_flexibacteria.yaml",
+    "culturemech_id": "CultureMech:008091",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "anaerobic_tryptic_soy_broth_medium",
+    "file_path": "specialized/anaerobic_tryptic_soy_broth_medium.yaml",
+    "culturemech_id": "CultureMech:015369",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "thiobacillus_thioparus_tk_m_medium",
@@ -1068,10 +672,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "marichromatium_bheemlicum_medium",
+    "file_path": "bacterial/marichromatium_bheemlicum_medium.yaml",
+    "culturemech_id": "CultureMech:002881",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M3228_Defined_medium",
+    "file_path": "bacterial/TOGO_M3228_Defined_medium.yaml",
+    "culturemech_id": "CultureMech:009667",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "r2a_fumarate_anaerobic",
+    "file_path": "bacterial/r2a_fumarate_anaerobic.yaml",
+    "culturemech_id": "CultureMech:009554",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "mme_nonitrogen_nocarbon",
     "file_path": "specialized/mme_nonitrogen_nocarbon.yaml",
     "culturemech_id": "CultureMech:015600",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "for_dsm_24312",
+    "file_path": "bacterial/for_dsm_24312.yaml",
+    "culturemech_id": "CultureMech:003633",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn",
+    "file_path": "bacterial/leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn.yaml",
+    "culturemech_id": "CultureMech:008670",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "malt_extract_agar",
+    "file_path": "fungal/malt_extract_agar.yaml",
+    "culturemech_id": "CultureMech:010520",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_877_LUEDEMANN_medium_LUEDEMANN_1968",
@@ -1080,10 +720,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "succinate_minimal_salts_medium_sms",
+    "file_path": "bacterial/succinate_minimal_salts_medium_sms.yaml",
+    "culturemech_id": "CultureMech:000833",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "leeming_amp_notman_agar_modified_mlna",
+    "file_path": "bacterial/leeming_amp_notman_agar_modified_mlna.yaml",
+    "culturemech_id": "CultureMech:008353",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "KOMODO_952_1_10_NUTRIENT_AGAR_NO.2",
+    "file_path": "bacterial/KOMODO_952_1_10_NUTRIENT_AGAR_NO.2.yaml",
+    "culturemech_id": "CultureMech:006895",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "levulinic_acid_medium",
     "file_path": "bacterial/levulinic_acid_medium.yaml",
     "culturemech_id": "CultureMech:008697",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "nasu_iron_reducer_medium",
+    "file_path": "bacterial/nasu_iron_reducer_medium.yaml",
+    "culturemech_id": "CultureMech:002199",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2378_Natronobacteria_medium",
+    "file_path": "bacterial/TOGO_M2378_Natronobacteria_medium.yaml",
+    "culturemech_id": "CultureMech:008962",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_bhi_with_sodium_acetate",
+    "file_path": "bacterial/brain_heart_infusion_bhi_with_sodium_acetate.yaml",
+    "culturemech_id": "CultureMech:009557",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "KOMODO_650_CENTENUM_medium",
@@ -1092,10 +768,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium",
+    "file_path": "bacterial/KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium.yaml",
+    "culturemech_id": "CultureMech:006400",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "enriched_anaerobe_medium",
+    "file_path": "bacterial/enriched_anaerobe_medium.yaml",
+    "culturemech_id": "CultureMech:009304",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "m9_minimal_medium_with_acetate",
+    "file_path": "bacterial/m9_minimal_medium_with_acetate.yaml",
+    "culturemech_id": "CultureMech:007300",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "reactivation_with_liquid_medium_115",
     "file_path": "bacterial/reactivation_with_liquid_medium_115.yaml",
     "culturemech_id": "CultureMech:000599",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "rhodovulum_imhoffii_medium",
+    "file_path": "bacterial/rhodovulum_imhoffii_medium.yaml",
+    "culturemech_id": "CultureMech:002871",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "clostridia_growth_medium_cgm",
+    "file_path": "bacterial/clostridia_growth_medium_cgm.yaml",
+    "culturemech_id": "CultureMech:009356",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2511_brain_heart_infusion_broth",
+    "file_path": "bacterial/TOGO_M2511_brain_heart_infusion_broth.yaml",
+    "culturemech_id": "CultureMech:009083",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "caryophanon_latum_medium",
@@ -1104,10 +816,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "marine_methanobacterium_medium",
+    "file_path": "archaea/marine_methanobacterium_medium.yaml",
+    "culturemech_id": "CultureMech:007804",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643",
+    "file_path": "bacterial/medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643.yaml",
+    "culturemech_id": "CultureMech:008408",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M94_Nutrient_Agar_With_25_Soil_Extract",
+    "file_path": "bacterial/TOGO_M94_Nutrient_Agar_With_25_Soil_Extract.yaml",
+    "culturemech_id": "CultureMech:010373",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "zmb_als_novaline",
     "file_path": "specialized/zmb_als_novaline.yaml",
     "culturemech_id": "CultureMech:015827",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M1275_Vallitalea_70B-A_Medium",
+    "file_path": "bacterial/TOGO_M1275_Vallitalea_70B-A_Medium.yaml",
+    "culturemech_id": "CultureMech:007808",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "chocolate_agar_polyvitex_pvx",
+    "file_path": "bacterial/chocolate_agar_polyvitex_pvx.yaml",
+    "culturemech_id": "CultureMech:008743",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2520_R2A_Medium",
+    "file_path": "bacterial/TOGO_M2520_R2A_Medium.yaml",
+    "culturemech_id": "CultureMech:009090",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "medium_for_aciduric_thermophilic_bacillus_strains",
@@ -1116,10 +864,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine",
+    "file_path": "bacterial/acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine.yaml",
+    "culturemech_id": "CultureMech:005622",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid",
+    "file_path": "bacterial/basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid.yaml",
+    "culturemech_id": "CultureMech:008825",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "czapek_yeast_extract_agar_cya",
+    "file_path": "fungal/czapek_yeast_extract_agar_cya.yaml",
+    "culturemech_id": "CultureMech:010511",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "bicarbonate_buffered_medium_with_acethylene",
     "file_path": "bacterial/bicarbonate_buffered_medium_with_acethylene.yaml",
     "culturemech_id": "CultureMech:002412",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "methanospirillum_lacunae_medium",
+    "file_path": "archaea/methanospirillum_lacunae_medium.yaml",
+    "culturemech_id": "CultureMech:000735",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_bhi_broth_oxoid",
+    "file_path": "bacterial/brain_heart_infusion_bhi_broth_oxoid.yaml",
+    "culturemech_id": "CultureMech:008801",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M21_Brain_Heart_Infusion_Agar",
+    "file_path": "bacterial/TOGO_M21_Brain_Heart_Infusion_Agar.yaml",
+    "culturemech_id": "CultureMech:008793",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "medium_693_modified_for_dsm_22886",
@@ -1128,10 +912,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "KOMODO_1360_HIPPEA_JASONIAE_medium",
+    "file_path": "bacterial/KOMODO_1360_HIPPEA_JASONIAE_medium.yaml",
+    "culturemech_id": "CultureMech:004108",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "isosphaera_medium",
+    "file_path": "bacterial/isosphaera_medium.yaml",
+    "culturemech_id": "CultureMech:008891",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_with_soil_extract",
+    "file_path": "bacterial/brain_heart_infusion_agar_with_soil_extract.yaml",
+    "culturemech_id": "CultureMech:002702",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "medium_65_modified_for_dsm_41868",
     "file_path": "bacterial/medium_65_modified_for_dsm_41868.yaml",
     "culturemech_id": "CultureMech:006201",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784",
+    "file_path": "bacterial/natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784.yaml",
+    "culturemech_id": "CultureMech:006483",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "meiothermus_hypogaeus_medium",
+    "file_path": "bacterial/meiothermus_hypogaeus_medium.yaml",
+    "culturemech_id": "CultureMech:000920",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "columbia_blood_agar_containing_10_bovine_blood",
+    "file_path": "bacterial/columbia_blood_agar_containing_10_bovine_blood.yaml",
+    "culturemech_id": "CultureMech:009496",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "for_dsm_21650",
@@ -1140,10 +960,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "norris_ferroplasma_medium",
+    "file_path": "archaea/norris_ferroplasma_medium.yaml",
+    "culturemech_id": "CultureMech:002877",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M3200_Defined_minimal_medium",
+    "file_path": "bacterial/TOGO_M3200_Defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009643",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "luria_bertani_lb_medium_buffered_mops",
+    "file_path": "bacterial/luria_bertani_lb_medium_buffered_mops.yaml",
+    "culturemech_id": "CultureMech:009075",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "ysg_medium_ph_4_5",
     "file_path": "bacterial/ysg_medium_ph_4_5.yaml",
     "culturemech_id": "CultureMech:008347",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "geothermobacter_medium",
+    "file_path": "bacterial/geothermobacter_medium.yaml",
+    "culturemech_id": "CultureMech:002163",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood",
+    "file_path": "bacterial/brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood.yaml",
+    "culturemech_id": "CultureMech:009466",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M16_1_10_Nutrient_Agar_NO._2",
+    "file_path": "bacterial/TOGO_M16_1_10_Nutrient_Agar_NO._2.yaml",
+    "culturemech_id": "CultureMech:008261",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "Bristol_Medium",
@@ -1152,10 +1008,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "ird_marine_clostrida_medium",
+    "file_path": "specialized/ird_marine_clostrida_medium.yaml",
+    "culturemech_id": "CultureMech:015423",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "desulfovibrio_mv_medium_for_dsm_13257",
+    "file_path": "bacterial/desulfovibrio_mv_medium_for_dsm_13257.yaml",
+    "culturemech_id": "CultureMech:009288",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood",
+    "file_path": "bacterial/tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood.yaml",
+    "culturemech_id": "CultureMech:009342",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "KOMODO_1108a_CYS_MEDIUM_WITH_MODIFIED_NACL_CONCENTRATION",
     "file_path": "bacterial/KOMODO_1108a_CYS_MEDIUM_WITH_MODIFIED_NACL_CONCENTRATION.yaml",
     "culturemech_id": "CultureMech:003809",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "for_dsm_19306",
+    "file_path": "bacterial/for_dsm_19306.yaml",
+    "culturemech_id": "CultureMech:006946",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "alkaline_halophile_medium",
+    "file_path": "bacterial/alkaline_halophile_medium.yaml",
+    "culturemech_id": "CultureMech:008289",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "bhi_glucose_medium",
+    "file_path": "bacterial/bhi_glucose_medium.yaml",
+    "culturemech_id": "CultureMech:001983",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "s_w",
@@ -1164,10 +1056,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "lca",
+    "file_path": "bacterial/lca.yaml",
+    "culturemech_id": "CultureMech:008306",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_tick_cells_rickettsia",
+    "file_path": "bacterial/medium_for_tick_cells_rickettsia.yaml",
+    "culturemech_id": "CultureMech:001032",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater",
+    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater.yaml",
+    "culturemech_id": "CultureMech:010536",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "JCM_J1429_M1H_NAG_ASW",
     "file_path": "bacterial/JCM_J1429_M1H_NAG_ASW.yaml",
     "culturemech_id": "CultureMech:015864",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "t49_medium",
+    "file_path": "bacterial/t49_medium.yaml",
+    "culturemech_id": "CultureMech:004041",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated",
+    "file_path": "bacterial/TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated.yaml",
+    "culturemech_id": "CultureMech:009142",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "half_strength_nutrient_broth_or_agar",
+    "file_path": "bacterial/half_strength_nutrient_broth_or_agar.yaml",
+    "culturemech_id": "CultureMech:001813",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "mycoplasma_medium_with_sucrose",
@@ -1176,10 +1104,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "rhodomicrobium_medium",
+    "file_path": "bacterial/rhodomicrobium_medium.yaml",
+    "culturemech_id": "CultureMech:008166",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M2711_Clostridium_Cellulolytic_medium",
+    "file_path": "bacterial/TOGO_M2711_Clostridium_Cellulolytic_medium.yaml",
+    "culturemech_id": "CultureMech:009263",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5",
+    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5.yaml",
+    "culturemech_id": "CultureMech:008390",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "medium_971_modified_for_dsm_18087",
     "file_path": "bacterial/medium_971_modified_for_dsm_18087.yaml",
     "culturemech_id": "CultureMech:006928",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "rhodobium_gokurnum_medium",
+    "file_path": "bacterial/rhodobium_gokurnum_medium.yaml",
+    "culturemech_id": "CultureMech:002867",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2",
+    "file_path": "bacterial/columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2.yaml",
+    "culturemech_id": "CultureMech:008843",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood",
+    "file_path": "bacterial/TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood.yaml",
+    "culturemech_id": "CultureMech:010365",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "medium_for_chlorobium_ferrooxidans",
@@ -1188,10 +1152,46 @@
     "stratum": "OTHER"
   },
   {
+    "recipe_name": "modified_balchs_methanogen_medium_1_b",
+    "file_path": "archaea/modified_balchs_methanogen_medium_1_b.yaml",
+    "culturemech_id": "CultureMech:000304",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "k_101_flexibacter_medium",
+    "file_path": "bacterial/k_101_flexibacter_medium.yaml",
+    "culturemech_id": "CultureMech:009160",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3116_Nutrient_Agar",
+    "file_path": "bacterial/TOGO_M3116_Nutrient_Agar.yaml",
+    "culturemech_id": "CultureMech:009588",
+    "stratum": "WELL_KNOWN"
+  },
+  {
     "recipe_name": "TOGO_M1117_Halomonas_CUG_Medium",
     "file_path": "bacterial/TOGO_M1117_Halomonas_CUG_Medium.yaml",
     "culturemech_id": "CultureMech:007637",
     "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "planctomyces_pyreformis_medium",
+    "file_path": "bacterial/planctomyces_pyreformis_medium.yaml",
+    "culturemech_id": "CultureMech:001009",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "defined_minimal_medium",
+    "file_path": "bacterial/defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009638",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "lb_luria_bertani_medium",
+    "file_path": "bacterial/lb_luria_bertani_medium.yaml",
+    "culturemech_id": "CultureMech:001486",
+    "stratum": "WELL_KNOWN"
   },
   {
     "recipe_name": "cornmeal_seawater_agar_cmswa",

--- a/data/import_tracking/reports/axis_research_batch.json
+++ b/data/import_tracking/reports/axis_research_batch.json
@@ -1,0 +1,1202 @@
+[
+  {
+    "recipe_name": "KOMODO_221_AZOSPIRILLUM_medium",
+    "file_path": "bacterial/KOMODO_221_AZOSPIRILLUM_medium.yaml",
+    "culturemech_id": "CultureMech:004576",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M923_Dethiosulfovibrio_Belb1_Medium",
+    "file_path": "bacterial/TOGO_M923_Dethiosulfovibrio_Belb1_Medium.yaml",
+    "culturemech_id": "CultureMech:010344",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "sd0_medium",
+    "file_path": "bacterial/sd0_medium.yaml",
+    "culturemech_id": "CultureMech:002698",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "for_arhodomonas",
+    "file_path": "bacterial/for_arhodomonas.yaml",
+    "culturemech_id": "CultureMech:006871",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "methanobacterium_medium_ii",
+    "file_path": "archaea/methanobacterium_medium_ii.yaml",
+    "culturemech_id": "CultureMech:003048",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "chthonomonas_medium",
+    "file_path": "bacterial/chthonomonas_medium.yaml",
+    "culturemech_id": "CultureMech:000754",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "for_dsm_17771",
+    "file_path": "bacterial/for_dsm_17771.yaml",
+    "culturemech_id": "CultureMech:006915",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "desulfotomaculum_lam5_medium",
+    "file_path": "bacterial/desulfotomaculum_lam5_medium.yaml",
+    "culturemech_id": "CultureMech:002893",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "artificial_seawater_for_halophiles",
+    "file_path": "bacterial/artificial_seawater_for_halophiles.yaml",
+    "culturemech_id": "CultureMech:009844",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M1041_MPOB_Medium",
+    "file_path": "bacterial/TOGO_M1041_MPOB_Medium.yaml",
+    "culturemech_id": "CultureMech:007557",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "methanolinea_medium",
+    "file_path": "archaea/methanolinea_medium.yaml",
+    "culturemech_id": "CultureMech:002777",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA",
+    "file_path": "bacterial/KOMODO_253_medium_FOR_ECTOTHIORHODOSPIRA.yaml",
+    "culturemech_id": "CultureMech:004655",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M1377_Glucose_bicarbonate-Buffered_Medium",
+    "file_path": "bacterial/TOGO_M1377_Glucose_bicarbonate-Buffered_Medium.yaml",
+    "culturemech_id": "CultureMech:007916",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "acidianus_medium_anaerobic",
+    "file_path": "specialized/acidianus_medium_anaerobic.yaml",
+    "culturemech_id": "CultureMech:015354",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "thiorhodococcus_medium",
+    "file_path": "bacterial/thiorhodococcus_medium.yaml",
+    "culturemech_id": "CultureMech:000816",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "for_dsm_17721",
+    "file_path": "bacterial/for_dsm_17721.yaml",
+    "culturemech_id": "CultureMech:003631",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "yem_agar",
+    "file_path": "bacterial/yem_agar.yaml",
+    "culturemech_id": "CultureMech:009635",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M1634_Methanosarcina_Medium",
+    "file_path": "archaea/TOGO_M1634_Methanosarcina_Medium.yaml",
+    "culturemech_id": "CultureMech:008189",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "thermodesulfovibrio_yellowstonii_medium",
+    "file_path": "bacterial/thermodesulfovibrio_yellowstonii_medium.yaml",
+    "culturemech_id": "CultureMech:001883",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "KOMODO_1038_ACIDICALDUS_medium",
+    "file_path": "bacterial/KOMODO_1038_ACIDICALDUS_medium.yaml",
+    "culturemech_id": "CultureMech:003552",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "lactate_bicarbonate_buffered_medium",
+    "file_path": "bacterial/lactate_bicarbonate_buffered_medium.yaml",
+    "culturemech_id": "CultureMech:003203",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "medium_for_strain_mp_01",
+    "file_path": "bacterial/medium_for_strain_mp_01.yaml",
+    "culturemech_id": "CultureMech:010405",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "sdo_medium",
+    "file_path": "bacterial/sdo_medium.yaml",
+    "culturemech_id": "CultureMech:000590",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium",
+    "file_path": "bacterial/TOGO_M678_Magnetospirillum_Gryphiswaldense_Medium.yaml",
+    "culturemech_id": "CultureMech:010082",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "marine_h2_using_methanogen_medium",
+    "file_path": "archaea/marine_h2_using_methanogen_medium.yaml",
+    "culturemech_id": "CultureMech:008267",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "KOMODO_1174_NITRINCOLA_medium",
+    "file_path": "bacterial/KOMODO_1174_NITRINCOLA_medium.yaml",
+    "culturemech_id": "CultureMech:003894",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "methanosalsum_wen5_medium",
+    "file_path": "archaea/methanosalsum_wen5_medium.yaml",
+    "culturemech_id": "CultureMech:001829",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "acidianus_infernus_medium",
+    "file_path": "archaea/acidianus_infernus_medium.yaml",
+    "culturemech_id": "CultureMech:005077",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "marichromatium_bheemlicum_medium",
+    "file_path": "bacterial/marichromatium_bheemlicum_medium.yaml",
+    "culturemech_id": "CultureMech:002881",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "for_dsm_24312",
+    "file_path": "bacterial/for_dsm_24312.yaml",
+    "culturemech_id": "CultureMech:003633",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "succinate_minimal_salts_medium_sms",
+    "file_path": "bacterial/succinate_minimal_salts_medium_sms.yaml",
+    "culturemech_id": "CultureMech:000833",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "nasu_iron_reducer_medium",
+    "file_path": "bacterial/nasu_iron_reducer_medium.yaml",
+    "culturemech_id": "CultureMech:002199",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium",
+    "file_path": "bacterial/KOMODO_749_THERMODESULFOVIBRIO_YELLOWSTONII_medium.yaml",
+    "culturemech_id": "CultureMech:006400",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "rhodovulum_imhoffii_medium",
+    "file_path": "bacterial/rhodovulum_imhoffii_medium.yaml",
+    "culturemech_id": "CultureMech:002871",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "marine_methanobacterium_medium",
+    "file_path": "archaea/marine_methanobacterium_medium.yaml",
+    "culturemech_id": "CultureMech:007804",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "TOGO_M1275_Vallitalea_70B-A_Medium",
+    "file_path": "bacterial/TOGO_M1275_Vallitalea_70B-A_Medium.yaml",
+    "culturemech_id": "CultureMech:007808",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine",
+    "file_path": "bacterial/acetohalobium_medium_replace_trimethylamine_x_hcl_with_glycinebetaine.yaml",
+    "culturemech_id": "CultureMech:005622",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "methanospirillum_lacunae_medium",
+    "file_path": "archaea/methanospirillum_lacunae_medium.yaml",
+    "culturemech_id": "CultureMech:000735",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "KOMODO_1360_HIPPEA_JASONIAE_medium",
+    "file_path": "bacterial/KOMODO_1360_HIPPEA_JASONIAE_medium.yaml",
+    "culturemech_id": "CultureMech:004108",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784",
+    "file_path": "bacterial/natroniella_medium_replace_trace_element_solution_sl_4_medium_457_with_trace_element_solution_sl_11_medium_784.yaml",
+    "culturemech_id": "CultureMech:006483",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "norris_ferroplasma_medium",
+    "file_path": "archaea/norris_ferroplasma_medium.yaml",
+    "culturemech_id": "CultureMech:002877",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "geothermobacter_medium",
+    "file_path": "bacterial/geothermobacter_medium.yaml",
+    "culturemech_id": "CultureMech:002163",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "ird_marine_clostrida_medium",
+    "file_path": "specialized/ird_marine_clostrida_medium.yaml",
+    "culturemech_id": "CultureMech:015423",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "for_dsm_19306",
+    "file_path": "bacterial/for_dsm_19306.yaml",
+    "culturemech_id": "CultureMech:006946",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "lca",
+    "file_path": "bacterial/lca.yaml",
+    "culturemech_id": "CultureMech:008306",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "t49_medium",
+    "file_path": "bacterial/t49_medium.yaml",
+    "culturemech_id": "CultureMech:004041",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "rhodomicrobium_medium",
+    "file_path": "bacterial/rhodomicrobium_medium.yaml",
+    "culturemech_id": "CultureMech:008166",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "rhodobium_gokurnum_medium",
+    "file_path": "bacterial/rhodobium_gokurnum_medium.yaml",
+    "culturemech_id": "CultureMech:002867",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "modified_balchs_methanogen_medium_1_b",
+    "file_path": "archaea/modified_balchs_methanogen_medium_1_b.yaml",
+    "culturemech_id": "CultureMech:000304",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "planctomyces_pyreformis_medium",
+    "file_path": "bacterial/planctomyces_pyreformis_medium.yaml",
+    "culturemech_id": "CultureMech:001009",
+    "stratum": "SEMI_DEFINED"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_bhi_broth_containing_c_difficile_supplement_and_0_04_cysteine",
+    "file_path": "bacterial/brain_heart_infusion_bhi_broth_containing_c_difficile_supplement_and_0_04_cysteine.yaml",
+    "culturemech_id": "CultureMech:009359",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "frey_broth",
+    "file_path": "bacterial/frey_broth.yaml",
+    "culturemech_id": "CultureMech:008822",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "desulfobulbus_sp_medium_freshwater_for_dsm_14880",
+    "file_path": "bacterial/desulfobulbus_sp_medium_freshwater_for_dsm_14880.yaml",
+    "culturemech_id": "CultureMech:009098",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M1875_Thermus_medium",
+    "file_path": "bacterial/TOGO_M1875_Thermus_medium.yaml",
+    "culturemech_id": "CultureMech:008450",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "allen_medium",
+    "file_path": "bacterial/allen_medium.yaml",
+    "culturemech_id": "CultureMech:008820",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium",
+    "file_path": "bacterial/TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium.yaml",
+    "culturemech_id": "CultureMech:008883",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12",
+    "file_path": "bacterial/mn_marine_medium_atcc_medium_957_with_20_mcg_l_of_vitamin_b12.yaml",
+    "culturemech_id": "CultureMech:009056",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3231_Minimal_media",
+    "file_path": "bacterial/TOGO_M3231_Minimal_media.yaml",
+    "culturemech_id": "CultureMech:009671",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2726_Clostridium_medium",
+    "file_path": "bacterial/TOGO_M2726_Clostridium_medium.yaml",
+    "culturemech_id": "CultureMech:009276",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "mag_modified_arabinose_gluconate_medium",
+    "file_path": "bacterial/mag_modified_arabinose_gluconate_medium.yaml",
+    "culturemech_id": "CultureMech:001150",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2228_Friis_medium",
+    "file_path": "bacterial/TOGO_M2228_Friis_medium.yaml",
+    "culturemech_id": "CultureMech:008816",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "anaerobic_freshwater_fwm_medium_for_dsm_15978",
+    "file_path": "bacterial/anaerobic_freshwater_fwm_medium_for_dsm_15978.yaml",
+    "culturemech_id": "CultureMech:009205",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "mineral_medium_jagmann",
+    "file_path": "bacterial/mineral_medium_jagmann.yaml",
+    "culturemech_id": "CultureMech:001199",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_strain_r_1",
+    "file_path": "bacterial/medium_for_strain_r_1.yaml",
+    "culturemech_id": "CultureMech:008433",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "chopped_meat_medium_with_1_glucose",
+    "file_path": "bacterial/chopped_meat_medium_with_1_glucose.yaml",
+    "culturemech_id": "CultureMech:009305",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "formate_medium",
+    "file_path": "bacterial/formate_medium.yaml",
+    "culturemech_id": "CultureMech:009652",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "clostridium_thermocellum_medium_d58_medium",
+    "file_path": "bacterial/clostridium_thermocellum_medium_d58_medium.yaml",
+    "culturemech_id": "CultureMech:008330",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "dsm_135_medium",
+    "file_path": "bacterial/dsm_135_medium.yaml",
+    "culturemech_id": "CultureMech:009613",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "gbs_salts_modified_for_thermocrinis_jamiesonii",
+    "file_path": "bacterial/gbs_salts_modified_for_thermocrinis_jamiesonii.yaml",
+    "culturemech_id": "CultureMech:000953",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3036_Thiomonas_cuprina_medium",
+    "file_path": "bacterial/TOGO_M3036_Thiomonas_cuprina_medium.yaml",
+    "culturemech_id": "CultureMech:009548",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2692_Alkaline_xylan_medium",
+    "file_path": "bacterial/TOGO_M2692_Alkaline_xylan_medium.yaml",
+    "culturemech_id": "CultureMech:009244",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_strains_ja121_and_ja322",
+    "file_path": "bacterial/medium_for_strains_ja121_and_ja322.yaml",
+    "culturemech_id": "CultureMech:008370",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "minimal_medium_containing_nicotin",
+    "file_path": "bacterial/minimal_medium_containing_nicotin.yaml",
+    "culturemech_id": "CultureMech:009420",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_freshwater_flexibacteria",
+    "file_path": "bacterial/medium_for_freshwater_flexibacteria.yaml",
+    "culturemech_id": "CultureMech:008096",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2576_Modified_chopped_meat_medium",
+    "file_path": "bacterial/TOGO_M2576_Modified_chopped_meat_medium.yaml",
+    "culturemech_id": "CultureMech:009145",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "actinotalea_fermentas_medium",
+    "file_path": "bacterial/actinotalea_fermentas_medium.yaml",
+    "culturemech_id": "CultureMech:008423",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3199_Defined_minimal_medium",
+    "file_path": "bacterial/TOGO_M3199_Defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009640",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_marine_flexibacteria",
+    "file_path": "bacterial/medium_for_marine_flexibacteria.yaml",
+    "culturemech_id": "CultureMech:008091",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3228_Defined_medium",
+    "file_path": "bacterial/TOGO_M3228_Defined_medium.yaml",
+    "culturemech_id": "CultureMech:009667",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn",
+    "file_path": "bacterial/leeming_amp_notman_agar_lna_leeming_amp_notman_1987_in_the_yeasts_a_taxonomic_study_5th_edn.yaml",
+    "culturemech_id": "CultureMech:008670",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "leeming_amp_notman_agar_modified_mlna",
+    "file_path": "bacterial/leeming_amp_notman_agar_modified_mlna.yaml",
+    "culturemech_id": "CultureMech:008353",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2378_Natronobacteria_medium",
+    "file_path": "bacterial/TOGO_M2378_Natronobacteria_medium.yaml",
+    "culturemech_id": "CultureMech:008962",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "enriched_anaerobe_medium",
+    "file_path": "bacterial/enriched_anaerobe_medium.yaml",
+    "culturemech_id": "CultureMech:009304",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "clostridia_growth_medium_cgm",
+    "file_path": "bacterial/clostridia_growth_medium_cgm.yaml",
+    "culturemech_id": "CultureMech:009356",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643",
+    "file_path": "bacterial/medium_for_strains_ja145_ja193_ja310_ja334_ja415_ja430_ja447_and_ja643.yaml",
+    "culturemech_id": "CultureMech:008408",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "chocolate_agar_polyvitex_pvx",
+    "file_path": "bacterial/chocolate_agar_polyvitex_pvx.yaml",
+    "culturemech_id": "CultureMech:008743",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid",
+    "file_path": "bacterial/basal_salts_medium_bsm_modified_from_that_of_hareland_et_al_j_bacteriol_121_272_285_1975_by_removal_of_the_nitriloacetic_acid.yaml",
+    "culturemech_id": "CultureMech:008825",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_bhi_broth_oxoid",
+    "file_path": "bacterial/brain_heart_infusion_bhi_broth_oxoid.yaml",
+    "culturemech_id": "CultureMech:008801",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "isosphaera_medium",
+    "file_path": "bacterial/isosphaera_medium.yaml",
+    "culturemech_id": "CultureMech:008891",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "meiothermus_hypogaeus_medium",
+    "file_path": "bacterial/meiothermus_hypogaeus_medium.yaml",
+    "culturemech_id": "CultureMech:000920",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M3200_Defined_minimal_medium",
+    "file_path": "bacterial/TOGO_M3200_Defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009643",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood",
+    "file_path": "bacterial/brain_heart_infusion_agar_amended_with_5_v_v_laked_horse_blood.yaml",
+    "culturemech_id": "CultureMech:009466",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "desulfovibrio_mv_medium_for_dsm_13257",
+    "file_path": "bacterial/desulfovibrio_mv_medium_for_dsm_13257.yaml",
+    "culturemech_id": "CultureMech:009288",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "alkaline_halophile_medium",
+    "file_path": "bacterial/alkaline_halophile_medium.yaml",
+    "culturemech_id": "CultureMech:008289",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "medium_for_tick_cells_rickettsia",
+    "file_path": "bacterial/medium_for_tick_cells_rickettsia.yaml",
+    "culturemech_id": "CultureMech:001032",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated",
+    "file_path": "bacterial/TOGO_M2573_Tryptic_Soy_Agar_Broth_with_5_Sheep_Blood_defibrinated.yaml",
+    "culturemech_id": "CultureMech:009142",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "TOGO_M2711_Clostridium_Cellulolytic_medium",
+    "file_path": "bacterial/TOGO_M2711_Clostridium_Cellulolytic_medium.yaml",
+    "culturemech_id": "CultureMech:009263",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2",
+    "file_path": "bacterial/columbia_broth_supplemented_with_0_01_3_nad_and_25_mm_cacl2.yaml",
+    "culturemech_id": "CultureMech:008843",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "k_101_flexibacter_medium",
+    "file_path": "bacterial/k_101_flexibacter_medium.yaml",
+    "culturemech_id": "CultureMech:009160",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "defined_minimal_medium",
+    "file_path": "bacterial/defined_minimal_medium.yaml",
+    "culturemech_id": "CultureMech:009638",
+    "stratum": "DEEP_RESEARCH"
+  },
+  {
+    "recipe_name": "tryptic_soy_agar_containing_2_5_nacl",
+    "file_path": "bacterial/tryptic_soy_agar_containing_2_5_nacl.yaml",
+    "culturemech_id": "CultureMech:008995",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex",
+    "file_path": "bacterial/brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex.yaml",
+    "culturemech_id": "CultureMech:009397",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "lb_rifampicin_medium",
+    "file_path": "bacterial/lb_rifampicin_medium.yaml",
+    "culturemech_id": "CultureMech:008553",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "tryptic_soy_agar_tsa_carl_roth_gmbh_co",
+    "file_path": "bacterial/tryptic_soy_agar_tsa_carl_roth_gmbh_co.yaml",
+    "culturemech_id": "CultureMech:009450",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "nutrient_agar_broth",
+    "file_path": "bacterial/nutrient_agar_broth.yaml",
+    "culturemech_id": "CultureMech:008307",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_5_nacl",
+    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_2_with_5_nacl.yaml",
+    "culturemech_id": "CultureMech:008596",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "1_100_nutrient_agar_no_2",
+    "file_path": "bacterial/1_100_nutrient_agar_no_2.yaml",
+    "culturemech_id": "CultureMech:002131",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2",
+    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2.yaml",
+    "culturemech_id": "CultureMech:010528",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "2_malt_extract_agar",
+    "file_path": "bacterial/2_malt_extract_agar.yaml",
+    "culturemech_id": "CultureMech:008671",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "r2a_agar",
+    "file_path": "bacterial/r2a_agar.yaml",
+    "culturemech_id": "CultureMech:002706",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "blood_agar_tsa_with_5_sheep_blood_remel",
+    "file_path": "bacterial/blood_agar_tsa_with_5_sheep_blood_remel.yaml",
+    "culturemech_id": "CultureMech:009339",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M2199_LB_Agar_Broth_Miller",
+    "file_path": "bacterial/TOGO_M2199_LB_Agar_Broth_Miller.yaml",
+    "culturemech_id": "CultureMech:008791",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "JCM_J100_ALKALINE_NUTRIENT_AGAR",
+    "file_path": "bacterial/JCM_J100_ALKALINE_NUTRIENT_AGAR.yaml",
+    "culturemech_id": "CultureMech:002194",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "m9_farmer_et_al",
+    "file_path": "bacterial/m9_farmer_et_al.yaml",
+    "culturemech_id": "CultureMech:007010",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR",
+    "file_path": "bacterial/KOMODO_672_HALF_STRENGTH_NUTRIENT_BROTH_OR_AGAR.yaml",
+    "culturemech_id": "CultureMech:006268",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "sea_water_luria_bertani_medium",
+    "file_path": "bacterial/sea_water_luria_bertani_medium.yaml",
+    "culturemech_id": "CultureMech:001039",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "mueller_hinton_medium",
+    "file_path": "bacterial/mueller_hinton_medium.yaml",
+    "culturemech_id": "CultureMech:009463",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "r2a_with_artificial_soda_salt_lake_water",
+    "file_path": "bacterial/r2a_with_artificial_soda_salt_lake_water.yaml",
+    "culturemech_id": "CultureMech:001197",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M2362_Columbia_Blood_Agar",
+    "file_path": "bacterial/TOGO_M2362_Columbia_Blood_Agar.yaml",
+    "culturemech_id": "CultureMech:008948",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "r2a_agar_with_2_nacl",
+    "file_path": "bacterial/r2a_agar_with_2_nacl.yaml",
+    "culturemech_id": "CultureMech:002325",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "modified_m9_medium",
+    "file_path": "bacterial/modified_m9_medium.yaml",
+    "culturemech_id": "CultureMech:009533",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "nutrient_agar_oxoid_cm3_with_phosphate",
+    "file_path": "bacterial/nutrient_agar_oxoid_cm3_with_phosphate.yaml",
+    "culturemech_id": "CultureMech:001733",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M492_1_2_MRS_1_2_BHI_Agar",
+    "file_path": "bacterial/TOGO_M492_1_2_MRS_1_2_BHI_Agar.yaml",
+    "culturemech_id": "CultureMech:009880",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M18_YM_Agar",
+    "file_path": "bacterial/TOGO_M18_YM_Agar.yaml",
+    "culturemech_id": "CultureMech:008476",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "m9_minimal_media_plus",
+    "file_path": "specialized/m9_minimal_media_plus.yaml",
+    "culturemech_id": "CultureMech:015550",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_2_nacl",
+    "file_path": "bacterial/brain_heart_infusion_2_nacl.yaml",
+    "culturemech_id": "CultureMech:008546",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar",
+    "file_path": "bacterial/TOGO_M1707_Casamino_acids-peptone-Czapek_s_agar.yaml",
+    "culturemech_id": "CultureMech:008269",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "anaerobic_tryptic_soy_broth_medium",
+    "file_path": "specialized/anaerobic_tryptic_soy_broth_medium.yaml",
+    "culturemech_id": "CultureMech:015369",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "r2a_fumarate_anaerobic",
+    "file_path": "bacterial/r2a_fumarate_anaerobic.yaml",
+    "culturemech_id": "CultureMech:009554",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "malt_extract_agar",
+    "file_path": "fungal/malt_extract_agar.yaml",
+    "culturemech_id": "CultureMech:010520",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "KOMODO_952_1_10_NUTRIENT_AGAR_NO.2",
+    "file_path": "bacterial/KOMODO_952_1_10_NUTRIENT_AGAR_NO.2.yaml",
+    "culturemech_id": "CultureMech:006895",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_bhi_with_sodium_acetate",
+    "file_path": "bacterial/brain_heart_infusion_bhi_with_sodium_acetate.yaml",
+    "culturemech_id": "CultureMech:009557",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "m9_minimal_medium_with_acetate",
+    "file_path": "bacterial/m9_minimal_medium_with_acetate.yaml",
+    "culturemech_id": "CultureMech:007300",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M2511_brain_heart_infusion_broth",
+    "file_path": "bacterial/TOGO_M2511_brain_heart_infusion_broth.yaml",
+    "culturemech_id": "CultureMech:009083",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M94_Nutrient_Agar_With_25_Soil_Extract",
+    "file_path": "bacterial/TOGO_M94_Nutrient_Agar_With_25_Soil_Extract.yaml",
+    "culturemech_id": "CultureMech:010373",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M2520_R2A_Medium",
+    "file_path": "bacterial/TOGO_M2520_R2A_Medium.yaml",
+    "culturemech_id": "CultureMech:009090",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "czapek_yeast_extract_agar_cya",
+    "file_path": "fungal/czapek_yeast_extract_agar_cya.yaml",
+    "culturemech_id": "CultureMech:010511",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M21_Brain_Heart_Infusion_Agar",
+    "file_path": "bacterial/TOGO_M21_Brain_Heart_Infusion_Agar.yaml",
+    "culturemech_id": "CultureMech:008793",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "brain_heart_infusion_agar_with_soil_extract",
+    "file_path": "bacterial/brain_heart_infusion_agar_with_soil_extract.yaml",
+    "culturemech_id": "CultureMech:002702",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "columbia_blood_agar_containing_10_bovine_blood",
+    "file_path": "bacterial/columbia_blood_agar_containing_10_bovine_blood.yaml",
+    "culturemech_id": "CultureMech:009496",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "luria_bertani_lb_medium_buffered_mops",
+    "file_path": "bacterial/luria_bertani_lb_medium_buffered_mops.yaml",
+    "culturemech_id": "CultureMech:009075",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M16_1_10_Nutrient_Agar_NO._2",
+    "file_path": "bacterial/TOGO_M16_1_10_Nutrient_Agar_NO._2.yaml",
+    "culturemech_id": "CultureMech:008261",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood",
+    "file_path": "bacterial/tryptic_soy_broth_medium_supplemented_with_0_5_yeast_extract_0_05_cysteine_hcl_h2o_0_5_mg_ml_of_hemin_2_g_ml_of_vitamin_k1_and_5_sheep_blood.yaml",
+    "culturemech_id": "CultureMech:009342",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "bhi_glucose_medium",
+    "file_path": "bacterial/bhi_glucose_medium.yaml",
+    "culturemech_id": "CultureMech:001983",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater",
+    "file_path": "fungal/yeast_extract_malt_extract_agar_isp_2_with_artificial_seawater.yaml",
+    "culturemech_id": "CultureMech:010536",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "half_strength_nutrient_broth_or_agar",
+    "file_path": "bacterial/half_strength_nutrient_broth_or_agar.yaml",
+    "culturemech_id": "CultureMech:001813",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5",
+    "file_path": "bacterial/yeast_extract_malt_extract_agar_isp_medium_no_2_ph_5_5.yaml",
+    "culturemech_id": "CultureMech:008390",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood",
+    "file_path": "bacterial/TOGO_M942_Brain_Heart_Infusion_Agar_With_5_Rabbit_Blood.yaml",
+    "culturemech_id": "CultureMech:010365",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "TOGO_M3116_Nutrient_Agar",
+    "file_path": "bacterial/TOGO_M3116_Nutrient_Agar.yaml",
+    "culturemech_id": "CultureMech:009588",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "lb_luria_bertani_medium",
+    "file_path": "bacterial/lb_luria_bertani_medium.yaml",
+    "culturemech_id": "CultureMech:001486",
+    "stratum": "WELL_KNOWN"
+  },
+  {
+    "recipe_name": "anaerobic_sulfolobales_medium",
+    "file_path": "archaea/anaerobic_sulfolobales_medium.yaml",
+    "culturemech_id": "CultureMech:010119",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "JCM_J1425_SPOROMUSA_MEDIUM_2",
+    "file_path": "bacterial/JCM_J1425_SPOROMUSA_MEDIUM_2.yaml",
+    "culturemech_id": "CultureMech:015862",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "desulfoglaeba_medium",
+    "file_path": "bacterial/desulfoglaeba_medium.yaml",
+    "culturemech_id": "CultureMech:000506",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "rc_medium",
+    "file_path": "bacterial/rc_medium.yaml",
+    "culturemech_id": "CultureMech:002656",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "gemmatimonas_medium",
+    "file_path": "bacterial/gemmatimonas_medium.yaml",
+    "culturemech_id": "CultureMech:001129",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "v2_medium",
+    "file_path": "bacterial/v2_medium.yaml",
+    "culturemech_id": "CultureMech:001117",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "JCM_J54_POTATO-CARROT_AGAR",
+    "file_path": "bacterial/JCM_J54_POTATO-CARROT_AGAR.yaml",
+    "culturemech_id": "CultureMech:002897",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_651_R_8_A_H_medium",
+    "file_path": "bacterial/KOMODO_651_R_8_A_H_medium.yaml",
+    "culturemech_id": "CultureMech:006228",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen",
+    "file_path": "specialized/varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen.yaml",
+    "culturemech_id": "CultureMech:015780",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "m17_broth_containing_glucose",
+    "file_path": "bacterial/m17_broth_containing_glucose.yaml",
+    "culturemech_id": "CultureMech:009066",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "trace_element_solution_medium_929",
+    "file_path": "bacterial/trace_element_solution_medium_929.yaml",
+    "culturemech_id": "CultureMech:004330",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_104_modified_for_dsm_21651",
+    "file_path": "bacterial/medium_104_modified_for_dsm_21651.yaml",
+    "culturemech_id": "CultureMech:003575",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "th_agar",
+    "file_path": "bacterial/th_agar.yaml",
+    "culturemech_id": "CultureMech:002731",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "NBRC_1021",
+    "file_path": "bacterial/NBRC_1021.yaml",
+    "culturemech_id": "CultureMech:007450",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_492_CLOSTRIDIUM_METHYLPENTOSUM_MEDIUM",
+    "file_path": "bacterial/KOMODO_492_CLOSTRIDIUM_METHYLPENTOSUM_MEDIUM.yaml",
+    "culturemech_id": "CultureMech:005620",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "trace_elements_solution_medium_1019",
+    "file_path": "bacterial/trace_elements_solution_medium_1019.yaml",
+    "culturemech_id": "CultureMech:004881",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "batch_cultivation_medium_for_ta1",
+    "file_path": "bacterial/batch_cultivation_medium_for_ta1.yaml",
+    "culturemech_id": "CultureMech:007209",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_391-1_For_DSM_4254",
+    "file_path": "bacterial/KOMODO_391-1_For_DSM_4254.yaml",
+    "culturemech_id": "CultureMech:005173",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_402_modified_for_dsm_18237",
+    "file_path": "bacterial/medium_402_modified_for_dsm_18237.yaml",
+    "culturemech_id": "CultureMech:005203",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_1181_METHYLOCELLA_SILVERSTRIS_MEDIUM",
+    "file_path": "bacterial/KOMODO_1181_METHYLOCELLA_SILVERSTRIS_MEDIUM.yaml",
+    "culturemech_id": "CultureMech:003901",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "DSMZ_1405_PYG_MEDIUM_MODIFIED",
+    "file_path": "bacterial/DSMZ_1405_PYG_MEDIUM_MODIFIED.yaml",
+    "culturemech_id": "CultureMech:000866",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "histidine_salt_schaechter_et_al",
+    "file_path": "bacterial/histidine_salt_schaechter_et_al.yaml",
+    "culturemech_id": "CultureMech:007130",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M970_Peat_Medium_2_For_Methanobacteria",
+    "file_path": "archaea/TOGO_M970_Peat_Medium_2_For_Methanobacteria.yaml",
+    "culturemech_id": "CultureMech:010396",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_830_modified_for_dsm_18704",
+    "file_path": "bacterial/medium_830_modified_for_dsm_18704.yaml",
+    "culturemech_id": "CultureMech:006583",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "beijerinckia_medium",
+    "file_path": "bacterial/beijerinckia_medium.yaml",
+    "culturemech_id": "CultureMech:000556",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_726_RHIZOMONAS_SUBERIFACIENS_medium",
+    "file_path": "bacterial/KOMODO_726_RHIZOMONAS_SUBERIFACIENS_medium.yaml",
+    "culturemech_id": "CultureMech:006369",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M160_Halobacteria_Medium",
+    "file_path": "archaea/TOGO_M160_Halobacteria_Medium.yaml",
+    "culturemech_id": "CultureMech:008163",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "thiobacillus_thioparus_tk_m_medium",
+    "file_path": "bacterial/thiobacillus_thioparus_tk_m_medium.yaml",
+    "culturemech_id": "CultureMech:001614",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "mme_nonitrogen_nocarbon",
+    "file_path": "specialized/mme_nonitrogen_nocarbon.yaml",
+    "culturemech_id": "CultureMech:015600",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_877_LUEDEMANN_medium_LUEDEMANN_1968",
+    "file_path": "bacterial/KOMODO_877_LUEDEMANN_medium_LUEDEMANN_1968.yaml",
+    "culturemech_id": "CultureMech:006714",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "levulinic_acid_medium",
+    "file_path": "bacterial/levulinic_acid_medium.yaml",
+    "culturemech_id": "CultureMech:008697",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_650_CENTENUM_medium",
+    "file_path": "bacterial/KOMODO_650_CENTENUM_medium.yaml",
+    "culturemech_id": "CultureMech:006227",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "reactivation_with_liquid_medium_115",
+    "file_path": "bacterial/reactivation_with_liquid_medium_115.yaml",
+    "culturemech_id": "CultureMech:000599",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "caryophanon_latum_medium",
+    "file_path": "bacterial/caryophanon_latum_medium.yaml",
+    "culturemech_id": "CultureMech:001449",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "zmb_als_novaline",
+    "file_path": "specialized/zmb_als_novaline.yaml",
+    "culturemech_id": "CultureMech:015827",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_for_aciduric_thermophilic_bacillus_strains",
+    "file_path": "bacterial/medium_for_aciduric_thermophilic_bacillus_strains.yaml",
+    "culturemech_id": "CultureMech:006270",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "bicarbonate_buffered_medium_with_acethylene",
+    "file_path": "bacterial/bicarbonate_buffered_medium_with_acethylene.yaml",
+    "culturemech_id": "CultureMech:002412",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_693_modified_for_dsm_22886",
+    "file_path": "bacterial/medium_693_modified_for_dsm_22886.yaml",
+    "culturemech_id": "CultureMech:006308",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_65_modified_for_dsm_41868",
+    "file_path": "bacterial/medium_65_modified_for_dsm_41868.yaml",
+    "culturemech_id": "CultureMech:006201",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "for_dsm_21650",
+    "file_path": "bacterial/for_dsm_21650.yaml",
+    "culturemech_id": "CultureMech:003611",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "ysg_medium_ph_4_5",
+    "file_path": "bacterial/ysg_medium_ph_4_5.yaml",
+    "culturemech_id": "CultureMech:008347",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "Bristol_Medium",
+    "file_path": "algae/Bristol_Medium.yaml",
+    "culturemech_id": "CultureMech:000037",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "KOMODO_1108a_CYS_MEDIUM_WITH_MODIFIED_NACL_CONCENTRATION",
+    "file_path": "bacterial/KOMODO_1108a_CYS_MEDIUM_WITH_MODIFIED_NACL_CONCENTRATION.yaml",
+    "culturemech_id": "CultureMech:003809",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "s_w",
+    "file_path": "algae/s_w.yaml",
+    "culturemech_id": "CultureMech:000138",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "JCM_J1429_M1H_NAG_ASW",
+    "file_path": "bacterial/JCM_J1429_M1H_NAG_ASW.yaml",
+    "culturemech_id": "CultureMech:015864",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "mycoplasma_medium_with_sucrose",
+    "file_path": "bacterial/mycoplasma_medium_with_sucrose.yaml",
+    "culturemech_id": "CultureMech:008194",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_971_modified_for_dsm_18087",
+    "file_path": "bacterial/medium_971_modified_for_dsm_18087.yaml",
+    "culturemech_id": "CultureMech:006928",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "medium_for_chlorobium_ferrooxidans",
+    "file_path": "bacterial/medium_for_chlorobium_ferrooxidans.yaml",
+    "culturemech_id": "CultureMech:001398",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "TOGO_M1117_Halomonas_CUG_Medium",
+    "file_path": "bacterial/TOGO_M1117_Halomonas_CUG_Medium.yaml",
+    "culturemech_id": "CultureMech:007637",
+    "stratum": "OTHER"
+  },
+  {
+    "recipe_name": "cornmeal_seawater_agar_cmswa",
+    "file_path": "bacterial/cornmeal_seawater_agar_cmswa.yaml",
+    "culturemech_id": "CultureMech:007956",
+    "stratum": "OTHER"
+  }
+]

--- a/data/import_tracking/researched_media.json
+++ b/data/import_tracking/researched_media.json
@@ -2,6 +2,18 @@
   "description": "Media records with a completed (non-dry-run) Edison deep-research run. Tracked so that deep_research_priority*.json are reproducible from git alone (see issue #121). Refresh with `just refresh-researched-manifest`; entries are merged, never dropped, so multiple machines can contribute.",
   "entries": [
     {
+      "slug": "JCM_J1425_SPOROMUSA_MEDIUM_2",
+      "job": "literature",
+      "task_id": "ad65fc0f-ff36-4321-8d32-3a9ba32673b3",
+      "kind": "axis"
+    },
+    {
+      "slug": "KOMODO_221_AZOSPIRILLUM_medium",
+      "job": "literature",
+      "task_id": "fbdb863d-312d-4357-9df5-a07c44dd8621",
+      "kind": "axis"
+    },
+    {
       "slug": "TOGO_M1620_Leuconostoc_oenos_Medium",
       "job": "literature",
       "task_id": "8d102d3a-72bc-4310-ad6d-8ebc51a33574",
@@ -78,6 +90,36 @@
       "kind": "medium"
     },
     {
+      "slug": "TOGO_M1875_Thermus_medium",
+      "job": "literature",
+      "task_id": "77bcc09e-dfa3-47c1-b5cb-cb410c98d108",
+      "kind": "axis"
+    },
+    {
+      "slug": "TOGO_M2297_Acidithiobacillus_ferrooxidans_Medium",
+      "job": "literature",
+      "task_id": "8d573b07-e5b5-45f0-8f99-cb331f42a2be",
+      "kind": "axis"
+    },
+    {
+      "slug": "TOGO_M923_Dethiosulfovibrio_Belb1_Medium",
+      "job": "literature",
+      "task_id": "608e71bf-01dd-4f17-b70e-5897b71ebb79",
+      "kind": "axis"
+    },
+    {
+      "slug": "allen_medium",
+      "job": "literature",
+      "task_id": "a5e618eb-304b-4971-b14d-5374e5266609",
+      "kind": "axis"
+    },
+    {
+      "slug": "anaerobic_sulfolobales_medium",
+      "job": "literature",
+      "task_id": "5730f28d-21d4-4c93-8e2e-e5eab6d76314",
+      "kind": "axis"
+    },
+    {
       "slug": "archaeoglobus_medium_dsm_399",
       "job": "literature",
       "task_id": "b62d20b4-56f6-439b-aacc-4b24ae41ee10",
@@ -131,6 +173,18 @@
       "media_slug": "beijerinckia_medium_lmg_18"
     },
     {
+      "slug": "brain_heart_infusion_agar_containing_7_horse_blood_and_0_4_isovitalex",
+      "job": "literature",
+      "task_id": "aec1ca62-d931-4ad0-a63a-18b21f448aca",
+      "kind": "axis"
+    },
+    {
+      "slug": "brain_heart_infusion_bhi_broth_containing_c_difficile_supplement_and_0_04_cysteine",
+      "job": "literature",
+      "task_id": "ffda4aec-965d-499d-a741-b49f8f1afc0f",
+      "kind": "axis"
+    },
+    {
       "slug": "caldicellulosiruptor_medium_for_dsm_10319",
       "job": "literature",
       "task_id": "6b70021e-a69d-4ec6-a2b9-0617e8210180",
@@ -171,6 +225,48 @@
       "media_slug": "chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733"
     },
     {
+      "slug": "chthonomonas_medium",
+      "job": "literature",
+      "task_id": "56ee703e-04ae-4485-a75f-1812dbac6959",
+      "kind": "axis"
+    },
+    {
+      "slug": "desulfobulbus_sp_medium_freshwater_for_dsm_14880",
+      "job": "literature",
+      "task_id": "1b450442-33f2-4200-b0f6-049923a8d767",
+      "kind": "axis"
+    },
+    {
+      "slug": "desulfoglaeba_medium",
+      "job": "literature",
+      "task_id": "cf14a7f7-76ef-41c1-929f-03f0c6256258",
+      "kind": "axis"
+    },
+    {
+      "slug": "for_arhodomonas",
+      "job": "literature",
+      "task_id": "9f2f9903-04da-4b30-9189-b3a9ddb0428e",
+      "kind": "axis"
+    },
+    {
+      "slug": "for_dsm_17771",
+      "job": "literature",
+      "task_id": "bb0e6b2e-3804-42ca-a0f8-573b8b981a8a",
+      "kind": "axis"
+    },
+    {
+      "slug": "frey_broth",
+      "job": "literature",
+      "task_id": "e6274512-dcb0-45c4-9656-2d361b13856f",
+      "kind": "axis"
+    },
+    {
+      "slug": "gemmatimonas_medium",
+      "job": "literature",
+      "task_id": "26804135-0d18-4ce3-91ef-89f3a327c6dd",
+      "kind": "axis"
+    },
+    {
       "slug": "ignicoccus_medium_for_dsm_18386",
       "job": "literature",
       "task_id": "69f6f5e4-5667-4bbe-9141-785dd7561e0e",
@@ -198,6 +294,12 @@
       "media_slug": "ignicoccus_medium_for_dsm_18386"
     },
     {
+      "slug": "lb_rifampicin_medium",
+      "job": "literature",
+      "task_id": "c089d7f2-96c1-4e63-ab85-1c1bcd8c2cd8",
+      "kind": "axis"
+    },
+    {
       "slug": "medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397",
       "job": "literature",
       "task_id": "2008b204-5b8f-41bd-9523-acfa060c7689",
@@ -222,6 +324,30 @@
       "job": "literature",
       "task_id": "427ad7fa-79e5-405f-96ab-6cd47e1ff792",
       "kind": "medium"
+    },
+    {
+      "slug": "methanobacterium_medium_ii",
+      "job": "literature",
+      "task_id": "68474bdc-4d16-4c4a-acf5-50472ca8839d",
+      "kind": "axis"
+    },
+    {
+      "slug": "nutrient_agar_broth",
+      "job": "literature",
+      "task_id": "08b4fc8c-e69e-41a5-bc46-299365ed0c94",
+      "kind": "axis"
+    },
+    {
+      "slug": "rc_medium",
+      "job": "literature",
+      "task_id": "e2ba5e77-5f54-400c-9b65-580a8c402aeb",
+      "kind": "axis"
+    },
+    {
+      "slug": "sd0_medium",
+      "job": "literature",
+      "task_id": "28a41a6e-8f6b-439d-b395-0cac4264221e",
+      "kind": "axis"
     },
     {
       "slug": "sulfolobus_medium_anaerobic_for_dsm_2162",
@@ -346,10 +472,34 @@
       "media_slug": "syntrophomonas_medium_for_syntrophospora_cellicola_19j_3"
     },
     {
+      "slug": "tryptic_soy_agar_containing_2_5_nacl",
+      "job": "literature",
+      "task_id": "113c5097-76c0-4773-8281-78295c416935",
+      "kind": "axis"
+    },
+    {
+      "slug": "tryptic_soy_agar_tsa_carl_roth_gmbh_co",
+      "job": "literature",
+      "task_id": "b5ec290d-ea3c-4fec-8974-e565e1cdbbd8",
+      "kind": "axis"
+    },
+    {
+      "slug": "v2_medium",
+      "job": "literature",
+      "task_id": "c75d8395-f313-4f7d-92bc-f7d1f5853369",
+      "kind": "axis"
+    },
+    {
       "slug": "wilkins_chalgren_anaerobe_broth_n2_co2_for_dsm_15567",
       "job": "literature",
       "task_id": "a66b292a-8a02-4991-88c3-74ce1a248373",
       "kind": "medium"
+    },
+    {
+      "slug": "yeast_extract_malt_extract_agar_isp_2_with_5_nacl",
+      "job": "literature",
+      "task_id": "c79bf577-2531-4dbc-88a3-cf4997dea03c",
+      "kind": "axis"
     }
   ]
 }

--- a/project.justfile
+++ b/project.justfile
@@ -73,6 +73,14 @@ research-media-edison target *args="":
 # Records with a completed run for the same job are skipped, so `--limit 5`
 # advances 5 FRESH records per invocation rather than re-billing the first
 # five. Pass `--force` to re-submit them anyway.
+# Draw a stratified sample of media for Edison axis classification (#152), across
+# SEMI_DEFINED / deep-research-ranked / well-known / other. Seeded, so a rerun
+# researches the same records rather than a new set. Writes:
+#   data/import_tracking/reports/axis_research_batch.json
+[group('Research')]
+sample-axis-research-batch *args="":
+    uv run --extra dev python scripts/sample_axis_research_batch.py {{args}}
+
 [group('Research')]
 research-media-edison-batch batch *args="":
     uv run --extra dev python scripts/research_media_edison.py \

--- a/project.justfile
+++ b/project.justfile
@@ -81,6 +81,21 @@ research-media-edison target *args="":
 sample-axis-research-batch *args="":
     uv run --extra dev python scripts/sample_axis_research_batch.py {{args}}
 
+# Edison axis classification (#152) — nutritional_class / functional_role.
+#
+# Deliberately a SEPARATE recipe with a SEPARATE out-dir, not a --template flag on
+# research-media-edison-batch. Both templates run under job LITERATURE and the
+# output filename is <slug>-edison-literature.md, so writing axis reports into
+# research/media/ would make a later growth-research run on those slugs skip
+# itself as "already researched" — a silent no-op, not an error.
+[group('Research')]
+research-media-edison-axis batch *args="":
+    uv run --extra dev python scripts/research_media_edison.py \
+      --batch {{batch}} \
+      --template {{templates_dir}}/media_axis_classification.md \
+      --out-dir {{research_dir}}/media_axis \
+      {{args}}
+
 [group('Research')]
 research-media-edison-batch batch *args="":
     uv run --extra dev python scripts/research_media_edison.py \

--- a/scripts/refresh_researched_manifest.py
+++ b/scripts/refresh_researched_manifest.py
@@ -34,12 +34,16 @@ def main(argv: list[str] | None = None) -> int:
                     help="Tracked manifest to update.")
     ap.add_argument("--research-dir", type=Path, default=rmf.DEFAULT_RESEARCH_DIR,
                     help="Local (gitignored) Edison output directory to scan.")
+    ap.add_argument("--axis-research-dir", type=Path, default=rmf.AXIS_RESEARCH_DIR,
+                    help="Axis-classification output dir, also scanned. Its entries are\n"
+                         "tagged kind=axis and excluded from the medium-level filter.")
     ap.add_argument("--dry-run", action="store_true",
                     help="Report what would be added without writing.")
     args = ap.parse_args(argv)
 
     existing = rmf.load_manifest(args.manifest)
-    discovered = rmf.scan_research_dir(args.research_dir)
+    discovered = (rmf.scan_research_dir(args.research_dir)
+                  + rmf.scan_research_dir(args.axis_research_dir))
     merged, added = rmf.merge_entries(existing, discovered)
 
     print(f"Manifest:     {args.manifest}")

--- a/scripts/researched_manifest.py
+++ b/scripts/researched_manifest.py
@@ -40,6 +40,9 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO_ROOT / "data" / "import_tracking" / "researched_media.json"
 DEFAULT_RESEARCH_DIR = REPO_ROOT / "research" / "media"
+# Axis classification writes to its own directory so its reports cannot claim the
+# `<slug>-edison-literature.md` filenames growth research keys its skip on.
+AXIS_RESEARCH_DIR = REPO_ROOT / "research" / "media_axis"
 
 _DESCRIPTION = (
     "Media records with a completed (non-dry-run) Edison deep-research run. "
@@ -49,8 +52,20 @@ _DESCRIPTION = (
 )
 
 
-def _entry_key(entry: dict[str, Any]) -> tuple[str, str]:
-    return (str(entry.get("slug") or ""), str(entry.get("job") or ""))
+def _entry_key(entry: dict[str, Any]) -> tuple[str, str, str]:
+    """Identity of a run, for dedup and stable sort.
+
+    `kind` is part of the key because growth research and axis classification run
+    under the SAME job ("literature") on the same slug. Keyed on (slug, job) alone
+    they collide, and since `merge_entries` unions by key, whichever ran first
+    would permanently mask the other — a real growth run silently dropped as a
+    duplicate of an axis run.
+
+    Entries written before `kind` existed default to "medium", matching
+    `researched_slugs()`, so legacy rows keep their identity and do not re-add.
+    """
+    return (str(entry.get("slug") or ""), str(entry.get("job") or ""),
+            str(entry.get("kind") or "medium"))
 
 
 def load_manifest(path: Path = DEFAULT_MANIFEST) -> list[dict[str, Any]]:
@@ -91,6 +106,19 @@ def researched_slugs(path: Path = DEFAULT_MANIFEST) -> set[str]:
     }
 
 
+AXIS_TEMPLATE_STEM = "media_axis_classification"
+
+
+def _is_axis_run(meta: dict[str, Any]) -> bool:
+    """True iff this meta came from the axis-classification template.
+
+    Keyed on the template rather than the output directory: the directory is a
+    caller-supplied argument, so a run written elsewhere would be misclassified,
+    while `template_path` is stamped into the meta by the runner itself.
+    """
+    return AXIS_TEMPLATE_STEM in str(meta.get("template_path") or "")
+
+
 def scan_research_dir(research_dir: Path = DEFAULT_RESEARCH_DIR) -> list[dict[str, Any]]:
     """Read local `*-edison-*-meta.yaml` files into manifest entries.
 
@@ -129,6 +157,20 @@ def scan_research_dir(research_dir: Path = DEFAULT_RESEARCH_DIR) -> list[dict[st
         if "-organism-" in slug:
             entry["kind"] = "organism"
             entry["media_slug"] = slug.split("-organism-", 1)[0]
+        elif _is_axis_run(meta):
+            # Axis classification (#152) asks which nutritional_class / functional_role
+            # a medium has. It runs under the SAME job ("literature") as growth
+            # research and produces the same `<slug>-edison-literature-meta.yaml`
+            # filename, so job and filename cannot tell them apart — only the
+            # template can.
+            #
+            # This distinction is load-bearing, not cosmetic. `researched_slugs()`
+            # feeds the deep-research prioritizer's already-researched filter, so
+            # tagging these "medium" would drop every axis-classified record out of
+            # the growth-research queue — silently, since a smaller candidate list
+            # looks like progress. Same failure the separate out-dir prevents one
+            # layer down.
+            entry["kind"] = "axis"
         else:
             entry["kind"] = "medium"
         found.append(entry)

--- a/scripts/sample_axis_research_batch.py
+++ b/scripts/sample_axis_research_batch.py
@@ -33,7 +33,8 @@ set.
 Usage::
 
     just sample-axis-research-batch --size 200
-    just research-media-edison-batch data/import_tracking/reports/axis_research_batch.json --limit 1 --dry-run
+    just research-media-edison-batch data/import_tracking/reports/axis_research_batch.json \\
+        --limit 25 --dry-run
 """
 
 from __future__ import annotations
@@ -146,11 +147,11 @@ def main(argv: list[str] | None = None) -> int:
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(batch, indent=2) + "\n")
-    print(f"\nDrew {len(batch)} records (seed {args.seed}) -> "
-          f"{args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+    rel = args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out
+    print(f"\nDrew {len(batch)} records (seed {args.seed}) -> {rel}")
     print("\nCanary the BATCH path before running it — --target and --batch are\n"
           "different code paths, and only the batch one resolves by slug:\n"
-          f"  just research-media-edison-batch {args.out.name} --limit 1 --dry-run")
+          f"  just research-media-edison-batch {rel} --limit 1 --dry-run")
     return 0
 
 

--- a/scripts/sample_axis_research_batch.py
+++ b/scripts/sample_axis_research_batch.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Draw a stratified sample of media for Edison axis classification (#152).
+
+`nutritional_class` and `functional_role` sit on 1 record each. Filling them needs
+signal the corpus does not carry, so it needs literature research — and there are
+11,094 media at minutes per record, which is a campaign rather than a batch.
+
+This draws a bounded sample instead, across four strata chosen because they answer
+different questions:
+
+  SEMI_DEFINED      composition already characterised (#152/#171), so the axes are
+                    the only missing piece — highest signal per record.
+  DEEP_RESEARCH     the existing priority ranking's top-N. Note that ranking
+                    optimises for ORGANISM yield, not axis-classification value, so
+                    it is included to test whether the two agree rather than
+                    assumed to be the right frame.
+  WELL_KNOWN        LB, TSB, M9, MacConkey and similar, where the correct answer is
+                    independently checkable. This stratum is the ACCURACY CONTROL:
+                    without it the run produces classifications nobody can grade.
+  OTHER             a uniform draw from everything else, so the sample says
+                    something about the corpus rather than only about its
+                    interesting corners.
+
+Strata are disjoint and assigned in the order above, so a record already taken as
+SEMI_DEFINED is not redrawn as WELL_KNOWN. The `stratum` field is carried into the
+batch so results can be scored per stratum afterwards — the point of sampling is
+to learn the hit rate before committing to the remaining ~10,900.
+
+Sampling is seeded and deterministic: the same corpus and seed reproduce the same
+batch, so a rerun after a partial failure does not silently research a different
+set.
+
+Usage::
+
+    just sample-axis-research-batch --size 200
+    just research-media-edison-batch data/import_tracking/reports/axis_research_batch.json --limit 1 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+RANKING = REPO / "data" / "import_tracking" / "reports" / "deep_research_priority_top100.json"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "axis_research_batch.json"
+
+# Media whose nutritional class and functional role are documented in any
+# microbiology text, so a wrong answer is immediately visible.
+WELL_KNOWN = re.compile(
+    r"\b(lb|luria|tryptic soy|tsb|tsa|brain heart|bhi|m9|nutrient (agar|broth)|"
+    r"macconkey|sabouraud|potato dextrose|pda|mueller|blood agar|chocolate agar|"
+    r"r2a|marine broth|czapek|malt extract agar|ym|yp[dg])\b", re.I)
+
+
+def load_media(normalized: Path) -> list[tuple[Path, dict[str, Any]]]:
+    out = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        if isinstance(doc, dict) and not is_solution_record(doc):
+            out.append((path, doc))
+    return out
+
+
+def assign_strata(records, ranking_paths: set[str], normalized: Path
+                  ) -> dict[str, list[tuple[Path, dict[str, Any]]]]:
+    """Disjoint strata, assigned in priority order so no record appears twice."""
+    strata: dict[str, list] = {"SEMI_DEFINED": [], "DEEP_RESEARCH": [],
+                               "WELL_KNOWN": [], "OTHER": []}
+    for path, doc in records:
+        rel = str(path.relative_to(normalized))
+        name = f"{doc.get('name', '')} {doc.get('original_name', '')}"
+        if str(doc.get("composition_type")) == "SEMI_DEFINED":
+            strata["SEMI_DEFINED"].append((path, doc))
+        elif rel in ranking_paths:
+            strata["DEEP_RESEARCH"].append((path, doc))
+        elif WELL_KNOWN.search(name):
+            strata["WELL_KNOWN"].append((path, doc))
+        else:
+            strata["OTHER"].append((path, doc))
+    return strata
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--ranking", type=Path, default=RANKING)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--size", type=int, default=200)
+    ap.add_argument("--seed", type=int, default=20260803,
+                    help="fixed so a rerun researches the same records, not a new set")
+    args = ap.parse_args(argv)
+
+    ranking_paths: set[str] = set()
+    if args.ranking.is_file():
+        ranking_paths = {e["file_path"] for e in json.loads(args.ranking.read_text())
+                         if isinstance(e, dict) and e.get("file_path")}
+
+    records = load_media(args.normalized_dir)
+    strata = assign_strata(records, ranking_paths, args.normalized_dir)
+
+    rng = random.Random(args.seed)
+    per = args.size // len(strata)
+    batch: list[dict[str, Any]] = []
+    print(f"{'stratum':16s} {'available':>10s} {'drawn':>7s}")
+    for name, pool in strata.items():
+        take = min(per, len(pool))
+        if take < per:
+            print(f"  NOTE: {name} has only {len(pool)}; drawing all of them",
+                  file=sys.stderr)
+        for path, doc in rng.sample(pool, take):
+            batch.append({
+                "recipe_name": path.stem,
+                "file_path": str(path.relative_to(args.normalized_dir)),
+                "culturemech_id": str(doc.get("id") or ""),
+                "stratum": name,
+            })
+        print(f"{name:16s} {len(pool):10d} {take:7d}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(batch, indent=2) + "\n")
+    print(f"\nDrew {len(batch)} records (seed {args.seed}) -> "
+          f"{args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+    print("\nCanary the BATCH path before running it — --target and --batch are\n"
+          "different code paths, and only the batch one resolves by slug:\n"
+          f"  just research-media-edison-batch {args.out.name} --limit 1 --dry-run")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sample_axis_research_batch.py
+++ b/scripts/sample_axis_research_batch.py
@@ -116,21 +116,33 @@ def main(argv: list[str] | None = None) -> int:
 
     rng = random.Random(args.seed)
     per = args.size // len(strata)
-    batch: list[dict[str, Any]] = []
+    drawn: dict[str, list[dict[str, Any]]] = {}
     print(f"{'stratum':16s} {'available':>10s} {'drawn':>7s}")
     for name, pool in strata.items():
         take = min(per, len(pool))
         if take < per:
             print(f"  NOTE: {name} has only {len(pool)}; drawing all of them",
                   file=sys.stderr)
-        for path, doc in rng.sample(pool, take):
-            batch.append({
-                "recipe_name": path.stem,
-                "file_path": str(path.relative_to(args.normalized_dir)),
-                "culturemech_id": str(doc.get("id") or ""),
-                "stratum": name,
-            })
+        drawn[name] = [{
+            "recipe_name": path.stem,
+            "file_path": str(path.relative_to(args.normalized_dir)),
+            "culturemech_id": str(doc.get("id") or ""),
+            "stratum": name,
+        } for path, doc in rng.sample(pool, take)]
         print(f"{name:16s} {len(pool):10d} {take:7d}")
+
+    # Round-robin the strata rather than concatenating them, so EVERY PREFIX of the
+    # batch is itself stratified. This matters because the runner researches in file
+    # order and `--limit N` takes the first N: with the strata concatenated, a
+    # 25-record probe would have drawn all 25 from SEMI_DEFINED and measured nothing
+    # about the other three. Interleaved, `--limit 25` samples all four ~evenly, and
+    # the probe is a strict subset of the full run — so the remaining records can be
+    # finished later without re-researching any.
+    batch: list[dict[str, Any]] = []
+    for i in range(max((len(v) for v in drawn.values()), default=0)):
+        for name in strata:
+            if i < len(drawn[name]):
+                batch.append(drawn[name][i])
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(batch, indent=2) + "\n")

--- a/scripts/sample_axis_research_batch.py
+++ b/scripts/sample_axis_research_batch.py
@@ -33,7 +33,7 @@ set.
 Usage::
 
     just sample-axis-research-batch --size 200
-    just research-media-edison-batch data/import_tracking/reports/axis_research_batch.json \\
+    just research-media-edison-axis data/import_tracking/reports/axis_research_batch.json \\
         --limit 25 --dry-run
 """
 
@@ -96,6 +96,39 @@ def assign_strata(records, ranking_paths: set[str], normalized: Path
     return strata
 
 
+def allocate(size: int, capacity: dict[str, int]) -> dict[str, int]:
+    """Split `size` across strata as evenly as their capacity allows.
+
+    Flooring `size // n_strata` is not enough, and neither is handing the
+    remainder to the biggest pools. Strata are genuinely uneven — DEEP_RESEARCH
+    holds only 99 records against OTHER's 9,730 — so once a small stratum is
+    exhausted its unused quota has to go somewhere, or the batch comes back short
+    while reporting success (#185).
+
+    Fills in rounds: each round shares what is still needed among the strata that
+    still have room, so a stratum that runs out donates its remainder to the ones
+    that can absorb it. Returns exactly `size` unless the whole corpus is smaller.
+    """
+    quota = dict.fromkeys(capacity, 0)
+    remaining = min(size, sum(capacity.values()))
+    while remaining > 0:
+        open_strata = [n for n in capacity if quota[n] < capacity[n]]
+        if not open_strata:
+            break
+        # Largest-capacity first, so the leftover single records land in the pools
+        # deep enough to absorb them without skewing their character.
+        share, extra = divmod(remaining, len(open_strata))
+        order = sorted(open_strata, key=lambda n: -capacity[n])
+        if share == 0:  # fewer records left than open strata
+            share, extra = 0, remaining
+        for i, name in enumerate(order):
+            want = share + (1 if i < extra else 0)
+            take = min(want, capacity[name] - quota[name])
+            quota[name] += take
+            remaining -= take
+    return quota
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -116,14 +149,11 @@ def main(argv: list[str] | None = None) -> int:
     strata = assign_strata(records, ranking_paths, args.normalized_dir)
 
     rng = random.Random(args.seed)
-    per = args.size // len(strata)
+    quota = allocate(args.size, {k: len(v) for k, v in strata.items()})
     drawn: dict[str, list[dict[str, Any]]] = {}
     print(f"{'stratum':16s} {'available':>10s} {'drawn':>7s}")
     for name, pool in strata.items():
-        take = min(per, len(pool))
-        if take < per:
-            print(f"  NOTE: {name} has only {len(pool)}; drawing all of them",
-                  file=sys.stderr)
+        take = min(quota[name], len(pool))
         drawn[name] = [{
             "recipe_name": path.stem,
             "file_path": str(path.relative_to(args.normalized_dir)),
@@ -148,10 +178,16 @@ def main(argv: list[str] | None = None) -> int:
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(batch, indent=2) + "\n")
     rel = args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out
+    # `allocate` already caps each stratum at its capacity, so a shortfall can
+    # only mean the corpus itself is smaller than --size. Say so rather than
+    # returning a short batch that reads as full coverage.
+    if len(batch) < args.size:
+        print(f"  NOTE: corpus holds only {len(batch)} eligible records; "
+              f"--size {args.size} was capped", file=sys.stderr)
     print(f"\nDrew {len(batch)} records (seed {args.seed}) -> {rel}")
     print("\nCanary the BATCH path before running it — --target and --batch are\n"
           "different code paths, and only the batch one resolves by slug:\n"
-          f"  just research-media-edison-batch {rel} --limit 1 --dry-run")
+          f"  just research-media-edison-axis {rel} --limit 25 --dry-run")
     return 0
 
 

--- a/tests/test_axis_research_batch.py
+++ b/tests/test_axis_research_batch.py
@@ -1,0 +1,192 @@
+"""Tests for the axis-classification batch sampler.
+
+Every property here fails SILENTLY if it regresses. A batch drawn from one
+stratum, or with duplicates, or shorter than requested, still runs to completion
+and still reports fill rates — it just answers a different question than the one
+asked. Nothing errors, so only these tests can catch it.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def sarb():
+    return _load("sample_axis_research_batch")
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    """A synthetic corpus with all four strata represented."""
+    d = tmp_path / "bacterial"
+    d.mkdir(parents=True)
+    for i in range(12):
+        (d / f"semi_{i}.yaml").write_text(yaml.dump(
+            {"id": f"CultureMech:1{i:03d}", "name": f"semi_{i}",
+             "composition_type": "SEMI_DEFINED"}))
+    for i in range(12):
+        (d / f"lb_broth_{i}.yaml").write_text(yaml.dump(
+            {"id": f"CultureMech:2{i:03d}", "name": f"lb_broth_{i}",
+             "original_name": f"LB broth {i}"}))
+    for i in range(12):
+        (d / f"plain_{i}.yaml").write_text(yaml.dump(
+            {"id": f"CultureMech:3{i:03d}", "name": f"plain_{i}",
+             "original_name": f"Obscure medium {i}"}))
+    return tmp_path
+
+
+def _run(sarb, corpus, tmp_path, size, ranking=None, seed=7):
+    out = tmp_path / f"batch_{size}_{seed}.json"
+    rank = tmp_path / f"rank_{seed}.json"
+    rank.write_text(json.dumps(ranking or []))
+    rc = sarb.main(["--normalized-dir", str(corpus), "--out", str(out),
+                    "--ranking", str(rank), "--size", str(size), "--seed", str(seed)])
+    assert rc == 0
+    return json.loads(out.read_text())
+
+
+# --- the load-bearing property ---------------------------------------------
+
+
+def test_every_prefix_is_stratified(sarb, corpus, tmp_path):
+    """The whole basis for probing with --limit N and generalising the result.
+
+    The runner researches in file order and --limit takes the first N, so if the
+    strata were concatenated instead of interleaved, a 25-record probe would draw
+    all 25 from one stratum — completing normally and reporting fill rates for a
+    sample that represents nothing.
+    """
+    batch = _run(sarb, corpus, tmp_path, 12)
+    for n in (4, 8, 12):
+        strata = {r["stratum"] for r in batch[:n]}
+        assert len(strata) >= 3, f"prefix of {n} covers only {strata}"
+
+
+def test_strata_are_disjoint(sarb, corpus, tmp_path):
+    batch = _run(sarb, corpus, tmp_path, 12)
+    paths = [r["file_path"] for r in batch]
+    assert len(paths) == len(set(paths)), "a record was drawn into two strata"
+
+
+def test_size_is_honoured_when_not_divisible_by_stratum_count(sarb, corpus, tmp_path):
+    """#185: `per = size // len(strata)` floored the remainder away, so --size 25
+    returned 24 while reporting success — a silent cap."""
+    for size in (4, 5, 6, 7, 9):
+        batch = _run(sarb, corpus, tmp_path, size)
+        assert len(batch) == size, f"asked {size}, got {len(batch)}"
+
+
+def test_seed_is_deterministic(sarb, corpus, tmp_path):
+    """A rerun after a partial failure must research the same records, not a new
+    set — otherwise the completed runs are orphaned and re-billed."""
+    a = _run(sarb, corpus, tmp_path, 8, seed=99)
+    b = _run(sarb, corpus, tmp_path, 8, seed=99)
+    assert [r["file_path"] for r in a] == [r["file_path"] for r in b]
+
+
+def test_different_seeds_draw_differently(sarb, corpus, tmp_path):
+    a = _run(sarb, corpus, tmp_path, 8, seed=1)
+    b = _run(sarb, corpus, tmp_path, 8, seed=2)
+    assert [r["file_path"] for r in a] != [r["file_path"] for r in b]
+
+
+def test_every_entry_carries_the_fields_the_runner_needs(sarb, corpus, tmp_path):
+    for row in _run(sarb, corpus, tmp_path, 8):
+        assert row["recipe_name"] and row["file_path"] and row["stratum"]
+        assert "culturemech_id" in row
+
+
+def test_an_undersized_stratum_is_absorbed_not_dropped(sarb, corpus, tmp_path):
+    """DEEP_RESEARCH holds only 99 records corpus-wide, so an exhausted stratum is
+    the normal case. Its unused quota goes to strata with room, rather than
+    shortening the batch."""
+    batch = _run(sarb, corpus, tmp_path, 30)
+    assert len(batch) == 30, f"undersized stratum shortened the batch to {len(batch)}"
+
+
+def test_a_corpus_smaller_than_size_says_so(sarb, corpus, tmp_path, capsys):
+    """The only shortfall `allocate` cannot absorb. Silence here would read as
+    full coverage of a --size that was never met."""
+    batch = _run(sarb, corpus, tmp_path, 500)
+    assert len(batch) == 36, len(batch)
+    assert "NOTE" in capsys.readouterr().err
+
+
+def test_well_known_stratum_recognises_well_known_media(sarb, corpus, tmp_path):
+    """Without this stratum the run yields classifications nobody can grade."""
+    batch = _run(sarb, corpus, tmp_path, 12)
+    wk = [r for r in batch if r["stratum"] == "WELL_KNOWN"]
+    assert wk and all("lb_broth" in r["recipe_name"] for r in wk)
+
+
+def test_semi_defined_wins_over_well_known_when_a_record_is_both(sarb, tmp_path):
+    """Strata are assigned in priority order; the docstring promises disjointness."""
+    d = tmp_path / "c" / "bacterial"
+    d.mkdir(parents=True)
+    (d / "lb.yaml").write_text(yaml.dump(
+        {"id": "CultureMech:1", "name": "lb_broth", "original_name": "LB broth",
+         "composition_type": "SEMI_DEFINED"}))
+    strata = sarb.assign_strata(sarb.load_media(tmp_path / "c"), set(), tmp_path / "c")
+    assert len(strata["SEMI_DEFINED"]) == 1 and not strata["WELL_KNOWN"]
+
+
+# --- the tracked artifact (#186) -------------------------------------------
+
+
+def test_committed_batch_paths_still_resolve():
+    """The batch is a tracked derived artifact holding paths into the corpus, and
+    records do move — 629 were recategorised in #114.
+
+    This rots quietly: the runner's tiered resolver (#173) falls back to filename
+    and name, so a moved record still resolves and the batch looks healthy. A
+    deleted or renamed one fails only at submission time, partway into a run of
+    several hours.
+    """
+    batch_path = (REPO_ROOT / "data" / "import_tracking" / "reports"
+                  / "axis_research_batch.json")
+    if not batch_path.is_file():
+        pytest.skip("batch artifact not present")
+    normalized = REPO_ROOT / "data" / "normalized_yaml"
+    missing = [r["file_path"] for r in json.loads(batch_path.read_text())
+               if not (normalized / r["file_path"]).is_file()]
+    assert not missing, (
+        f"{len(missing)} batch entries no longer resolve, e.g. {missing[:5]}. "
+        "Re-run `just sample-axis-research-batch` — but note that re-drawing "
+        "orphans any completed runs against the old batch.")
+
+
+def test_allocate_redistributes_an_exhausted_stratum(sarb):
+    """DEEP_RESEARCH holds 99 records against OTHER's 9,730, so an exhausted
+    stratum is the normal case. Its unused quota must go somewhere."""
+    cap = {"SEMI_DEFINED": 612, "DEEP_RESEARCH": 99, "WELL_KNOWN": 653, "OTHER": 9730}
+    for size in (25, 200, 500, 1000):
+        q = sarb.allocate(size, cap)
+        assert sum(q.values()) == size, f"size {size} -> {sum(q.values())}: {q}"
+        assert all(q[k] <= cap[k] for k in cap), q
+
+
+def test_allocate_caps_at_total_capacity(sarb):
+    q = sarb.allocate(10_000, {"a": 3, "b": 4})
+    assert sum(q.values()) == 7
+
+
+def test_allocate_handles_empty_strata(sarb):
+    q = sarb.allocate(6, {"a": 0, "b": 10})
+    assert q == {"a": 0, "b": 6}

--- a/tests/test_researched_manifest.py
+++ b/tests/test_researched_manifest.py
@@ -183,3 +183,70 @@ def test_prioritizer_output_does_not_depend_on_local_research_dir(tmp_path, monk
 
     assert [e["recipe_name"] for e in first] == [e["recipe_name"] for e in second]
     assert "tyl_medium" not in {e["recipe_name"] for e in first}
+
+
+# --- axis classification vs growth research (#152) -------------------------
+#
+# Both run under job "literature" on the same slug and write the same
+# `<slug>-edison-literature-meta.yaml` filename, so only the template
+# distinguishes them. These pin that they stay distinct, because every failure
+# mode here is silent: a shorter candidate list looks like progress.
+
+
+def _meta(tmp_path, slug, template, task_id="t1"):
+    d = tmp_path
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{slug}-edison-literature-meta.yaml").write_text(
+        f"slug: {slug}\nstatus: success\ntask_id: {task_id}\ntemplate_path: {template}\n")
+    return d
+
+
+def test_axis_runs_are_tagged_axis_not_medium(tmp_path):
+    rmf = _load("researched_manifest")
+    d = _meta(tmp_path / "media_axis", "lb_broth", "templates/media_axis_classification.md")
+    entries = rmf.scan_research_dir(d)
+    assert [e["kind"] for e in entries] == ["axis"]
+
+
+def test_growth_runs_are_still_tagged_medium(tmp_path):
+    rmf = _load("researched_manifest")
+    d = _meta(tmp_path / "media", "lb_broth", "templates/media_growth_research.md")
+    assert [e["kind"] for e in rmf.scan_research_dir(d)] == ["medium"]
+
+
+def test_axis_run_does_not_mark_a_medium_researched(tmp_path):
+    """The load-bearing one: researched_slugs() feeds the prioritizer's
+    already-researched filter, so tagging axis runs "medium" would drop every
+    axis-classified record out of the growth-research queue."""
+    rmf = _load("researched_manifest")
+    d = _meta(tmp_path / "media_axis", "lb_broth", "templates/media_axis_classification.md")
+    manifest = tmp_path / "m.json"
+    rmf.write_manifest(rmf.scan_research_dir(d), manifest)
+    assert rmf.researched_slugs(manifest) == set(), \
+        "an axis run must not count as the medium having been researched"
+
+
+def test_axis_and_growth_runs_for_one_slug_coexist(tmp_path):
+    """Keyed on (slug, job) alone these collide and the union drops one."""
+    rmf = _load("researched_manifest")
+    axis = rmf.scan_research_dir(
+        _meta(tmp_path / "media_axis", "lb_broth", "templates/media_axis_classification.md", "a1"))
+    growth = rmf.scan_research_dir(
+        _meta(tmp_path / "media", "lb_broth", "templates/media_growth_research.md", "g1"))
+    merged, added = rmf.merge_entries(axis, growth)
+    assert len(merged) == 2, f"growth run masked by the axis run: {merged}"
+    assert {e["kind"] for e in merged} == {"axis", "medium"}
+    assert len(added) == 1
+
+    manifest = tmp_path / "m.json"
+    rmf.write_manifest(merged, manifest)
+    assert rmf.researched_slugs(manifest) == {"lb_broth"}
+
+
+def test_legacy_entries_without_kind_do_not_re_add(tmp_path):
+    """_entry_key gained a third element; legacy rows must keep their identity."""
+    rmf = _load("researched_manifest")
+    legacy = [{"slug": "lb_broth", "job": "literature", "task_id": "old"}]
+    same = [{"slug": "lb_broth", "job": "literature", "task_id": "old", "kind": "medium"}]
+    merged, added = rmf.merge_entries(legacy, same)
+    assert added == [] and len(merged) == 1


### PR DESCRIPTION
Fills `nutritional_class` / `functional_role` for #152, which sat on 1 record each.

Rather than launch 11,094 media (~44 days sequential), this bounds the work: draw
a stratified 200, probe 25, measure, then decide.

## What is here

- `scripts/sample_axis_research_batch.py` — seeded, deterministic stratified sampler
- `just research-media-edison-axis` — separate recipe and out-dir (see below)
- `just sample-axis-research-batch`
- manifest support for a third run kind
- the drawn 200-record batch

## Strata

| stratum | available | drawn | why |
|---|--:|--:|---|
| SEMI_DEFINED | 612 | 50 | composition already characterised; axes are the only gap |
| DEEP_RESEARCH | 99 | 50 | tests whether the organism-yield ranking agrees with axis value |
| WELL_KNOWN | 653 | 50 | **accuracy control** — answers independently checkable |
| OTHER | 9,730 | 50 | so the sample describes the corpus, not just its corners |

Disjoint, assigned in that order. Round-robin interleaved so **every prefix is
stratified**: `--limit 25` draws 7/6/6/6 and is a strict subset of the 200, so the
remaining 175 can be finished later without re-researching any.

## Three silent failures caught before spending time

Each produces no error, no output, and no signal that anything was missed.

1. **Batch ordered by stratum.** `--limit 25` would have drawn all 25 from
   SEMI_DEFINED — a probe that looks fine and answers the wrong question.
2. **Template collision.** Both templates run under job `LITERATURE` and write
   `<slug>-edison-literature.md`, which is the key the already-researched skip
   tests. Writing axis reports into `research/media/` would have marked 200
   records done for a job they never had. Hence the separate out-dir.
3. **Manifest collision.** Same root cause one layer up: `researched_slugs()`
   feeds the prioritizer's filter, and `_entry_key` was `(slug, job)` with a
   union merge. Axis entries would have dropped records from the growth queue and
   masked later growth runs as duplicates. Fixed with the existing `kind`
   discriminator; medium-level slugs verified unchanged at 21.

## Probe results (25/25, mean 345s/record, cost 0.0000)

```
nutritional_class handled 25/25   (23 valued + 2 evidenced abstentions)
functional_role   filled  10/25

                n   conf   functional_role
SEMI_DEFINED    7   0.74       2/7
DEEP_RESEARCH   6   0.86       2/6
WELL_KNOWN      6   0.92       5/6
OTHER           6   0.81       1/6
```

**Accuracy control: 6/6.** `lb_rifampicin_medium` looked like an obvious false
negative — LB + rifampicin with no `SELECTIVE`. It was not: the record contains no
rifampicin. The model refused to classify from the name, cited a DOI establishing
rifampicin *is* selective, then declined `GENERAL_PURPOSE` too rather than resolve
the contradiction it had found. That generalised to 13 records — filed as #181.

Empty `functional_role` is principled rather than a failure: `sd0_medium` returned
`value: null` with evidence reading "GENERAL_PURPOSE would be an unsupported
residual assignment", while still assigning `SELECTIVE` at 0.9 for ~10% w/v NaCl.

## What is not settled

The stratum gradient held at every check: `WELL_KNOWN` 5/6 at 0.92 vs `OTHER` 1/6.
`OTHER` is 88% of the corpus, so a corpus-wide campaign would be dominated by the
weakest-yield stratum. The remaining 175 is ~17h sequential and is **not** launched
here — that is a separate decision this PR is meant to inform.

Reports live in gitignored `research/media_axis/`; the manifest is the tracked record.