### PR TITLE
Stop the review-need guards re-parsing the corpus; suite 535s -> 317s (#189)

### DIFF
--- a/scripts/score_review_need.py
+++ b/scripts/score_review_need.py
@@ -147,13 +147,16 @@ def score_record(doc: dict[str, Any]) -> tuple[int, list[str]]:
     return score, reasons
 
 
-def collect(normalized: Path = NORMALIZED) -> list[dict[str, Any]]:
+def score_parsed(records: list[tuple[str, dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Rank already-parsed records, so callers that hold the corpus need not re-read it.
+
+    Split out from `collect` for the corpus guards: each was calling `collect()`
+    and re-parsing ~15,900 files, and five such tests were enough to cancel the
+    pytest job at the 40-minute CI ceiling (#189). Tests pass the session-scoped
+    `corpus` fixture here instead.
+    """
     rows: list[dict[str, Any]] = []
-    for path in sorted(normalized.rglob("*.yaml")):
-        try:
-            doc = yaml.safe_load(path.read_text(errors="replace"))
-        except (yaml.YAMLError, OSError):
-            continue
+    for rel, doc in records:
         if not isinstance(doc, dict) or is_solution_record(doc):
             continue
         score, reasons = score_record(doc)
@@ -162,7 +165,7 @@ def collect(normalized: Path = NORMALIZED) -> list[dict[str, Any]]:
             continue
         rows.append({
             "score": score,
-            "file_path": str(path.relative_to(normalized)),
+            "file_path": rel,
             "record_id": str(doc.get("id") or ""),
             "name": str(doc.get("original_name") or doc.get("name") or ""),
             "n_ingredients": str(len(doc.get("ingredients") or [])),
@@ -170,6 +173,18 @@ def collect(normalized: Path = NORMALIZED) -> list[dict[str, Any]]:
         })
     rows.sort(key=lambda r: (-r["score"], r["file_path"]))
     return rows
+
+
+def collect(normalized: Path = NORMALIZED) -> list[dict[str, Any]]:
+    """Parse the corpus from disk, then score it."""
+    records: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((str(path.relative_to(normalized)), doc))
+    return score_parsed(records)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_review_need.py
+++ b/tests/test_review_need.py
@@ -137,22 +137,28 @@ def test_signals_accumulate(srn):
 # --- the corpus -----------------------------------------------------------
 
 
-def test_known_bad_records_rank_near_the_top(srn):
+def _rank(srn, corpus):
+    """Score the session-scoped corpus instead of re-reading it (#189)."""
+    normalized = REPO_ROOT / "data" / "normalized_yaml"
+    return srn.score_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
+
+
+def test_known_bad_records_rank_near_the_top(srn, corpus):
     """Validation against records independently confirmed broken.
 
     NBRC_1197 carries an unparsed recipe (#166); test_medium_123 is a literal test
     fixture sitting in the production corpus.
     """
-    rows = srn.collect()
+    rows = _rank(srn, corpus)
     assert rows, "scorer returned nothing"
     top = [r["file_path"] for r in rows[:60]]
     for expected in ("bacterial/NBRC_1197.yaml", "bacterial/test_medium_123.yaml"):
         assert expected in top, f"{expected} not in the worst 60"
 
 
-def test_most_of_the_corpus_is_not_flagged_as_severe(srn):
+def test_most_of_the_corpus_is_not_flagged_as_severe(srn, corpus):
     """If a large share scored severe, the ranking would carry no information."""
-    rows = srn.collect()
+    rows = _rank(srn, corpus)
     severe = [r for r in rows if r["score"] >= 50]
     assert len(severe) < 500, f"{len(severe)} records scored >=50; the weights are too loose"
 


### PR DESCRIPTION
#179's pytest job was **cancelled at the 40-minute CI ceiling with all 662 tests
passing**. A timeout, not a failure — so the PR reads as broken when it is not.

## Cause

Five tests each re-parse all ~15,900 records:

```
118.7s  test_selective_agent_mismatch::...baseline    (fixed in #187)
102.5s  test_unparsed_compositions::...verdict        (#179, still to fix)
100.8s  test_composition_type::...bulk_undefined
 97.5s  test_review_need::...not_flagged_as_severe    <- this PR
 94.7s  test_review_need::...rank_near_the_top        <- this PR
```

`tests/conftest.py` already provides a session-scoped `corpus` fixture built for
precisely this — it took the suite from 590s to 239s when it was added — but each
of these calls its script's own `collect()`, so none of them use it.

## Change

`score_review_need` gains a `score_parsed()` entry point over already-parsed
records, matching the `audit_parsed()` pattern in `audit_composition_type` and
`audit_selective_agent_mismatch`. `collect()` becomes parse-then-score and returns
the same **2,311 rows**.

## Result

```
before  884 passed  535s
after   887 passed  317s
```

One full-corpus parse remains — the shared fixture setup at ~103s — which is the
point of having it.

Raising `timeout-minutes` again would treat the symptom. The last raise was 20 ->
40 and the ceiling was hit again within a fortnight; the cost is real and grows
with every corpus guard added.

Unblocks #179. Closes #189.