### PR TITLE
Correct #181 (15 of 17 were false positives) and triage the 428 media with no composition (#175)

### DIFF
--- a/data/import_tracking/reports/missing_compositions.tsv
+++ b/data/import_tracking/reports/missing_compositions.tsv
@@ -1,0 +1,429 @@
+file_path	record_id	name	kind	source	looks_like_a_solution	name_cites_medium	cited_medium_in_local_dump
+archaea/KOMODO_131_METHANOBACTERIUM_THERMOAUTOTROPHICUM_MEDIUM.yaml	CultureMech:004074	METHANOBACTERIUM THERMOAUTOTROPHICUM MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/KOMODO_304_METHANOSARCINA_ACETIVORANS_medium.yaml	CultureMech:004832	METHANOSARCINA ACETIVORANS medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/KOMODO_510_STYGIOLOBUS_medium.yaml	CultureMech:005712	STYGIOLOBUS medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/aeropyrum_jxt_medium.yaml	CultureMech:006547	AEROPYRUM-JXT medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/metallosphaera_medium.yaml	CultureMech:005608	METALLOSPHAERA medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanocorpusculum_medium.yaml	CultureMech:004706	METHANOCORPUSCULUM medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanogenium_sp_medium.yaml	CultureMech:005910	METHANOGENIUM SP. medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanolobus_ii_medium.yaml	CultureMech:005015	METHANOLOBUS II medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanosarcina_acetivorans_medium_replace_trimethylamine_hcl_with_methanol.yaml	CultureMech:004821	METHANOSARCINA ACETIVORANS medium_replace_Trimethylamine-HCl_with_Methanol	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanosarcina_frisia_medium.yaml	CultureMech:005072	METHANOSARCINA FRISIA medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanosarcina_thermophilic_medium.yaml	CultureMech:004191	METHANOSARCINA (thermophilic) medium	no ingredients and no solutions	KOMODO ModelSEED			
+archaea/methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119.yaml	CultureMech:004190	METHANOSARCINA (thermophilic) medium_replace_Rumen fluid, clarified_with_Sludge fluid (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
+archaea/thermophilic_methanosaeta_medium.yaml	CultureMech:005164	THERMOPHILIC METHANOSAETA MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/100x_vitamin_solution_medium_1398.yaml	CultureMech:004994	100x Vitamin solution (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED	yes	1398	yes
+bacterial/10_x_m9_salts.yaml	CultureMech:004267	10 x M9 salts	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/4_times_concentrated_sea_water_medium_821.yaml	CultureMech:004993	4 times concentrated sea water (medium 821)	no ingredients and no solutions	KOMODO ModelSEED		821	yes
+bacterial/50_x_pye.yaml	CultureMech:006514	50 x PYE	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/50x_heterotrophic_basal_salts_solution_medium_1190.yaml	CultureMech:004779	50x Heterotrophic basal salts solution (medium 1190)	no ingredients and no solutions	KOMODO ModelSEED	yes	1190	yes
+bacterial/KOMODO_1254_NAUTILIA_NITRATIREDUCENS_MEDIUM.yaml	CultureMech:004015	NAUTILIA NITRATIREDUCENS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/KOMODO_272_DESULFOVIBRIO_medium_choline.yaml	CultureMech:004700	DESULFOVIBRIO medium (choline)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/KOMODO_3018_H3P-Vitamin_solution_medium_428.yaml	CultureMech:004797	H3P-Vitamin solution (medium 428)	no ingredients and no solutions	KOMODO ModelSEED	yes	428	yes
+bacterial/KOMODO_3071_Trace_element_solution_medium_155.yaml	CultureMech:004857	Trace element solution (medium 155)	no ingredients and no solutions	KOMODO ModelSEED	yes	155	yes
+bacterial/KOMODO_3077_Trace_element_solution_medium_84.yaml	CultureMech:004863	Trace element solution (medium 84)	no ingredients and no solutions	KOMODO ModelSEED	yes	84	yes
+bacterial/KOMODO_3087_Trace_element_solution_SL-8.yaml	CultureMech:004873	Trace element solution SL-8	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml	CultureMech:004984	Fastidious Anaerobe Agar	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/KOMODO_7001_Trace_elements_medium_596.yaml	CultureMech:006327	Trace elements (medium 596)	no ingredients and no solutions	KOMODO ModelSEED		596	yes
+bacterial/KOMODO_787_ACETOBACTERIUM_DEHALOGENANS_medium.yaml	CultureMech:006488	ACETOBACTERIUM DEHALOGENANS medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/acetobacterium_2_medium.yaml	CultureMech:005062	ACETOBACTERIUM 2 medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/acetobacterium_carbinolicum_medium.yaml	CultureMech:004988	ACETOBACTERIUM CARBINOLICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/acetobacterium_sp_komac1_medium.yaml	CultureMech:005592	ACETOBACTERIUM SP. KoMAc1 medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/acetonema_medium.yaml	CultureMech:005871	ACETONEMA medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/amino_acid_solution_medium_78.yaml	CultureMech:004780	Amino acid solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED		78	yes
+bacterial/anaerobic_acetoin_medium.yaml	CultureMech:005020	ANAEROBIC ACETOIN medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/anaerobic_oxalate_medium.yaml	CultureMech:005624	ANAEROBIC OXALATE MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/anaerovibrio_burkinabensis_medium.yaml	CultureMech:006022	ANAEROVIBRIO BURKINABENSIS medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml	CultureMech:004785	Artificial sea water, 3 times concentrated (medium 1137)	no ingredients and no solutions	KOMODO ModelSEED		1137	yes
+bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml	CultureMech:004389	Artificial sea water, 3 times concentrated (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
+bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml	CultureMech:005655	Artificial sea water from a marine aquarium salts mixture	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/artificial_sea_water_medium_1075.yaml	CultureMech:004783	Artificial sea water (medium 1075)	no ingredients and no solutions	KOMODO ModelSEED		1075	yes
+bacterial/artificial_sea_water_medium_246.yaml	CultureMech:004996	Artificial sea water (medium 246)	no ingredients and no solutions	KOMODO ModelSEED		246	yes
+bacterial/artificial_sea_water_medium_343.yaml	CultureMech:004782	Artificial sea water (medium 343)	no ingredients and no solutions	KOMODO ModelSEED		343	yes
+bacterial/artificial_sea_water_medium_405.yaml	CultureMech:004784	Artificial sea water (medium 405)	no ingredients and no solutions	KOMODO ModelSEED		405	yes
+bacterial/artificial_sea_water_medium_600.yaml	CultureMech:004395	Artificial sea water (medium 600)	no ingredients and no solutions	KOMODO ModelSEED		600	yes
+bacterial/artificial_sea_water_medium_600a.yaml	CultureMech:004995	Artificial sea water (medium 600a)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/artificial_sea_water_medium_607.yaml	CultureMech:004781	Artificial sea water (medium 607)	no ingredients and no solutions	KOMODO ModelSEED		607	yes
+bacterial/artificial_seawater_medium_1231.yaml	CultureMech:004786	Artificial seawater (medium 1231)	no ingredients and no solutions	KOMODO ModelSEED		1231	yes
+bacterial/artificial_seawater_medium_1326.yaml	CultureMech:004787	Artificial seawater (medium 1326)	no ingredients and no solutions	KOMODO ModelSEED		1326	yes
+bacterial/artificial_tap_water_medium_1167.yaml	CultureMech:004789	Artificial tap water (medium 1167)	no ingredients and no solutions	KOMODO ModelSEED		1167	yes
+bacterial/bacto_middelbrook_7h11_agar_medium_911.yaml	CultureMech:004790	Bacto Middelbrook 7H11 agar (medium 911)	no ingredients and no solutions	KOMODO ModelSEED		911	yes
+bacterial/bacto_middelbrook_oadc_enrichment_medium_911.yaml	CultureMech:004791	Bacto Middelbrook OADC enrichment (medium 911)	no ingredients and no solutions	KOMODO ModelSEED		911	yes
+bacterial/basal_salts_solution_medium_791.yaml	CultureMech:004792	Basal salts solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
+bacterial/bbl_actinomyces_broth_medium_1029.yaml	CultureMech:004983	BBL Actinomyces broth (medium 1029)	no ingredients and no solutions	KOMODO ModelSEED		1029	yes
+bacterial/blood_agar_base_from_difco_0045.yaml	CultureMech:006515	Blood Agar Base from Difco 0045	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/blood_agar_no_2_oxoid.yaml	CultureMech:006086	blood agar No 2 (Oxoid)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/bordet_gengou_agar_base.yaml	CultureMech:005645	Bordet-Gengou-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/brucella_broth_becton_dickinson.yaml	CultureMech:005646	Brucella Broth (Becton Dickinson)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/casman_agar_base.yaml	CultureMech:005647	Casman-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/chelated_iron_solution_medium_737.yaml	CultureMech:004268	Chelated iron solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED		737	yes
+bacterial/chelated_iron_solution_medium_748.yaml	CultureMech:004793	Chelated Iron solution (medium 748)	no ingredients and no solutions	KOMODO ModelSEED		748	yes
+bacterial/clostridium_estertheticum_medium.yaml	CultureMech:006182	CLOSTRIDIUM ESTERTHETICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/clostridium_longisporum_medium.yaml	CultureMech:006392	CLOSTRIDIUM LONGISPORUM medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/clostridium_neopropionicum_medium.yaml	CultureMech:005884	CLOSTRIDIUM NEOPROPIONICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml	CultureMech:005648	CMRL-1066 medium (10x concentrated; GIBCO)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/co_factors_solution_medium_843.yaml	CultureMech:006083	Co-factors solution (medium 843)	no ingredients and no solutions	KOMODO ModelSEED		843	yes
+bacterial/columbia_agar_base.yaml	CultureMech:005649	Columbia agar base	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/corn_meal_agar_oxoid_cm103.yaml	CultureMech:005651	Corn meal Agar (Oxoid CM103)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/czapek_dox_agar_merck.yaml	CultureMech:005643	Czapek Dox agar (Merck)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfobacterium_anilini_medium.yaml	CultureMech:005590	DESULFOBACTERIUM ANILINI MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfococcus_medium.yaml	CultureMech:004258	DESULFOCOCCUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfococcus_niacini_medium.yaml	CultureMech:004752	DESULFOCOCCUS NIACINI MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfomicrobium_whb_medium.yaml	CultureMech:006367	DESULFOMICROBIUM WHB MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfotomaculum_geothermicum_medium.yaml	CultureMech:005226	DESULFOTOMACULUM GEOTHERMICUM MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfotomaculum_sp_medium_ii.yaml	CultureMech:006282	DESULFOTOMACULUM SP. MEDIUM II	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_aespoeensis_medium.yaml	CultureMech:006364	DESULFOVIBRIO AESPOEENSIS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_alcoholovorans_medium.yaml	CultureMech:005613	DESULFOVIBRIO ALCOHOLOVORANS medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_alcoholovorans_medium_replace_desulfovibrio_medium_with_desulfobulbus_medium.yaml	CultureMech:005612	DESULFOVIBRIO ALCOHOLOVORANS medium_replace_DESULFOVIBRIO medium_with_DESULFOBULBUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_baarsii_medium.yaml	CultureMech:004368	DESULFOVIBRIO BAARSII MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_carbinolicus_medium.yaml	CultureMech:005160	DESULFOVIBRIO CARBINOLICUS medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_giganteus_medium.yaml	CultureMech:005196	DESULFOVIBRIO GIGANTEUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_inopinatus_medium.yaml	CultureMech:006511	DESULFOVIBRIO INOPINATUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_inopinatus_medium_replace_na_pyruvate_with_1_2_4_trihydroxybenzene.yaml	CultureMech:006510	DESULFOVIBRIO INOPINATUS MEDIUM_replace_Na-pyruvate_with_1,2,4-trihydroxybenzene	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_sapovorans_medium.yaml	CultureMech:004260	DESULFOVIBRIO SAPOVORANS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_shv_medium.yaml	CultureMech:006368	DESULFOVIBRIO SHV MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/desulfovibrio_sp_medium.yaml	CultureMech:004276	DESULFOVIBRIO SP. MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/dmj_synthetic_seawater_medium_997.yaml	CultureMech:004270	DMJ synthetic seawater (medium 997)	no ingredients and no solutions	KOMODO ModelSEED		997	yes
+bacterial/dsm_4156_b_and_dsm_4156.yaml	CultureMech:005229	DSM 4156 B and DSM 4156	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/fatty_acid_mixture_medium_119.yaml	CultureMech:004794	Fatty acid mixture (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
+bacterial/fatty_acid_mixture_medium_328.yaml	CultureMech:004795	Fatty acid mixture (medium 328)	no ingredients and no solutions	KOMODO ModelSEED		328	yes
+bacterial/fatty_acid_mixture_medium_436.yaml	CultureMech:004796	Fatty acid mixture (medium 436)	no ingredients and no solutions	KOMODO ModelSEED		436	yes
+bacterial/ferric_quinate_solution_medium_380.yaml	CultureMech:004272	Ferric Quinate Solution (medium 380)	no ingredients and no solutions	KOMODO ModelSEED		380	yes
+bacterial/for_dsm_2805.yaml	CultureMech:004855	For DSM 2805	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/for_dsm_3246.yaml	CultureMech:005056	For DSM 3246	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/for_dsm_3247.yaml	CultureMech:005055	For DSM 3247	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/for_s_buswellii_dsm_2612m.yaml	CultureMech:006276	For S. buswellii DSM 2612M	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/for_s_wolinii_dsm_2805m.yaml	CultureMech:006277	For S. wolinii DSM 2805M	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/glutarate_medium.yaml	CultureMech:006014	GLUTARATE medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/h3p_vitamin_solution_medium_428.yaml	CultureMech:004397	H3P-vitamin solution (medium 428)	no ingredients and no solutions	KOMODO ModelSEED	yes	428	yes
+bacterial/haemin_solution_medium_104.yaml	CultureMech:004798	Haemin solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED		104	yes
+bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml	CultureMech:004800	Hank's balanced salt solution (BSS, medium 1078)	no ingredients and no solutions	KOMODO ModelSEED	yes	1078	yes
+bacterial/heavy_metal_solution_medium_867.yaml	CultureMech:004273	Heavy metal solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED		867	yes
+bacterial/ilyobacter_tartaricus_medium.yaml	CultureMech:004761	ILYOBACTER TARTARICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/inorganic_salt_solution_medium_754.yaml	CultureMech:004801	Inorganic salt solution (medium 754)	no ingredients and no solutions	KOMODO ModelSEED	yes	754	yes
+bacterial/isovitalex.yaml	CultureMech:005642	Isovitalex	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/lip_solution_medium_391.yaml	CultureMech:004802	LIP-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED		391	yes
+bacterial/mab1_medium.yaml	CultureMech:006272	mAB1-MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml	CultureMech:004803	Marine-Medium/Synthetic seawater-mix (medium 611)	no ingredients and no solutions	KOMODO ModelSEED		611	yes
+bacterial/marine_trace_elements_medium_511.yaml	CultureMech:004274	Marine trace elements (medium 511)	no ingredients and no solutions	KOMODO ModelSEED		511	yes
+bacterial/medium_131_modified_for_dsm_6216.yaml	CultureMech:004066	MEDIUM 131 MODIFIED FOR DSM 6216	no ingredients and no solutions	KOMODO ModelSEED		131	
+bacterial/medium_777_modified_for_dsm_14980.yaml	CultureMech:006434	MEDIUM 777 MODIFIED FOR DSM 14980	no ingredients and no solutions	KOMODO ModelSEED		777	
+bacterial/medium_820_modified_for_dsm_16960.yaml	CultureMech:006546	MEDIUM 820 MODIFIED FOR DSM 16960	no ingredients and no solutions	KOMODO ModelSEED		820	
+bacterial/medium_md1_medium_9.yaml	CultureMech:004986	medium MD1 (medium 9)	no ingredients and no solutions	KOMODO ModelSEED		9	yes
+bacterial/metals_44_medium_590.yaml	CultureMech:004393	Metals 44 (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
+bacterial/micronutrient_solution_sl8_medium_1128.yaml	CultureMech:004804	Micronutrient solution SL8 (medium 1128)	no ingredients and no solutions	KOMODO ModelSEED		1128	yes
+bacterial/middlebrook_7h10_agar.yaml	CultureMech:004805	Middlebrook 7H10 agar	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/min_e_base_10x.yaml	CultureMech:004275	MIN E - Base (10x)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/mineral_mix_medium_1001.yaml	CultureMech:004277	Mineral Mix (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED		1001	yes
+bacterial/mineral_salt_solution_2xw_medium_391.yaml	CultureMech:004806	"Mineral salt solution ""2xW"" (medium 391)"	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
+bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml	CultureMech:004987	Mineral salts solution for liquid medium (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
+bacterial/mineral_salts_solution_for_solid_medium_medium_1396.yaml	CultureMech:004989	Mineral salts solution for solid medium (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
+bacterial/mineral_solution_1_medium_165.yaml	CultureMech:004278	Mineral solution 1 (medium 165)	no ingredients and no solutions	KOMODO ModelSEED	yes	165	yes
+bacterial/mineral_solution_2_medium_1033.yaml	CultureMech:004815	Mineral solution 2 (medium 1033)	no ingredients and no solutions	KOMODO ModelSEED	yes	1033	yes
+bacterial/mineral_solution_2_medium_165.yaml	CultureMech:004279	Mineral solution 2 (medium 165)	no ingredients and no solutions	KOMODO ModelSEED	yes	165	yes
+bacterial/mineral_solution_2_medium_203.yaml	CultureMech:004997	Mineral solution 2 (medium 203)	no ingredients and no solutions	KOMODO ModelSEED	yes	203	yes
+bacterial/mineral_solution_2_medium_404.yaml	CultureMech:004816	Mineral solution 2 (medium 404)	no ingredients and no solutions	KOMODO ModelSEED	yes	404	yes
+bacterial/mineral_solution_2_medium_436.yaml	CultureMech:004817	Mineral solution 2 (medium 436)	no ingredients and no solutions	KOMODO ModelSEED	yes	436	yes
+bacterial/mineral_solution_a_medium_492.yaml	CultureMech:004280	Mineral solution A (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
+bacterial/mineral_solution_b_medium_492.yaml	CultureMech:004281	Mineral solution B (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
+bacterial/mineral_solution_c_medium_492.yaml	CultureMech:004282	Mineral solution C (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
+bacterial/mineral_solution_medium_212.yaml	CultureMech:005195	Mineral solution (medium 212)	no ingredients and no solutions	KOMODO ModelSEED	yes	212	yes
+bacterial/mineral_solution_medium_317.yaml	CultureMech:004818	Mineral solution (medium 317)	no ingredients and no solutions	KOMODO ModelSEED	yes	317	yes
+bacterial/mineral_solution_medium_321.yaml	CultureMech:004810	Mineral solution (medium 321)	no ingredients and no solutions	KOMODO ModelSEED	yes	321	yes
+bacterial/mineral_solution_medium_328.yaml	CultureMech:004811	Mineral solution (medium 328)	no ingredients and no solutions	KOMODO ModelSEED	yes	328	yes
+bacterial/mineral_solution_medium_330.yaml	CultureMech:004812	Mineral solution (medium 330)	no ingredients and no solutions	KOMODO ModelSEED	yes	330	yes
+bacterial/mineral_solution_medium_335.yaml	CultureMech:004813	Mineral solution (medium 335)	no ingredients and no solutions	KOMODO ModelSEED	yes	335	yes
+bacterial/modified_hoagland_trace_element_solution_medium_867.yaml	CultureMech:004283	Modified hoagland trace element solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
+bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml	CultureMech:004284	Modified MJ synthetic sea water (medium 1131)	no ingredients and no solutions	KOMODO ModelSEED		1131	yes
+bacterial/mtp4_medium.yaml	CultureMech:006012	MTP4 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/mueller_hinton_broth.yaml	CultureMech:005193	Mueller-Hinton broth	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/na_sesquicarbonate_solution_medium_31.yaml	CultureMech:004819	Na-sesquicarbonate solution (medium 31)	no ingredients and no solutions	KOMODO ModelSEED		31	yes
+bacterial/nutrient_broth_difco.yaml	CultureMech:005652	Nutrient broth (Difco)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/nutrient_broth_oxoid_medium_948.yaml	CultureMech:004822	Nutrient broth (Oxoid) (medium 948)	no ingredients and no solutions	KOMODO ModelSEED		948	yes
+bacterial/pelobacter_acetylenicus_medium.yaml	CultureMech:005057	PELOBACTER ACETYLENICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/pelobacter_medium.yaml	CultureMech:005242	PELOBACTER medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/pelobacter_venetianus_fresh_water_medium.yaml	CultureMech:004774	PELOBACTER VENETIANUS (fresh water) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/pelobacter_venetianus_marine_medium.yaml	CultureMech:004760	PELOBACTER VENETIANUS (marine) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/pennassay_broth.yaml	CultureMech:005653	Pennassay Broth	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/phosphate_buffer_10x_medium_1341.yaml	CultureMech:004285	Phosphate buffer (10x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED		1341	yes
+bacterial/phosphate_buffer_medium_878.yaml	CultureMech:004823	Phosphate buffer (medium 878)	no ingredients and no solutions	KOMODO ModelSEED		878	yes
+bacterial/phosphate_buffer_medium_921.yaml	CultureMech:004286	Phosphate buffer (medium 921)	no ingredients and no solutions	KOMODO ModelSEED		921	yes
+bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml	CultureMech:004287	Phosphate buffer (pH 6.8, see medium 1132)	no ingredients and no solutions	KOMODO ModelSEED		1132	yes
+bacterial/phosphate_buffer_ph_7_2.yaml	CultureMech:004824	Phosphate buffer pH 7.2	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/phosphate_solution_medium_1191.yaml	CultureMech:004825	Phosphate solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED		1191	yes
+bacterial/phosphate_solution_medium_791.yaml	CultureMech:004826	Phosphate solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED		791	yes
+bacterial/pplo_broth.yaml	CultureMech:005654	PPLO broth	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/propionigenium_maris_medium.yaml	CultureMech:006291	PROPIONIGENIUM MARIS medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/rumen_fluid_clarified.yaml	CultureMech:006085	Rumen fluid, clarified	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/sabouraud_2_glucose_bouillon_merck_108339.yaml	CultureMech:006517	SABOURAUD-2% Glucose-Bouillon (Merck 108339)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/salt_base_solution_medium_88.yaml	CultureMech:005194	Salt base solution (medium 88)	no ingredients and no solutions	KOMODO ModelSEED	yes	88	yes
+bacterial/salt_concentrate_medium_517.yaml	CultureMech:004288	Salt concentrate (medium 517)	no ingredients and no solutions	KOMODO ModelSEED		517	yes
+bacterial/salt_solution_medium_104.yaml	CultureMech:004828	salt solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
+bacterial/salt_solution_medium_1191.yaml	CultureMech:004829	salt solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
+bacterial/salt_solution_medium_58.yaml	CultureMech:004830	salt solution (medium 58)	no ingredients and no solutions	KOMODO ModelSEED	yes	58	yes
+bacterial/salt_solution_medium_852.yaml	CultureMech:004831	salt solution (medium 852)	no ingredients and no solutions	KOMODO ModelSEED	yes	852	yes
+bacterial/salts_solution_medium_1139.yaml	CultureMech:004833	salts solution (medium 1139)	no ingredients and no solutions	KOMODO ModelSEED	yes	1139	yes
+bacterial/sb_sw_medium.yaml	CultureMech:006278	SB/SW MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/sea_water_salts_solution_medium_958.yaml	CultureMech:004834	Sea water salts solution (medium 958)	no ingredients and no solutions	KOMODO ModelSEED	yes	958	yes
+bacterial/selenite_tungstate_solution_medium_385.yaml	CultureMech:004289	Selenite/tungstate solution (medium 385)	no ingredients and no solutions	KOMODO ModelSEED	yes	385	yes
+bacterial/seven_vitamin_solution_medium_1332.yaml	CultureMech:004835	Seven Vitamin solution (medium 1332)	no ingredients and no solutions	KOMODO ModelSEED	yes	1332	yes
+bacterial/seven_vitamins_solution_medium_503.yaml	CultureMech:004290	Seven vitamins solution (medium 503)	no ingredients and no solutions	KOMODO ModelSEED		503	yes
+bacterial/sludge_fluid_medium_119.yaml	CultureMech:004990	Sludge fluid (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
+bacterial/soil_extract_medium_98.yaml	CultureMech:004991	Soil extract (medium 98)	no ingredients and no solutions	KOMODO ModelSEED		98	yes
+bacterial/solution_1_10x_nms_salts_medium_921.yaml	CultureMech:004291	Solution 1 (10x NMS salts) (medium 921)	no ingredients and no solutions	KOMODO ModelSEED		921	yes
+bacterial/solution_a_medium_1267.yaml	CultureMech:005221	Solution A (medium 1267)	no ingredients and no solutions	KOMODO ModelSEED	yes	1267	yes
+bacterial/solution_a_medium_1275.yaml	CultureMech:005222	Solution A, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
+bacterial/solution_a_medium_858.yaml	CultureMech:005220	Solution A (medium 858)	no ingredients and no solutions	KOMODO ModelSEED	yes	858	yes
+bacterial/solution_b_medium_1275.yaml	CultureMech:005223	Solution B, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
+bacterial/solution_b_medium_807.yaml	CultureMech:006084	Solution B (medium 807)	no ingredients and no solutions	KOMODO ModelSEED	yes	807	yes
+bacterial/solution_c_medium_1275.yaml	CultureMech:005224	Solution C, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
+bacterial/solution_ii_medium_1308.yaml	CultureMech:004836	solution II (medium 1308)	no ingredients and no solutions	KOMODO ModelSEED		1308	yes
+bacterial/solution_ii_medium_1398.yaml	CultureMech:004837	solution II (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED		1398	yes
+bacterial/spirochaeta_aurantia_medium.yaml	CultureMech:004195	SPIROCHAETA AURANTIA medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/spirochaeta_isovalerica_medium.yaml	CultureMech:004701	SPIROCHAETA ISOVALERICA medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/sporomusa_silvacetica_medium.yaml	CultureMech:006435	SPOROMUSA SILVACETICA medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/sse_double_concentrated_medium_1426.yaml	CultureMech:004838	SSE (double concentrated) (medium 1426)	no ingredients and no solutions	KOMODO ModelSEED		1426	yes
+bacterial/stearate_solution_0_1_m_medium_517.yaml	CultureMech:004295	Stearate solution (0.1 M) (medium 517)	no ingredients and no solutions	KOMODO ModelSEED		517	yes
+bacterial/stock_solution_from_medium_756.yaml	CultureMech:004387	Stock solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
+bacterial/stock_solution_medium_462.yaml	CultureMech:004398	Stock solution (medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
+bacterial/sugar_stock_solution_medium_1245.yaml	CultureMech:006082	Sugar Stock Solution (medium 1245)	no ingredients and no solutions	KOMODO ModelSEED	yes	1245	yes
+bacterial/synthetic_sea_water_medium_79.yaml	CultureMech:004839	Synthetic sea water (medium 79)	no ingredients and no solutions	KOMODO ModelSEED		79	yes
+bacterial/synthetic_seawater_2_x_conc_medium_795.yaml	CultureMech:004840	Synthetic seawater (2 x conc.) (medium 795)	no ingredients and no solutions	KOMODO ModelSEED		795	yes
+bacterial/syntrophobacter_wolinii_medium.yaml	CultureMech:004866	SYNTROPHOBACTER WOLINII medium	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/syntrophus_buswellii_ii_medium.yaml	CultureMech:005230	SYNTROPHUS BUSWELLII II MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/syntrophus_medium_sulfate_free.yaml	CultureMech:004742	SYNTROPHUS medium - SULFATE FREE	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/thermus_macronutrients_10x_solution.yaml	CultureMech:004841	Thermus macronutrients 10X solution	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/thermus_micronutrients_100x_solution.yaml	CultureMech:004842	Thermus micronutrients 100X solution	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml	CultureMech:006372	THIOBACILLUS FERROOXIDANS MEDIUM WITH TETRATHIONATE	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/thioglycolate_ascorbate_solution_medium_210.yaml	CultureMech:004844	Thioglycolate-ascorbate solution (medium 210)	no ingredients and no solutions	KOMODO ModelSEED		210	yes
+bacterial/trace_element_solution_a_medium_537.yaml	CultureMech:004865	Trace element solution A (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
+bacterial/trace_element_solution_b_medium_537.yaml	CultureMech:004867	Trace element solution B (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
+bacterial/trace_element_solution_from_medium_756.yaml	CultureMech:004388	Trace element solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
+bacterial/trace_element_solution_ho_le_medium_668.yaml	CultureMech:004868	Trace element solution Ho-le (medium 668)	no ingredients and no solutions	KOMODO ModelSEED	yes	668	yes
+bacterial/trace_element_solution_medium_1007.yaml	CultureMech:004296	Trace element solution (medium 1007)	no ingredients and no solutions	KOMODO ModelSEED	yes	1007	yes
+bacterial/trace_element_solution_medium_1072.yaml	CultureMech:004847	Trace element solution (medium 1072)	no ingredients and no solutions	KOMODO ModelSEED	yes	1072	yes
+bacterial/trace_element_solution_medium_1149.yaml	CultureMech:004848	Trace element solution (medium 1149)	no ingredients and no solutions	KOMODO ModelSEED	yes	1149	yes
+bacterial/trace_element_solution_medium_1156.yaml	CultureMech:004302	Trace element solution (medium 1156)	no ingredients and no solutions	KOMODO ModelSEED	yes	1156	yes
+bacterial/trace_element_solution_medium_1165.yaml	CultureMech:004849	Trace element solution (medium 1165)	no ingredients and no solutions	KOMODO ModelSEED	yes	1165	yes
+bacterial/trace_element_solution_medium_1180.yaml	CultureMech:004303	Trace element solution (medium 1180)	no ingredients and no solutions	KOMODO ModelSEED	yes	1180	yes
+bacterial/trace_element_solution_medium_1181.yaml	CultureMech:004304	Trace element solution (medium 1181)	no ingredients and no solutions	KOMODO ModelSEED	yes	1181	yes
+bacterial/trace_element_solution_medium_1190.yaml	CultureMech:005000	Trace element solution (medium 1190)	no ingredients and no solutions	KOMODO ModelSEED	yes	1190	yes
+bacterial/trace_element_solution_medium_124.yaml	CultureMech:004850	Trace element solution (medium 124)	no ingredients and no solutions	KOMODO ModelSEED	yes	124	yes
+bacterial/trace_element_solution_medium_1282.yaml	CultureMech:004852	Trace element solution (medium 1282)	no ingredients and no solutions	KOMODO ModelSEED	yes	1282	yes
+bacterial/trace_element_solution_medium_131.yaml	CultureMech:004308	Trace element solution (medium 131)	no ingredients and no solutions	KOMODO ModelSEED	yes	131	
+bacterial/trace_element_solution_medium_1396.yaml	CultureMech:004853	Trace Element solution (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
+bacterial/trace_element_solution_medium_1403.yaml	CultureMech:004309	Trace element solution (medium 1403)	no ingredients and no solutions	KOMODO ModelSEED	yes	1403	yes
+bacterial/trace_element_solution_medium_150a.yaml	CultureMech:004312	Trace element solution (medium 150a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_medium_155.yaml	CultureMech:004399	Trace element solution (medium 155)	no ingredients and no solutions	KOMODO ModelSEED	yes	155	yes
+bacterial/trace_element_solution_medium_158.yaml	CultureMech:004858	Trace element solution (medium 158)	no ingredients and no solutions	KOMODO ModelSEED	yes	158	yes
+bacterial/trace_element_solution_medium_333.yaml	CultureMech:004314	Trace element solution (medium 333)	no ingredients and no solutions	KOMODO ModelSEED	yes	333	yes
+bacterial/trace_element_solution_medium_463.yaml	CultureMech:004315	Trace element solution (medium 463)	no ingredients and no solutions	KOMODO ModelSEED	yes	463	yes
+bacterial/trace_element_solution_medium_463a.yaml	CultureMech:004316	Trace element solution (medium 463a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_medium_533.yaml	CultureMech:004317	Trace element solution (medium 533)	no ingredients and no solutions	KOMODO ModelSEED	yes	533	yes
+bacterial/trace_element_solution_medium_534.yaml	CultureMech:004318	Trace element solution (medium 534)	no ingredients and no solutions	KOMODO ModelSEED	yes	534	yes
+bacterial/trace_element_solution_medium_632.yaml	CultureMech:004320	Trace element solution (medium 632)	no ingredients and no solutions	KOMODO ModelSEED	yes	632	yes
+bacterial/trace_element_solution_medium_652.yaml	CultureMech:004860	Trace element solution (medium 652)	no ingredients and no solutions	KOMODO ModelSEED	yes	652	yes
+bacterial/trace_element_solution_medium_705.yaml	CultureMech:004862	Trace element solution (medium 705)	no ingredients and no solutions	KOMODO ModelSEED	yes	705	yes
+bacterial/trace_element_solution_medium_737.yaml	CultureMech:004323	Trace element solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED	yes	737	yes
+bacterial/trace_element_solution_medium_84.yaml	CultureMech:004401	Trace element solution (medium 84)	no ingredients and no solutions	KOMODO ModelSEED	yes	84	yes
+bacterial/trace_element_solution_medium_878.yaml	CultureMech:004864	Trace element solution (medium 878)	no ingredients and no solutions	KOMODO ModelSEED	yes	878	yes
+bacterial/trace_element_solution_medium_918.yaml	CultureMech:004326	Trace element solution (medium 918)	no ingredients and no solutions	KOMODO ModelSEED	yes	918	yes
+bacterial/trace_element_solution_medium_921.yaml	CultureMech:004327	Trace element solution (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
+bacterial/trace_element_solution_medium_922.yaml	CultureMech:004328	Trace element solution (medium 922)	no ingredients and no solutions	KOMODO ModelSEED	yes	922	yes
+bacterial/trace_element_solution_medium_929.yaml	CultureMech:004330	Trace element solution (medium 929)	no ingredients and no solutions	KOMODO ModelSEED	yes	929	yes
+bacterial/trace_element_solution_medium_976.yaml	CultureMech:004332	Trace element solution (medium 976)	no ingredients and no solutions	KOMODO ModelSEED	yes	976	yes
+bacterial/trace_element_solution_medium_996.yaml	CultureMech:004334	Trace element solution (medium 996)	no ingredients and no solutions	KOMODO ModelSEED	yes	996	yes
+bacterial/trace_element_solution_sl12_medium_998.yaml	CultureMech:004870	Trace element solution SL12 (medium 998)	no ingredients and no solutions	KOMODO ModelSEED	yes	998	yes
+bacterial/trace_element_solution_sl7.yaml	CultureMech:004871	Trace element solution SL7	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_sl8_medium_1119.yaml	CultureMech:004874	Trace element solution SL8 (medium 1119)	no ingredients and no solutions	KOMODO ModelSEED	yes	1119	yes
+bacterial/trace_element_solution_sl_10_b.yaml	CultureMech:004337	Trace element solution SL-10 B	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_sl_10_medium_320.yaml	CultureMech:004336	Trace element solution SL-10 (medium 320)	no ingredients and no solutions	KOMODO ModelSEED	yes	320	yes
+bacterial/trace_element_solution_sl_11_medium_784.yaml	CultureMech:004869	Trace element solution SL-11 (medium 784)	no ingredients and no solutions	KOMODO ModelSEED	yes	784	yes
+bacterial/trace_element_solution_sl_12_b.yaml	CultureMech:004338	Trace element solution SL-12 B	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_sl_6_medium_457.yaml	CultureMech:004340	Trace element solution SL-6 (medium 457)	no ingredients and no solutions	KOMODO ModelSEED	yes	457	yes
+bacterial/trace_element_solution_sl_7_medium_660.yaml	CultureMech:004341	Trace element solution SL-7 (medium 660)	no ingredients and no solutions	KOMODO ModelSEED	yes	660	yes
+bacterial/trace_element_solution_sl_7_medium_941.yaml	CultureMech:004872	Trace element solution SL-7 (medium 941)	no ingredients and no solutions	KOMODO ModelSEED	yes	941	yes
+bacterial/trace_element_solution_sl_8.yaml	CultureMech:004342	Trace element solution SL-8	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_element_solution_sl_9_medium_828.yaml	CultureMech:004343	Trace element solution SL-9 (medium 828)	no ingredients and no solutions	KOMODO ModelSEED	yes	828	yes
+bacterial/trace_element_solution_sla.yaml	CultureMech:004335	Trace element solution (SLA)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/trace_elements_medium_1108a.yaml	CultureMech:006328	Trace elements (medium 1108a)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/trace_elements_medium_1147.yaml	CultureMech:004875	Trace elements (medium 1147)	no ingredients and no solutions	KOMODO ModelSEED		1147	yes
+bacterial/trace_elements_medium_596.yaml	CultureMech:004877	Trace elements (medium 596)	no ingredients and no solutions	KOMODO ModelSEED		596	yes
+bacterial/trace_elements_medium_651.yaml	CultureMech:004878	Trace elements (medium 651)	no ingredients and no solutions	KOMODO ModelSEED		651	yes
+bacterial/trace_elements_pfennig_medium_1264.yaml	CultureMech:004879	Trace elements (Pfennig) (medium 1264)	no ingredients and no solutions	KOMODO ModelSEED		1264	yes
+bacterial/trace_elements_sl_12.yaml	CultureMech:004880	Trace elements SL-12	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/trace_elements_solution_medium_1280.yaml	CultureMech:004883	Trace elements solution (medium 1280)	no ingredients and no solutions	KOMODO ModelSEED	yes	1280	yes
+bacterial/trace_metals_500x_medium_1341.yaml	CultureMech:004347	Trace Metals (500x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED		1341	yes
+bacterial/trace_metals_solution_medium_802.yaml	CultureMech:004884	Trace metals solution (medium 802)	no ingredients and no solutions	KOMODO ModelSEED	yes	802	yes
+bacterial/trace_mineral_solution_medium_1000.yaml	CultureMech:004351	Trace mineral solution (medium 1000)	no ingredients and no solutions	KOMODO ModelSEED	yes	1000	yes
+bacterial/trace_mineral_solution_medium_1121.yaml	CultureMech:004353	Trace mineral solution (medium 1121)	no ingredients and no solutions	KOMODO ModelSEED	yes	1121	yes
+bacterial/trace_mineral_solution_medium_997.yaml	CultureMech:004355	Trace mineral solution (medium 997)	no ingredients and no solutions	KOMODO ModelSEED	yes	997	yes
+bacterial/trace_salt_solution_medium_609.yaml	CultureMech:005191	Trace salt solution (medium 609)	no ingredients and no solutions	KOMODO ModelSEED	yes	609	yes
+bacterial/trace_salt_solution_medium_856.yaml	CultureMech:004885	Trace salt solution (medium 856)	no ingredients and no solutions	KOMODO ModelSEED	yes	856	yes
+bacterial/trace_salts_solution_medium_978.yaml	CultureMech:004938	Trace salts solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
+bacterial/true_blue_trace_elements_medium_748.yaml	CultureMech:004939	True Blue Trace Elements (medium 748)	no ingredients and no solutions	KOMODO ModelSEED		748	yes
+bacterial/tyc_solution_medium_391.yaml	CultureMech:004992	TYC-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED		391	yes
+bacterial/vitamin_b12_solution_medium_867.yaml	CultureMech:004356	Vitamin B12 solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
+bacterial/vitamin_b_solution_medium_978.yaml	CultureMech:004940	Vitamin B solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
+bacterial/vitamin_k1_solution_medium_104.yaml	CultureMech:004941	Vitamin K1 solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
+bacterial/vitamin_mixture_medium_1001.yaml	CultureMech:004358	Vitamin mixture (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED		1001	yes
+bacterial/vitamin_mixture_medium_484.yaml	CultureMech:004359	Vitamin mixture (medium 484)	no ingredients and no solutions	KOMODO ModelSEED		484	yes
+bacterial/vitamin_mixture_medium_619.yaml	CultureMech:004360	Vitamin mixture (medium 619)	no ingredients and no solutions	KOMODO ModelSEED		619	yes
+bacterial/vitamin_solution_7_medium_842.yaml	CultureMech:004975	Vitamin solution 7 (medium 842)	no ingredients and no solutions	KOMODO ModelSEED	yes	842	yes
+bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml	CultureMech:004384	Vitamin solution according to Wolin and coauthors	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/vitamin_solution_b_medium_253.yaml	CultureMech:004942	Vitamin solution (B) (medium 253)	no ingredients and no solutions	KOMODO ModelSEED	yes	253	yes
+bacterial/vitamin_solution_ca_medium_87a.yaml	CultureMech:004976	Vitamin solution CA (medium 87a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/vitamin_solution_double_conc_medium_621.yaml	CultureMech:004943	Vitamin solution (double conc.) (medium 621)	no ingredients and no solutions	KOMODO ModelSEED	yes	621	yes
+bacterial/vitamin_solution_medium_1072.yaml	CultureMech:004945	Vitamin solution (medium 1072)	no ingredients and no solutions	KOMODO ModelSEED	yes	1072	yes
+bacterial/vitamin_solution_medium_1116.yaml	CultureMech:004361	Vitamin solution (medium 1116)	no ingredients and no solutions	KOMODO ModelSEED	yes	1116	yes
+bacterial/vitamin_solution_medium_1121.yaml	CultureMech:004362	Vitamin solution (medium 1121)	no ingredients and no solutions	KOMODO ModelSEED	yes	1121	yes
+bacterial/vitamin_solution_medium_1131.yaml	CultureMech:004363	Vitamin solution (medium 1131)	no ingredients and no solutions	KOMODO ModelSEED	yes	1131	yes
+bacterial/vitamin_solution_medium_1149.yaml	CultureMech:004946	Vitamin solution (medium 1149)	no ingredients and no solutions	KOMODO ModelSEED	yes	1149	yes
+bacterial/vitamin_solution_medium_1165.yaml	CultureMech:004947	Vitamin solution (medium 1165)	no ingredients and no solutions	KOMODO ModelSEED	yes	1165	yes
+bacterial/vitamin_solution_medium_1183.yaml	CultureMech:004954	Vitamin solution (medium 1183)	no ingredients and no solutions	KOMODO ModelSEED	yes	1183	yes
+bacterial/vitamin_solution_medium_1191.yaml	CultureMech:004955	Vitamin solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
+bacterial/vitamin_solution_medium_124.yaml	CultureMech:005001	Vitamin solution (medium 124)	no ingredients and no solutions	KOMODO ModelSEED	yes	124	yes
+bacterial/vitamin_solution_medium_1263.yaml	CultureMech:004956	Vitamin solution (medium 1263)	no ingredients and no solutions	KOMODO ModelSEED	yes	1263	yes
+bacterial/vitamin_solution_medium_1275.yaml	CultureMech:004364	Vitamin solution (medium 1275)	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
+bacterial/vitamin_solution_medium_1282.yaml	CultureMech:004957	Vitamin solution (medium 1282)	no ingredients and no solutions	KOMODO ModelSEED	yes	1282	yes
+bacterial/vitamin_solution_medium_1306.yaml	CultureMech:004958	Vitamin solution (medium 1306)	no ingredients and no solutions	KOMODO ModelSEED	yes	1306	yes
+bacterial/vitamin_solution_medium_131.yaml	CultureMech:004365	Vitamin solution (medium 131)	no ingredients and no solutions	KOMODO ModelSEED	yes	131	
+bacterial/vitamin_solution_medium_1315.yaml	CultureMech:004366	Vitamin solution (medium 1315)	no ingredients and no solutions	KOMODO ModelSEED	yes	1315	yes
+bacterial/vitamin_solution_medium_141.yaml	CultureMech:004367	Vitamin solution (medium 141)	no ingredients and no solutions	KOMODO ModelSEED	yes	141	yes
+bacterial/vitamin_solution_medium_1426.yaml	CultureMech:004959	Vitamin solution (medium 1426)	no ingredients and no solutions	KOMODO ModelSEED	yes	1426	yes
+bacterial/vitamin_solution_medium_1457.yaml	CultureMech:006516	Vitamin solution (medium 1457)	no ingredients and no solutions	KOMODO ModelSEED	yes	1457	yes
+bacterial/vitamin_solution_medium_148.yaml	CultureMech:004369	Vitamin solution (medium 148)	no ingredients and no solutions	KOMODO ModelSEED	yes	148	yes
+bacterial/vitamin_solution_medium_212.yaml	CultureMech:004960	Vitamin solution (medium 212)	no ingredients and no solutions	KOMODO ModelSEED	yes	212	yes
+bacterial/vitamin_solution_medium_315.yaml	CultureMech:004370	Vitamin solution (medium 315)	no ingredients and no solutions	KOMODO ModelSEED	yes	315	yes
+bacterial/vitamin_solution_medium_322.yaml	CultureMech:004961	Vitamin solution (medium 322)	no ingredients and no solutions	KOMODO ModelSEED	yes	322	yes
+bacterial/vitamin_solution_medium_461.yaml	CultureMech:004371	Vitamin solution (medium 461)	no ingredients and no solutions	KOMODO ModelSEED	yes	461	yes
+bacterial/vitamin_solution_medium_463.yaml	CultureMech:004372	Vitamin solution (medium 463)	no ingredients and no solutions	KOMODO ModelSEED	yes	463	yes
+bacterial/vitamin_solution_medium_463a.yaml	CultureMech:004373	Vitamin solution (medium 463a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/vitamin_solution_medium_473.yaml	CultureMech:004374	Vitamin solution (medium 473)	no ingredients and no solutions	KOMODO ModelSEED	yes	473	yes
+bacterial/vitamin_solution_medium_521.yaml	CultureMech:004962	Vitamin solution (medium 521)	no ingredients and no solutions	KOMODO ModelSEED	yes	521	yes
+bacterial/vitamin_solution_medium_559.yaml	CultureMech:004963	Vitamin solution (medium 559)	no ingredients and no solutions	KOMODO ModelSEED	yes	559	yes
+bacterial/vitamin_solution_medium_589.yaml	CultureMech:004967	Vitamin solution (medium 589)	no ingredients and no solutions	KOMODO ModelSEED	yes	589	yes
+bacterial/vitamin_solution_medium_598.yaml	CultureMech:004944	Vitamin solution (medium 598)	no ingredients and no solutions	KOMODO ModelSEED	yes	598	yes
+bacterial/vitamin_solution_medium_600.yaml	CultureMech:004394	Vitamin solution (medium 600)	no ingredients and no solutions	KOMODO ModelSEED	yes	600	yes
+bacterial/vitamin_solution_medium_600a.yaml	CultureMech:004969	Vitamin solution (medium 600a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/vitamin_solution_medium_602.yaml	CultureMech:004970	Vitamin solution (medium 602)	no ingredients and no solutions	KOMODO ModelSEED	yes	602	yes
+bacterial/vitamin_solution_medium_603.yaml	CultureMech:004375	Vitamin solution (medium 603)	no ingredients and no solutions	KOMODO ModelSEED	yes	603	yes
+bacterial/vitamin_solution_medium_628.yaml	CultureMech:004968	Vitamin solution (medium 628)	no ingredients and no solutions	KOMODO ModelSEED	yes	628	yes
+bacterial/vitamin_solution_medium_651.yaml	CultureMech:004971	Vitamin solution (medium 651)	no ingredients and no solutions	KOMODO ModelSEED	yes	651	yes
+bacterial/vitamin_solution_medium_663.yaml	CultureMech:004972	Vitamin solution (medium 663)	no ingredients and no solutions	KOMODO ModelSEED	yes	663	yes
+bacterial/vitamin_solution_medium_78.yaml	CultureMech:004973	Vitamin solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED	yes	78	yes
+bacterial/vitamin_solution_medium_791.yaml	CultureMech:004974	Vitamin solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
+bacterial/vitamin_solution_medium_867.yaml	CultureMech:004376	Vitamin solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
+bacterial/vitamin_solution_medium_908.yaml	CultureMech:004377	Vitamin solution (medium 908)	no ingredients and no solutions	KOMODO ModelSEED	yes	908	yes
+bacterial/vitamin_solution_medium_929.yaml	CultureMech:004378	Vitamin solution (medium 929)	no ingredients and no solutions	KOMODO ModelSEED	yes	929	yes
+bacterial/vitamin_solution_medium_944.yaml	CultureMech:004382	Vitamin solution (medium 944)	no ingredients and no solutions	KOMODO ModelSEED	yes	944	yes
+bacterial/vitamin_solution_medium_951.yaml	CultureMech:004380	Vitamin solution (medium 951)	no ingredients and no solutions	KOMODO ModelSEED	yes	951	yes
+bacterial/vitamin_solution_schlegel_medium_462.yaml	CultureMech:004381	Vitamin solution (Schlegel, medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
+bacterial/vitamin_solution_v10.yaml	CultureMech:004385	Vitamin solution V10	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/vitamin_solution_va_medium_351.yaml	CultureMech:004383	Vitamin solution (VA) (medium 351)	no ingredients and no solutions	KOMODO ModelSEED	yes	351	yes
+bacterial/vitamins_v7_solution_medium_998.yaml	CultureMech:004978	Vitamins V7 solution (medium 998)	no ingredients and no solutions	KOMODO ModelSEED		998	yes
+bacterial/vitox.yaml	CultureMech:005644	Vitox	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/volatile_fatty_acid_mixture_medium_330.yaml	CultureMech:004979	Volatile fatty acid mixture (medium 330)	no ingredients and no solutions	KOMODO ModelSEED		330	yes
+bacterial/volatile_fatty_acid_solution_medium_909.yaml	CultureMech:004980	Volatile fatty acid solution (medium 909)	no ingredients and no solutions	KOMODO ModelSEED		909	yes
+bacterial/xb45_xb90_pb90_2_medium.yaml	CultureMech:006693	XB45/XB90/PB90-2 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
+algae/artificial_seawater.yaml	CultureMech:000189	Artificial_Seawater	placeholder ingredient only				
+algae/bacillariophycean.yaml	CultureMech:000192	Bacillariophycean	placeholder ingredient only				
+algae/basal.yaml	CultureMech:000191	Basal	placeholder ingredient only				
+algae/beggiatoa.yaml	CultureMech:000193	Beggiatoa	placeholder ingredient only				
+algae/bold_modified_basal.yaml	CultureMech:000194	Bold_Modified_Basal	placeholder ingredient only				
+algae/bold_modified_basal_tom.yaml	CultureMech:000195	Bold_Modified_Basal&TOM	placeholder ingredient only				
+algae/brackish_water_medium.yaml	CultureMech:000196	Brackish_water_medium	placeholder ingredient only				
+algae/ch.yaml	CultureMech:000059	CH	placeholder ingredient only				
+algae/chapman_andresens_modified_pringsheims_solution.yaml	CultureMech:000062	Chapman-Andresen's Modified Pringsheim's Solution	placeholder ingredient only				
+algae/chilomonas.yaml	CultureMech:000197	Chilomonas	placeholder ingredient only				
+algae/cyanidium.yaml	CultureMech:000198	Cyanidium	placeholder ingredient only				
+algae/desmidiacean.yaml	CultureMech:000199	Desmidiacean	placeholder ingredient only				
+algae/dunaliella.yaml	CultureMech:000200	Dunaliella	placeholder ingredient only				
+algae/dunaliella_acid.yaml	CultureMech:000201	Dunaliella_acid	placeholder ingredient only				
+algae/enriched_seawater.yaml	CultureMech:000202	Enriched_Seawater	placeholder ingredient only				
+algae/euglena.yaml	CultureMech:000203	Euglena	placeholder ingredient only				
+algae/malt_peptone.yaml	CultureMech:000204	Malt_Peptone	placeholder ingredient only				
+algae/merds.yaml	CultureMech:000089	MErds	placeholder ingredient only				
+algae/mw.yaml	CultureMech:000093	MW	placeholder ingredient only				
+algae/note_on_biphasic_soilwater_media_20081216.yaml	CultureMech:000205	Note_on_biphasic_soilwater_media_20081216	placeholder ingredient only				
+algae/ochromonas.yaml	CultureMech:000206	Ochromonas	placeholder ingredient only				
+algae/pes.yaml	CultureMech:000207	PES	placeholder ingredient only				
+algae/polytoma.yaml	CultureMech:000208	Polytoma	placeholder ingredient only				
+algae/polytomella.yaml	CultureMech:000209	Polytomella	placeholder ingredient only				
+algae/porphyridium.yaml	CultureMech:000210	Porphyridium	placeholder ingredient only				
+algae/s_w.yaml	CultureMech:000138	S/W	placeholder ingredient only				
+algae/s_w_amp.yaml	CultureMech:000136	S/W + AMP	placeholder ingredient only				
+algae/s_w_ca.yaml	CultureMech:000137	S/W + Ca	placeholder ingredient only				
+algae/se1.yaml	CultureMech:000128	SE1	placeholder ingredient only				
+algae/se2.yaml	CultureMech:000129	SE2	placeholder ingredient only				
+algae/seawater.yaml	CultureMech:000211	Seawater	placeholder ingredient only				
+algae/ses.yaml	CultureMech:000130	SES	placeholder ingredient only				
+algae/soil_water_media.yaml	CultureMech:000212	Soil_Water_Media	placeholder ingredient only				
+algae/spirulina.yaml	CultureMech:000213	Spirulina	placeholder ingredient only				
+algae/unicellular_green_algae.yaml	CultureMech:000214	Unicellular_Green_Algae	placeholder ingredient only				
+algae/volvox.yaml	CultureMech:000215	Volvox	placeholder ingredient only				
+algae/wees.yaml	CultureMech:000216	WEES	placeholder ingredient only				
+algae/woods_hole_mbl_medium.yaml	CultureMech:000217	Woods Hole MBL Medium	placeholder ingredient only				
+algae/yel.yaml	CultureMech:000144	YEL	placeholder ingredient only				
+algae/z_medium_for_cyanos.yaml	CultureMech:000218	Z-Medium_for_Cyanos	placeholder ingredient only				
+bacterial/test_medium_123.yaml	CultureMech:000306	Test Medium 123	placeholder ingredient only			123	yes
+bacterial/2sna.yaml	CultureMech:000411	2SNA	placeholder ingredient only	CCAP			
+bacterial/nss_low.yaml	CultureMech:000383	NSS Low	placeholder ingredient only	CCAP			
+fungal/wmalt_yeast_extract_medium_wmy.yaml	CultureMech:010440	wMalt Yeast Extract Medium (wMY)	placeholder ingredient only	CCAP			
+bacterial/cultivation_medium_for_sf1ep_cells_for_treponema_pallidum.yaml	CultureMech:001271	Cultivation Medium for Sf1Ep cells for Treponema pallidum	placeholder ingredient only	DSMZ			
+bacterial/l_15b_tick_cell_medium.yaml	CultureMech:001068	L-15B Tick Cell Medium	placeholder ingredient only	DSMZ			
+bacterial/liver_broth_oxoid_cm_77.yaml	CultureMech:001915	LIVER BROTH (Oxoid CM 77)	placeholder ingredient only	DSMZ			
+bacterial/rhodocyclus_purpureus_medium.yaml	CultureMech:001559	RHODOCYCLUS PURPUREUS MEDIUM	placeholder ingredient only	DSMZ			
+archaea/archaeoglobus_mcr_medium.yaml	CultureMech:002362	ARCHAEOGLOBUS MCR MEDIUM	placeholder ingredient only	JCM			
+archaea/methanobacterium_medium_ii_with_formae.yaml	CultureMech:003049	METHANOBACTERIUM MEDIUM (II) WITH FORMAE	placeholder ingredient only	JCM			
+archaea/methanocaldococcus_indiensis_medium.yaml	CultureMech:002720	METHANOCALDOCOCCUS INDIENSIS MEDIUM	placeholder ingredient only	JCM			
+archaea/modified_halosimplex_medium.yaml	CultureMech:003286	MODIFIED HALOSIMPLEX MEDIUM	placeholder ingredient only	JCM			
+archaea/thermoproteus_medium_c.yaml	CultureMech:002977	THERMOPROTEUS MEDIUM (C)	placeholder ingredient only	JCM			
+bacterial/JCM_J806_GS_MEDIUM.yaml	CultureMech:003151	GS MEDIUM	placeholder ingredient only	JCM			
+bacterial/agc2_medium.yaml	CultureMech:002739	AGC2 MEDIUM	placeholder ingredient only	JCM			
+bacterial/beer_medium.yaml	CultureMech:002778	BEER MEDIUM	placeholder ingredient only	JCM			
+bacterial/bm_for_tepidanaerobacter_acetoxydans.yaml	CultureMech:003081	BM FOR TEPIDANAEROBACTER ACETOXYDANS	placeholder ingredient only	JCM			
+bacterial/bs_107_medium.yaml	CultureMech:003213	Bs 107 MEDIUM	placeholder ingredient only	JCM			
+bacterial/car_bacillus_medium.yaml	CultureMech:003345	CAR BACILLUS MEDIUM	placeholder ingredient only	JCM			
+bacterial/clostridium_bovis_medium.yaml	CultureMech:002982	CLOSTRIDIUM BOVIS MEDIUM	placeholder ingredient only	JCM			
+bacterial/desulfovibrio_piger_medium.yaml	CultureMech:002756	DESULFOVIBRIO PIGER MEDIUM	placeholder ingredient only	JCM			
+bacterial/diluted_asm_medium.yaml	CultureMech:003160	DILUTED ASM MEDIUM	placeholder ingredient only	JCM			
+bacterial/eg_medium_with_10_nacl.yaml	CultureMech:002618	EG MEDIUM WITH 10% NaCl	placeholder ingredient only	JCM			
+bacterial/ferric_citrate_fwmedia.yaml	CultureMech:002821	FERRIC CITRATE FWMEDIA	placeholder ingredient only	JCM			
+bacterial/fresh_water_media.yaml	CultureMech:002823	FRESH WATER MEDIA	placeholder ingredient only	JCM			
+bacterial/jcm_medium_no_1324.yaml	CultureMech:002488	JCM MEDIUM No. 1324	placeholder ingredient only	JCM			
+bacterial/jcm_medium_no_313.yaml	CultureMech:002671	JCM MEDIUM No. 313	placeholder ingredient only	JCM			
+bacterial/ji_medium.yaml	CultureMech:002747	JI MEDIUM	placeholder ingredient only	JCM			
+bacterial/lind_8a_medium.yaml	CultureMech:003136	LIND 8A MEDIUM	placeholder ingredient only	JCM			
+bacterial/medium_10_broth.yaml	CultureMech:002539	MEDIUM 10 BROTH	placeholder ingredient only	JCM		10	yes
+bacterial/methanosaeta_brevibacterium_medium.yaml	CultureMech:002826	METHANOSAETA BREVIBACTERIUM MEDIUM	placeholder ingredient only	JCM			
+bacterial/mg50_medium.yaml	CultureMech:002841	Mg50 MEDIUM	placeholder ingredient only	JCM			
+bacterial/modified_medium_10.yaml	CultureMech:002572	MODIFIED MEDIUM 10	placeholder ingredient only	JCM		10	yes
+bacterial/modified_roseospira_medium.yaml	CultureMech:002318	MODIFIED ROSEOSPIRA MEDIUM	placeholder ingredient only	JCM			
+bacterial/nb_fumarate_nbaf_medium.yaml	CultureMech:002822	NB FUMARATE (NBAF) MEDIUM	placeholder ingredient only	JCM			
+bacterial/poremedia_b_cye_945_agar_medium.yaml	CultureMech:002267	POREMEDIA B-CYE&#945; AGAR MEDIUM	placeholder ingredient only	JCM			
+bacterial/r2a_agar_ph_9_0.yaml	CultureMech:002475	R2A AGAR (pH 9.0)	placeholder ingredient only	JCM			
+bacterial/rumen_fluid_medium.yaml	CultureMech:003115	RUMEN FLUID MEDIUM	placeholder ingredient only	JCM			
+bacterial/smy_medium.yaml	CultureMech:003297	SMY MEDIUM	placeholder ingredient only	JCM			
+bacterial/thermovenbulum_medium.yaml	CultureMech:003202	THERMOVENBULUM MEDIUM	placeholder ingredient only	JCM			
+bacterial/widdel_freshwater_medium_with_glycerin.yaml	CultureMech:002391	WIDDEL FRESHWATER MEDIUM WITH GLYCERIN	placeholder ingredient only	JCM			
+bacterial/widdel_freshwater_medium_with_pyruvate.yaml	CultureMech:002392	WIDDEL FRESHWATER MEDIUM WITH PYRUVATE	placeholder ingredient only	JCM			
+bacterial/xylanobacter_medium.yaml	CultureMech:002873	XYLANOBACTER MEDIUM	placeholder ingredient only	JCM			
+fungal/yeast_extract_medium_ye.yaml	CultureMech:010512	YEAST EXTRACT MEDIUM (YE)	placeholder ingredient only	JCM			
+specialized/marine_medium_with_thiosulfate.yaml	CultureMech:015402	MARINE MEDIUM WITH THIOSULFATE	placeholder ingredient only	JCM			
+bacterial/nissui_plate_sheep_blood_agar.yaml	CultureMech:008099	Nissui Plate Sheep Blood Agar*	placeholder ingredient only	https://togomedium.org/medium/M1550			
+bacterial/imk_with_porphyra.yaml	CultureMech:008334	IMK with Porphyra	placeholder ingredient only	https://togomedium.org/medium/M1769			
+bacterial/seawater_with_porphyra.yaml	CultureMech:008336	Seawater with Porphyra	placeholder ingredient only	https://togomedium.org/medium/M1770			
+bacterial/yeast_extract_medium_ye.yaml	CultureMech:009002	Yeast Extract Medium (YE)	placeholder ingredient only	https://togomedium.org/medium/M241			
+bacterial/TOGO_M904_Bs_107_Medium.yaml	CultureMech:010323	Bs 107 Medium	placeholder ingredient only	https://togomedium.org/medium/M904			
+bacterial/togo_medium_m967.yaml	CultureMech:010392	(Unnamed medium)	placeholder ingredient only	https://togomedium.org/medium/M967			
+bacterial/bekisolidmedium_hydrogenovibrio_crunogenus_quimiolitotrofo.yaml	CultureMech:010430	BekiSolidMedium (Hydrogenovibrio crunogenus QUIMIOLITOTROFO)	placeholder ingredient only	public			
+bacterial/haha_agar.yaml	CultureMech:010431	HaHa agar	placeholder ingredient only	public			
+bacterial/king_b.yaml	CultureMech:010433	King B	placeholder ingredient only	public			
+bacterial/m9_sng_medium.yaml	CultureMech:010438	M9-SNG medium	placeholder ingredient only	public			
+bacterial/mta10.yaml	CultureMech:010436	mTA10	placeholder ingredient only	public			
+bacterial/n27_rhodospirillaceae_medium_modified.yaml	CultureMech:010437	N27 RHODOSPIRILLACEAE MEDIUM (modified)	placeholder ingredient only	public			
+bacterial/pdb_sng_medium.yaml	CultureMech:010439	PDB-SNG medium	placeholder ingredient only	public			
+bacterial/rs_medium_non_nutrient_medium_nnm_component.yaml	CultureMech:010434	RS Medium - Non-Nutrient Medium (NNM) Component	placeholder ingredient only	public			
+bacterial/rs_medium_nutrient_medium_nm_component.yaml	CultureMech:010435	RS Medium - Nutrient Medium (NM) Component	placeholder ingredient only	public			
+bacterial/taiyang_medium_no_9_prototype.yaml	CultureMech:010432	Taiyang Medium No.9 (prototype)	placeholder ingredient only	public			

--- a/data/import_tracking/reports/missing_compositions.tsv
+++ b/data/import_tracking/reports/missing_compositions.tsv
@@ -30,13 +30,13 @@ bacterial/acetobacterium_2_medium.yaml	CultureMech:005062	ACETOBACTERIUM 2 mediu
 bacterial/acetobacterium_carbinolicum_medium.yaml	CultureMech:004988	ACETOBACTERIUM CARBINOLICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/acetobacterium_sp_komac1_medium.yaml	CultureMech:005592	ACETOBACTERIUM SP. KoMAc1 medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/acetonema_medium.yaml	CultureMech:005871	ACETONEMA medium	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/amino_acid_solution_medium_78.yaml	CultureMech:004780	Amino acid solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED		78	yes
+bacterial/amino_acid_solution_medium_78.yaml	CultureMech:004780	Amino acid solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED	yes	78	yes
 bacterial/anaerobic_acetoin_medium.yaml	CultureMech:005020	ANAEROBIC ACETOIN medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/anaerobic_oxalate_medium.yaml	CultureMech:005624	ANAEROBIC OXALATE MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/anaerovibrio_burkinabensis_medium.yaml	CultureMech:006022	ANAEROVIBRIO BURKINABENSIS medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml	CultureMech:004785	Artificial sea water, 3 times concentrated (medium 1137)	no ingredients and no solutions	KOMODO ModelSEED		1137	yes
 bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml	CultureMech:004389	Artificial sea water, 3 times concentrated (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
-bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml	CultureMech:005655	Artificial sea water from a marine aquarium salts mixture	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml	CultureMech:005655	Artificial sea water from a marine aquarium salts mixture	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/artificial_sea_water_medium_1075.yaml	CultureMech:004783	Artificial sea water (medium 1075)	no ingredients and no solutions	KOMODO ModelSEED		1075	yes
 bacterial/artificial_sea_water_medium_246.yaml	CultureMech:004996	Artificial sea water (medium 246)	no ingredients and no solutions	KOMODO ModelSEED		246	yes
 bacterial/artificial_sea_water_medium_343.yaml	CultureMech:004782	Artificial sea water (medium 343)	no ingredients and no solutions	KOMODO ModelSEED		343	yes
@@ -56,13 +56,13 @@ bacterial/blood_agar_no_2_oxoid.yaml	CultureMech:006086	blood agar No 2 (Oxoid)	
 bacterial/bordet_gengou_agar_base.yaml	CultureMech:005645	Bordet-Gengou-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/brucella_broth_becton_dickinson.yaml	CultureMech:005646	Brucella Broth (Becton Dickinson)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/casman_agar_base.yaml	CultureMech:005647	Casman-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/chelated_iron_solution_medium_737.yaml	CultureMech:004268	Chelated iron solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED		737	yes
-bacterial/chelated_iron_solution_medium_748.yaml	CultureMech:004793	Chelated Iron solution (medium 748)	no ingredients and no solutions	KOMODO ModelSEED		748	yes
+bacterial/chelated_iron_solution_medium_737.yaml	CultureMech:004268	Chelated iron solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED	yes	737	yes
+bacterial/chelated_iron_solution_medium_748.yaml	CultureMech:004793	Chelated Iron solution (medium 748)	no ingredients and no solutions	KOMODO ModelSEED	yes	748	yes
 bacterial/clostridium_estertheticum_medium.yaml	CultureMech:006182	CLOSTRIDIUM ESTERTHETICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/clostridium_longisporum_medium.yaml	CultureMech:006392	CLOSTRIDIUM LONGISPORUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/clostridium_neopropionicum_medium.yaml	CultureMech:005884	CLOSTRIDIUM NEOPROPIONICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml	CultureMech:005648	CMRL-1066 medium (10x concentrated; GIBCO)	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/co_factors_solution_medium_843.yaml	CultureMech:006083	Co-factors solution (medium 843)	no ingredients and no solutions	KOMODO ModelSEED		843	yes
+bacterial/co_factors_solution_medium_843.yaml	CultureMech:006083	Co-factors solution (medium 843)	no ingredients and no solutions	KOMODO ModelSEED	yes	843	yes
 bacterial/columbia_agar_base.yaml	CultureMech:005649	Columbia agar base	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/corn_meal_agar_oxoid_cm103.yaml	CultureMech:005651	Corn meal Agar (Oxoid CM103)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/czapek_dox_agar_merck.yaml	CultureMech:005643	Czapek Dox agar (Merck)	no ingredients and no solutions	KOMODO ModelSEED			
@@ -85,10 +85,10 @@ bacterial/desulfovibrio_shv_medium.yaml	CultureMech:006368	DESULFOVIBRIO SHV MED
 bacterial/desulfovibrio_sp_medium.yaml	CultureMech:004276	DESULFOVIBRIO SP. MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/dmj_synthetic_seawater_medium_997.yaml	CultureMech:004270	DMJ synthetic seawater (medium 997)	no ingredients and no solutions	KOMODO ModelSEED		997	yes
 bacterial/dsm_4156_b_and_dsm_4156.yaml	CultureMech:005229	DSM 4156 B and DSM 4156	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/fatty_acid_mixture_medium_119.yaml	CultureMech:004794	Fatty acid mixture (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
-bacterial/fatty_acid_mixture_medium_328.yaml	CultureMech:004795	Fatty acid mixture (medium 328)	no ingredients and no solutions	KOMODO ModelSEED		328	yes
-bacterial/fatty_acid_mixture_medium_436.yaml	CultureMech:004796	Fatty acid mixture (medium 436)	no ingredients and no solutions	KOMODO ModelSEED		436	yes
-bacterial/ferric_quinate_solution_medium_380.yaml	CultureMech:004272	Ferric Quinate Solution (medium 380)	no ingredients and no solutions	KOMODO ModelSEED		380	yes
+bacterial/fatty_acid_mixture_medium_119.yaml	CultureMech:004794	Fatty acid mixture (medium 119)	no ingredients and no solutions	KOMODO ModelSEED	yes	119	yes
+bacterial/fatty_acid_mixture_medium_328.yaml	CultureMech:004795	Fatty acid mixture (medium 328)	no ingredients and no solutions	KOMODO ModelSEED	yes	328	yes
+bacterial/fatty_acid_mixture_medium_436.yaml	CultureMech:004796	Fatty acid mixture (medium 436)	no ingredients and no solutions	KOMODO ModelSEED	yes	436	yes
+bacterial/ferric_quinate_solution_medium_380.yaml	CultureMech:004272	Ferric Quinate Solution (medium 380)	no ingredients and no solutions	KOMODO ModelSEED	yes	380	yes
 bacterial/for_dsm_2805.yaml	CultureMech:004855	For DSM 2805	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_dsm_3246.yaml	CultureMech:005056	For DSM 3246	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_dsm_3247.yaml	CultureMech:005055	For DSM 3247	no ingredients and no solutions	KOMODO ModelSEED			
@@ -96,13 +96,13 @@ bacterial/for_s_buswellii_dsm_2612m.yaml	CultureMech:006276	For S. buswellii DSM
 bacterial/for_s_wolinii_dsm_2805m.yaml	CultureMech:006277	For S. wolinii DSM 2805M	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/glutarate_medium.yaml	CultureMech:006014	GLUTARATE medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/h3p_vitamin_solution_medium_428.yaml	CultureMech:004397	H3P-vitamin solution (medium 428)	no ingredients and no solutions	KOMODO ModelSEED	yes	428	yes
-bacterial/haemin_solution_medium_104.yaml	CultureMech:004798	Haemin solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED		104	yes
+bacterial/haemin_solution_medium_104.yaml	CultureMech:004798	Haemin solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
 bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml	CultureMech:004800	Hank's balanced salt solution (BSS, medium 1078)	no ingredients and no solutions	KOMODO ModelSEED	yes	1078	yes
-bacterial/heavy_metal_solution_medium_867.yaml	CultureMech:004273	Heavy metal solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED		867	yes
+bacterial/heavy_metal_solution_medium_867.yaml	CultureMech:004273	Heavy metal solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
 bacterial/ilyobacter_tartaricus_medium.yaml	CultureMech:004761	ILYOBACTER TARTARICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/inorganic_salt_solution_medium_754.yaml	CultureMech:004801	Inorganic salt solution (medium 754)	no ingredients and no solutions	KOMODO ModelSEED	yes	754	yes
 bacterial/isovitalex.yaml	CultureMech:005642	Isovitalex	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/lip_solution_medium_391.yaml	CultureMech:004802	LIP-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED		391	yes
+bacterial/lip_solution_medium_391.yaml	CultureMech:004802	LIP-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
 bacterial/mab1_medium.yaml	CultureMech:006272	mAB1-MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml	CultureMech:004803	Marine-Medium/Synthetic seawater-mix (medium 611)	no ingredients and no solutions	KOMODO ModelSEED		611	yes
 bacterial/marine_trace_elements_medium_511.yaml	CultureMech:004274	Marine trace elements (medium 511)	no ingredients and no solutions	KOMODO ModelSEED		511	yes
@@ -111,9 +111,9 @@ bacterial/medium_777_modified_for_dsm_14980.yaml	CultureMech:006434	MEDIUM 777 M
 bacterial/medium_820_modified_for_dsm_16960.yaml	CultureMech:006546	MEDIUM 820 MODIFIED FOR DSM 16960	no ingredients and no solutions	KOMODO ModelSEED		820	
 bacterial/medium_md1_medium_9.yaml	CultureMech:004986	medium MD1 (medium 9)	no ingredients and no solutions	KOMODO ModelSEED		9	yes
 bacterial/metals_44_medium_590.yaml	CultureMech:004393	Metals 44 (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
-bacterial/micronutrient_solution_sl8_medium_1128.yaml	CultureMech:004804	Micronutrient solution SL8 (medium 1128)	no ingredients and no solutions	KOMODO ModelSEED		1128	yes
+bacterial/micronutrient_solution_sl8_medium_1128.yaml	CultureMech:004804	Micronutrient solution SL8 (medium 1128)	no ingredients and no solutions	KOMODO ModelSEED	yes	1128	yes
 bacterial/middlebrook_7h10_agar.yaml	CultureMech:004805	Middlebrook 7H10 agar	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/min_e_base_10x.yaml	CultureMech:004275	MIN E - Base (10x)	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/min_e_base_10x.yaml	CultureMech:004275	MIN E - Base (10x)	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/mineral_mix_medium_1001.yaml	CultureMech:004277	Mineral Mix (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED		1001	yes
 bacterial/mineral_salt_solution_2xw_medium_391.yaml	CultureMech:004806	"Mineral salt solution ""2xW"" (medium 391)"	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
 bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml	CultureMech:004987	Mineral salts solution for liquid medium (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
@@ -137,7 +137,7 @@ bacterial/modified_hoagland_trace_element_solution_medium_867.yaml	CultureMech:0
 bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml	CultureMech:004284	Modified MJ synthetic sea water (medium 1131)	no ingredients and no solutions	KOMODO ModelSEED		1131	yes
 bacterial/mtp4_medium.yaml	CultureMech:006012	MTP4 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/mueller_hinton_broth.yaml	CultureMech:005193	Mueller-Hinton broth	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/na_sesquicarbonate_solution_medium_31.yaml	CultureMech:004819	Na-sesquicarbonate solution (medium 31)	no ingredients and no solutions	KOMODO ModelSEED		31	yes
+bacterial/na_sesquicarbonate_solution_medium_31.yaml	CultureMech:004819	Na-sesquicarbonate solution (medium 31)	no ingredients and no solutions	KOMODO ModelSEED	yes	31	yes
 bacterial/nutrient_broth_difco.yaml	CultureMech:005652	Nutrient broth (Difco)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/nutrient_broth_oxoid_medium_948.yaml	CultureMech:004822	Nutrient broth (Oxoid) (medium 948)	no ingredients and no solutions	KOMODO ModelSEED		948	yes
 bacterial/pelobacter_acetylenicus_medium.yaml	CultureMech:005057	PELOBACTER ACETYLENICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
@@ -145,13 +145,13 @@ bacterial/pelobacter_medium.yaml	CultureMech:005242	PELOBACTER medium	no ingredi
 bacterial/pelobacter_venetianus_fresh_water_medium.yaml	CultureMech:004774	PELOBACTER VENETIANUS (fresh water) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/pelobacter_venetianus_marine_medium.yaml	CultureMech:004760	PELOBACTER VENETIANUS (marine) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/pennassay_broth.yaml	CultureMech:005653	Pennassay Broth	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/phosphate_buffer_10x_medium_1341.yaml	CultureMech:004285	Phosphate buffer (10x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED		1341	yes
-bacterial/phosphate_buffer_medium_878.yaml	CultureMech:004823	Phosphate buffer (medium 878)	no ingredients and no solutions	KOMODO ModelSEED		878	yes
-bacterial/phosphate_buffer_medium_921.yaml	CultureMech:004286	Phosphate buffer (medium 921)	no ingredients and no solutions	KOMODO ModelSEED		921	yes
-bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml	CultureMech:004287	Phosphate buffer (pH 6.8, see medium 1132)	no ingredients and no solutions	KOMODO ModelSEED		1132	yes
-bacterial/phosphate_buffer_ph_7_2.yaml	CultureMech:004824	Phosphate buffer pH 7.2	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/phosphate_solution_medium_1191.yaml	CultureMech:004825	Phosphate solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED		1191	yes
-bacterial/phosphate_solution_medium_791.yaml	CultureMech:004826	Phosphate solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED		791	yes
+bacterial/phosphate_buffer_10x_medium_1341.yaml	CultureMech:004285	Phosphate buffer (10x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED	yes	1341	yes
+bacterial/phosphate_buffer_medium_878.yaml	CultureMech:004823	Phosphate buffer (medium 878)	no ingredients and no solutions	KOMODO ModelSEED	yes	878	yes
+bacterial/phosphate_buffer_medium_921.yaml	CultureMech:004286	Phosphate buffer (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
+bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml	CultureMech:004287	Phosphate buffer (pH 6.8, see medium 1132)	no ingredients and no solutions	KOMODO ModelSEED	yes	1132	yes
+bacterial/phosphate_buffer_ph_7_2.yaml	CultureMech:004824	Phosphate buffer pH 7.2	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/phosphate_solution_medium_1191.yaml	CultureMech:004825	Phosphate solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
+bacterial/phosphate_solution_medium_791.yaml	CultureMech:004826	Phosphate solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
 bacterial/pplo_broth.yaml	CultureMech:005654	PPLO broth	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/propionigenium_maris_medium.yaml	CultureMech:006291	PROPIONIGENIUM MARIS medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/rumen_fluid_clarified.yaml	CultureMech:006085	Rumen fluid, clarified	no ingredients and no solutions	KOMODO ModelSEED			
@@ -167,23 +167,23 @@ bacterial/sb_sw_medium.yaml	CultureMech:006278	SB/SW MEDIUM	no ingredients and n
 bacterial/sea_water_salts_solution_medium_958.yaml	CultureMech:004834	Sea water salts solution (medium 958)	no ingredients and no solutions	KOMODO ModelSEED	yes	958	yes
 bacterial/selenite_tungstate_solution_medium_385.yaml	CultureMech:004289	Selenite/tungstate solution (medium 385)	no ingredients and no solutions	KOMODO ModelSEED	yes	385	yes
 bacterial/seven_vitamin_solution_medium_1332.yaml	CultureMech:004835	Seven Vitamin solution (medium 1332)	no ingredients and no solutions	KOMODO ModelSEED	yes	1332	yes
-bacterial/seven_vitamins_solution_medium_503.yaml	CultureMech:004290	Seven vitamins solution (medium 503)	no ingredients and no solutions	KOMODO ModelSEED		503	yes
+bacterial/seven_vitamins_solution_medium_503.yaml	CultureMech:004290	Seven vitamins solution (medium 503)	no ingredients and no solutions	KOMODO ModelSEED	yes	503	yes
 bacterial/sludge_fluid_medium_119.yaml	CultureMech:004990	Sludge fluid (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
 bacterial/soil_extract_medium_98.yaml	CultureMech:004991	Soil extract (medium 98)	no ingredients and no solutions	KOMODO ModelSEED		98	yes
-bacterial/solution_1_10x_nms_salts_medium_921.yaml	CultureMech:004291	Solution 1 (10x NMS salts) (medium 921)	no ingredients and no solutions	KOMODO ModelSEED		921	yes
+bacterial/solution_1_10x_nms_salts_medium_921.yaml	CultureMech:004291	Solution 1 (10x NMS salts) (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
 bacterial/solution_a_medium_1267.yaml	CultureMech:005221	Solution A (medium 1267)	no ingredients and no solutions	KOMODO ModelSEED	yes	1267	yes
 bacterial/solution_a_medium_1275.yaml	CultureMech:005222	Solution A, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
 bacterial/solution_a_medium_858.yaml	CultureMech:005220	Solution A (medium 858)	no ingredients and no solutions	KOMODO ModelSEED	yes	858	yes
 bacterial/solution_b_medium_1275.yaml	CultureMech:005223	Solution B, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
 bacterial/solution_b_medium_807.yaml	CultureMech:006084	Solution B (medium 807)	no ingredients and no solutions	KOMODO ModelSEED	yes	807	yes
 bacterial/solution_c_medium_1275.yaml	CultureMech:005224	Solution C, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
-bacterial/solution_ii_medium_1308.yaml	CultureMech:004836	solution II (medium 1308)	no ingredients and no solutions	KOMODO ModelSEED		1308	yes
-bacterial/solution_ii_medium_1398.yaml	CultureMech:004837	solution II (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED		1398	yes
+bacterial/solution_ii_medium_1308.yaml	CultureMech:004836	solution II (medium 1308)	no ingredients and no solutions	KOMODO ModelSEED	yes	1308	yes
+bacterial/solution_ii_medium_1398.yaml	CultureMech:004837	solution II (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED	yes	1398	yes
 bacterial/spirochaeta_aurantia_medium.yaml	CultureMech:004195	SPIROCHAETA AURANTIA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/spirochaeta_isovalerica_medium.yaml	CultureMech:004701	SPIROCHAETA ISOVALERICA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/sporomusa_silvacetica_medium.yaml	CultureMech:006435	SPOROMUSA SILVACETICA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/sse_double_concentrated_medium_1426.yaml	CultureMech:004838	SSE (double concentrated) (medium 1426)	no ingredients and no solutions	KOMODO ModelSEED		1426	yes
-bacterial/stearate_solution_0_1_m_medium_517.yaml	CultureMech:004295	Stearate solution (0.1 M) (medium 517)	no ingredients and no solutions	KOMODO ModelSEED		517	yes
+bacterial/stearate_solution_0_1_m_medium_517.yaml	CultureMech:004295	Stearate solution (0.1 M) (medium 517)	no ingredients and no solutions	KOMODO ModelSEED	yes	517	yes
 bacterial/stock_solution_from_medium_756.yaml	CultureMech:004387	Stock solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
 bacterial/stock_solution_medium_462.yaml	CultureMech:004398	Stock solution (medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
 bacterial/sugar_stock_solution_medium_1245.yaml	CultureMech:006082	Sugar Stock Solution (medium 1245)	no ingredients and no solutions	KOMODO ModelSEED	yes	1245	yes
@@ -192,10 +192,10 @@ bacterial/synthetic_seawater_2_x_conc_medium_795.yaml	CultureMech:004840	Synthet
 bacterial/syntrophobacter_wolinii_medium.yaml	CultureMech:004866	SYNTROPHOBACTER WOLINII medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/syntrophus_buswellii_ii_medium.yaml	CultureMech:005230	SYNTROPHUS BUSWELLII II MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/syntrophus_medium_sulfate_free.yaml	CultureMech:004742	SYNTROPHUS medium - SULFATE FREE	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/thermus_macronutrients_10x_solution.yaml	CultureMech:004841	Thermus macronutrients 10X solution	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/thermus_micronutrients_100x_solution.yaml	CultureMech:004842	Thermus micronutrients 100X solution	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/thermus_macronutrients_10x_solution.yaml	CultureMech:004841	Thermus macronutrients 10X solution	no ingredients and no solutions	KOMODO ModelSEED	yes		
+bacterial/thermus_micronutrients_100x_solution.yaml	CultureMech:004842	Thermus micronutrients 100X solution	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml	CultureMech:006372	THIOBACILLUS FERROOXIDANS MEDIUM WITH TETRATHIONATE	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/thioglycolate_ascorbate_solution_medium_210.yaml	CultureMech:004844	Thioglycolate-ascorbate solution (medium 210)	no ingredients and no solutions	KOMODO ModelSEED		210	yes
+bacterial/thioglycolate_ascorbate_solution_medium_210.yaml	CultureMech:004844	Thioglycolate-ascorbate solution (medium 210)	no ingredients and no solutions	KOMODO ModelSEED	yes	210	yes
 bacterial/trace_element_solution_a_medium_537.yaml	CultureMech:004865	Trace element solution A (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
 bacterial/trace_element_solution_b_medium_537.yaml	CultureMech:004867	Trace element solution B (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
 bacterial/trace_element_solution_from_medium_756.yaml	CultureMech:004388	Trace element solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
@@ -251,9 +251,9 @@ bacterial/trace_elements_medium_1147.yaml	CultureMech:004875	Trace elements (med
 bacterial/trace_elements_medium_596.yaml	CultureMech:004877	Trace elements (medium 596)	no ingredients and no solutions	KOMODO ModelSEED		596	yes
 bacterial/trace_elements_medium_651.yaml	CultureMech:004878	Trace elements (medium 651)	no ingredients and no solutions	KOMODO ModelSEED		651	yes
 bacterial/trace_elements_pfennig_medium_1264.yaml	CultureMech:004879	Trace elements (Pfennig) (medium 1264)	no ingredients and no solutions	KOMODO ModelSEED		1264	yes
-bacterial/trace_elements_sl_12.yaml	CultureMech:004880	Trace elements SL-12	no ingredients and no solutions	KOMODO ModelSEED			
+bacterial/trace_elements_sl_12.yaml	CultureMech:004880	Trace elements SL-12	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/trace_elements_solution_medium_1280.yaml	CultureMech:004883	Trace elements solution (medium 1280)	no ingredients and no solutions	KOMODO ModelSEED	yes	1280	yes
-bacterial/trace_metals_500x_medium_1341.yaml	CultureMech:004347	Trace Metals (500x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED		1341	yes
+bacterial/trace_metals_500x_medium_1341.yaml	CultureMech:004347	Trace Metals (500x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED	yes	1341	yes
 bacterial/trace_metals_solution_medium_802.yaml	CultureMech:004884	Trace metals solution (medium 802)	no ingredients and no solutions	KOMODO ModelSEED	yes	802	yes
 bacterial/trace_mineral_solution_medium_1000.yaml	CultureMech:004351	Trace mineral solution (medium 1000)	no ingredients and no solutions	KOMODO ModelSEED	yes	1000	yes
 bacterial/trace_mineral_solution_medium_1121.yaml	CultureMech:004353	Trace mineral solution (medium 1121)	no ingredients and no solutions	KOMODO ModelSEED	yes	1121	yes
@@ -262,13 +262,13 @@ bacterial/trace_salt_solution_medium_609.yaml	CultureMech:005191	Trace salt solu
 bacterial/trace_salt_solution_medium_856.yaml	CultureMech:004885	Trace salt solution (medium 856)	no ingredients and no solutions	KOMODO ModelSEED	yes	856	yes
 bacterial/trace_salts_solution_medium_978.yaml	CultureMech:004938	Trace salts solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
 bacterial/true_blue_trace_elements_medium_748.yaml	CultureMech:004939	True Blue Trace Elements (medium 748)	no ingredients and no solutions	KOMODO ModelSEED		748	yes
-bacterial/tyc_solution_medium_391.yaml	CultureMech:004992	TYC-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED		391	yes
+bacterial/tyc_solution_medium_391.yaml	CultureMech:004992	TYC-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
 bacterial/vitamin_b12_solution_medium_867.yaml	CultureMech:004356	Vitamin B12 solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
 bacterial/vitamin_b_solution_medium_978.yaml	CultureMech:004940	Vitamin B solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
 bacterial/vitamin_k1_solution_medium_104.yaml	CultureMech:004941	Vitamin K1 solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
-bacterial/vitamin_mixture_medium_1001.yaml	CultureMech:004358	Vitamin mixture (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED		1001	yes
-bacterial/vitamin_mixture_medium_484.yaml	CultureMech:004359	Vitamin mixture (medium 484)	no ingredients and no solutions	KOMODO ModelSEED		484	yes
-bacterial/vitamin_mixture_medium_619.yaml	CultureMech:004360	Vitamin mixture (medium 619)	no ingredients and no solutions	KOMODO ModelSEED		619	yes
+bacterial/vitamin_mixture_medium_1001.yaml	CultureMech:004358	Vitamin mixture (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED	yes	1001	yes
+bacterial/vitamin_mixture_medium_484.yaml	CultureMech:004359	Vitamin mixture (medium 484)	no ingredients and no solutions	KOMODO ModelSEED	yes	484	yes
+bacterial/vitamin_mixture_medium_619.yaml	CultureMech:004360	Vitamin mixture (medium 619)	no ingredients and no solutions	KOMODO ModelSEED	yes	619	yes
 bacterial/vitamin_solution_7_medium_842.yaml	CultureMech:004975	Vitamin solution 7 (medium 842)	no ingredients and no solutions	KOMODO ModelSEED	yes	842	yes
 bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml	CultureMech:004384	Vitamin solution according to Wolin and coauthors	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/vitamin_solution_b_medium_253.yaml	CultureMech:004942	Vitamin solution (B) (medium 253)	no ingredients and no solutions	KOMODO ModelSEED	yes	253	yes
@@ -321,10 +321,10 @@ bacterial/vitamin_solution_medium_951.yaml	CultureMech:004380	Vitamin solution (
 bacterial/vitamin_solution_schlegel_medium_462.yaml	CultureMech:004381	Vitamin solution (Schlegel, medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
 bacterial/vitamin_solution_v10.yaml	CultureMech:004385	Vitamin solution V10	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/vitamin_solution_va_medium_351.yaml	CultureMech:004383	Vitamin solution (VA) (medium 351)	no ingredients and no solutions	KOMODO ModelSEED	yes	351	yes
-bacterial/vitamins_v7_solution_medium_998.yaml	CultureMech:004978	Vitamins V7 solution (medium 998)	no ingredients and no solutions	KOMODO ModelSEED		998	yes
+bacterial/vitamins_v7_solution_medium_998.yaml	CultureMech:004978	Vitamins V7 solution (medium 998)	no ingredients and no solutions	KOMODO ModelSEED	yes	998	yes
 bacterial/vitox.yaml	CultureMech:005644	Vitox	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/volatile_fatty_acid_mixture_medium_330.yaml	CultureMech:004979	Volatile fatty acid mixture (medium 330)	no ingredients and no solutions	KOMODO ModelSEED		330	yes
-bacterial/volatile_fatty_acid_solution_medium_909.yaml	CultureMech:004980	Volatile fatty acid solution (medium 909)	no ingredients and no solutions	KOMODO ModelSEED		909	yes
+bacterial/volatile_fatty_acid_mixture_medium_330.yaml	CultureMech:004979	Volatile fatty acid mixture (medium 330)	no ingredients and no solutions	KOMODO ModelSEED	yes	330	yes
+bacterial/volatile_fatty_acid_solution_medium_909.yaml	CultureMech:004980	Volatile fatty acid solution (medium 909)	no ingredients and no solutions	KOMODO ModelSEED	yes	909	yes
 bacterial/xb45_xb90_pb90_2_medium.yaml	CultureMech:006693	XB45/XB90/PB90-2 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 algae/artificial_seawater.yaml	CultureMech:000189	Artificial_Seawater	placeholder ingredient only				
 algae/bacillariophycean.yaml	CultureMech:000192	Bacillariophycean	placeholder ingredient only				
@@ -334,7 +334,7 @@ algae/bold_modified_basal.yaml	CultureMech:000194	Bold_Modified_Basal	placeholde
 algae/bold_modified_basal_tom.yaml	CultureMech:000195	Bold_Modified_Basal&TOM	placeholder ingredient only				
 algae/brackish_water_medium.yaml	CultureMech:000196	Brackish_water_medium	placeholder ingredient only				
 algae/ch.yaml	CultureMech:000059	CH	placeholder ingredient only				
-algae/chapman_andresens_modified_pringsheims_solution.yaml	CultureMech:000062	Chapman-Andresen's Modified Pringsheim's Solution	placeholder ingredient only				
+algae/chapman_andresens_modified_pringsheims_solution.yaml	CultureMech:000062	Chapman-Andresen's Modified Pringsheim's Solution	placeholder ingredient only		yes		
 algae/chilomonas.yaml	CultureMech:000197	Chilomonas	placeholder ingredient only				
 algae/cyanidium.yaml	CultureMech:000198	Cyanidium	placeholder ingredient only				
 algae/desmidiacean.yaml	CultureMech:000199	Desmidiacean	placeholder ingredient only				

--- a/data/import_tracking/reports/selective_agent_mismatch.tsv
+++ b/data/import_tracking/reports/selective_agent_mismatch.tsv
@@ -1,18 +1,3 @@
 file_path	record_id	name	missing_agents	named_conc	n_ingredients
 bacterial/KOMODO_309_NEOMYCIN_AGAR.yaml	CultureMech:004886	NEOMYCIN AGAR	neomycin		5
-bacterial/am3_nalidixic_acid_kanamycin_medium.yaml	CultureMech:008611	AM3 + Nalidixic acid, Kanamycin medium	kanamycin; nalidixic acid		9
-bacterial/am3_nalidixic_acid_medium.yaml	CultureMech:008610	AM3 + Nalidixic acid medium	nalidixic acid		9
-bacterial/lb_50_ug_ml_kanamycin_medium.yaml	CultureMech:008689	LB + 50 ug/ml Kanamycin medium	kanamycin	kanamycin=50 ug/ml	5
-bacterial/lb_ampicilin_hygromycin_medium.yaml	CultureMech:008514	LB + Ampicilin, Hygromycin medium	ampicillin; hygromycin		5
-bacterial/lb_ampicillin_cefpodoxime_kanamycin_medium.yaml	CultureMech:008599	LB + Ampicillin, Cefpodoxime, Kanamycin medium	ampicillin; cefpodoxime; kanamycin		5
-bacterial/lb_ampicillin_kanamycin_medium.yaml	CultureMech:008641	LB + Ampicillin, Kanamycin medium	ampicillin; kanamycin		5
-bacterial/lb_ampicillin_medium.yaml	CultureMech:008244	LB + Ampicillin medium	ampicillin		5
-bacterial/lb_chloramphenicol_medium.yaml	CultureMech:008474	LB + Chloramphenicol medium	chloramphenicol		5
-bacterial/lb_kanamycin_hygromycin_medium.yaml	CultureMech:008513	LB + Kanamycin, Hygromycin medium	hygromycin; kanamycin		5
-bacterial/lb_kanamycin_medium.yaml	CultureMech:008515	LB + Kanamycin medium	kanamycin		5
-bacterial/lb_nalidixic_acid_ciprofloxacin_medium.yaml	CultureMech:008600	LB + Nalidixic acid, Ciprofloxacin medium	ciprofloxacin; nalidixic acid		5
-bacterial/lb_rifampicin_medium.yaml	CultureMech:008553	LB + Rifampicin medium	rifampicin		5
-bacterial/lb_streptomycin_medium.yaml	CultureMech:008552	LB + Streptomycin medium	streptomycin		5
-bacterial/lb_streptomycin_rifampicin_medium.yaml	CultureMech:008554	LB + Streptomycin, Rifampicin medium	rifampicin; streptomycin		5
 bacterial/neomycin_agar.yaml	CultureMech:001407	NEOMYCIN AGAR	neomycin		5
-bacterial/pda_hygromycin_medium.yaml	CultureMech:008534	PDA +Hygromycin medium	hygromycin		4

--- a/project.justfile
+++ b/project.justfile
@@ -184,6 +184,13 @@ audit-filename-collisions *args="":
 # Report media named for a selective agent their ingredient list omits (#181).
 # Report-only: recovering a lost concentration needs the upstream record, and a
 # plausible guess that round-trips is still false chemistry (#166).
+# Triage the media that carry no usable composition (#175). Report-only: the
+# obvious repair — resolving "X solution (medium N)" to medium N's composition —
+# would write a whole medium's recipe into a solution record. See the docstring.
+[group('QC')]
+triage-missing-compositions *args="":
+    uv run --extra dev python scripts/triage_missing_compositions.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/audit_selective_agent_mismatch.py
+++ b/scripts/audit_selective_agent_mismatch.py
@@ -1,39 +1,58 @@
 #!/usr/bin/env python3
-"""Report media named for a selective agent their ingredient list omits (#181).
+"""Report media named for a selective agent their composition omits (#181).
 
-Found by the Edison axis-classification probe, not by any existing gate. Asked to
-classify `lb_rifampicin_medium`, the model declined `functional_role: SELECTIVE`
-because "the supplied ingredient list contains no rifampicin entry or
-concentration", and declined `GENERAL_PURPOSE` too rather than resolve the
-contradiction. It was right: the record is plain LB.
+An antibiotic-selective medium whose composition has no antibiotic is a real
+defect: the record asserts a formulation that is not the medium it names, so
+growth inference, grounding and axis classification all get a confident wrong
+answer with no signal.
 
-Why this matters more than a missing ingredient usually would: the record asserts
-a composition that is not the medium it names. Anything reading it — growth
-inference, ingredient grounding, axis classification — gets a confident wrong
-answer with no signal. A `functional_role` assigned from the name would launder
-the defect into the schema.
+## What "composition" means here — the correction that halved this audit twice
 
-REPORT ONLY. It does not repair, for the #166 reason: a plausible-looking
-concentration that round-trips, validates, and passes every gate is still false
-chemistry, and only reading the output catches it. Where the source recorded a
-concentration in the NAME ("LB + 50 ug/ml Kanamycin medium"), the value is
-recoverable from tracked data and is surfaced in the `named_conc` column for a
-curator to act on — surfaced, not applied.
+A stock-supplied antibiotic is recorded as a SOLUTION, not an ingredient.
+`lb_rifampicin_medium` carries "Rifampicin solution (50 mg/ml)*" under
+`solutions`, and its `ingredients` really are just plain LB. An earlier version of
+this script checked only `ingredients` and reported 17 records; 15 were FALSE
+POSITIVES on exactly that basis.
 
-Two traps, both hit while scoping this:
+That mattered beyond the count. The Edison axis probe which prompted #181 declined
+to classify `lb_rifampicin_medium` as SELECTIVE, saying "the supplied ingredient
+list contains no rifampicin entry". That was accurate about the ingredient list it
+was handed — which is precisely the slot the research template passes. The record
+was not defective; the VIEW of it was partial, and this script reproduced the same
+partial view before concluding the corpus was broken.
 
-  * Match on WORD BOUNDARIES. A substring matcher reported 28 records because
-    `streptomyc` matches the GENUS *Streptomyces* (`GYM_Streptomyces_Medium`) and
-    `bile` matches `alkalispirillum_mobile_medium`. More than half the initial
-    hits were artifacts of the matcher, not defects in the corpus.
+`composition_terms()` therefore spans `ingredients`, `solutions`, and the nested
+`solutions[].composition`. Current baseline: **2** records, both DSMZ Medium 309
+reached via two sources. Neither has a `solutions` entry, and the local mediadive
+extraction of medium 309 lacks the neomycin too — so the gap is upstream, not in
+this import, and is not locally recoverable.
+
+## REPORT ONLY
+
+Recovering a lost concentration needs the upstream record, and a plausible guess
+that round-trips and validates is still false chemistry (#166). Where the source
+kept a concentration in the NAME ("LB + 50 ug/ml Kanamycin medium"), it is
+surfaced in `named_conc` for a curator — surfaced, not applied.
+
+## Traps, each hit while building this
+
+  * Match on WORD BOUNDARIES. A substring matcher reported 28 because `streptomyc`
+    matches the GENUS *Streptomyces* and `bile` matches
+    `alkalispirillum_mobile_medium`. Sixteen of the twenty-eight were artifacts.
+  * "A or B" names an either/or formulation. The record holds one alternative and
+    is complete, so it is suppressed — but only when at least one named agent is
+    actually present.
+  * A concentration belongs to the agent in ITS OWN name segment. A character
+    window reached across the comma and reported `ampicillin=50 ug/ml` for a name
+    reading "...Kanamycin, 100 ug/ml Ampicillin" (#188).
   * Presence in a name proves the agent belongs; ABSENCE from a finite agent list
-    proves nothing. This bounds a known family. It does not certify the rest of
-    the corpus, and `--max-allowed 0` would be a claim this script cannot support.
+    proves nothing. This bounds a known family; `--max-allowed 0` would be a claim
+    this script cannot support.
 
 Usage::
 
     just audit-selective-agent-mismatch
-    just audit-selective-agent-mismatch --max-allowed 17   # current baseline
+    just audit-selective-agent-mismatch --max-allowed 2    # current baseline
 """
 
 from __future__ import annotations
@@ -110,6 +129,34 @@ _EITHER_OR = re.compile(r"\bor\b", re.I)
 _CONC = r"\d+(?:\.\d+)?\s*(?:%|ug/ml|µg/ml|mg/ml|mg/l|g/l|u/ml)"
 
 
+def composition_terms(doc: dict[str, Any]) -> list[str]:
+    """Every term naming something actually IN the medium.
+
+    Must span `ingredients` AND `solutions`, and the nested `solutions[].composition`.
+    Checking only `ingredients` reported 15 false positives out of 17: an
+    antibiotic supplied as a stock is recorded as a SOLUTION, so
+    `lb_rifampicin_medium` carries "Rifampicin solution (50 mg/ml)*" under
+    `solutions` and reads as antibiotic-free if you look only at `ingredients`.
+
+    The Edison probe that started #181 said "the supplied ingredient list contains
+    no rifampicin entry" — accurate about the ingredient list it was given, which
+    is exactly the slot the research template passes. The record was not defective;
+    the view of it was partial.
+    """
+    terms: list[str] = []
+    for ing in doc.get("ingredients") or []:
+        if isinstance(ing, dict):
+            terms.append(str(ing.get("preferred_term") or ""))
+    for sol in doc.get("solutions") or []:
+        if not isinstance(sol, dict):
+            continue
+        terms.append(str(sol.get("preferred_term") or ""))
+        for sub in sol.get("composition") or []:
+            if isinstance(sub, dict):
+                terms.append(str(sub.get("preferred_term") or ""))
+    return [t for t in terms if t]
+
+
 def _compiled() -> list[tuple[str, re.Pattern[str]]]:
     return [(label, re.compile(rf"\b{rx}\b", re.I)) for label, rx in SELECTIVE_AGENTS]
 
@@ -146,7 +193,7 @@ def audit_parsed(records: list[tuple[str, dict[str, Any]]]) -> list[dict[str, st
             continue
         name = f"{doc.get('name') or ''} {doc.get('original_name') or ''}".strip()
         ingredients = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
-        ing_text = " ".join(str(i.get("preferred_term") or "") for i in ingredients)
+        ing_text = " ".join(composition_terms(doc))
         missing, concs = [], []
         present = False
         for label, rx in agents:

--- a/scripts/triage_missing_compositions.py
+++ b/scripts/triage_missing_compositions.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Triage media that carry no usable composition (#175).
+
+Classifies every record with nothing to work from, so the backlog can be attacked
+by cause rather than one record at a time. REPORT ONLY — see "the trap" below for
+why the obvious repair is not attempted.
+
+## The count is 428, not 463
+
+The original issue measured `ingredients` alone. A stock-supplied component is
+recorded under `solutions`, so 35 records that look empty are not: they carry
+their whole composition there. The same oversight made 15 of 17 findings in #181
+false positives, so it is worth stating plainly — a record's composition lives in
+`ingredients` AND `solutions`, and any audit that reads one slot will invent a
+defect.
+
+## What the 428 are
+
+  327  KOMODO ModelSEED, no ingredients and no solutions
+  101  a single placeholder ingredient ("See source for composition")
+
+Of the 327 KOMODO records, **183 are named like a stock solution rather than a
+medium** — "Trace element solution (medium 929)", "Solution C, medium 1275",
+"10 x M9 salts". These are not media missing a composition; they are solutions
+imported as media records. `record_kinds.is_solution_record()` does not catch them
+because it keys on a `term.id` prefix these records lack, deliberately: an id
+prefix is an explicit provenance assertion, whereas guessing from a name would
+also swallow genuine media.
+
+## The trap — why 214 records are NOT auto-repairable
+
+Those names cite a medium number, and 214 of them resolve to a composition file in
+`data/raw/mediadive/compositions/`. Applying it would be wrong.
+
+"Trace element solution (medium 1072)" means *the trace element solution defined
+inside medium 1072* — not medium 1072 itself. And `dsmz_1072`'s composition is the
+whole medium: KH2PO4, MgSO4, NH4Cl, KCl, CaCl2, Na-acetate, yeast extract,
+casamino acids, NaCl at 15 g/L — plus a line reading "Trace element solution (see
+below) 2.0ml", which is the thing actually wanted.
+
+So the mapping that looks like a 214-record fix would write an entire medium's
+recipe into each solution record. That is #166 at scale: plausible, round-trips,
+validates, and wrong.
+
+The local dump is independently unreliable. `dsmz_929` records its `medium_name`
+as "NaCl" (its first component), and `dsmz_1275` lists "Solution A:" as a 0.65 g
+component — a section header parsed as a chemical. It is
+`extraction_method: pdf_tabular_parsing` output, not a curated source.
+
+Recovering these needs the sub-solution block within each medium's DSMZ record,
+which the local extraction does not preserve.
+
+Usage::
+
+    just triage-missing-compositions
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+MEDIADIVE_COMPOSITIONS = REPO / "data" / "raw" / "mediadive" / "compositions"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "missing_compositions.tsv"
+
+PLACEHOLDER = re.compile(
+    r"see\s+source|refer\s+to|not\s+specified|composition\s+not\s+available|"
+    r"contact\s+source|proprietary", re.I)
+
+# "Trace element solution (medium 929)", "Solution C, medium 1275", "10 x M9 salts"
+SOLUTION_NAMED = re.compile(
+    r"\b(?:trace\s+(?:element|salts|metal)s?|vitamin|mineral|selenite|tungstate|"
+    r"salts?)\b.*\bsolution\b|\bsolution\s+[A-Z]\b|^\d+\s*x\s+|\bstock\b", re.I)
+NAME_CITES_MEDIUM = re.compile(r"\bmedium\s+(\d+)\b", re.I)
+
+
+def composition_terms(doc: dict[str, Any]) -> tuple[list[dict], list[dict]]:
+    ings = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
+    sols = [s for s in doc.get("solutions") or [] if isinstance(s, dict)]
+    return ings, sols
+
+
+def has_no_usable_composition(doc: dict[str, Any]) -> str | None:
+    """Return the kind of emptiness, or None when the record is fine."""
+    ings, sols = composition_terms(doc)
+    if not ings and not sols:
+        return "no ingredients and no solutions"
+    if sols:
+        return None
+    names = [str(i.get("preferred_term") or "") for i in ings]
+    if len(ings) <= 1 and any(PLACEHOLDER.search(n) for n in names):
+        return "placeholder ingredient only"
+    return None
+
+
+def _mediadive_ids() -> set[str]:
+    if not MEDIADIVE_COMPOSITIONS.is_dir():
+        return set()
+    out = set()
+    for f in os.listdir(MEDIADIVE_COMPOSITIONS):
+        m = re.match(r"dsmz_(\d+)_composition\.json$", f)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def triage_parsed(records: list[tuple[str, dict[str, Any]]],
+                  mediadive_ids: set[str] | None = None) -> list[dict[str, str]]:
+    """Pure function over parsed records, so tests need no fixture files."""
+    if mediadive_ids is None:
+        mediadive_ids = _mediadive_ids()
+    rows: list[dict[str, str]] = []
+    for rel, doc in records:
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        kind = has_no_usable_composition(doc)
+        if not kind:
+            continue
+        name = str(doc.get("original_name") or doc.get("name") or "")
+        notes = str(doc.get("notes") or "")
+        source = (m.group(1).strip() if (m := re.search(r"Source:\s*([^|\n]+)", notes))
+                  else "")
+        looks_like_solution = bool(SOLUTION_NAMED.search(name))
+        cited = NAME_CITES_MEDIUM.search(name)
+        # Recorded, NOT proposed as a fix: the cited medium is the one the solution
+        # is defined INSIDE, so its composition is the whole medium (see docstring).
+        cites = cited.group(1) if cited else ""
+        rows.append({
+            "file_path": rel,
+            "record_id": str(doc.get("id") or ""),
+            "name": name,
+            "kind": kind,
+            "source": source[:40],
+            "looks_like_a_solution": "yes" if looks_like_solution else "",
+            "name_cites_medium": cites,
+            "cited_medium_in_local_dump": "yes" if cites in mediadive_ids and cites else "",
+        })
+    rows.sort(key=lambda r: (r["kind"], r["source"], r["file_path"]))
+    return rows
+
+
+def collect(normalized: Path = NORMALIZED) -> list[dict[str, str]]:
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((str(path.relative_to(normalized)), doc))
+    return triage_parsed(records)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--max-allowed", type=int, default=None,
+                    help="Exit 1 if more than N records lack a composition.")
+    args = ap.parse_args(argv)
+
+    rows = collect(args.normalized_dir)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
+            "file_path", "record_id", "name", "kind", "source",
+            "looks_like_a_solution", "name_cites_medium",
+            "cited_medium_in_local_dump"])
+        w.writeheader()
+        w.writerows(rows)
+
+    from collections import Counter
+    print(f"Records with no usable composition: {len(rows)}\n")
+    for k, v in Counter(r["kind"] for r in rows).most_common():
+        print(f"  {v:5d}  {k}")
+    print("\nby source:")
+    for k, v in Counter(r["source"] or "(none)" for r in rows).most_common(6):
+        print(f"  {v:5d}  {k}")
+    sol = [r for r in rows if r["looks_like_a_solution"]]
+    print(f"\n  {len(sol)} are named like a stock SOLUTION, not a medium — these are "
+          f"mis-typed\n      records rather than media with a missing recipe.")
+    cited = [r for r in rows if r["cited_medium_in_local_dump"]]
+    print(f"  {len(cited)} cite a medium number present in the local mediadive dump.")
+    print("      NOT auto-repairable: the cited medium is the one the solution is")
+    print("      defined INSIDE, so its composition is the whole medium. Applying it")
+    print("      would write a full recipe into a solution record (#166 at scale).")
+    print(f"\nWrote {args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+
+    if args.max_allowed is not None and len(rows) > args.max_allowed:
+        print(f"\nFAIL: {len(rows)} exceeds --max-allowed {args.max_allowed}",
+              file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage_missing_compositions.py
+++ b/scripts/triage_missing_compositions.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import json
 import os
 import re
 import sys

--- a/scripts/triage_missing_compositions.py
+++ b/scripts/triage_missing_compositions.py
@@ -19,7 +19,7 @@ defect.
   327  KOMODO ModelSEED, no ingredients and no solutions
   101  a single placeholder ingredient ("See source for composition")
 
-**162 of the 428 are named like a stock solution rather than a medium** —
+**202 of the 428 are named like a stock solution rather than a medium** —
 "Trace element solution (medium 929)", "Solution C, medium 1275",
 "10 x M9 salts". These are not media missing a composition; they are solutions
 imported as media records. `record_kinds.is_solution_record()` does not catch them
@@ -79,10 +79,19 @@ PLACEHOLDER = re.compile(
     r"see\s+source|refer\s+to|not\s+specified|composition\s+not\s+available|"
     r"contact\s+source|proprietary", re.I)
 
-# "Trace element solution (medium 929)", "Solution C, medium 1275", "10 x M9 salts"
+# "Trace element solution (medium 929)", "Solution C, medium 1275", "10 x M9 salts",
+# "Phosphate buffer (10x) (medium 1341)".
+#
+# Matches the word "solution" directly rather than enumerating the reagents that
+# may precede it. An earlier version listed trace element / vitamin / mineral /
+# salts and missed 34 records — "Amino acid solution", "Haemin solution",
+# "Chelated iron solution", "Na-sesquicarbonate solution" (#194). The reagent list
+# was never going to be completable; the word "solution" is the signal.
+# `mixture` and the SL-nn / SL8 series are the same thing under another word:
+# "Vitamin mixture (medium 1001)", "Trace elements SL-12".
 SOLUTION_NAMED = re.compile(
-    r"\b(?:trace\s+(?:element|salts|metal)s?|vitamin|mineral|selenite|tungstate|"
-    r"salts?)\b.*\bsolution\b|\bsolution\s+[A-Z]\b|^\d+\s*x\s+|\bstock\b", re.I)
+    r"\bsolutions?\b|\bbuffer\b|\bstock\b|\bmixture\b|\bSL-?\d+\b|"
+    r"^\s*\d+\s*x\b|\(\s*\d+\s*x\s*\)", re.I)
 NAME_CITES_MEDIUM = re.compile(r"\bmedium\s+(\d+)\b", re.I)
 
 

--- a/scripts/triage_missing_compositions.py
+++ b/scripts/triage_missing_compositions.py
@@ -19,17 +19,17 @@ defect.
   327  KOMODO ModelSEED, no ingredients and no solutions
   101  a single placeholder ingredient ("See source for composition")
 
-Of the 327 KOMODO records, **183 are named like a stock solution rather than a
-medium** — "Trace element solution (medium 929)", "Solution C, medium 1275",
+**162 of the 428 are named like a stock solution rather than a medium** —
+"Trace element solution (medium 929)", "Solution C, medium 1275",
 "10 x M9 salts". These are not media missing a composition; they are solutions
 imported as media records. `record_kinds.is_solution_record()` does not catch them
 because it keys on a `term.id` prefix these records lack, deliberately: an id
 prefix is an explicit provenance assertion, whereas guessing from a name would
 also swallow genuine media.
 
-## The trap — why 214 records are NOT auto-repairable
+## The trap — why 217 records are NOT auto-repairable
 
-Those names cite a medium number, and 214 of them resolve to a composition file in
+Those names cite a medium number, and 217 of them resolve to a composition file in
 `data/raw/mediadive/compositions/`. Applying it would be wrong.
 
 "Trace element solution (medium 1072)" means *the trace element solution defined
@@ -38,7 +38,7 @@ whole medium: KH2PO4, MgSO4, NH4Cl, KCl, CaCl2, Na-acetate, yeast extract,
 casamino acids, NaCl at 15 g/L — plus a line reading "Trace element solution (see
 below) 2.0ml", which is the thing actually wanted.
 
-So the mapping that looks like a 214-record fix would write an entire medium's
+So the mapping that looks like a 217-record fix would write an entire medium's
 recipe into each solution record. That is #166 at scale: plausible, round-trips,
 validates, and wrong.
 

--- a/tests/test_missing_compositions.py
+++ b/tests/test_missing_compositions.py
@@ -1,0 +1,106 @@
+"""Tests for the missing-composition triage (#175).
+
+The load-bearing tests here are the two NEGATIVE ones: that `solutions` counts as
+a composition, and that a solution record naming a medium is not treated as
+repairable from that medium. Both were mistakes made while building this — the
+first inflated the count by 35, the second looked like a 214-record fix and would
+have written a whole medium's recipe into each solution record.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def tmc():
+    return _load("triage_missing_compositions")
+
+
+def _rec(**kw):
+    base = {"id": "CultureMech:1", "name": "x", "original_name": "X medium"}
+    base.update(kw)
+    return ("bacterial/x.yaml", base)
+
+
+def test_a_record_with_nothing_is_reported(tmc):
+    rows = tmc.triage_parsed([_rec(ingredients=[], solutions=[])], set())
+    assert len(rows) == 1 and rows[0]["kind"] == "no ingredients and no solutions"
+
+
+def test_solutions_count_as_a_composition(tmc):
+    """#175 originally said 463; it is 428. A record whose composition lives in
+    `solutions` is not empty — the same slot that made 15 of 17 findings in #181
+    false positives."""
+    rows = tmc.triage_parsed([_rec(
+        ingredients=[], solutions=[{"preferred_term": "Trace element solution SL-10"}])], set())
+    assert rows == [], "a record with solutions was reported as having no composition"
+
+
+def test_a_placeholder_ingredient_is_reported(tmc):
+    rows = tmc.triage_parsed([_rec(
+        ingredients=[{"preferred_term": "See source for composition"}], solutions=[])], set())
+    assert rows[0]["kind"] == "placeholder ingredient only"
+
+
+def test_a_real_composition_is_not_reported(tmc):
+    rows = tmc.triage_parsed([_rec(
+        ingredients=[{"preferred_term": "Peptone"}, {"preferred_term": "NaCl"}])], set())
+    assert rows == []
+
+
+def test_solution_named_records_are_flagged_as_mis_typed(tmc):
+    """183 of the 327 KOMODO empties are stock solutions imported as media. They
+    are not media missing a recipe, and counting them as such overstates the
+    data-quality problem."""
+    rows = tmc.triage_parsed([_rec(
+        original_name="Trace element solution (medium 929)", ingredients=[], solutions=[])], set())
+    assert rows[0]["looks_like_a_solution"] == "yes"
+
+
+def test_the_cited_medium_is_recorded_but_never_proposed_as_a_fix(tmc):
+    """The trap. "Trace element solution (medium 1072)" is the solution defined
+    INSIDE medium 1072, and dsmz_1072's composition is the whole medium — KH2PO4,
+    NaCl, yeast extract, casamino acids — including a line reading "Trace element
+    solution (see below) 2.0ml", which is the part actually wanted.
+
+    The column records that a candidate exists. There must be no column, flag or
+    field proposing it as the composition.
+    """
+    rows = tmc.triage_parsed([_rec(
+        original_name="Trace element solution (medium 1072)",
+        ingredients=[], solutions=[])], {"1072"})
+    row = rows[0]
+    assert row["name_cites_medium"] == "1072"
+    assert row["cited_medium_in_local_dump"] == "yes"
+    assert not any("propos" in k or "repair" in k or "suggest" in k for k in row), \
+        "the report must not propose the cited medium as the composition"
+
+
+def test_solution_records_themselves_are_skipped(tmc):
+    rows = tmc.triage_parsed([("s.yaml", {
+        "id": "CultureMech:9", "original_name": "Some stock",
+        "term": {"id": "mediadive.solution:1"}, "ingredients": []})], set())
+    assert rows == []
+
+
+def test_corpus_baseline(tmc, corpus):
+    normalized = REPO_ROOT / "data" / "normalized_yaml"
+    rows = tmc.triage_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
+    assert len(rows) <= 428, (
+        f"{len(rows)} records lack a composition, above the documented baseline of "
+        "428 — a new import dropped one, or the detector widened.")

--- a/tests/test_missing_compositions.py
+++ b/tests/test_missing_compositions.py
@@ -64,7 +64,7 @@ def test_a_real_composition_is_not_reported(tmc):
 
 
 def test_solution_named_records_are_flagged_as_mis_typed(tmc):
-    """162 of the 428 are stock solutions imported as media. They
+    """202 of the 428 are stock solutions imported as media. They
     are not media missing a recipe, and counting them as such overstates the
     data-quality problem."""
     rows = tmc.triage_parsed([_rec(
@@ -104,3 +104,23 @@ def test_corpus_baseline(tmc, corpus):
     assert len(rows) <= 428, (
         f"{len(rows)} records lack a composition, above the documented baseline of "
         "428 — a new import dropped one, or the detector widened.")
+
+
+def test_the_solution_classifier_does_not_enumerate_reagents(tmc):
+    """#194: requiring a known word before "solution" missed 34 records —
+    "Amino acid solution", "Haemin solution", "Na-sesquicarbonate solution". The
+    reagent list was never completable; the word "solution" is the signal."""
+    for name in ("Amino acid solution (medium 78)", "Haemin solution (medium 104)",
+                 "Chelated iron solution (medium 737)", "LIP-solution (medium 391)",
+                 "Na-sesquicarbonate solution (medium 31)",
+                 "Phosphate buffer (10x) (medium 1341)",
+                 "Vitamin mixture (medium 1001)", "Trace elements SL-12"):
+        rows = tmc.triage_parsed([_rec(original_name=name, ingredients=[], solutions=[])], set())
+        assert rows and rows[0]["looks_like_a_solution"] == "yes", name
+
+
+def test_a_real_medium_name_is_not_called_a_solution(tmc):
+    for name in ("DESULFOBACTERIUM ANILINI MEDIUM", "Fastidious Anaerobe Agar",
+                 "NEOMYCIN AGAR", "Nutrient broth"):
+        rows = tmc.triage_parsed([_rec(original_name=name, ingredients=[], solutions=[])], set())
+        assert rows and not rows[0]["looks_like_a_solution"], name

--- a/tests/test_missing_compositions.py
+++ b/tests/test_missing_compositions.py
@@ -3,7 +3,7 @@
 The load-bearing tests here are the two NEGATIVE ones: that `solutions` counts as
 a composition, and that a solution record naming a medium is not treated as
 repairable from that medium. Both were mistakes made while building this — the
-first inflated the count by 35, the second looked like a 214-record fix and would
+first inflated the count by 35, the second looked like a 217-record fix and would
 have written a whole medium's recipe into each solution record.
 """
 from __future__ import annotations
@@ -64,7 +64,7 @@ def test_a_real_composition_is_not_reported(tmc):
 
 
 def test_solution_named_records_are_flagged_as_mis_typed(tmc):
-    """183 of the 327 KOMODO empties are stock solutions imported as media. They
+    """162 of the 428 are stock solutions imported as media. They
     are not media missing a recipe, and counting them as such overstates the
     data-quality problem."""
     rows = tmc.triage_parsed([_rec(

--- a/tests/test_selective_agent_mismatch.py
+++ b/tests/test_selective_agent_mismatch.py
@@ -145,8 +145,8 @@ def test_corpus_count_matches_the_documented_baseline(aud, corpus):
     """
     normalized = REPO_ROOT / "data" / "normalized_yaml"
     rows = aud.audit_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
-    assert len(rows) <= 17, (
-        f"{len(rows)} records now mismatch, above the documented baseline of 17. "
+    assert len(rows) <= 2, (
+        f"{len(rows)} records now mismatch, above the documented baseline of 2. "
         "Either a new defect landed or the agent list grew — update both the gate "
         "and #181.")
 
@@ -173,3 +173,42 @@ def test_the_unit_slash_does_not_split_a_segment(aud):
     column — a regression that looked exactly like "no data available"."""
     rows = aud.audit_parsed([_rec("LB + 50 ug/ml Kanamycin medium", [])])
     assert rows[0]["named_conc"] == "kanamycin=50 ug/ml"
+
+
+# --- the slot that made 15 of 17 findings false ----------------------------
+
+
+def test_an_agent_supplied_as_a_solution_is_not_missing(aud):
+    """The correction that shrank this audit from 17 records to 2.
+
+    A stock-supplied antibiotic is a SOLUTION, not an ingredient.
+    `lb_rifampicin_medium`'s `ingredients` really are plain LB — the rifampicin
+    sits in `solutions`. Checking only `ingredients` called 15 complete records
+    defective.
+    """
+    rows = aud.audit_parsed([("x.yaml", {
+        "id": "CultureMech:1", "original_name": "LB + Rifampicin medium",
+        "ingredients": [{"preferred_term": "Yeast extract"},
+                        {"preferred_term": "NaCl"}],
+        "solutions": [{"preferred_term": "Rifampicin solution (50 mg/ml)*"}]})])
+    assert rows == [], f"agent present in `solutions` reported as missing: {rows}"
+
+
+def test_an_agent_nested_in_a_solution_composition_is_not_missing(aud):
+    rows = aud.audit_parsed([("x.yaml", {
+        "id": "CultureMech:1", "original_name": "LB + Kanamycin medium",
+        "ingredients": [{"preferred_term": "Yeast extract"}],
+        "solutions": [{"preferred_term": "Antibiotic stock",
+                       "composition": [{"preferred_term": "Kanamycin sulfate"}]}]})])
+    assert rows == []
+
+
+def test_an_agent_in_neither_slot_is_still_reported(aud):
+    """The suppression must not swallow the genuine case — DSMZ 309 has no
+    `solutions` entry and no neomycin anywhere."""
+    rows = aud.audit_parsed([("x.yaml", {
+        "id": "CultureMech:1", "original_name": "NEOMYCIN AGAR",
+        "ingredients": [{"preferred_term": "Beef extract"},
+                        {"preferred_term": "Peptone"}],
+        "solutions": []})])
+    assert len(rows) == 1 and "neomycin" in rows[0]["missing_agents"]


### PR DESCRIPTION
Both issues were overstated, for the same reason: a record's composition lives in
`ingredients` **and** `solutions`, and both measurements read only the first.

## #181 — 17 records was really 2

A stock-supplied antibiotic is recorded as a SOLUTION. `lb_rifampicin_medium`
carries `"Rifampicin solution (50 mg/ml)*"` under `solutions`; its `ingredients`
genuinely are plain LB. The audit merged in #187 checked only `ingredients` and
called **15 complete records defective**.

This matters beyond the count. The Edison probe that prompted #181 declined to
classify that medium as SELECTIVE because *"the supplied ingredient list contains
no rifampicin entry"* — accurate about the ingredient list it was handed, which is
exactly the slot the research template passes. **The record was never defective;
the view of it was partial.** My audit then reproduced the same partial view and
concluded the corpus was broken — a tool built to avoid confident wrong answers
producing one.

Found by asking whether the missing agents were recoverable from `data/raw/togo`.
Every one was there, which raised the question of why the import had dropped
them. It hadn't.

`composition_terms()` now spans `ingredients`, `solutions` and nested
`solutions[].composition`. **Baseline 17 → 2.**

The 2 survivors are both DSMZ Medium 309 via KOMODO and DSMZ. Neither has a
`solutions` entry, and the local mediadive extraction of medium 309 lacks the
neomycin too — and the agar, despite the name "NEOMYCIN AGAR". That gap is
upstream, not in this import.

## #175 — 463 records was really 428

35 carry their whole composition under `solutions`.

```
327  KOMODO ModelSEED, nothing in either slot
101  a single placeholder ingredient
```

**162 are named like a stock solution, not a medium** — "Trace element solution
(medium 929)", "Solution C, medium 1275", "10 x M9 salts". These are solutions
imported as media records, not media missing a recipe.

### The trap this report exists to document

217 of them cite a medium number resolving to a local composition file, which
looks like a large automatic fix.

`Trace element solution (medium 1072)` means the solution defined **inside**
medium 1072. And `dsmz_1072`'s composition is the whole medium — KH2PO4, MgSO4,
NH4Cl, KCl, CaCl2, Na-acetate, yeast extract, casamino acids, NaCl at 15 g/L —
including a line reading `Trace element solution (see below) 2.0ml`, which is the
part actually wanted.

Applying it would write a full medium's recipe into 217 solution records:
plausible, round-trips, validates, wrong. #166 at scale.

The dump is independently unreliable — `dsmz_929` records its `medium_name` as
"NaCl" (its first component), and `dsmz_1275` lists `"Solution A:"` as a 0.65 g
component. It is `pdf_tabular_parsing` output, not curated.

The report records that a candidate exists; **a test asserts no column proposes it
as the composition.**

Refs #181, #175.