### PR TITLE
Promote medium_type from deprecated to actively curated (#165)

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -191,6 +191,13 @@ audit-filename-collisions *args="":
 triage-missing-compositions *args="":
     uv run --extra dev python scripts/triage_missing_compositions.py {{args}}
 
+# Keep medium_type populated and derived from composition_type (#165). It is a
+# MAINTAINED axis: kgx_export emits one edge per record from it, so a missing value
+# silently drops an edge from the knowledge graph. Report-only without --apply.
+[group('Curation')]
+curate-medium-type *args="":
+    uv run --extra dev python scripts/curate_medium_type.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/curate_medium_type.py
+++ b/scripts/curate_medium_type.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Keep `medium_type` populated and derived from `composition_type` (#165).
+
+`medium_type` is a MAINTAINED compatibility axis, not a vestige. `kgx_export`
+emits one edge per record from it (`medium_to_type_edge`), so a record missing the
+slot silently contributes no type edge to the knowledge graph — no error, no
+warning, just an absent edge among ~11,092. `browser_export` publishes it as a
+field. Keeping it correct is therefore curation work, not tidying.
+
+## The derivation
+
+The mapping is READ FROM THE SCHEMA, not hardcoded here. Each `MediumTypeEnum`
+value documents its own relationship to the composition axis ("Migrates to
+composition_type=UNDEFINED"), and this script inverts that:
+
+    composition_type=DEFINED       -> medium_type=DEFINED
+    composition_type=UNDEFINED     -> medium_type=COMPLEX
+    composition_type=SEMI_DEFINED  -> medium_type=COMPLEX
+
+SEMI_DEFINED is #171's refinement of UNDEFINED; the single-valued slot cannot
+express it, so it collapses to COMPLEX. That is a real loss of resolution, and it
+is the reason composition_type — not this slot — is the primary axis for curation.
+
+## What is NOT derived
+
+`BUFFER` and `NEGATIVE_CONTROL` have no composition_type counterpart:
+`specialized/pbs.yaml` and `specialized/water.yaml` carry no composition_type at
+all, and MediumFunctionalRoleEnum has no such values. They are curated directly
+and this script leaves them alone. Deriving over them would erase the only
+classification those records have.
+
+Report-only by default. `--apply` writes, and only ever writes the derived value
+onto records that are missing it or contradict the schema mapping.
+
+Usage::
+
+    just curate-medium-type              # report drift
+    just curate-medium-type --apply      # stamp it
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import is_solution_record  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+SCHEMA = REPO / "src" / "culturemech" / "schema" / "culturemech.yaml"
+
+# Values curated directly rather than derived — they describe what the record is
+# FOR, which the composition axis does not capture.
+DIRECTLY_CURATED = frozenset({"BUFFER", "NEGATIVE_CONTROL"})
+
+
+def schema_mapping(schema_path: Path = SCHEMA) -> dict[str, str]:
+    """medium_type -> composition_type, parsed from the schema's own prose."""
+    doc = yaml.safe_load(schema_path.read_text())
+    pv = doc["enums"]["MediumTypeEnum"]["permissible_values"]
+    out: dict[str, str] = {}
+    for name, body in pv.items():
+        m = re.search(r"Migrates to composition_type=(\w+)",
+                      str((body or {}).get("description") or ""))
+        if m:
+            out[name] = m.group(1)
+    return out
+
+
+def inverse_mapping(mapping: dict[str, str]) -> dict[str, str]:
+    """composition_type -> the medium_type to stamp.
+
+    Several composition values collapse onto one medium_type (UNDEFINED and
+    SEMI_DEFINED both give COMPLEX), so the inverse is many-to-one. SEMI_DEFINED is
+    added explicitly because the schema does not state it: it postdates this enum.
+    """
+    inv = {v: k for k, v in mapping.items()}
+    if "UNDEFINED" in inv:
+        inv.setdefault("SEMI_DEFINED", inv["UNDEFINED"])
+    return inv
+
+
+def expected_medium_type(doc: dict[str, Any], inv: dict[str, str]) -> str | None:
+    ct = doc.get("composition_type")
+    return inv.get(str(ct)) if ct else None
+
+
+def assess(doc: dict[str, Any], mapping: dict[str, str], inv: dict[str, str]) -> str | None:
+    """Return the reason this record needs stamping, or None when it is correct."""
+    current = doc.get("medium_type")
+    if current is not None and str(current) in DIRECTLY_CURATED:
+        return None
+    want = expected_medium_type(doc, inv)
+    if want is None:
+        # No composition_type to derive from. Only a problem if the slot is empty
+        # too — otherwise the record is curated directly, like pbs/water.
+        return "no composition_type and no medium_type" if current is None else None
+    if current is None:
+        return f"missing; composition_type={doc.get('composition_type')} -> {want}"
+    expected_composition = mapping.get(str(current))
+    ct = str(doc.get("composition_type"))
+    if expected_composition is None:
+        return None
+    if ct == expected_composition or (expected_composition == "UNDEFINED"
+                                      and ct == "SEMI_DEFINED"):
+        return None
+    return f"{current} contradicts composition_type={ct} -> {want}"
+
+
+def scan(normalized: Path, mapping: dict[str, str], inv: dict[str, str]
+         ) -> list[tuple[Path, dict[str, Any], str, str | None]]:
+    out = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        reason = assess(doc, mapping, inv)
+        if reason:
+            out.append((path, doc, reason, expected_medium_type(doc, inv)))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--schema", type=Path, default=SCHEMA)
+    ap.add_argument("--apply", action="store_true",
+                    help="Write the derived medium_type. Default is report-only.")
+    args = ap.parse_args(argv)
+
+    mapping = schema_mapping(args.schema)
+    if not mapping:
+        print("No 'Migrates to composition_type=' found in the schema; refusing to "
+              "guess a mapping.", file=sys.stderr)
+        return 1
+    inv = inverse_mapping(mapping)
+    print(f"Derivation (from the schema): "
+          f"{', '.join(f'{k}->{v}' for k, v in sorted(inv.items()))}")
+    print(f"Curated directly, never derived: {', '.join(sorted(DIRECTLY_CURATED))}\n")
+
+    drift = scan(args.normalized_dir, mapping, inv)
+    if not drift:
+        print("All records populated and consistent with composition_type.")
+        return 0
+
+    print(f"{len(drift)} record(s) need attention:")
+    for path, _doc, reason, _want in drift[:40]:
+        print(f"  {str(path.relative_to(args.normalized_dir))[:52]:54s} {reason}")
+    if len(drift) > 40:
+        print(f"  ... and {len(drift) - 40} more")
+
+    if not args.apply:
+        print("\nReport only. Re-run with --apply to stamp the derived value.")
+        return 0
+
+    written = 0
+    for path, _doc, _reason, want in drift:
+        if want is None:
+            continue  # nothing to derive from; needs a curator, not a script
+        text = path.read_text()
+        if re.search(r"^medium_type:.*$", text, re.M):
+            new = re.sub(r"^medium_type:.*$", f"medium_type: {want}", text, count=1, flags=re.M)
+        else:
+            # Insert after composition_type so the two axes read together.
+            new, n = re.subn(r"^(composition_type:.*)$", rf"\1\nmedium_type: {want}",
+                             text, count=1, flags=re.M)
+            if not n:
+                print(f"  SKIP {path.name}: no anchor to insert after", file=sys.stderr)
+                continue
+        if new != text:
+            path.write_text(new)
+            written += 1
+    print(f"\nStamped {written} record(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_medium_type_axes.py
+++ b/scripts/migrate_medium_type_axes.py
@@ -1,4 +1,4 @@
-"""Backfill the multi-axis media-type vocabulary from the deprecated medium_type slot.
+"""Backfill the multi-axis media-type vocabulary from the single-valued medium_type slot.
 
 medium_type (MediumTypeEnum) conflated three orthogonal properties into one
 single-valued slot. This migration derives the new axis slots from it without
@@ -221,7 +221,7 @@ def main(argv: list[str] | None = None) -> int:
                     doc,
                     curator=CURATOR,
                     action="Backfilled multi-axis media type",
-                    notes="Derived " + "; ".join(notes) + " from deprecated medium_type="
+                    notes="Derived " + "; ".join(notes) + " from medium_type="
                     + str(mt) + ".",
                 )
                 write_yaml(path, doc)

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -252,11 +252,16 @@ classes:
 
       medium_type:
         description: >-
-          DEPRECATED single-axis classification. Superseded by composition_type,
-          nutritional_class, and functional_role. Retained for backward compatibility;
-          do not populate on new records.
+          MAINTAINED compatibility axis, derived from composition_type. It is the
+          single-valued classification published to downstream consumers: kgx_export
+          emits one edge per record from this slot, so it is load-bearing rather than
+          vestigial. Populate it on every record, and keep it consistent with
+          composition_type — DEFINED maps to DEFINED, UNDEFINED and SEMI_DEFINED both
+          map to COMPLEX. BUFFER and NEGATIVE_CONTROL have no composition_type
+          counterpart and are curated directly. Use `just curate-medium-type` to stamp
+          it; a guard fails the build if any record is missing it or contradicts
+          composition_type.
         range: MediumTypeEnum
-        deprecated: Use composition_type / nutritional_class / functional_role instead.
 
       composition_type:
         description: >-
@@ -2109,13 +2114,16 @@ classes:
 enums:
   MediumTypeEnum:
     description: >-
-      DEPRECATED single-axis classification of culture medium. It conflated three
-      orthogonal properties (composition, nutritional level, functional role) into one
-      single-valued slot. Superseded by MediumCompositionTypeEnum (composition_type),
-      MediumNutritionalClassEnum (nutritional_class), and MediumFunctionalRoleEnum
-      (functional_role). Retained for backward compatibility; populate the three axis
-      slots on new and migrated records instead.
-    deprecated: Use composition_type / nutritional_class / functional_role instead.
+      Single-axis classification of culture medium, MAINTAINED alongside the three
+      orthogonal axes rather than replaced by them. It conflates composition,
+      nutritional level and functional role into one slot, which is why
+      MediumCompositionTypeEnum (composition_type), MediumNutritionalClassEnum
+      (nutritional_class) and MediumFunctionalRoleEnum (functional_role) exist and
+      are the primary axes for new curation. This enum remains the published
+      single-valued view: populate BOTH, and keep this slot derived from
+      composition_type. The per-value "Migrates to" notes below define that
+      derivation and are parsed by the consistency guard, so they are load-bearing
+      documentation rather than historical commentary.
     permissible_values:
       DEFINED:
         description: Chemically defined medium with known composition. Migrates to

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -2162,8 +2162,9 @@ enums:
         meaning: NCIT:C64372
       UNDEFINED:
         description: Medium containing one or more chemically undefined components (e.g.
-          yeast extract, peptone, casamino acids, tissue or plant extracts). Replaces the
-          deprecated MediumTypeEnum value COMPLEX. Synonyms —complex.
+          yeast extract, peptone, casamino acids, tissue or plant extracts). Multi-axis
+          counterpart of MediumTypeEnum value COMPLEX, which remains maintained
+          and derived from this slot. Synonyms —complex.
         meaning: NCIT:C64371
       SEMI_DEFINED:
         description: Predominantly defined medium supplemented with a small amount of one

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-30T21:23:00
+# Generation date: 2026-08-04T18:26:13
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -2583,11 +2583,13 @@ class Dataset(YAMLRoot):
 # Enumerations
 class MediumTypeEnum(EnumDefinitionImpl):
     """
-    DEPRECATED single-axis classification of culture medium. It conflated three orthogonal properties (composition,
-    nutritional level, functional role) into one single-valued slot. Superseded by MediumCompositionTypeEnum
-    (composition_type), MediumNutritionalClassEnum (nutritional_class), and MediumFunctionalRoleEnum
-    (functional_role). Retained for backward compatibility; populate the three axis slots on new and migrated records
-    instead.
+    Single-axis classification of culture medium, MAINTAINED alongside the three orthogonal axes rather than replaced
+    by them. It conflates composition, nutritional level and functional role into one slot, which is why
+    MediumCompositionTypeEnum (composition_type), MediumNutritionalClassEnum (nutritional_class) and
+    MediumFunctionalRoleEnum (functional_role) exist and are the primary axes for new curation. This enum remains the
+    published single-valued view: populate BOTH, and keep this slot derived from composition_type. The per-value
+    "Migrates to" notes below define that derivation and are parsed by the consistency guard, so they are load-bearing
+    documentation rather than historical commentary.
     """
     DEFINED = PermissibleValue(
         text="DEFINED",
@@ -2618,7 +2620,7 @@ class MediumTypeEnum(EnumDefinitionImpl):
 
     _defn = EnumDefinition(
         name="MediumTypeEnum",
-        description="""DEPRECATED single-axis classification of culture medium. It conflated three orthogonal properties (composition, nutritional level, functional role) into one single-valued slot. Superseded by MediumCompositionTypeEnum (composition_type), MediumNutritionalClassEnum (nutritional_class), and MediumFunctionalRoleEnum (functional_role). Retained for backward compatibility; populate the three axis slots on new and migrated records instead.""",
+        description="""Single-axis classification of culture medium, MAINTAINED alongside the three orthogonal axes rather than replaced by them. It conflates composition, nutritional level and functional role into one slot, which is why MediumCompositionTypeEnum (composition_type), MediumNutritionalClassEnum (nutritional_class) and MediumFunctionalRoleEnum (functional_role) exist and are the primary axes for new curation. This enum remains the published single-valued view: populate BOTH, and keep this slot derived from composition_type. The per-value \"Migrates to\" notes below define that derivation and are parsed by the consistency guard, so they are load-bearing documentation rather than historical commentary.""",
     )
 
 class MediumCompositionTypeEnum(EnumDefinitionImpl):

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T18:26:13
+# Generation date: 2026-08-04T18:41:17
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -2634,7 +2634,7 @@ class MediumCompositionTypeEnum(EnumDefinitionImpl):
         meaning=NCIT["C64372"])
     UNDEFINED = PermissibleValue(
         text="UNDEFINED",
-        description="""Medium containing one or more chemically undefined components (e.g. yeast extract, peptone, casamino acids, tissue or plant extracts). Replaces the deprecated MediumTypeEnum value COMPLEX. Synonyms —complex.""",
+        description="""Medium containing one or more chemically undefined components (e.g. yeast extract, peptone, casamino acids, tissue or plant extracts). Multi-axis counterpart of MediumTypeEnum value COMPLEX, which remains maintained and derived from this slot. Synonyms —complex.""",
         meaning=NCIT["C64371"])
     SEMI_DEFINED = PermissibleValue(
         text="SEMI_DEFINED",

--- a/tests/test_composition_type.py
+++ b/tests/test_composition_type.py
@@ -135,21 +135,24 @@ def test_no_defined_record_carries_a_bulk_undefined_component(act, media_records
 
 
 def test_medium_type_and_composition_type_do_not_contradict(media_records):
-    """The deprecated slot must not disagree with the live one (#165).
+    """The two axes must not disagree (#165).
 
-    `medium_type` is deprecated and #154 removed its last reader, but it is still
-    present on 11,092 records and still schema-valid, so a reader could pick it
-    up. Restamping only `composition_type` in #164 broke this invariant on 239
-    records — 0 disagreements before, 239 after — which is how this test came to
-    exist.
+    `medium_type` is a MAINTAINED compatibility axis, not a vestige. An earlier
+    version of this docstring said it was deprecated and that #154 had removed its
+    last reader; both were wrong, and that claim is what led #165 to propose
+    deleting the slot. `kgx_export` emits one edge per record from it
+    (`medium_to_type_edge`), and browser_export, umap_generator, dsmz_resolver and
+    multi_database_crossref all read it.
 
-    Mapping is the schema's own: `composition_type: UNDEFINED` "replaces the
-    deprecated MediumTypeEnum value COMPLEX".
+    Restamping only `composition_type` in #164 broke this invariant on 239 records
+    — 0 disagreements before, 239 after — which is how this test came to exist.
+    `just curate-medium-type` now keeps the derivation, and
+    tests/test_medium_type_consistency.py holds the fuller guard.
 
-    Dropping `medium_type` from the corpus entirely is the better long-term fix
-    and is tracked in #165; this only holds the line until then.
+    Mapping is the schema's own: `composition_type: UNDEFINED` is the multi-axis
+    counterpart of `MediumTypeEnum: COMPLEX`.
     """
-    # The deprecated vocabulary is COARSER than the live one: it has no
+    # The single-valued vocabulary is COARSER than the multi-axis one: it has no
     # SEMI_DEFINED. A record that is SEMI_DEFINED today was legitimately COMPLEX
     # under the old single-axis enum, because COMPLEX meant "contains an undefined
     # component" and a SEMI_DEFINED medium does. So COMPLEX maps to a SET.
@@ -167,7 +170,7 @@ def test_medium_type_and_composition_type_do_not_contradict(media_records):
         if str(ct) not in expect.get(str(mt), {str(mt)}):
             bad.append(f"{path.name}: medium_type={mt} composition_type={ct}")
     assert not bad, (
-        f"{len(bad)} record(s) have a deprecated medium_type contradicting "
+        f"{len(bad)} record(s) have a medium_type contradicting "
         f"composition_type (e.g. {bad[:3]}) — see #165"
     )
 

--- a/tests/test_curate_medium_type.py
+++ b/tests/test_curate_medium_type.py
@@ -1,0 +1,115 @@
+"""Tests for the medium_type curator (#165).
+
+`medium_type` is a maintained axis: kgx_export emits one edge per record from it,
+so a missing or wrong value is invisible in every artifact until someone counts
+edges. These pin the derivation, and — more carefully — pin what the curator must
+NOT touch.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cmt():
+    return _load("curate_medium_type")
+
+
+@pytest.fixture(scope="module")
+def maps(cmt):
+    m = cmt.schema_mapping()
+    return m, cmt.inverse_mapping(m)
+
+
+def test_the_derivation_comes_from_the_schema(maps):
+    """Hardcoding a second copy of the mapping is how the slots disagreed in #164."""
+    mapping, inv = maps
+    assert mapping["DEFINED"] == "DEFINED" and mapping["COMPLEX"] == "UNDEFINED"
+    assert inv["DEFINED"] == "DEFINED"
+    assert inv["UNDEFINED"] == "COMPLEX"
+
+
+def test_semi_defined_collapses_to_complex(maps):
+    """#171's refinement has no single-valued equivalent. Recording the collapse is
+    the point: it is why composition_type, not this slot, is the primary axis."""
+    _, inv = maps
+    assert inv["SEMI_DEFINED"] == "COMPLEX"
+
+
+def test_a_missing_value_is_reported(cmt, maps):
+    mapping, inv = maps
+    assert cmt.assess({"composition_type": "UNDEFINED"}, mapping, inv)
+
+
+def test_a_contradiction_is_reported(cmt, maps):
+    mapping, inv = maps
+    r = cmt.assess({"composition_type": "DEFINED", "medium_type": "COMPLEX"}, mapping, inv)
+    assert r and "contradicts" in r
+
+
+@pytest.mark.parametrize("ct,mt", [("DEFINED", "DEFINED"), ("UNDEFINED", "COMPLEX"),
+                                   ("SEMI_DEFINED", "COMPLEX")])
+def test_a_correct_record_is_left_alone(cmt, maps, ct, mt):
+    mapping, inv = maps
+    assert cmt.assess({"composition_type": ct, "medium_type": mt}, mapping, inv) is None
+
+
+@pytest.mark.parametrize("value", ["BUFFER", "NEGATIVE_CONTROL"])
+def test_directly_curated_values_are_never_derived_over(cmt, maps, value):
+    """pbs.yaml and water.yaml have NO composition_type, so a deriver that ignored
+    this would overwrite the only classification they carry — losing information
+    while appearing to tidy up."""
+    mapping, inv = maps
+    assert cmt.assess({"medium_type": value}, mapping, inv) is None
+    assert cmt.assess({"medium_type": value, "composition_type": None}, mapping, inv) is None
+
+
+def test_a_record_with_neither_axis_is_reported_not_guessed(cmt, maps):
+    mapping, inv = maps
+    r = cmt.assess({"name": "x"}, mapping, inv)
+    assert r and "no composition_type" in r
+
+
+def test_apply_stamps_missing_and_fixes_contradictions(cmt, tmp_path):
+    d = tmp_path / "bacterial"
+    d.mkdir(parents=True)
+    (d / "a.yaml").write_text("id: CultureMech:1\nname: a\ncomposition_type: UNDEFINED\n")
+    (d / "b.yaml").write_text(
+        "id: CultureMech:2\nname: b\ncomposition_type: DEFINED\nmedium_type: COMPLEX\n")
+    assert cmt.main(["--normalized-dir", str(d.parent), "--apply"]) == 0
+    assert yaml.safe_load((d / "a.yaml").read_text())["medium_type"] == "COMPLEX"
+    assert yaml.safe_load((d / "b.yaml").read_text())["medium_type"] == "DEFINED"
+
+
+def test_report_only_by_default(cmt, tmp_path):
+    """The default must not write. A curator that edits on a bare invocation is how
+    20 records got false chemistry in #166."""
+    d = tmp_path / "bacterial"
+    d.mkdir(parents=True)
+    before = "id: CultureMech:1\nname: a\ncomposition_type: UNDEFINED\n"
+    (d / "a.yaml").write_text(before)
+    assert cmt.main(["--normalized-dir", str(d.parent)]) == 0
+    assert (d / "a.yaml").read_text() == before
+
+
+def test_the_corpus_needs_no_stamping(cmt, maps):
+    """If this fails, `just curate-medium-type --apply` was not run before commit."""
+    mapping, inv = maps
+    drift = cmt.scan(REPO_ROOT / "data" / "normalized_yaml", mapping, inv)
+    assert not drift, f"{len(drift)} records drifted, e.g. {[str(p) for p,_,_,_ in drift[:5]]}"

--- a/tests/test_medium_type_consistency.py
+++ b/tests/test_medium_type_consistency.py
@@ -151,11 +151,27 @@ def test_every_medium_type_value_in_use_has_a_successor_slot(media_records, sche
         "Extend MediumFunctionalRoleEnum before adding more.")
 
 
-def test_no_new_record_populates_the_deprecated_slot_without_the_new_one(media_records):
-    """`medium_type` is documented "do not populate on new records". A record with
-    the deprecated slot and no `composition_type` is a regression in the importer,
-    not merely untidy — the axis slots are what everything downstream reads."""
-    bad = [p.name for p, d in media_records
-           if d.get("medium_type") is not None and d.get("composition_type") is None]
-    assert len(bad) <= 2, (
-        f"{len(bad)} records carry medium_type but no composition_type: {bad[:10]}")
+def test_every_media_record_carries_a_medium_type(media_records):
+    """`medium_type` is a MAINTAINED axis, not a vestige (#165).
+
+    kgx_export emits one edge per record from this slot, so a record missing it
+    contributes no type edge to the knowledge graph — silently, among ~11,092. That
+    is why this asserts presence rather than merely consistency: an absent value is
+    invisible in every downstream artifact until someone counts edges.
+
+    Stamp with `just curate-medium-type --apply`.
+    """
+    missing = [p.name for p, d in media_records if d.get("medium_type") is None]
+    assert not missing, (
+        f"{len(missing)} media records have no medium_type: {missing[:10]}. "
+        "Run `just curate-medium-type --apply`.")
+
+
+def test_a_record_has_either_a_composition_type_or_a_directly_curated_value(media_records):
+    """The two records with no composition_type are BUFFER and NEGATIVE_CONTROL,
+    curated directly because the composition axis cannot express them. A third
+    record in that state is an importer regression."""
+    stranded = [p.name for p, d in media_records
+                if d.get("composition_type") is None
+                and str(d.get("medium_type")) not in {"BUFFER", "NEGATIVE_CONTROL"}]
+    assert not stranded, f"records with neither axis populated: {stranded[:10]}"


### PR DESCRIPTION
Implements the decision to **keep `medium_type` and maintain it**, rather than
drop it.

## Why the schema was wrong

#195 established that dropping the slot would delete ~11,092 edges from the KGX
export (`kgx_export` emits one per record via `medium_to_type_edge`) and strip the
only classification from `pbs.yaml` and `water.yaml`.

A field that load-bearing should not carry `deprecated:` and the instruction
*"do not populate on new records"*. The schema was telling curators to starve a
slot the knowledge graph depends on — which is how it ended up contradicting
`composition_type` on 239 records in the first place.

## Changes

**Schema.** Removed `deprecated:` from both the slot and `MediumTypeEnum`, and
rewrote both descriptions to state what is true now: a maintained single-valued
view, derived from `composition_type`, published downstream. The per-value
"Migrates to" notes are documented as **load-bearing** — the guard and the curator
both parse them, so rewording them breaks tooling.

**`just curate-medium-type`.** Keeps the slot derived:

```
composition_type=DEFINED       -> DEFINED
composition_type=UNDEFINED     -> COMPLEX
composition_type=SEMI_DEFINED  -> COMPLEX
```

The mapping is **read from the schema and inverted**, never hardcoded — a second
copy is exactly how the slots came to disagree in #164.

`SEMI_DEFINED` collapsing to `COMPLEX` is a genuine loss of resolution. That is
recorded in the docstring rather than glossed, because it is the reason
`composition_type` remains the primary axis for curation.

`BUFFER` and `NEGATIVE_CONTROL` are **never derived over**. Those records have no
`composition_type` at all, so a deriver that ignored them would erase their only
classification while appearing to tidy up.

**Report-only by default.** `--apply` writes. Canaried on synthetic records before
trusting it — a missing value is inserted after `composition_type`, a
contradiction is corrected.

## State

```
11,094 / 11,094 populated
0 contradictions
--apply is currently a no-op
```

## Guards

Presence is now asserted, not just consistency: a record missing the slot
contributes no type edge to the KG, silently, among ~11,092. A further test
asserts the corpus needs no stamping, so drift fails the build instead of
accumulating.

25 tests across the two files.

Closes #165.