### PR TITLE
Detect media named for a selective agent their composition omits (#181)

### DIFF
--- a/data/import_tracking/reports/selective_agent_mismatch.tsv
+++ b/data/import_tracking/reports/selective_agent_mismatch.tsv
@@ -1,0 +1,18 @@
+file_path	record_id	name	missing_agents	named_conc	n_ingredients
+bacterial/KOMODO_309_NEOMYCIN_AGAR.yaml	CultureMech:004886	NEOMYCIN AGAR	neomycin		5
+bacterial/am3_nalidixic_acid_kanamycin_medium.yaml	CultureMech:008611	AM3 + Nalidixic acid, Kanamycin medium	kanamycin; nalidixic acid		9
+bacterial/am3_nalidixic_acid_medium.yaml	CultureMech:008610	AM3 + Nalidixic acid medium	nalidixic acid		9
+bacterial/lb_50_ug_ml_kanamycin_medium.yaml	CultureMech:008689	LB + 50 ug/ml Kanamycin medium	kanamycin	kanamycin=50 ug/ml	5
+bacterial/lb_ampicilin_hygromycin_medium.yaml	CultureMech:008514	LB + Ampicilin, Hygromycin medium	ampicillin; hygromycin		5
+bacterial/lb_ampicillin_cefpodoxime_kanamycin_medium.yaml	CultureMech:008599	LB + Ampicillin, Cefpodoxime, Kanamycin medium	ampicillin; cefpodoxime; kanamycin		5
+bacterial/lb_ampicillin_kanamycin_medium.yaml	CultureMech:008641	LB + Ampicillin, Kanamycin medium	ampicillin; kanamycin		5
+bacterial/lb_ampicillin_medium.yaml	CultureMech:008244	LB + Ampicillin medium	ampicillin		5
+bacterial/lb_chloramphenicol_medium.yaml	CultureMech:008474	LB + Chloramphenicol medium	chloramphenicol		5
+bacterial/lb_kanamycin_hygromycin_medium.yaml	CultureMech:008513	LB + Kanamycin, Hygromycin medium	hygromycin; kanamycin		5
+bacterial/lb_kanamycin_medium.yaml	CultureMech:008515	LB + Kanamycin medium	kanamycin		5
+bacterial/lb_nalidixic_acid_ciprofloxacin_medium.yaml	CultureMech:008600	LB + Nalidixic acid, Ciprofloxacin medium	ciprofloxacin; nalidixic acid		5
+bacterial/lb_rifampicin_medium.yaml	CultureMech:008553	LB + Rifampicin medium	rifampicin		5
+bacterial/lb_streptomycin_medium.yaml	CultureMech:008552	LB + Streptomycin medium	streptomycin		5
+bacterial/lb_streptomycin_rifampicin_medium.yaml	CultureMech:008554	LB + Streptomycin, Rifampicin medium	rifampicin; streptomycin		5
+bacterial/neomycin_agar.yaml	CultureMech:001407	NEOMYCIN AGAR	neomycin		5
+bacterial/pda_hygromycin_medium.yaml	CultureMech:008534	PDA +Hygromycin medium	hygromycin		4

--- a/project.justfile
+++ b/project.justfile
@@ -149,6 +149,13 @@ audit-filename-collisions *args="":
 # blocks NEW implausible concentrations without demanding the backlog be cleared
 # first, the same convention as `check-chebi-grounding`. LOWER the baseline as
 # records are repaired; raising it to make a run pass defeats the point.
+# Report media named for a selective agent their ingredient list omits (#181).
+# Report-only: recovering a lost concentration needs the upstream record, and a
+# plausible guess that round-trips is still false chemistry (#166).
+[group('QC')]
+audit-selective-agent-mismatch *args="":
+    uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}
+
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py \

--- a/scripts/audit_selective_agent_mismatch.py
+++ b/scripts/audit_selective_agent_mismatch.py
@@ -96,6 +96,13 @@ SELECTIVE_AGENTS: list[tuple[str, str]] = [
     ("thallous acetate", r"thallous"),
 ]
 
+# Name separators. A concentration belongs to the agent in ITS OWN segment; the
+# comma in "50 ug/ml Kanamycin, 100 ug/ml Ampicillin" is what keeps the two apart.
+#
+# "/" is NOT a separator: units are written "ug/ml", so splitting on it turns
+# every concentration into "50 ug" + "ml" and the column silently empties.
+_SEGMENT = re.compile(r"\s*(?:[,;+]|\band\b)\s*", re.I)
+
 # An either/or formulation: the record holds one alternative, not both.
 _EITHER_OR = re.compile(r"\bor\b", re.I)
 
@@ -108,18 +115,26 @@ def _compiled() -> list[tuple[str, re.Pattern[str]]]:
 
 
 def named_concentration(name: str, agent_rx: re.Pattern[str]) -> str:
-    """A concentration adjacent to the agent in the NAME, if the source kept one.
+    """A concentration attached to THIS agent in the NAME, if the source kept one.
 
     "LB + 50 ug/ml Kanamycin medium" is the useful case: the value survived in the
     name even though it never reached `ingredients`, so it is recoverable from
     tracked data rather than invented.
+
+    Scoped to the name SEGMENT holding the agent, not a character window. A window
+    reaches across separators and picks up the neighbouring agent's value —
+    "LB + 50 ug/ml Kanamycin, 100 ug/ml Ampicillin" yielded `ampicillin=50 ug/ml`
+    (#188). That is the #166 failure inside the very tool meant to prevent it: a
+    plausible, confident, wrong concentration presented as recovered fact.
+
+    Returns "" when the segment carries no concentration. Silence is the correct
+    answer; a guess is not.
     """
-    m = agent_rx.search(name)
-    if not m:
-        return ""
-    window = name[max(0, m.start() - 40): m.end() + 40]
-    found = re.search(_CONC, window, re.I)
-    return found.group(0) if found else ""
+    for segment in _SEGMENT.split(name):
+        if agent_rx.search(segment):
+            found = re.search(_CONC, segment, re.I)
+            return found.group(0) if found else ""
+    return ""
 
 
 def audit_parsed(records: list[tuple[str, dict[str, Any]]]) -> list[dict[str, str]]:

--- a/scripts/audit_selective_agent_mismatch.py
+++ b/scripts/audit_selective_agent_mismatch.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Report media named for a selective agent their ingredient list omits (#181).
+
+Found by the Edison axis-classification probe, not by any existing gate. Asked to
+classify `lb_rifampicin_medium`, the model declined `functional_role: SELECTIVE`
+because "the supplied ingredient list contains no rifampicin entry or
+concentration", and declined `GENERAL_PURPOSE` too rather than resolve the
+contradiction. It was right: the record is plain LB.
+
+Why this matters more than a missing ingredient usually would: the record asserts
+a composition that is not the medium it names. Anything reading it — growth
+inference, ingredient grounding, axis classification — gets a confident wrong
+answer with no signal. A `functional_role` assigned from the name would launder
+the defect into the schema.
+
+REPORT ONLY. It does not repair, for the #166 reason: a plausible-looking
+concentration that round-trips, validates, and passes every gate is still false
+chemistry, and only reading the output catches it. Where the source recorded a
+concentration in the NAME ("LB + 50 ug/ml Kanamycin medium"), the value is
+recoverable from tracked data and is surfaced in the `named_conc` column for a
+curator to act on — surfaced, not applied.
+
+Two traps, both hit while scoping this:
+
+  * Match on WORD BOUNDARIES. A substring matcher reported 28 records because
+    `streptomyc` matches the GENUS *Streptomyces* (`GYM_Streptomyces_Medium`) and
+    `bile` matches `alkalispirillum_mobile_medium`. More than half the initial
+    hits were artifacts of the matcher, not defects in the corpus.
+  * Presence in a name proves the agent belongs; ABSENCE from a finite agent list
+    proves nothing. This bounds a known family. It does not certify the rest of
+    the corpus, and `--max-allowed 0` would be a claim this script cannot support.
+
+Usage::
+
+    just audit-selective-agent-mismatch
+    just audit-selective-agent-mismatch --max-allowed 17   # current baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "selective_agent_mismatch.tsv"
+
+# Agents whose presence makes a medium selective, and whose absence from the
+# composition is therefore a defect rather than a detail. Each entry is
+# (label, regex) and every regex is applied with \b...\b anchors.
+#
+# NOT included, deliberately: "streptomycin" is here but the genus *Streptomyces*
+# is not an agent — word boundaries separate them, which is the whole reason this
+# is a list of anchored patterns rather than substrings.
+SELECTIVE_AGENTS: list[tuple[str, str]] = [
+    # "Ampicilin" (one L) appears twice in source names — a misspelling upstream,
+    # not something to normalise away, since the name is the evidence.
+    ("ampicillin", r"ampicill?in"),
+    ("carbenicillin", r"carbenicillin"),
+    ("cefpodoxime", r"cefpodoxime"),
+    ("chloramphenicol", r"chloramphenicol"),
+    ("ciprofloxacin", r"ciprofloxacin"),
+    ("cycloheximide", r"cycloheximide"),
+    ("erythromycin", r"erythromycin"),
+    ("gentamicin", r"gentamic[iy]n"),
+    ("hygromycin", r"hygromycin"),
+    ("kanamycin", r"kanamycin"),
+    ("nalidixic acid", r"nalidixic"),
+    ("neomycin", r"neomycin"),
+    ("novobiocin", r"novobiocin"),
+    ("nystatin", r"nystatin"),
+    ("penicillin", r"penicillin"),
+    ("polymyxin", r"polymyxin"),
+    # "rifampin" is the US generic name (USAN) for rifampicin (INN), not a typo.
+    ("rifampicin", r"(?:rifampicin|rifampin)"),
+    ("spectinomycin", r"spectinomycin"),
+    ("streptomycin", r"streptomycin"),
+    ("tetracycline", r"tetracyclines?"),
+    ("trimethoprim", r"trimethoprim"),
+    ("vancomycin", r"vancomycin"),
+    ("bile salts", r"bile"),
+    ("crystal violet", r"crystal violet"),
+    ("brilliant green", r"brilliant green"),
+    ("malachite green", r"malachite green"),
+    ("sodium azide", r"azide"),
+    ("potassium tellurite", r"tellurite"),
+    ("thallous acetate", r"thallous"),
+]
+
+# An either/or formulation: the record holds one alternative, not both.
+_EITHER_OR = re.compile(r"\bor\b", re.I)
+
+# "50 ug/ml Kanamycin", "Kanamycin (100 mg/l)", "0.5% bile"
+_CONC = r"\d+(?:\.\d+)?\s*(?:%|ug/ml|µg/ml|mg/ml|mg/l|g/l|u/ml)"
+
+
+def _compiled() -> list[tuple[str, re.Pattern[str]]]:
+    return [(label, re.compile(rf"\b{rx}\b", re.I)) for label, rx in SELECTIVE_AGENTS]
+
+
+def named_concentration(name: str, agent_rx: re.Pattern[str]) -> str:
+    """A concentration adjacent to the agent in the NAME, if the source kept one.
+
+    "LB + 50 ug/ml Kanamycin medium" is the useful case: the value survived in the
+    name even though it never reached `ingredients`, so it is recoverable from
+    tracked data rather than invented.
+    """
+    m = agent_rx.search(name)
+    if not m:
+        return ""
+    window = name[max(0, m.start() - 40): m.end() + 40]
+    found = re.search(_CONC, window, re.I)
+    return found.group(0) if found else ""
+
+
+def audit_parsed(records: list[tuple[str, dict[str, Any]]]) -> list[dict[str, str]]:
+    """Pure function over already-parsed records, so tests need no fixture files."""
+    agents = _compiled()
+    rows: list[dict[str, str]] = []
+    for rel, doc in records:
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        name = f"{doc.get('name') or ''} {doc.get('original_name') or ''}".strip()
+        ingredients = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
+        ing_text = " ".join(str(i.get("preferred_term") or "") for i in ingredients)
+        missing, concs = [], []
+        present = False
+        for label, rx in agents:
+            in_name, in_ings = bool(rx.search(name)), bool(rx.search(ing_text))
+            if in_name and in_ings:
+                present = True
+            elif in_name:
+                missing.append(label)
+                conc = named_concentration(name, rx)
+                if conc:
+                    concs.append(f"{label}={conc}")
+
+        # "M2SGC broth containing tetracycline (10 ug/ml) OR rifampin (100 ug/ml)"
+        # names an either/or formulation, not a recipe holding both. The record is
+        # the tetracycline variant and is complete; rifampin is the documented
+        # alternative, so reporting it missing is a false positive.
+        #
+        # Requires at least one named agent to be PRESENT — a record naming "A or B"
+        # with neither in its composition is still defective, and still reported.
+        if missing and present and _EITHER_OR.search(name):
+            continue
+
+        if missing:
+            rows.append({
+                "file_path": rel,
+                "record_id": str(doc.get("id") or ""),
+                "name": str(doc.get("original_name") or doc.get("name") or ""),
+                "missing_agents": "; ".join(missing),
+                "named_conc": "; ".join(concs),
+                "n_ingredients": str(len(ingredients)),
+            })
+    rows.sort(key=lambda r: r["file_path"])
+    return rows
+
+
+def collect(normalized: Path = NORMALIZED) -> list[dict[str, str]]:
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((str(path.relative_to(normalized)), doc))
+    return audit_parsed(records)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--max-allowed", type=int, default=None,
+                    help="Exit 1 if more than N records are affected. Baseline gate: "
+                         "holds the line without demanding the backlog be fixed first.")
+    args = ap.parse_args(argv)
+
+    rows = collect(args.normalized_dir)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
+            "file_path", "record_id", "name", "missing_agents", "named_conc",
+            "n_ingredients"])
+        w.writeheader()
+        w.writerows(rows)
+
+    print(f"Media named for a selective agent absent from their ingredients: {len(rows)}")
+    recoverable = [r for r in rows if r["named_conc"]]
+    if recoverable:
+        print(f"  of which the NAME still carries a concentration: {len(recoverable)}"
+              f" (recoverable from tracked data, not invented)")
+    for r in rows:
+        print(f"  {r['file_path'][:52]:54s} {r['missing_agents'][:34]:36s} "
+              f"{r['named_conc'][:24]}")
+    print(f"\nWrote {args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+
+    if args.max_allowed is not None and len(rows) > args.max_allowed:
+        print(f"\nFAIL: {len(rows)} affected records exceeds --max-allowed "
+              f"{args.max_allowed}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_selective_agent_mismatch.py
+++ b/tests/test_selective_agent_mismatch.py
@@ -1,0 +1,144 @@
+"""Tests for the selective-agent name/composition mismatch audit (#181).
+
+Most of these pin FALSE POSITIVES rather than detections. That is deliberate: the
+first version of this check reported 28 records and more than half were artifacts
+of substring matching. A checker that cries wolf on the genus *Streptomyces* gets
+switched off, and then the 17 real defects go unnoticed too.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def aud():
+    return _load("audit_selective_agent_mismatch")
+
+
+def _rec(name, ingredients):
+    return ("bacterial/x.yaml", {
+        "id": "CultureMech:1", "name": "x", "original_name": name,
+        "ingredients": [{"preferred_term": i} for i in ingredients]})
+
+
+# --- detection --------------------------------------------------------------
+
+
+def test_agent_in_name_but_not_in_ingredients_is_reported(aud):
+    rows = aud.audit_parsed([_rec("LB + Rifampicin medium",
+                                  ["Distilled water", "Yeast extract", "NaCl"])])
+    assert len(rows) == 1 and "rifampicin" in rows[0]["missing_agents"]
+
+
+def test_agent_present_in_ingredients_is_not_reported(aud):
+    rows = aud.audit_parsed([_rec("LB + Rifampicin medium",
+                                  ["Yeast extract", "Rifampicin"])])
+    assert rows == []
+
+
+def test_a_partial_match_reports_only_the_missing_agent(aud):
+    rows = aud.audit_parsed([_rec("LB + Ampicillin, Kanamycin medium",
+                                  ["Yeast extract", "Ampicillin"])])
+    assert rows[0]["missing_agents"] == "kanamycin"
+
+
+# --- the false positives that made the first version useless ----------------
+
+
+def test_the_genus_streptomyces_is_not_the_drug_streptomycin(aud):
+    """`streptomyc` as a substring matched 8 GYM Streptomyces media."""
+    rows = aud.audit_parsed([_rec("GYM Streptomyces Medium",
+                                  ["Glucose", "Yeast extract", "Malt extract"])])
+    assert rows == [], f"flagged the genus as an antibiotic: {rows}"
+
+
+def test_mobile_does_not_contain_bile(aud):
+    """`bile` as a substring matched `alkalispirillum_mobile_medium`, 8 times over."""
+    rows = aud.audit_parsed([_rec("Alkalispirillum mobile medium", ["NaCl", "Yeast extract"])])
+    assert rows == [], f"matched 'bile' inside 'mobile': {rows}"
+
+
+def test_either_or_formulations_are_not_defects(aud):
+    """"tetracycline (10 ug/ml) OR rifampin (100 ug/ml)" names two alternatives.
+    The record holds one of them and is complete."""
+    rows = aud.audit_parsed([_rec(
+        "M2SGC broth containing tetracycline (10 ug/ml) or rifampin (100 ug/ml)",
+        ["Tetracycline", "Glucose"])])
+    assert rows == []
+
+
+def test_either_or_with_neither_agent_present_is_still_a_defect(aud):
+    """The suppression must not become a blanket excuse for any name with 'or'."""
+    rows = aud.audit_parsed([_rec(
+        "M2SGC broth containing tetracycline or rifampin", ["Glucose", "Yeast extract"])])
+    assert len(rows) == 1
+
+
+# --- spelling variants ------------------------------------------------------
+
+
+def test_ampicilin_one_l_is_matched(aud):
+    """The source spells it "Ampicilin" in two records; the name is the evidence,
+    so the matcher accommodates the misspelling rather than losing the record."""
+    rows = aud.audit_parsed([_rec("LB + Ampicilin, Hygromycin medium", ["Yeast extract"])])
+    assert "ampicillin" in rows[0]["missing_agents"]
+
+
+def test_rifampin_is_the_us_name_for_rifampicin_not_a_typo(aud):
+    rows = aud.audit_parsed([_rec("LB + rifampin medium", ["Yeast extract"])])
+    assert "rifampicin" in rows[0]["missing_agents"]
+
+
+# --- recoverable concentrations --------------------------------------------
+
+
+def test_a_concentration_kept_in_the_name_is_surfaced(aud):
+    """"LB + 50 ug/ml Kanamycin medium" — the value survived upstream and was lost
+    in transform, so it is recoverable from tracked data rather than invented."""
+    rows = aud.audit_parsed([_rec("LB + 50 ug/ml Kanamycin medium", ["Yeast extract"])])
+    assert rows[0]["named_conc"] == "kanamycin=50 ug/ml"
+
+
+def test_no_concentration_in_the_name_means_no_claim(aud):
+    """Absence must stay empty. A guessed concentration is the #166 failure."""
+    rows = aud.audit_parsed([_rec("LB + Kanamycin medium", ["Yeast extract"])])
+    assert rows[0]["named_conc"] == ""
+
+
+# --- corpus -----------------------------------------------------------------
+
+
+def test_solution_records_are_skipped(aud):
+    """A stock solution named for the agent it IS must not be reported as a medium
+    missing that agent. Keyed on `term.id`, matching `record_kinds` — the shared
+    rule both this audit and validate_strict import, so they cannot drift."""
+    rows = aud.audit_parsed([("bacterial/s.yaml", {
+        "id": "CultureMech:9", "original_name": "Kanamycin stock solution",
+        "term": {"id": "mediadive.solution:1"},
+        "ingredients": [{"preferred_term": "Water"}]})])
+    assert rows == []
+
+
+def test_corpus_count_matches_the_documented_baseline(aud):
+    """The gate's --max-allowed is set from this number; if it drifts, one of them
+    is wrong."""
+    rows = aud.collect()
+    assert len(rows) <= 17, (
+        f"{len(rows)} records now mismatch, above the documented baseline of 17. "
+        "Either a new defect landed or the agent list grew — update both the gate "
+        "and #181.")

--- a/tests/test_selective_agent_mismatch.py
+++ b/tests/test_selective_agent_mismatch.py
@@ -134,11 +134,42 @@ def test_solution_records_are_skipped(aud):
     assert rows == []
 
 
-def test_corpus_count_matches_the_documented_baseline(aud):
+def test_corpus_count_matches_the_documented_baseline(aud, corpus):
     """The gate's --max-allowed is set from this number; if it drifts, one of them
-    is wrong."""
-    rows = aud.collect()
+    is wrong.
+
+    Uses the session-scoped `corpus` fixture rather than `aud.collect()`. Calling
+    collect() re-parsed all ~15,900 records for this one test, costing 118s and
+    making it the fifth full-corpus scan in the suite — enough to push the pytest
+    job past the 40-minute CI ceiling (#189).
+    """
+    normalized = REPO_ROOT / "data" / "normalized_yaml"
+    rows = aud.audit_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
     assert len(rows) <= 17, (
         f"{len(rows)} records now mismatch, above the documented baseline of 17. "
         "Either a new defect landed or the agent list grew — update both the gate "
         "and #181.")
+
+
+# --- #188: the concentration must belong to ITS agent ----------------------
+
+
+def test_a_second_agents_concentration_is_not_stolen(aud):
+    """A +/-40 character window reached back across the comma and reported
+    `ampicillin=50 ug/ml` for a name that plainly says 100 — the #166 failure
+    inside the tool written to prevent it."""
+    rows = aud.audit_parsed([_rec("LB + 50 ug/ml Kanamycin, 100 ug/ml Ampicillin medium", [])])
+    assert rows[0]["named_conc"] == "ampicillin=100 ug/ml; kanamycin=50 ug/ml"
+
+
+def test_only_the_agent_that_has_a_concentration_gets_one(aud):
+    rows = aud.audit_parsed([_rec("LB + Ampicillin, 100 ug/ml Kanamycin medium", [])])
+    assert rows[0]["named_conc"] == "kanamycin=100 ug/ml"
+
+
+def test_the_unit_slash_does_not_split_a_segment(aud):
+    """Units are written "ug/ml". An early fix treated "/" as a segment separator,
+    which turned every concentration into "50 ug" + "ml" and silently emptied the
+    column — a regression that looked exactly like "no data available"."""
+    rows = aud.audit_parsed([_rec("LB + 50 ug/ml Kanamycin medium", [])])
+    assert rows[0]["named_conc"] == "kanamycin=50 ug/ml"


### PR DESCRIPTION
Report-only audit for the defect the Edison axis probe surfaced.

## What it found

**17 records** are named for a selective agent absent from their ingredient list.
11 are `lb_*_medium` with exactly 5 ingredients — the plain-LB base — so this is
one systematic import defect across the LB+antibiotic family, not 17 independent
omissions.

```
KOMODO_309_NEOMYCIN_AGAR              neomycin
am3_nalidixic_acid_kanamycin_medium   kanamycin; nalidixic acid
am3_nalidixic_acid_medium             nalidixic acid
lb_50_ug_ml_kanamycin_medium          kanamycin           kanamycin=50 ug/ml
lb_ampicilin_hygromycin_medium        ampicillin; hygromycin
lb_ampicillin_cefpodoxime_kanamycin   ampicillin; cefpodoxime; kanamycin
lb_ampicillin_kanamycin_medium        ampicillin; kanamycin
lb_ampicillin_medium                  ampicillin
lb_chloramphenicol_medium             chloramphenicol
lb_kanamycin_hygromycin_medium        hygromycin; kanamycin
lb_kanamycin_medium                   kanamycin
lb_nalidixic_acid_ciprofloxacin       ciprofloxacin; nalidixic acid
lb_rifampicin_medium                  rifampicin
lb_streptomycin_medium                streptomycin
lb_streptomycin_rifampicin_medium     rifampicin; streptomycin
neomycin_agar                         neomycin
pda_hygromycin_medium                 hygromycin
```

Each was spot-checked. `neomycin_agar` is beef extract, yeast extract, peptone,
glucose, casitone; `pda_hygromycin_medium` is water, glucose, agar, potato.

## Report-only, deliberately

Recovering a lost concentration needs the upstream TOGO/NBRC record, and a
plausible guess that round-trips and validates is still false chemistry — the
#166 failure, which passed every automated check and was caught only by reading
the output.

Where the source kept the value in the **name** (`LB + 50 ug/ml Kanamycin
medium`), it is surfaced in a `named_conc` column for a curator. Surfaced, not
applied.

## The matcher was most of the work

The tests mostly pin **false positives**, because a checker that cries wolf gets
switched off and then the 17 real defects go unnoticed too.

- Substring matching reported **28**; sixteen were artifacts. `streptomyc`
  matches the genus *Streptomyces* (8 GYM media) and `bile` matches
  `alkalispirillum_mobile_medium` (8 more). Word boundaries throughout.
- `M2SGC broth containing tetracycline (10 ug/ml) **or** rifampin (100 ug/ml)` is
  an either/or formulation. The record holds tetracycline and is complete.
  Suppressed only when at least one named agent IS present — "A or B" with
  neither is still a defect, and still reported.
- The source spells it `Ampicilin` (one L) in two records, and `rifampin` is the
  US generic name for rifampicin, not a typo. Both matched. Found by scanning the
  corpus for near-miss spellings rather than guessed.

## Scope limit

Presence in a name proves the agent belongs; **absence from a finite agent list
proves nothing**. This bounds a known family — it does not certify the rest of the
corpus, which is why `--max-allowed 0` would be a claim the script cannot support.

No new CI workflow: the baseline is pinned by a test, and the pytest gate has no
path filter so it always runs.

Refs #181.