### PR TITLE
Re-type 202 stock solutions imported as media records (#175)

### DIFF
--- a/data/import_tracking/reports/missing_compositions.tsv
+++ b/data/import_tracking/reports/missing_compositions.tsv
@@ -12,17 +12,9 @@ archaea/methanosarcina_frisia_medium.yaml	CultureMech:005072	METHANOSARCINA FRIS
 archaea/methanosarcina_thermophilic_medium.yaml	CultureMech:004191	METHANOSARCINA (thermophilic) medium	no ingredients and no solutions	KOMODO ModelSEED			
 archaea/methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119.yaml	CultureMech:004190	METHANOSARCINA (thermophilic) medium_replace_Rumen fluid, clarified_with_Sludge fluid (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
 archaea/thermophilic_methanosaeta_medium.yaml	CultureMech:005164	THERMOPHILIC METHANOSAETA MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/100x_vitamin_solution_medium_1398.yaml	CultureMech:004994	100x Vitamin solution (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED	yes	1398	yes
-bacterial/10_x_m9_salts.yaml	CultureMech:004267	10 x M9 salts	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/4_times_concentrated_sea_water_medium_821.yaml	CultureMech:004993	4 times concentrated sea water (medium 821)	no ingredients and no solutions	KOMODO ModelSEED		821	yes
-bacterial/50_x_pye.yaml	CultureMech:006514	50 x PYE	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/50x_heterotrophic_basal_salts_solution_medium_1190.yaml	CultureMech:004779	50x Heterotrophic basal salts solution (medium 1190)	no ingredients and no solutions	KOMODO ModelSEED	yes	1190	yes
 bacterial/KOMODO_1254_NAUTILIA_NITRATIREDUCENS_MEDIUM.yaml	CultureMech:004015	NAUTILIA NITRATIREDUCENS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/KOMODO_272_DESULFOVIBRIO_medium_choline.yaml	CultureMech:004700	DESULFOVIBRIO medium (choline)	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/KOMODO_3018_H3P-Vitamin_solution_medium_428.yaml	CultureMech:004797	H3P-Vitamin solution (medium 428)	no ingredients and no solutions	KOMODO ModelSEED	yes	428	yes
-bacterial/KOMODO_3071_Trace_element_solution_medium_155.yaml	CultureMech:004857	Trace element solution (medium 155)	no ingredients and no solutions	KOMODO ModelSEED	yes	155	yes
-bacterial/KOMODO_3077_Trace_element_solution_medium_84.yaml	CultureMech:004863	Trace element solution (medium 84)	no ingredients and no solutions	KOMODO ModelSEED	yes	84	yes
-bacterial/KOMODO_3087_Trace_element_solution_SL-8.yaml	CultureMech:004873	Trace element solution SL-8	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml	CultureMech:004984	Fastidious Anaerobe Agar	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/KOMODO_7001_Trace_elements_medium_596.yaml	CultureMech:006327	Trace elements (medium 596)	no ingredients and no solutions	KOMODO ModelSEED		596	yes
 bacterial/KOMODO_787_ACETOBACTERIUM_DEHALOGENANS_medium.yaml	CultureMech:006488	ACETOBACTERIUM DEHALOGENANS medium	no ingredients and no solutions	KOMODO ModelSEED			
@@ -30,13 +22,11 @@ bacterial/acetobacterium_2_medium.yaml	CultureMech:005062	ACETOBACTERIUM 2 mediu
 bacterial/acetobacterium_carbinolicum_medium.yaml	CultureMech:004988	ACETOBACTERIUM CARBINOLICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/acetobacterium_sp_komac1_medium.yaml	CultureMech:005592	ACETOBACTERIUM SP. KoMAc1 medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/acetonema_medium.yaml	CultureMech:005871	ACETONEMA medium	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/amino_acid_solution_medium_78.yaml	CultureMech:004780	Amino acid solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED	yes	78	yes
 bacterial/anaerobic_acetoin_medium.yaml	CultureMech:005020	ANAEROBIC ACETOIN medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/anaerobic_oxalate_medium.yaml	CultureMech:005624	ANAEROBIC OXALATE MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/anaerovibrio_burkinabensis_medium.yaml	CultureMech:006022	ANAEROVIBRIO BURKINABENSIS medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml	CultureMech:004785	Artificial sea water, 3 times concentrated (medium 1137)	no ingredients and no solutions	KOMODO ModelSEED		1137	yes
 bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml	CultureMech:004389	Artificial sea water, 3 times concentrated (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
-bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml	CultureMech:005655	Artificial sea water from a marine aquarium salts mixture	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/artificial_sea_water_medium_1075.yaml	CultureMech:004783	Artificial sea water (medium 1075)	no ingredients and no solutions	KOMODO ModelSEED		1075	yes
 bacterial/artificial_sea_water_medium_246.yaml	CultureMech:004996	Artificial sea water (medium 246)	no ingredients and no solutions	KOMODO ModelSEED		246	yes
 bacterial/artificial_sea_water_medium_343.yaml	CultureMech:004782	Artificial sea water (medium 343)	no ingredients and no solutions	KOMODO ModelSEED		343	yes
@@ -49,20 +39,16 @@ bacterial/artificial_seawater_medium_1326.yaml	CultureMech:004787	Artificial sea
 bacterial/artificial_tap_water_medium_1167.yaml	CultureMech:004789	Artificial tap water (medium 1167)	no ingredients and no solutions	KOMODO ModelSEED		1167	yes
 bacterial/bacto_middelbrook_7h11_agar_medium_911.yaml	CultureMech:004790	Bacto Middelbrook 7H11 agar (medium 911)	no ingredients and no solutions	KOMODO ModelSEED		911	yes
 bacterial/bacto_middelbrook_oadc_enrichment_medium_911.yaml	CultureMech:004791	Bacto Middelbrook OADC enrichment (medium 911)	no ingredients and no solutions	KOMODO ModelSEED		911	yes
-bacterial/basal_salts_solution_medium_791.yaml	CultureMech:004792	Basal salts solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
 bacterial/bbl_actinomyces_broth_medium_1029.yaml	CultureMech:004983	BBL Actinomyces broth (medium 1029)	no ingredients and no solutions	KOMODO ModelSEED		1029	yes
 bacterial/blood_agar_base_from_difco_0045.yaml	CultureMech:006515	Blood Agar Base from Difco 0045	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/blood_agar_no_2_oxoid.yaml	CultureMech:006086	blood agar No 2 (Oxoid)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/bordet_gengou_agar_base.yaml	CultureMech:005645	Bordet-Gengou-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/brucella_broth_becton_dickinson.yaml	CultureMech:005646	Brucella Broth (Becton Dickinson)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/casman_agar_base.yaml	CultureMech:005647	Casman-Agar-Base	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/chelated_iron_solution_medium_737.yaml	CultureMech:004268	Chelated iron solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED	yes	737	yes
-bacterial/chelated_iron_solution_medium_748.yaml	CultureMech:004793	Chelated Iron solution (medium 748)	no ingredients and no solutions	KOMODO ModelSEED	yes	748	yes
 bacterial/clostridium_estertheticum_medium.yaml	CultureMech:006182	CLOSTRIDIUM ESTERTHETICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/clostridium_longisporum_medium.yaml	CultureMech:006392	CLOSTRIDIUM LONGISPORUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/clostridium_neopropionicum_medium.yaml	CultureMech:005884	CLOSTRIDIUM NEOPROPIONICUM medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml	CultureMech:005648	CMRL-1066 medium (10x concentrated; GIBCO)	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/co_factors_solution_medium_843.yaml	CultureMech:006083	Co-factors solution (medium 843)	no ingredients and no solutions	KOMODO ModelSEED	yes	843	yes
 bacterial/columbia_agar_base.yaml	CultureMech:005649	Columbia agar base	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/corn_meal_agar_oxoid_cm103.yaml	CultureMech:005651	Corn meal Agar (Oxoid CM103)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/czapek_dox_agar_merck.yaml	CultureMech:005643	Czapek Dox agar (Merck)	no ingredients and no solutions	KOMODO ModelSEED			
@@ -85,24 +71,14 @@ bacterial/desulfovibrio_shv_medium.yaml	CultureMech:006368	DESULFOVIBRIO SHV MED
 bacterial/desulfovibrio_sp_medium.yaml	CultureMech:004276	DESULFOVIBRIO SP. MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/dmj_synthetic_seawater_medium_997.yaml	CultureMech:004270	DMJ synthetic seawater (medium 997)	no ingredients and no solutions	KOMODO ModelSEED		997	yes
 bacterial/dsm_4156_b_and_dsm_4156.yaml	CultureMech:005229	DSM 4156 B and DSM 4156	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/fatty_acid_mixture_medium_119.yaml	CultureMech:004794	Fatty acid mixture (medium 119)	no ingredients and no solutions	KOMODO ModelSEED	yes	119	yes
-bacterial/fatty_acid_mixture_medium_328.yaml	CultureMech:004795	Fatty acid mixture (medium 328)	no ingredients and no solutions	KOMODO ModelSEED	yes	328	yes
-bacterial/fatty_acid_mixture_medium_436.yaml	CultureMech:004796	Fatty acid mixture (medium 436)	no ingredients and no solutions	KOMODO ModelSEED	yes	436	yes
-bacterial/ferric_quinate_solution_medium_380.yaml	CultureMech:004272	Ferric Quinate Solution (medium 380)	no ingredients and no solutions	KOMODO ModelSEED	yes	380	yes
 bacterial/for_dsm_2805.yaml	CultureMech:004855	For DSM 2805	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_dsm_3246.yaml	CultureMech:005056	For DSM 3246	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_dsm_3247.yaml	CultureMech:005055	For DSM 3247	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_s_buswellii_dsm_2612m.yaml	CultureMech:006276	For S. buswellii DSM 2612M	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/for_s_wolinii_dsm_2805m.yaml	CultureMech:006277	For S. wolinii DSM 2805M	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/glutarate_medium.yaml	CultureMech:006014	GLUTARATE medium	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/h3p_vitamin_solution_medium_428.yaml	CultureMech:004397	H3P-vitamin solution (medium 428)	no ingredients and no solutions	KOMODO ModelSEED	yes	428	yes
-bacterial/haemin_solution_medium_104.yaml	CultureMech:004798	Haemin solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
-bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml	CultureMech:004800	Hank's balanced salt solution (BSS, medium 1078)	no ingredients and no solutions	KOMODO ModelSEED	yes	1078	yes
-bacterial/heavy_metal_solution_medium_867.yaml	CultureMech:004273	Heavy metal solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
 bacterial/ilyobacter_tartaricus_medium.yaml	CultureMech:004761	ILYOBACTER TARTARICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/inorganic_salt_solution_medium_754.yaml	CultureMech:004801	Inorganic salt solution (medium 754)	no ingredients and no solutions	KOMODO ModelSEED	yes	754	yes
 bacterial/isovitalex.yaml	CultureMech:005642	Isovitalex	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/lip_solution_medium_391.yaml	CultureMech:004802	LIP-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
 bacterial/mab1_medium.yaml	CultureMech:006272	mAB1-MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml	CultureMech:004803	Marine-Medium/Synthetic seawater-mix (medium 611)	no ingredients and no solutions	KOMODO ModelSEED		611	yes
 bacterial/marine_trace_elements_medium_511.yaml	CultureMech:004274	Marine trace elements (medium 511)	no ingredients and no solutions	KOMODO ModelSEED		511	yes
@@ -111,33 +87,11 @@ bacterial/medium_777_modified_for_dsm_14980.yaml	CultureMech:006434	MEDIUM 777 M
 bacterial/medium_820_modified_for_dsm_16960.yaml	CultureMech:006546	MEDIUM 820 MODIFIED FOR DSM 16960	no ingredients and no solutions	KOMODO ModelSEED		820	
 bacterial/medium_md1_medium_9.yaml	CultureMech:004986	medium MD1 (medium 9)	no ingredients and no solutions	KOMODO ModelSEED		9	yes
 bacterial/metals_44_medium_590.yaml	CultureMech:004393	Metals 44 (medium 590)	no ingredients and no solutions	KOMODO ModelSEED		590	yes
-bacterial/micronutrient_solution_sl8_medium_1128.yaml	CultureMech:004804	Micronutrient solution SL8 (medium 1128)	no ingredients and no solutions	KOMODO ModelSEED	yes	1128	yes
 bacterial/middlebrook_7h10_agar.yaml	CultureMech:004805	Middlebrook 7H10 agar	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/min_e_base_10x.yaml	CultureMech:004275	MIN E - Base (10x)	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/mineral_mix_medium_1001.yaml	CultureMech:004277	Mineral Mix (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED		1001	yes
-bacterial/mineral_salt_solution_2xw_medium_391.yaml	CultureMech:004806	"Mineral salt solution ""2xW"" (medium 391)"	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
-bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml	CultureMech:004987	Mineral salts solution for liquid medium (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
-bacterial/mineral_salts_solution_for_solid_medium_medium_1396.yaml	CultureMech:004989	Mineral salts solution for solid medium (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
-bacterial/mineral_solution_1_medium_165.yaml	CultureMech:004278	Mineral solution 1 (medium 165)	no ingredients and no solutions	KOMODO ModelSEED	yes	165	yes
-bacterial/mineral_solution_2_medium_1033.yaml	CultureMech:004815	Mineral solution 2 (medium 1033)	no ingredients and no solutions	KOMODO ModelSEED	yes	1033	yes
-bacterial/mineral_solution_2_medium_165.yaml	CultureMech:004279	Mineral solution 2 (medium 165)	no ingredients and no solutions	KOMODO ModelSEED	yes	165	yes
-bacterial/mineral_solution_2_medium_203.yaml	CultureMech:004997	Mineral solution 2 (medium 203)	no ingredients and no solutions	KOMODO ModelSEED	yes	203	yes
-bacterial/mineral_solution_2_medium_404.yaml	CultureMech:004816	Mineral solution 2 (medium 404)	no ingredients and no solutions	KOMODO ModelSEED	yes	404	yes
-bacterial/mineral_solution_2_medium_436.yaml	CultureMech:004817	Mineral solution 2 (medium 436)	no ingredients and no solutions	KOMODO ModelSEED	yes	436	yes
-bacterial/mineral_solution_a_medium_492.yaml	CultureMech:004280	Mineral solution A (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
-bacterial/mineral_solution_b_medium_492.yaml	CultureMech:004281	Mineral solution B (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
-bacterial/mineral_solution_c_medium_492.yaml	CultureMech:004282	Mineral solution C (medium 492)	no ingredients and no solutions	KOMODO ModelSEED	yes	492	yes
-bacterial/mineral_solution_medium_212.yaml	CultureMech:005195	Mineral solution (medium 212)	no ingredients and no solutions	KOMODO ModelSEED	yes	212	yes
-bacterial/mineral_solution_medium_317.yaml	CultureMech:004818	Mineral solution (medium 317)	no ingredients and no solutions	KOMODO ModelSEED	yes	317	yes
-bacterial/mineral_solution_medium_321.yaml	CultureMech:004810	Mineral solution (medium 321)	no ingredients and no solutions	KOMODO ModelSEED	yes	321	yes
-bacterial/mineral_solution_medium_328.yaml	CultureMech:004811	Mineral solution (medium 328)	no ingredients and no solutions	KOMODO ModelSEED	yes	328	yes
-bacterial/mineral_solution_medium_330.yaml	CultureMech:004812	Mineral solution (medium 330)	no ingredients and no solutions	KOMODO ModelSEED	yes	330	yes
-bacterial/mineral_solution_medium_335.yaml	CultureMech:004813	Mineral solution (medium 335)	no ingredients and no solutions	KOMODO ModelSEED	yes	335	yes
-bacterial/modified_hoagland_trace_element_solution_medium_867.yaml	CultureMech:004283	Modified hoagland trace element solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
 bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml	CultureMech:004284	Modified MJ synthetic sea water (medium 1131)	no ingredients and no solutions	KOMODO ModelSEED		1131	yes
 bacterial/mtp4_medium.yaml	CultureMech:006012	MTP4 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/mueller_hinton_broth.yaml	CultureMech:005193	Mueller-Hinton broth	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/na_sesquicarbonate_solution_medium_31.yaml	CultureMech:004819	Na-sesquicarbonate solution (medium 31)	no ingredients and no solutions	KOMODO ModelSEED	yes	31	yes
 bacterial/nutrient_broth_difco.yaml	CultureMech:005652	Nutrient broth (Difco)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/nutrient_broth_oxoid_medium_948.yaml	CultureMech:004822	Nutrient broth (Oxoid) (medium 948)	no ingredients and no solutions	KOMODO ModelSEED		948	yes
 bacterial/pelobacter_acetylenicus_medium.yaml	CultureMech:005057	PELOBACTER ACETYLENICUS MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
@@ -145,186 +99,31 @@ bacterial/pelobacter_medium.yaml	CultureMech:005242	PELOBACTER medium	no ingredi
 bacterial/pelobacter_venetianus_fresh_water_medium.yaml	CultureMech:004774	PELOBACTER VENETIANUS (fresh water) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/pelobacter_venetianus_marine_medium.yaml	CultureMech:004760	PELOBACTER VENETIANUS (marine) MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/pennassay_broth.yaml	CultureMech:005653	Pennassay Broth	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/phosphate_buffer_10x_medium_1341.yaml	CultureMech:004285	Phosphate buffer (10x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED	yes	1341	yes
-bacterial/phosphate_buffer_medium_878.yaml	CultureMech:004823	Phosphate buffer (medium 878)	no ingredients and no solutions	KOMODO ModelSEED	yes	878	yes
-bacterial/phosphate_buffer_medium_921.yaml	CultureMech:004286	Phosphate buffer (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
-bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml	CultureMech:004287	Phosphate buffer (pH 6.8, see medium 1132)	no ingredients and no solutions	KOMODO ModelSEED	yes	1132	yes
-bacterial/phosphate_buffer_ph_7_2.yaml	CultureMech:004824	Phosphate buffer pH 7.2	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/phosphate_solution_medium_1191.yaml	CultureMech:004825	Phosphate solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
-bacterial/phosphate_solution_medium_791.yaml	CultureMech:004826	Phosphate solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
 bacterial/pplo_broth.yaml	CultureMech:005654	PPLO broth	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/propionigenium_maris_medium.yaml	CultureMech:006291	PROPIONIGENIUM MARIS medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/rumen_fluid_clarified.yaml	CultureMech:006085	Rumen fluid, clarified	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/sabouraud_2_glucose_bouillon_merck_108339.yaml	CultureMech:006517	SABOURAUD-2% Glucose-Bouillon (Merck 108339)	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/salt_base_solution_medium_88.yaml	CultureMech:005194	Salt base solution (medium 88)	no ingredients and no solutions	KOMODO ModelSEED	yes	88	yes
 bacterial/salt_concentrate_medium_517.yaml	CultureMech:004288	Salt concentrate (medium 517)	no ingredients and no solutions	KOMODO ModelSEED		517	yes
-bacterial/salt_solution_medium_104.yaml	CultureMech:004828	salt solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
-bacterial/salt_solution_medium_1191.yaml	CultureMech:004829	salt solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
-bacterial/salt_solution_medium_58.yaml	CultureMech:004830	salt solution (medium 58)	no ingredients and no solutions	KOMODO ModelSEED	yes	58	yes
-bacterial/salt_solution_medium_852.yaml	CultureMech:004831	salt solution (medium 852)	no ingredients and no solutions	KOMODO ModelSEED	yes	852	yes
-bacterial/salts_solution_medium_1139.yaml	CultureMech:004833	salts solution (medium 1139)	no ingredients and no solutions	KOMODO ModelSEED	yes	1139	yes
 bacterial/sb_sw_medium.yaml	CultureMech:006278	SB/SW MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/sea_water_salts_solution_medium_958.yaml	CultureMech:004834	Sea water salts solution (medium 958)	no ingredients and no solutions	KOMODO ModelSEED	yes	958	yes
-bacterial/selenite_tungstate_solution_medium_385.yaml	CultureMech:004289	Selenite/tungstate solution (medium 385)	no ingredients and no solutions	KOMODO ModelSEED	yes	385	yes
-bacterial/seven_vitamin_solution_medium_1332.yaml	CultureMech:004835	Seven Vitamin solution (medium 1332)	no ingredients and no solutions	KOMODO ModelSEED	yes	1332	yes
-bacterial/seven_vitamins_solution_medium_503.yaml	CultureMech:004290	Seven vitamins solution (medium 503)	no ingredients and no solutions	KOMODO ModelSEED	yes	503	yes
 bacterial/sludge_fluid_medium_119.yaml	CultureMech:004990	Sludge fluid (medium 119)	no ingredients and no solutions	KOMODO ModelSEED		119	yes
 bacterial/soil_extract_medium_98.yaml	CultureMech:004991	Soil extract (medium 98)	no ingredients and no solutions	KOMODO ModelSEED		98	yes
-bacterial/solution_1_10x_nms_salts_medium_921.yaml	CultureMech:004291	Solution 1 (10x NMS salts) (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
-bacterial/solution_a_medium_1267.yaml	CultureMech:005221	Solution A (medium 1267)	no ingredients and no solutions	KOMODO ModelSEED	yes	1267	yes
-bacterial/solution_a_medium_1275.yaml	CultureMech:005222	Solution A, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
-bacterial/solution_a_medium_858.yaml	CultureMech:005220	Solution A (medium 858)	no ingredients and no solutions	KOMODO ModelSEED	yes	858	yes
-bacterial/solution_b_medium_1275.yaml	CultureMech:005223	Solution B, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
-bacterial/solution_b_medium_807.yaml	CultureMech:006084	Solution B (medium 807)	no ingredients and no solutions	KOMODO ModelSEED	yes	807	yes
-bacterial/solution_c_medium_1275.yaml	CultureMech:005224	Solution C, medium 1275	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
-bacterial/solution_ii_medium_1308.yaml	CultureMech:004836	solution II (medium 1308)	no ingredients and no solutions	KOMODO ModelSEED	yes	1308	yes
-bacterial/solution_ii_medium_1398.yaml	CultureMech:004837	solution II (medium 1398)	no ingredients and no solutions	KOMODO ModelSEED	yes	1398	yes
 bacterial/spirochaeta_aurantia_medium.yaml	CultureMech:004195	SPIROCHAETA AURANTIA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/spirochaeta_isovalerica_medium.yaml	CultureMech:004701	SPIROCHAETA ISOVALERICA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/sporomusa_silvacetica_medium.yaml	CultureMech:006435	SPOROMUSA SILVACETICA medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/sse_double_concentrated_medium_1426.yaml	CultureMech:004838	SSE (double concentrated) (medium 1426)	no ingredients and no solutions	KOMODO ModelSEED		1426	yes
-bacterial/stearate_solution_0_1_m_medium_517.yaml	CultureMech:004295	Stearate solution (0.1 M) (medium 517)	no ingredients and no solutions	KOMODO ModelSEED	yes	517	yes
-bacterial/stock_solution_from_medium_756.yaml	CultureMech:004387	Stock solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
-bacterial/stock_solution_medium_462.yaml	CultureMech:004398	Stock solution (medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
-bacterial/sugar_stock_solution_medium_1245.yaml	CultureMech:006082	Sugar Stock Solution (medium 1245)	no ingredients and no solutions	KOMODO ModelSEED	yes	1245	yes
 bacterial/synthetic_sea_water_medium_79.yaml	CultureMech:004839	Synthetic sea water (medium 79)	no ingredients and no solutions	KOMODO ModelSEED		79	yes
 bacterial/synthetic_seawater_2_x_conc_medium_795.yaml	CultureMech:004840	Synthetic seawater (2 x conc.) (medium 795)	no ingredients and no solutions	KOMODO ModelSEED		795	yes
 bacterial/syntrophobacter_wolinii_medium.yaml	CultureMech:004866	SYNTROPHOBACTER WOLINII medium	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/syntrophus_buswellii_ii_medium.yaml	CultureMech:005230	SYNTROPHUS BUSWELLII II MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/syntrophus_medium_sulfate_free.yaml	CultureMech:004742	SYNTROPHUS medium - SULFATE FREE	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/thermus_macronutrients_10x_solution.yaml	CultureMech:004841	Thermus macronutrients 10X solution	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/thermus_micronutrients_100x_solution.yaml	CultureMech:004842	Thermus micronutrients 100X solution	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml	CultureMech:006372	THIOBACILLUS FERROOXIDANS MEDIUM WITH TETRATHIONATE	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/thioglycolate_ascorbate_solution_medium_210.yaml	CultureMech:004844	Thioglycolate-ascorbate solution (medium 210)	no ingredients and no solutions	KOMODO ModelSEED	yes	210	yes
-bacterial/trace_element_solution_a_medium_537.yaml	CultureMech:004865	Trace element solution A (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
-bacterial/trace_element_solution_b_medium_537.yaml	CultureMech:004867	Trace element solution B (medium 537)	no ingredients and no solutions	KOMODO ModelSEED	yes	537	yes
-bacterial/trace_element_solution_from_medium_756.yaml	CultureMech:004388	Trace element solution (from medium 756)	no ingredients and no solutions	KOMODO ModelSEED	yes	756	yes
-bacterial/trace_element_solution_ho_le_medium_668.yaml	CultureMech:004868	Trace element solution Ho-le (medium 668)	no ingredients and no solutions	KOMODO ModelSEED	yes	668	yes
-bacterial/trace_element_solution_medium_1007.yaml	CultureMech:004296	Trace element solution (medium 1007)	no ingredients and no solutions	KOMODO ModelSEED	yes	1007	yes
-bacterial/trace_element_solution_medium_1072.yaml	CultureMech:004847	Trace element solution (medium 1072)	no ingredients and no solutions	KOMODO ModelSEED	yes	1072	yes
-bacterial/trace_element_solution_medium_1149.yaml	CultureMech:004848	Trace element solution (medium 1149)	no ingredients and no solutions	KOMODO ModelSEED	yes	1149	yes
-bacterial/trace_element_solution_medium_1156.yaml	CultureMech:004302	Trace element solution (medium 1156)	no ingredients and no solutions	KOMODO ModelSEED	yes	1156	yes
-bacterial/trace_element_solution_medium_1165.yaml	CultureMech:004849	Trace element solution (medium 1165)	no ingredients and no solutions	KOMODO ModelSEED	yes	1165	yes
-bacterial/trace_element_solution_medium_1180.yaml	CultureMech:004303	Trace element solution (medium 1180)	no ingredients and no solutions	KOMODO ModelSEED	yes	1180	yes
-bacterial/trace_element_solution_medium_1181.yaml	CultureMech:004304	Trace element solution (medium 1181)	no ingredients and no solutions	KOMODO ModelSEED	yes	1181	yes
-bacterial/trace_element_solution_medium_1190.yaml	CultureMech:005000	Trace element solution (medium 1190)	no ingredients and no solutions	KOMODO ModelSEED	yes	1190	yes
-bacterial/trace_element_solution_medium_124.yaml	CultureMech:004850	Trace element solution (medium 124)	no ingredients and no solutions	KOMODO ModelSEED	yes	124	yes
-bacterial/trace_element_solution_medium_1282.yaml	CultureMech:004852	Trace element solution (medium 1282)	no ingredients and no solutions	KOMODO ModelSEED	yes	1282	yes
-bacterial/trace_element_solution_medium_131.yaml	CultureMech:004308	Trace element solution (medium 131)	no ingredients and no solutions	KOMODO ModelSEED	yes	131	
-bacterial/trace_element_solution_medium_1396.yaml	CultureMech:004853	Trace Element solution (medium 1396)	no ingredients and no solutions	KOMODO ModelSEED	yes	1396	yes
-bacterial/trace_element_solution_medium_1403.yaml	CultureMech:004309	Trace element solution (medium 1403)	no ingredients and no solutions	KOMODO ModelSEED	yes	1403	yes
-bacterial/trace_element_solution_medium_150a.yaml	CultureMech:004312	Trace element solution (medium 150a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_medium_155.yaml	CultureMech:004399	Trace element solution (medium 155)	no ingredients and no solutions	KOMODO ModelSEED	yes	155	yes
-bacterial/trace_element_solution_medium_158.yaml	CultureMech:004858	Trace element solution (medium 158)	no ingredients and no solutions	KOMODO ModelSEED	yes	158	yes
-bacterial/trace_element_solution_medium_333.yaml	CultureMech:004314	Trace element solution (medium 333)	no ingredients and no solutions	KOMODO ModelSEED	yes	333	yes
-bacterial/trace_element_solution_medium_463.yaml	CultureMech:004315	Trace element solution (medium 463)	no ingredients and no solutions	KOMODO ModelSEED	yes	463	yes
-bacterial/trace_element_solution_medium_463a.yaml	CultureMech:004316	Trace element solution (medium 463a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_medium_533.yaml	CultureMech:004317	Trace element solution (medium 533)	no ingredients and no solutions	KOMODO ModelSEED	yes	533	yes
-bacterial/trace_element_solution_medium_534.yaml	CultureMech:004318	Trace element solution (medium 534)	no ingredients and no solutions	KOMODO ModelSEED	yes	534	yes
-bacterial/trace_element_solution_medium_632.yaml	CultureMech:004320	Trace element solution (medium 632)	no ingredients and no solutions	KOMODO ModelSEED	yes	632	yes
-bacterial/trace_element_solution_medium_652.yaml	CultureMech:004860	Trace element solution (medium 652)	no ingredients and no solutions	KOMODO ModelSEED	yes	652	yes
-bacterial/trace_element_solution_medium_705.yaml	CultureMech:004862	Trace element solution (medium 705)	no ingredients and no solutions	KOMODO ModelSEED	yes	705	yes
-bacterial/trace_element_solution_medium_737.yaml	CultureMech:004323	Trace element solution (medium 737)	no ingredients and no solutions	KOMODO ModelSEED	yes	737	yes
-bacterial/trace_element_solution_medium_84.yaml	CultureMech:004401	Trace element solution (medium 84)	no ingredients and no solutions	KOMODO ModelSEED	yes	84	yes
-bacterial/trace_element_solution_medium_878.yaml	CultureMech:004864	Trace element solution (medium 878)	no ingredients and no solutions	KOMODO ModelSEED	yes	878	yes
-bacterial/trace_element_solution_medium_918.yaml	CultureMech:004326	Trace element solution (medium 918)	no ingredients and no solutions	KOMODO ModelSEED	yes	918	yes
-bacterial/trace_element_solution_medium_921.yaml	CultureMech:004327	Trace element solution (medium 921)	no ingredients and no solutions	KOMODO ModelSEED	yes	921	yes
-bacterial/trace_element_solution_medium_922.yaml	CultureMech:004328	Trace element solution (medium 922)	no ingredients and no solutions	KOMODO ModelSEED	yes	922	yes
-bacterial/trace_element_solution_medium_929.yaml	CultureMech:004330	Trace element solution (medium 929)	no ingredients and no solutions	KOMODO ModelSEED	yes	929	yes
-bacterial/trace_element_solution_medium_976.yaml	CultureMech:004332	Trace element solution (medium 976)	no ingredients and no solutions	KOMODO ModelSEED	yes	976	yes
-bacterial/trace_element_solution_medium_996.yaml	CultureMech:004334	Trace element solution (medium 996)	no ingredients and no solutions	KOMODO ModelSEED	yes	996	yes
-bacterial/trace_element_solution_sl12_medium_998.yaml	CultureMech:004870	Trace element solution SL12 (medium 998)	no ingredients and no solutions	KOMODO ModelSEED	yes	998	yes
-bacterial/trace_element_solution_sl7.yaml	CultureMech:004871	Trace element solution SL7	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_sl8_medium_1119.yaml	CultureMech:004874	Trace element solution SL8 (medium 1119)	no ingredients and no solutions	KOMODO ModelSEED	yes	1119	yes
-bacterial/trace_element_solution_sl_10_b.yaml	CultureMech:004337	Trace element solution SL-10 B	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_sl_10_medium_320.yaml	CultureMech:004336	Trace element solution SL-10 (medium 320)	no ingredients and no solutions	KOMODO ModelSEED	yes	320	yes
-bacterial/trace_element_solution_sl_11_medium_784.yaml	CultureMech:004869	Trace element solution SL-11 (medium 784)	no ingredients and no solutions	KOMODO ModelSEED	yes	784	yes
-bacterial/trace_element_solution_sl_12_b.yaml	CultureMech:004338	Trace element solution SL-12 B	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_sl_6_medium_457.yaml	CultureMech:004340	Trace element solution SL-6 (medium 457)	no ingredients and no solutions	KOMODO ModelSEED	yes	457	yes
-bacterial/trace_element_solution_sl_7_medium_660.yaml	CultureMech:004341	Trace element solution SL-7 (medium 660)	no ingredients and no solutions	KOMODO ModelSEED	yes	660	yes
-bacterial/trace_element_solution_sl_7_medium_941.yaml	CultureMech:004872	Trace element solution SL-7 (medium 941)	no ingredients and no solutions	KOMODO ModelSEED	yes	941	yes
-bacterial/trace_element_solution_sl_8.yaml	CultureMech:004342	Trace element solution SL-8	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_element_solution_sl_9_medium_828.yaml	CultureMech:004343	Trace element solution SL-9 (medium 828)	no ingredients and no solutions	KOMODO ModelSEED	yes	828	yes
-bacterial/trace_element_solution_sla.yaml	CultureMech:004335	Trace element solution (SLA)	no ingredients and no solutions	KOMODO ModelSEED	yes		
 bacterial/trace_elements_medium_1108a.yaml	CultureMech:006328	Trace elements (medium 1108a)	no ingredients and no solutions	KOMODO ModelSEED			
 bacterial/trace_elements_medium_1147.yaml	CultureMech:004875	Trace elements (medium 1147)	no ingredients and no solutions	KOMODO ModelSEED		1147	yes
 bacterial/trace_elements_medium_596.yaml	CultureMech:004877	Trace elements (medium 596)	no ingredients and no solutions	KOMODO ModelSEED		596	yes
 bacterial/trace_elements_medium_651.yaml	CultureMech:004878	Trace elements (medium 651)	no ingredients and no solutions	KOMODO ModelSEED		651	yes
 bacterial/trace_elements_pfennig_medium_1264.yaml	CultureMech:004879	Trace elements (Pfennig) (medium 1264)	no ingredients and no solutions	KOMODO ModelSEED		1264	yes
-bacterial/trace_elements_sl_12.yaml	CultureMech:004880	Trace elements SL-12	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/trace_elements_solution_medium_1280.yaml	CultureMech:004883	Trace elements solution (medium 1280)	no ingredients and no solutions	KOMODO ModelSEED	yes	1280	yes
-bacterial/trace_metals_500x_medium_1341.yaml	CultureMech:004347	Trace Metals (500x) (medium 1341)	no ingredients and no solutions	KOMODO ModelSEED	yes	1341	yes
-bacterial/trace_metals_solution_medium_802.yaml	CultureMech:004884	Trace metals solution (medium 802)	no ingredients and no solutions	KOMODO ModelSEED	yes	802	yes
-bacterial/trace_mineral_solution_medium_1000.yaml	CultureMech:004351	Trace mineral solution (medium 1000)	no ingredients and no solutions	KOMODO ModelSEED	yes	1000	yes
-bacterial/trace_mineral_solution_medium_1121.yaml	CultureMech:004353	Trace mineral solution (medium 1121)	no ingredients and no solutions	KOMODO ModelSEED	yes	1121	yes
-bacterial/trace_mineral_solution_medium_997.yaml	CultureMech:004355	Trace mineral solution (medium 997)	no ingredients and no solutions	KOMODO ModelSEED	yes	997	yes
-bacterial/trace_salt_solution_medium_609.yaml	CultureMech:005191	Trace salt solution (medium 609)	no ingredients and no solutions	KOMODO ModelSEED	yes	609	yes
-bacterial/trace_salt_solution_medium_856.yaml	CultureMech:004885	Trace salt solution (medium 856)	no ingredients and no solutions	KOMODO ModelSEED	yes	856	yes
-bacterial/trace_salts_solution_medium_978.yaml	CultureMech:004938	Trace salts solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
 bacterial/true_blue_trace_elements_medium_748.yaml	CultureMech:004939	True Blue Trace Elements (medium 748)	no ingredients and no solutions	KOMODO ModelSEED		748	yes
-bacterial/tyc_solution_medium_391.yaml	CultureMech:004992	TYC-solution (medium 391)	no ingredients and no solutions	KOMODO ModelSEED	yes	391	yes
-bacterial/vitamin_b12_solution_medium_867.yaml	CultureMech:004356	Vitamin B12 solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
-bacterial/vitamin_b_solution_medium_978.yaml	CultureMech:004940	Vitamin B solution (medium 978)	no ingredients and no solutions	KOMODO ModelSEED	yes	978	yes
-bacterial/vitamin_k1_solution_medium_104.yaml	CultureMech:004941	Vitamin K1 solution (medium 104)	no ingredients and no solutions	KOMODO ModelSEED	yes	104	yes
-bacterial/vitamin_mixture_medium_1001.yaml	CultureMech:004358	Vitamin mixture (medium 1001)	no ingredients and no solutions	KOMODO ModelSEED	yes	1001	yes
-bacterial/vitamin_mixture_medium_484.yaml	CultureMech:004359	Vitamin mixture (medium 484)	no ingredients and no solutions	KOMODO ModelSEED	yes	484	yes
-bacterial/vitamin_mixture_medium_619.yaml	CultureMech:004360	Vitamin mixture (medium 619)	no ingredients and no solutions	KOMODO ModelSEED	yes	619	yes
-bacterial/vitamin_solution_7_medium_842.yaml	CultureMech:004975	Vitamin solution 7 (medium 842)	no ingredients and no solutions	KOMODO ModelSEED	yes	842	yes
-bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml	CultureMech:004384	Vitamin solution according to Wolin and coauthors	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/vitamin_solution_b_medium_253.yaml	CultureMech:004942	Vitamin solution (B) (medium 253)	no ingredients and no solutions	KOMODO ModelSEED	yes	253	yes
-bacterial/vitamin_solution_ca_medium_87a.yaml	CultureMech:004976	Vitamin solution CA (medium 87a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/vitamin_solution_double_conc_medium_621.yaml	CultureMech:004943	Vitamin solution (double conc.) (medium 621)	no ingredients and no solutions	KOMODO ModelSEED	yes	621	yes
-bacterial/vitamin_solution_medium_1072.yaml	CultureMech:004945	Vitamin solution (medium 1072)	no ingredients and no solutions	KOMODO ModelSEED	yes	1072	yes
-bacterial/vitamin_solution_medium_1116.yaml	CultureMech:004361	Vitamin solution (medium 1116)	no ingredients and no solutions	KOMODO ModelSEED	yes	1116	yes
-bacterial/vitamin_solution_medium_1121.yaml	CultureMech:004362	Vitamin solution (medium 1121)	no ingredients and no solutions	KOMODO ModelSEED	yes	1121	yes
-bacterial/vitamin_solution_medium_1131.yaml	CultureMech:004363	Vitamin solution (medium 1131)	no ingredients and no solutions	KOMODO ModelSEED	yes	1131	yes
-bacterial/vitamin_solution_medium_1149.yaml	CultureMech:004946	Vitamin solution (medium 1149)	no ingredients and no solutions	KOMODO ModelSEED	yes	1149	yes
-bacterial/vitamin_solution_medium_1165.yaml	CultureMech:004947	Vitamin solution (medium 1165)	no ingredients and no solutions	KOMODO ModelSEED	yes	1165	yes
-bacterial/vitamin_solution_medium_1183.yaml	CultureMech:004954	Vitamin solution (medium 1183)	no ingredients and no solutions	KOMODO ModelSEED	yes	1183	yes
-bacterial/vitamin_solution_medium_1191.yaml	CultureMech:004955	Vitamin solution (medium 1191)	no ingredients and no solutions	KOMODO ModelSEED	yes	1191	yes
-bacterial/vitamin_solution_medium_124.yaml	CultureMech:005001	Vitamin solution (medium 124)	no ingredients and no solutions	KOMODO ModelSEED	yes	124	yes
-bacterial/vitamin_solution_medium_1263.yaml	CultureMech:004956	Vitamin solution (medium 1263)	no ingredients and no solutions	KOMODO ModelSEED	yes	1263	yes
-bacterial/vitamin_solution_medium_1275.yaml	CultureMech:004364	Vitamin solution (medium 1275)	no ingredients and no solutions	KOMODO ModelSEED	yes	1275	yes
-bacterial/vitamin_solution_medium_1282.yaml	CultureMech:004957	Vitamin solution (medium 1282)	no ingredients and no solutions	KOMODO ModelSEED	yes	1282	yes
-bacterial/vitamin_solution_medium_1306.yaml	CultureMech:004958	Vitamin solution (medium 1306)	no ingredients and no solutions	KOMODO ModelSEED	yes	1306	yes
-bacterial/vitamin_solution_medium_131.yaml	CultureMech:004365	Vitamin solution (medium 131)	no ingredients and no solutions	KOMODO ModelSEED	yes	131	
-bacterial/vitamin_solution_medium_1315.yaml	CultureMech:004366	Vitamin solution (medium 1315)	no ingredients and no solutions	KOMODO ModelSEED	yes	1315	yes
-bacterial/vitamin_solution_medium_141.yaml	CultureMech:004367	Vitamin solution (medium 141)	no ingredients and no solutions	KOMODO ModelSEED	yes	141	yes
-bacterial/vitamin_solution_medium_1426.yaml	CultureMech:004959	Vitamin solution (medium 1426)	no ingredients and no solutions	KOMODO ModelSEED	yes	1426	yes
-bacterial/vitamin_solution_medium_1457.yaml	CultureMech:006516	Vitamin solution (medium 1457)	no ingredients and no solutions	KOMODO ModelSEED	yes	1457	yes
-bacterial/vitamin_solution_medium_148.yaml	CultureMech:004369	Vitamin solution (medium 148)	no ingredients and no solutions	KOMODO ModelSEED	yes	148	yes
-bacterial/vitamin_solution_medium_212.yaml	CultureMech:004960	Vitamin solution (medium 212)	no ingredients and no solutions	KOMODO ModelSEED	yes	212	yes
-bacterial/vitamin_solution_medium_315.yaml	CultureMech:004370	Vitamin solution (medium 315)	no ingredients and no solutions	KOMODO ModelSEED	yes	315	yes
-bacterial/vitamin_solution_medium_322.yaml	CultureMech:004961	Vitamin solution (medium 322)	no ingredients and no solutions	KOMODO ModelSEED	yes	322	yes
-bacterial/vitamin_solution_medium_461.yaml	CultureMech:004371	Vitamin solution (medium 461)	no ingredients and no solutions	KOMODO ModelSEED	yes	461	yes
-bacterial/vitamin_solution_medium_463.yaml	CultureMech:004372	Vitamin solution (medium 463)	no ingredients and no solutions	KOMODO ModelSEED	yes	463	yes
-bacterial/vitamin_solution_medium_463a.yaml	CultureMech:004373	Vitamin solution (medium 463a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/vitamin_solution_medium_473.yaml	CultureMech:004374	Vitamin solution (medium 473)	no ingredients and no solutions	KOMODO ModelSEED	yes	473	yes
-bacterial/vitamin_solution_medium_521.yaml	CultureMech:004962	Vitamin solution (medium 521)	no ingredients and no solutions	KOMODO ModelSEED	yes	521	yes
-bacterial/vitamin_solution_medium_559.yaml	CultureMech:004963	Vitamin solution (medium 559)	no ingredients and no solutions	KOMODO ModelSEED	yes	559	yes
-bacterial/vitamin_solution_medium_589.yaml	CultureMech:004967	Vitamin solution (medium 589)	no ingredients and no solutions	KOMODO ModelSEED	yes	589	yes
-bacterial/vitamin_solution_medium_598.yaml	CultureMech:004944	Vitamin solution (medium 598)	no ingredients and no solutions	KOMODO ModelSEED	yes	598	yes
-bacterial/vitamin_solution_medium_600.yaml	CultureMech:004394	Vitamin solution (medium 600)	no ingredients and no solutions	KOMODO ModelSEED	yes	600	yes
-bacterial/vitamin_solution_medium_600a.yaml	CultureMech:004969	Vitamin solution (medium 600a)	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/vitamin_solution_medium_602.yaml	CultureMech:004970	Vitamin solution (medium 602)	no ingredients and no solutions	KOMODO ModelSEED	yes	602	yes
-bacterial/vitamin_solution_medium_603.yaml	CultureMech:004375	Vitamin solution (medium 603)	no ingredients and no solutions	KOMODO ModelSEED	yes	603	yes
-bacterial/vitamin_solution_medium_628.yaml	CultureMech:004968	Vitamin solution (medium 628)	no ingredients and no solutions	KOMODO ModelSEED	yes	628	yes
-bacterial/vitamin_solution_medium_651.yaml	CultureMech:004971	Vitamin solution (medium 651)	no ingredients and no solutions	KOMODO ModelSEED	yes	651	yes
-bacterial/vitamin_solution_medium_663.yaml	CultureMech:004972	Vitamin solution (medium 663)	no ingredients and no solutions	KOMODO ModelSEED	yes	663	yes
-bacterial/vitamin_solution_medium_78.yaml	CultureMech:004973	Vitamin solution (medium 78)	no ingredients and no solutions	KOMODO ModelSEED	yes	78	yes
-bacterial/vitamin_solution_medium_791.yaml	CultureMech:004974	Vitamin solution (medium 791)	no ingredients and no solutions	KOMODO ModelSEED	yes	791	yes
-bacterial/vitamin_solution_medium_867.yaml	CultureMech:004376	Vitamin solution (medium 867)	no ingredients and no solutions	KOMODO ModelSEED	yes	867	yes
-bacterial/vitamin_solution_medium_908.yaml	CultureMech:004377	Vitamin solution (medium 908)	no ingredients and no solutions	KOMODO ModelSEED	yes	908	yes
-bacterial/vitamin_solution_medium_929.yaml	CultureMech:004378	Vitamin solution (medium 929)	no ingredients and no solutions	KOMODO ModelSEED	yes	929	yes
-bacterial/vitamin_solution_medium_944.yaml	CultureMech:004382	Vitamin solution (medium 944)	no ingredients and no solutions	KOMODO ModelSEED	yes	944	yes
-bacterial/vitamin_solution_medium_951.yaml	CultureMech:004380	Vitamin solution (medium 951)	no ingredients and no solutions	KOMODO ModelSEED	yes	951	yes
-bacterial/vitamin_solution_schlegel_medium_462.yaml	CultureMech:004381	Vitamin solution (Schlegel, medium 462)	no ingredients and no solutions	KOMODO ModelSEED	yes	462	yes
-bacterial/vitamin_solution_v10.yaml	CultureMech:004385	Vitamin solution V10	no ingredients and no solutions	KOMODO ModelSEED	yes		
-bacterial/vitamin_solution_va_medium_351.yaml	CultureMech:004383	Vitamin solution (VA) (medium 351)	no ingredients and no solutions	KOMODO ModelSEED	yes	351	yes
-bacterial/vitamins_v7_solution_medium_998.yaml	CultureMech:004978	Vitamins V7 solution (medium 998)	no ingredients and no solutions	KOMODO ModelSEED	yes	998	yes
 bacterial/vitox.yaml	CultureMech:005644	Vitox	no ingredients and no solutions	KOMODO ModelSEED			
-bacterial/volatile_fatty_acid_mixture_medium_330.yaml	CultureMech:004979	Volatile fatty acid mixture (medium 330)	no ingredients and no solutions	KOMODO ModelSEED	yes	330	yes
-bacterial/volatile_fatty_acid_solution_medium_909.yaml	CultureMech:004980	Volatile fatty acid solution (medium 909)	no ingredients and no solutions	KOMODO ModelSEED	yes	909	yes
 bacterial/xb45_xb90_pb90_2_medium.yaml	CultureMech:006693	XB45/XB90/PB90-2 MEDIUM	no ingredients and no solutions	KOMODO ModelSEED			
 algae/artificial_seawater.yaml	CultureMech:000189	Artificial_Seawater	placeholder ingredient only				
 algae/bacillariophycean.yaml	CultureMech:000192	Bacillariophycean	placeholder ingredient only				
@@ -334,7 +133,6 @@ algae/bold_modified_basal.yaml	CultureMech:000194	Bold_Modified_Basal	placeholde
 algae/bold_modified_basal_tom.yaml	CultureMech:000195	Bold_Modified_Basal&TOM	placeholder ingredient only				
 algae/brackish_water_medium.yaml	CultureMech:000196	Brackish_water_medium	placeholder ingredient only				
 algae/ch.yaml	CultureMech:000059	CH	placeholder ingredient only				
-algae/chapman_andresens_modified_pringsheims_solution.yaml	CultureMech:000062	Chapman-Andresen's Modified Pringsheim's Solution	placeholder ingredient only		yes		
 algae/chilomonas.yaml	CultureMech:000197	Chilomonas	placeholder ingredient only				
 algae/cyanidium.yaml	CultureMech:000198	Cyanidium	placeholder ingredient only				
 algae/desmidiacean.yaml	CultureMech:000199	Desmidiacean	placeholder ingredient only				

--- a/data/import_tracking/reports/review_need_ranking.tsv
+++ b/data/import_tracking/reports/review_need_ranking.tsv
@@ -33,7 +33,6 @@ score	file_path	record_id	name	n_ingredients	reasons
 70	algae/bold_modified_basal_tom.yaml	CultureMech:000195	Bold_Modified_Basal&TOM	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
 70	algae/brackish_water_medium.yaml	CultureMech:000196	Brackish_water_medium	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
 70	algae/ch.yaml	CultureMech:000059	CH	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
-70	algae/chapman_andresens_modified_pringsheims_solution.yaml	CultureMech:000062	Chapman-Andresen's Modified Pringsheim's Solution	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
 70	algae/chilomonas.yaml	CultureMech:000197	Chilomonas	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
 70	algae/cyanidium.yaml	CultureMech:000198	Cyanidium	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
 70	algae/desmidiacean.yaml	CultureMech:000199	Desmidiacean	1	only 1 ingredient(s); placeholder ingredient text; no ingredient is grounded; no media_term (untraceable to a source catalogue)
@@ -383,10 +382,7 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	archaea/methanogenium_sp_medium.yaml	CultureMech:005910	METHANOGENIUM SP. medium	0	no ingredients; no pH and no temperature
 35	archaea/methanosarcina_thermophilic_medium.yaml	CultureMech:004191	METHANOSARCINA (thermophilic) medium	0	no ingredients; no pH and no temperature
 35	archaea/methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119.yaml	CultureMech:004190	METHANOSARCINA (thermophilic) medium_replace_Rumen fluid, clarified_with_Sludge fluid (medium 119)	0	no ingredients; no pH and no temperature
-35	bacterial/100x_vitamin_solution_medium_1398.yaml	CultureMech:004994	100x Vitamin solution (medium 1398)	0	no ingredients; no pH and no temperature
 35	bacterial/4_times_concentrated_sea_water_medium_821.yaml	CultureMech:004993	4 times concentrated sea water (medium 821)	0	no ingredients; no pH and no temperature
-35	bacterial/50_x_pye.yaml	CultureMech:006514	50 x PYE	0	no ingredients; no pH and no temperature
-35	bacterial/50x_heterotrophic_basal_salts_solution_medium_1190.yaml	CultureMech:004779	50x Heterotrophic basal salts solution (medium 1190)	0	no ingredients; no pH and no temperature
 35	bacterial/JCM_J1351_PELOSINUS_BKL1_MEDIUM.yaml	CultureMech:015835	PELOSINUS BKL1 MEDIUM	13	placeholder ingredient text; only 6/13 ingredients grounded
 35	bacterial/JCM_J1359_MINERAL_CARBONATE_MEDIUM_WITH_CASEIN_PEPTONE.yaml	CultureMech:015839	MINERAL CARBONATE MEDIUM WITH CASEIN PEPTONE	11	placeholder ingredient text; only 4/11 ingredients grounded
 35	bacterial/JCM_J1392_ATRIBACTEROTA_M15_MEDIUM.yaml	CultureMech:015850	ATRIBACTEROTA M15 MEDIUM	15	placeholder ingredient text; only 7/15 ingredients grounded
@@ -396,10 +392,6 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	bacterial/JCM_J1444_DESULFOSPOROSINUS_SB140_MEDIUM.yaml	CultureMech:015868	DESULFOSPOROSINUS SB140 MEDIUM	15	placeholder ingredient text; only 6/15 ingredients grounded
 35	bacterial/JCM_J1468_FRESHWATER_R2A_MEDIUM.yaml	CultureMech:015874	FRESHWATER R2A MEDIUM	19	placeholder ingredient text; only 7/19 ingredients grounded
 35	bacterial/KOMODO_272_DESULFOVIBRIO_medium_choline.yaml	CultureMech:004700	DESULFOVIBRIO medium (choline)	0	no ingredients; no pH and no temperature
-35	bacterial/KOMODO_3018_H3P-Vitamin_solution_medium_428.yaml	CultureMech:004797	H3P-Vitamin solution (medium 428)	0	no ingredients; no pH and no temperature
-35	bacterial/KOMODO_3071_Trace_element_solution_medium_155.yaml	CultureMech:004857	Trace element solution (medium 155)	0	no ingredients; no pH and no temperature
-35	bacterial/KOMODO_3077_Trace_element_solution_medium_84.yaml	CultureMech:004863	Trace element solution (medium 84)	0	no ingredients; no pH and no temperature
-35	bacterial/KOMODO_3087_Trace_element_solution_SL-8.yaml	CultureMech:004873	Trace element solution SL-8	0	no ingredients; no pH and no temperature
 35	bacterial/KOMODO_7001_Trace_elements_medium_596.yaml	CultureMech:006327	Trace elements (medium 596)	0	no ingredients; no pH and no temperature
 35	bacterial/TOGO_M103_MRS_Medium_pH_5.5.yaml	CultureMech:007555	MRS Medium (pH 5.5)	0	no ingredients; no pH and no temperature
 35	bacterial/TOGO_M1059_Acidic_HB-1_Medium.yaml	CultureMech:007575	Acidic HB-1 Medium	0	no ingredients; no pH and no temperature
@@ -429,11 +421,9 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	bacterial/acetonema_medium.yaml	CultureMech:005871	ACETONEMA medium	0	no ingredients; no pH and no temperature
 35	bacterial/acidic_yeast_extract_malt_extract_agar_ph_5_0.yaml	CultureMech:009798	Acidic Yeast Extract-Malt Extract Agar (pH 5.0)	0	no ingredients; no pH and no temperature
 35	bacterial/acidic_yeast_starch_agar_ph_5_0.yaml	CultureMech:010249	Acidic Yeast-Starch Agar (pH 5.0)	0	no ingredients; no pH and no temperature
-35	bacterial/amino_acid_solution_medium_78.yaml	CultureMech:004780	Amino acid solution (medium 78)	0	no ingredients; no pH and no temperature
 35	bacterial/anaerobic_acetoin_medium.yaml	CultureMech:005020	ANAEROBIC ACETOIN medium	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml	CultureMech:004785	Artificial sea water, 3 times concentrated (medium 1137)	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml	CultureMech:004389	Artificial sea water, 3 times concentrated (medium 590)	0	no ingredients; no pH and no temperature
-35	bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml	CultureMech:005655	Artificial sea water from a marine aquarium salts mixture	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_sea_water_medium_1075.yaml	CultureMech:004783	Artificial sea water (medium 1075)	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_sea_water_medium_246.yaml	CultureMech:004996	Artificial sea water (medium 246)	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_sea_water_medium_343.yaml	CultureMech:004782	Artificial sea water (medium 343)	0	no ingredients; no pH and no temperature
@@ -443,15 +433,11 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	bacterial/artificial_sea_water_medium_607.yaml	CultureMech:004781	Artificial sea water (medium 607)	0	no ingredients; no pH and no temperature
 35	bacterial/artificial_seawater_medium_1326.yaml	CultureMech:004787	Artificial seawater (medium 1326)	0	no ingredients; no pH and no temperature
 35	bacterial/bacto_middelbrook_oadc_enrichment_medium_911.yaml	CultureMech:004791	Bacto Middelbrook OADC enrichment (medium 911)	0	no ingredients; no pH and no temperature
-35	bacterial/basal_salts_solution_medium_791.yaml	CultureMech:004792	Basal salts solution (medium 791)	0	no ingredients; no pH and no temperature
 35	bacterial/bbl_actinomyces_broth_medium_1029.yaml	CultureMech:004983	BBL Actinomyces broth (medium 1029)	0	no ingredients; no pH and no temperature
 35	bacterial/bordet_gengou_agar_base.yaml	CultureMech:005645	Bordet-Gengou-Agar-Base	0	no ingredients; no pH and no temperature
 35	bacterial/casman_agar_base.yaml	CultureMech:005647	Casman-Agar-Base	0	no ingredients; no pH and no temperature
-35	bacterial/chelated_iron_solution_medium_737.yaml	CultureMech:004268	Chelated iron solution (medium 737)	0	no ingredients; no pH and no temperature
-35	bacterial/chelated_iron_solution_medium_748.yaml	CultureMech:004793	Chelated Iron solution (medium 748)	0	no ingredients; no pH and no temperature
 35	bacterial/chromagertm_malassezia_candida.yaml	CultureMech:008463	CHROMagerTM Malassezia/Candida*	0	no ingredients; no pH and no temperature
 35	bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml	CultureMech:005648	CMRL-1066 medium (10x concentrated; GIBCO)	0	no ingredients; no pH and no temperature
-35	bacterial/co_factors_solution_medium_843.yaml	CultureMech:006083	Co-factors solution (medium 843)	0	no ingredients; no pH and no temperature
 35	bacterial/desulfobacterium_anilini_medium.yaml	CultureMech:005590	DESULFOBACTERIUM ANILINI MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/desulfococcus_medium.yaml	CultureMech:004258	DESULFOCOCCUS MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/desulfomicrobium_whb_medium.yaml	CultureMech:006367	DESULFOMICROBIUM WHB MEDIUM	0	no ingredients; no pH and no temperature
@@ -466,22 +452,12 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	bacterial/desulfovibrio_shv_medium.yaml	CultureMech:006368	DESULFOVIBRIO SHV MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/dmj_synthetic_seawater_medium_997.yaml	CultureMech:004270	DMJ synthetic seawater (medium 997)	0	no ingredients; no pH and no temperature
 35	bacterial/dsm_4156_b_and_dsm_4156.yaml	CultureMech:005229	DSM 4156 B and DSM 4156	0	no ingredients; no pH and no temperature
-35	bacterial/fatty_acid_mixture_medium_119.yaml	CultureMech:004794	Fatty acid mixture (medium 119)	0	no ingredients; no pH and no temperature
-35	bacterial/fatty_acid_mixture_medium_328.yaml	CultureMech:004795	Fatty acid mixture (medium 328)	0	no ingredients; no pH and no temperature
-35	bacterial/fatty_acid_mixture_medium_436.yaml	CultureMech:004796	Fatty acid mixture (medium 436)	0	no ingredients; no pH and no temperature
-35	bacterial/ferric_quinate_solution_medium_380.yaml	CultureMech:004272	Ferric Quinate Solution (medium 380)	0	no ingredients; no pH and no temperature
 35	bacterial/for_s_buswellii_dsm_2612m.yaml	CultureMech:006276	For S. buswellii DSM 2612M	0	no ingredients; no pH and no temperature
 35	bacterial/for_s_wolinii_dsm_2805m.yaml	CultureMech:006277	For S. wolinii DSM 2805M	0	no ingredients; no pH and no temperature
 35	bacterial/glutarate_medium.yaml	CultureMech:006014	GLUTARATE medium	0	no ingredients; no pH and no temperature
-35	bacterial/h3p_vitamin_solution_medium_428.yaml	CultureMech:004397	H3P-vitamin solution (medium 428)	0	no ingredients; no pH and no temperature
-35	bacterial/haemin_solution_medium_104.yaml	CultureMech:004798	Haemin solution (medium 104)	0	no ingredients; no pH and no temperature
-35	bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml	CultureMech:004800	Hank's balanced salt solution (BSS, medium 1078)	0	no ingredients; no pH and no temperature
-35	bacterial/heavy_metal_solution_medium_867.yaml	CultureMech:004273	Heavy metal solution (medium 867)	0	no ingredients; no pH and no temperature
 35	bacterial/ilyobacter_tartaricus_medium.yaml	CultureMech:004761	ILYOBACTER TARTARICUS MEDIUM	0	no ingredients; no pH and no temperature
-35	bacterial/inorganic_salt_solution_medium_754.yaml	CultureMech:004801	Inorganic salt solution (medium 754)	0	no ingredients; no pH and no temperature
 35	bacterial/isovitalex.yaml	CultureMech:005642	Isovitalex	0	no ingredients; no pH and no temperature
 35	bacterial/lactic_acid_whey_medium_456.yaml	CultureMech:004985	Lactic acid whey (medium 456)	1	only 1 ingredient(s); no ingredient is grounded
-35	bacterial/lip_solution_medium_391.yaml	CultureMech:004802	LIP-solution (medium 391)	0	no ingredients; no pH and no temperature
 35	bacterial/marine_agar_2216_ph_8_5.yaml	CultureMech:007573	Marine Agar 2216 (pH 8.5)	0	no ingredients; no pH and no temperature
 35	bacterial/marine_agar_2216_ph_9_0.yaml	CultureMech:007592	Marine Agar 2216 (pH 9.0)	0	no ingredients; no pH and no temperature
 35	bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml	CultureMech:004803	Marine-Medium/Synthetic seawater-mix (medium 611)	0	no ingredients; no pH and no temperature
@@ -491,184 +467,38 @@ score	file_path	record_id	name	n_ingredients	reasons
 35	bacterial/medium_md1_medium_9.yaml	CultureMech:004986	medium MD1 (medium 9)	0	no ingredients; no pH and no temperature
 35	bacterial/metals_44_medium_590.yaml	CultureMech:004393	Metals 44 (medium 590)	0	no ingredients; no pH and no temperature
 35	bacterial/methanol_utilizing_bacteria_medium_d.yaml	CultureMech:002435	METHANOL-UTILIZING BACTERIA MEDIUM D	1	only 1 ingredient(s); no ingredient is grounded
-35	bacterial/min_e_base_10x.yaml	CultureMech:004275	MIN E - Base (10x)	0	no ingredients; no pH and no temperature
 35	bacterial/mineral_mix_medium_1001.yaml	CultureMech:004277	Mineral Mix (medium 1001)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_salt_solution_2xw_medium_391.yaml	CultureMech:004806	"Mineral salt solution ""2xW"" (medium 391)"	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml	CultureMech:004987	Mineral salts solution for liquid medium (medium 1396)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_salts_solution_for_solid_medium_medium_1396.yaml	CultureMech:004989	Mineral salts solution for solid medium (medium 1396)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_1_medium_165.yaml	CultureMech:004278	Mineral solution 1 (medium 165)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_2_medium_1033.yaml	CultureMech:004815	Mineral solution 2 (medium 1033)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_2_medium_165.yaml	CultureMech:004279	Mineral solution 2 (medium 165)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_2_medium_203.yaml	CultureMech:004997	Mineral solution 2 (medium 203)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_2_medium_404.yaml	CultureMech:004816	Mineral solution 2 (medium 404)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_2_medium_436.yaml	CultureMech:004817	Mineral solution 2 (medium 436)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_a_medium_492.yaml	CultureMech:004280	Mineral solution A (medium 492)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_b_medium_492.yaml	CultureMech:004281	Mineral solution B (medium 492)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_c_medium_492.yaml	CultureMech:004282	Mineral solution C (medium 492)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_212.yaml	CultureMech:005195	Mineral solution (medium 212)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_317.yaml	CultureMech:004818	Mineral solution (medium 317)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_321.yaml	CultureMech:004810	Mineral solution (medium 321)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_328.yaml	CultureMech:004811	Mineral solution (medium 328)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_330.yaml	CultureMech:004812	Mineral solution (medium 330)	0	no ingredients; no pH and no temperature
-35	bacterial/mineral_solution_medium_335.yaml	CultureMech:004813	Mineral solution (medium 335)	0	no ingredients; no pH and no temperature
 35	bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml	CultureMech:004284	Modified MJ synthetic sea water (medium 1131)	0	no ingredients; no pH and no temperature
 35	bacterial/mrs_medium_ph_5_5.yaml	CultureMech:002293	MRS MEDIUM (pH 5.5)	1	only 1 ingredient(s); no ingredient is grounded
 35	bacterial/mtp4_medium.yaml	CultureMech:006012	MTP4 MEDIUM	0	no ingredients; no pH and no temperature
-35	bacterial/na_sesquicarbonate_solution_medium_31.yaml	CultureMech:004819	Na-sesquicarbonate solution (medium 31)	0	no ingredients; no pH and no temperature
 35	bacterial/nutrient_broth_difco.yaml	CultureMech:005652	Nutrient broth (Difco)	0	no ingredients; no pH and no temperature
 35	bacterial/pelobacter_acetylenicus_medium.yaml	CultureMech:005057	PELOBACTER ACETYLENICUS MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/pelobacter_venetianus_fresh_water_medium.yaml	CultureMech:004774	PELOBACTER VENETIANUS (fresh water) MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/pelobacter_venetianus_marine_medium.yaml	CultureMech:004760	PELOBACTER VENETIANUS (marine) MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/pennassay_broth.yaml	CultureMech:005653	Pennassay Broth	0	no ingredients; no pH and no temperature
-35	bacterial/phosphate_solution_medium_791.yaml	CultureMech:004826	Phosphate solution (medium 791)	0	no ingredients; no pH and no temperature
 35	bacterial/propionigenium_maris_medium.yaml	CultureMech:006291	PROPIONIGENIUM MARIS medium	0	no ingredients; no pH and no temperature
 35	bacterial/rumen_fluid_clarified.yaml	CultureMech:006085	Rumen fluid, clarified	0	no ingredients; no pH and no temperature
 35	bacterial/s_w.yaml	CultureMech:000414	S/W	1	only 1 ingredient(s); no ingredient is grounded
 35	bacterial/s_w_amp.yaml	CultureMech:000307	S/W + AMP	2	only 2 ingredient(s); no ingredient is grounded
 35	bacterial/sabouraud_2_glucose_bouillon_merck_108339.yaml	CultureMech:006517	SABOURAUD-2% Glucose-Bouillon (Merck 108339)	0	no ingredients; no pH and no temperature
-35	bacterial/salt_base_solution_medium_88.yaml	CultureMech:005194	Salt base solution (medium 88)	0	no ingredients; no pH and no temperature
 35	bacterial/salt_concentrate_medium_517.yaml	CultureMech:004288	Salt concentrate (medium 517)	0	no ingredients; no pH and no temperature
-35	bacterial/salt_solution_medium_104.yaml	CultureMech:004828	salt solution (medium 104)	0	no ingredients; no pH and no temperature
-35	bacterial/salt_solution_medium_1191.yaml	CultureMech:004829	salt solution (medium 1191)	0	no ingredients; no pH and no temperature
-35	bacterial/salt_solution_medium_58.yaml	CultureMech:004830	salt solution (medium 58)	0	no ingredients; no pH and no temperature
-35	bacterial/salts_solution_medium_1139.yaml	CultureMech:004833	salts solution (medium 1139)	0	no ingredients; no pH and no temperature
 35	bacterial/sb_sw_medium.yaml	CultureMech:006278	SB/SW MEDIUM	0	no ingredients; no pH and no temperature
-35	bacterial/sea_water_salts_solution_medium_958.yaml	CultureMech:004834	Sea water salts solution (medium 958)	0	no ingredients; no pH and no temperature
-35	bacterial/selenite_tungstate_solution_medium_385.yaml	CultureMech:004289	Selenite/tungstate solution (medium 385)	0	no ingredients; no pH and no temperature
-35	bacterial/seven_vitamins_solution_medium_503.yaml	CultureMech:004290	Seven vitamins solution (medium 503)	0	no ingredients; no pH and no temperature
 35	bacterial/sludge_fluid_medium_119.yaml	CultureMech:004990	Sludge fluid (medium 119)	0	no ingredients; no pH and no temperature
-35	bacterial/solution_1_10x_nms_salts_medium_921.yaml	CultureMech:004291	Solution 1 (10x NMS salts) (medium 921)	0	no ingredients; no pH and no temperature
-35	bacterial/solution_a_medium_1267.yaml	CultureMech:005221	Solution A (medium 1267)	0	no ingredients; no pH and no temperature
-35	bacterial/solution_a_medium_1275.yaml	CultureMech:005222	Solution A, medium 1275	0	no ingredients; no pH and no temperature
-35	bacterial/solution_a_medium_858.yaml	CultureMech:005220	Solution A (medium 858)	0	no ingredients; no pH and no temperature
-35	bacterial/solution_b_medium_1275.yaml	CultureMech:005223	Solution B, medium 1275	0	no ingredients; no pH and no temperature
-35	bacterial/solution_c_medium_1275.yaml	CultureMech:005224	Solution C, medium 1275	0	no ingredients; no pH and no temperature
-35	bacterial/solution_ii_medium_1308.yaml	CultureMech:004836	solution II (medium 1308)	0	no ingredients; no pH and no temperature
-35	bacterial/solution_ii_medium_1398.yaml	CultureMech:004837	solution II (medium 1398)	0	no ingredients; no pH and no temperature
 35	bacterial/sse_double_concentrated_medium_1426.yaml	CultureMech:004838	SSE (double concentrated) (medium 1426)	0	no ingredients; no pH and no temperature
-35	bacterial/stearate_solution_0_1_m_medium_517.yaml	CultureMech:004295	Stearate solution (0.1 M) (medium 517)	0	no ingredients; no pH and no temperature
-35	bacterial/stock_solution_from_medium_756.yaml	CultureMech:004387	Stock solution (from medium 756)	0	no ingredients; no pH and no temperature
-35	bacterial/stock_solution_medium_462.yaml	CultureMech:004398	Stock solution (medium 462)	0	no ingredients; no pH and no temperature
-35	bacterial/sugar_stock_solution_medium_1245.yaml	CultureMech:006082	Sugar Stock Solution (medium 1245)	0	no ingredients; no pH and no temperature
 35	bacterial/synthetic_seawater_2_x_conc_medium_795.yaml	CultureMech:004840	Synthetic seawater (2 x conc.) (medium 795)	0	no ingredients; no pH and no temperature
 35	bacterial/syntrophobacter_pfennigii_medium.yaml	CultureMech:006338	SYNTROPHOBACTER PFENNIGII MEDIUM	1	only 1 ingredient(s); no ingredient is grounded
 35	bacterial/syntrophobacter_wolinii_medium.yaml	CultureMech:004866	SYNTROPHOBACTER WOLINII medium	0	no ingredients; no pH and no temperature
 35	bacterial/syntrophus_buswellii_ii_medium.yaml	CultureMech:005230	SYNTROPHUS BUSWELLII II MEDIUM	0	no ingredients; no pH and no temperature
 35	bacterial/syntrophus_medium_sulfate_free.yaml	CultureMech:004742	SYNTROPHUS medium - SULFATE FREE	0	no ingredients; no pH and no temperature
 35	bacterial/thermodesulforhabdus_medium.yaml	CultureMech:006339	THERMODESULFORHABDUS MEDIUM	1	only 1 ingredient(s); no ingredient is grounded
-35	bacterial/thermus_macronutrients_10x_solution.yaml	CultureMech:004841	Thermus macronutrients 10X solution	0	no ingredients; no pH and no temperature
-35	bacterial/thermus_micronutrients_100x_solution.yaml	CultureMech:004842	Thermus micronutrients 100X solution	0	no ingredients; no pH and no temperature
 35	bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml	CultureMech:006372	THIOBACILLUS FERROOXIDANS MEDIUM WITH TETRATHIONATE	0	no ingredients; no pH and no temperature
-35	bacterial/thioglycolate_ascorbate_solution_medium_210.yaml	CultureMech:004844	Thioglycolate-ascorbate solution (medium 210)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_a_medium_537.yaml	CultureMech:004865	Trace element solution A (medium 537)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_b_medium_537.yaml	CultureMech:004867	Trace element solution B (medium 537)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_from_medium_756.yaml	CultureMech:004388	Trace element solution (from medium 756)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_ho_le_medium_668.yaml	CultureMech:004868	Trace element solution Ho-le (medium 668)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1072.yaml	CultureMech:004847	Trace element solution (medium 1072)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1149.yaml	CultureMech:004848	Trace element solution (medium 1149)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1156.yaml	CultureMech:004302	Trace element solution (medium 1156)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1165.yaml	CultureMech:004849	Trace element solution (medium 1165)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1181.yaml	CultureMech:004304	Trace element solution (medium 1181)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_124.yaml	CultureMech:004850	Trace element solution (medium 124)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_1282.yaml	CultureMech:004852	Trace element solution (medium 1282)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_131.yaml	CultureMech:004308	Trace element solution (medium 131)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_150a.yaml	CultureMech:004312	Trace element solution (medium 150a)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_155.yaml	CultureMech:004399	Trace element solution (medium 155)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_158.yaml	CultureMech:004858	Trace element solution (medium 158)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_463.yaml	CultureMech:004315	Trace element solution (medium 463)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_463a.yaml	CultureMech:004316	Trace element solution (medium 463a)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_533.yaml	CultureMech:004317	Trace element solution (medium 533)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_534.yaml	CultureMech:004318	Trace element solution (medium 534)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_632.yaml	CultureMech:004320	Trace element solution (medium 632)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_652.yaml	CultureMech:004860	Trace element solution (medium 652)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_705.yaml	CultureMech:004862	Trace element solution (medium 705)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_84.yaml	CultureMech:004401	Trace element solution (medium 84)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_878.yaml	CultureMech:004864	Trace element solution (medium 878)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_921.yaml	CultureMech:004327	Trace element solution (medium 921)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_medium_976.yaml	CultureMech:004332	Trace element solution (medium 976)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl12_medium_998.yaml	CultureMech:004870	Trace element solution SL12 (medium 998)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl7.yaml	CultureMech:004871	Trace element solution SL7	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl8_medium_1119.yaml	CultureMech:004874	Trace element solution SL8 (medium 1119)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl_10_b.yaml	CultureMech:004337	Trace element solution SL-10 B	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl_10_medium_320.yaml	CultureMech:004336	Trace element solution SL-10 (medium 320)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl_6_medium_457.yaml	CultureMech:004340	Trace element solution SL-6 (medium 457)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl_7_medium_660.yaml	CultureMech:004341	Trace element solution SL-7 (medium 660)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_element_solution_sl_7_medium_941.yaml	CultureMech:004872	Trace element solution SL-7 (medium 941)	0	no ingredients; no pH and no temperature
 35	bacterial/trace_elements_medium_1108a.yaml	CultureMech:006328	Trace elements (medium 1108a)	0	no ingredients; no pH and no temperature
 35	bacterial/trace_elements_medium_1147.yaml	CultureMech:004875	Trace elements (medium 1147)	0	no ingredients; no pH and no temperature
 35	bacterial/trace_elements_medium_596.yaml	CultureMech:004877	Trace elements (medium 596)	0	no ingredients; no pH and no temperature
 35	bacterial/trace_elements_medium_651.yaml	CultureMech:004878	Trace elements (medium 651)	0	no ingredients; no pH and no temperature
 35	bacterial/trace_elements_pfennig_medium_1264.yaml	CultureMech:004879	Trace elements (Pfennig) (medium 1264)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_elements_solution_medium_1280.yaml	CultureMech:004883	Trace elements solution (medium 1280)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_metals_500x_medium_1341.yaml	CultureMech:004347	Trace Metals (500x) (medium 1341)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_metals_solution_medium_802.yaml	CultureMech:004884	Trace metals solution (medium 802)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_mineral_solution_medium_1000.yaml	CultureMech:004351	Trace mineral solution (medium 1000)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_mineral_solution_medium_1121.yaml	CultureMech:004353	Trace mineral solution (medium 1121)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_mineral_solution_medium_997.yaml	CultureMech:004355	Trace mineral solution (medium 997)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_salt_solution_medium_609.yaml	CultureMech:005191	Trace salt solution (medium 609)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_salt_solution_medium_856.yaml	CultureMech:004885	Trace salt solution (medium 856)	0	no ingredients; no pH and no temperature
-35	bacterial/trace_salts_solution_medium_978.yaml	CultureMech:004938	Trace salts solution (medium 978)	0	no ingredients; no pH and no temperature
 35	bacterial/true_blue_trace_elements_medium_748.yaml	CultureMech:004939	True Blue Trace Elements (medium 748)	0	no ingredients; no pH and no temperature
-35	bacterial/tyc_solution_medium_391.yaml	CultureMech:004992	TYC-solution (medium 391)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_b12_solution_medium_867.yaml	CultureMech:004356	Vitamin B12 solution (medium 867)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_b_solution_medium_978.yaml	CultureMech:004940	Vitamin B solution (medium 978)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_k1_solution_medium_104.yaml	CultureMech:004941	Vitamin K1 solution (medium 104)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_mixture_medium_1001.yaml	CultureMech:004358	Vitamin mixture (medium 1001)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_mixture_medium_619.yaml	CultureMech:004360	Vitamin mixture (medium 619)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_7_medium_842.yaml	CultureMech:004975	Vitamin solution 7 (medium 842)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml	CultureMech:004384	Vitamin solution according to Wolin and coauthors	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_b_medium_253.yaml	CultureMech:004942	Vitamin solution (B) (medium 253)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_double_conc_medium_621.yaml	CultureMech:004943	Vitamin solution (double conc.) (medium 621)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1072.yaml	CultureMech:004945	Vitamin solution (medium 1072)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1116.yaml	CultureMech:004361	Vitamin solution (medium 1116)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1121.yaml	CultureMech:004362	Vitamin solution (medium 1121)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1131.yaml	CultureMech:004363	Vitamin solution (medium 1131)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1149.yaml	CultureMech:004946	Vitamin solution (medium 1149)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1165.yaml	CultureMech:004947	Vitamin solution (medium 1165)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1183.yaml	CultureMech:004954	Vitamin solution (medium 1183)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1191.yaml	CultureMech:004955	Vitamin solution (medium 1191)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_124.yaml	CultureMech:005001	Vitamin solution (medium 124)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1263.yaml	CultureMech:004956	Vitamin solution (medium 1263)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1275.yaml	CultureMech:004364	Vitamin solution (medium 1275)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1282.yaml	CultureMech:004957	Vitamin solution (medium 1282)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1306.yaml	CultureMech:004958	Vitamin solution (medium 1306)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_131.yaml	CultureMech:004365	Vitamin solution (medium 131)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1315.yaml	CultureMech:004366	Vitamin solution (medium 1315)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_141.yaml	CultureMech:004367	Vitamin solution (medium 141)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1426.yaml	CultureMech:004959	Vitamin solution (medium 1426)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_1457.yaml	CultureMech:006516	Vitamin solution (medium 1457)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_148.yaml	CultureMech:004369	Vitamin solution (medium 148)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_212.yaml	CultureMech:004960	Vitamin solution (medium 212)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_315.yaml	CultureMech:004370	Vitamin solution (medium 315)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_322.yaml	CultureMech:004961	Vitamin solution (medium 322)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_461.yaml	CultureMech:004371	Vitamin solution (medium 461)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_463.yaml	CultureMech:004372	Vitamin solution (medium 463)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_463a.yaml	CultureMech:004373	Vitamin solution (medium 463a)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_473.yaml	CultureMech:004374	Vitamin solution (medium 473)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_521.yaml	CultureMech:004962	Vitamin solution (medium 521)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_589.yaml	CultureMech:004967	Vitamin solution (medium 589)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_598.yaml	CultureMech:004944	Vitamin solution (medium 598)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_600.yaml	CultureMech:004394	Vitamin solution (medium 600)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_600a.yaml	CultureMech:004969	Vitamin solution (medium 600a)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_602.yaml	CultureMech:004970	Vitamin solution (medium 602)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_603.yaml	CultureMech:004375	Vitamin solution (medium 603)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_628.yaml	CultureMech:004968	Vitamin solution (medium 628)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_651.yaml	CultureMech:004971	Vitamin solution (medium 651)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_663.yaml	CultureMech:004972	Vitamin solution (medium 663)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_78.yaml	CultureMech:004973	Vitamin solution (medium 78)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_791.yaml	CultureMech:004974	Vitamin solution (medium 791)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_867.yaml	CultureMech:004376	Vitamin solution (medium 867)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_908.yaml	CultureMech:004377	Vitamin solution (medium 908)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_929.yaml	CultureMech:004378	Vitamin solution (medium 929)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_944.yaml	CultureMech:004382	Vitamin solution (medium 944)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_medium_951.yaml	CultureMech:004380	Vitamin solution (medium 951)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_schlegel_medium_462.yaml	CultureMech:004381	Vitamin solution (Schlegel, medium 462)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_v10.yaml	CultureMech:004385	Vitamin solution V10	0	no ingredients; no pH and no temperature
-35	bacterial/vitamin_solution_va_medium_351.yaml	CultureMech:004383	Vitamin solution (VA) (medium 351)	0	no ingredients; no pH and no temperature
-35	bacterial/vitamins_v7_solution_medium_998.yaml	CultureMech:004978	Vitamins V7 solution (medium 998)	0	no ingredients; no pH and no temperature
 35	bacterial/vitox.yaml	CultureMech:005644	Vitox	0	no ingredients; no pH and no temperature
-35	bacterial/volatile_fatty_acid_mixture_medium_330.yaml	CultureMech:004979	Volatile fatty acid mixture (medium 330)	0	no ingredients; no pH and no temperature
-35	bacterial/volatile_fatty_acid_solution_medium_909.yaml	CultureMech:004980	Volatile fatty acid solution (medium 909)	0	no ingredients; no pH and no temperature
 35	bacterial/vy_medium.yaml	CultureMech:001704	VY MEDIUM	2	only 2 ingredient(s); no ingredient is grounded
 35	bacterial/yeast_extract_malt_extract_agar_isp_2_ph_8_5.yaml	CultureMech:010358	Yeast Extract-Malt Extract Agar (ISP-2) (pH 8.5)	0	no ingredients; no pH and no temperature
 35	bacterial/yeast_extract_malt_extract_agar_ph_5_5.yaml	CultureMech:007789	Yeast Extract-Malt Extract Agar (pH 5.5)	0	no ingredients; no pH and no temperature
@@ -691,7 +521,6 @@ score	file_path	record_id	name	n_ingredients	reasons
 30	archaea/natronolimnobius_aht32_medium_a.yaml	CultureMech:003235	NATRONOLIMNOBIUS AHT32 MEDIUM (A)	19	placeholder ingredient text; no pH and no temperature
 30	archaea/natronolimnobius_aht32_medium_b.yaml	CultureMech:002272	NATRONOLIMNOBIUS AHT32 MEDIUM (B)	11	placeholder ingredient text; no pH and no temperature
 30	archaea/thermophilic_methanosaeta_medium.yaml	CultureMech:005164	THERMOPHILIC METHANOSAETA MEDIUM	0	no ingredients
-30	bacterial/10_x_m9_salts.yaml	CultureMech:004267	10 x M9 salts	0	no ingredients
 30	bacterial/JCM_J1341_MODIFIED_PFENNIG_MEDIUM_WITH_ACETATE_AND_FUMARATE.yaml	CultureMech:015833	MODIFIED PFENNIG MEDIUM WITH ACETATE AND FUMARATE	14	placeholder ingredient text; no pH and no temperature
 30	bacterial/JCM_J1344_SEA_WATER_MEDIUM_WITH_ACETATE.yaml	CultureMech:015834	SEA WATER MEDIUM WITH ACETATE	14	placeholder ingredient text; no pH and no temperature
 30	bacterial/JCM_J1365_ACIDIC_LOW_SALT_MINERAL_MEDIUM.yaml	CultureMech:015843	ACIDIC LOW SALT MINERAL MEDIUM	17	placeholder ingredient text; no pH and no temperature
@@ -726,50 +555,19 @@ score	file_path	record_id	name	n_ingredients	reasons
 30	bacterial/mab1_medium.yaml	CultureMech:006272	mAB1-MEDIUM	0	no ingredients
 30	bacterial/mb_medium_with_methanol.yaml	CultureMech:003032	MB MEDIUM WITH METHANOL	27	placeholder ingredient text; no pH and no temperature
 30	bacterial/medium_820_modified_for_dsm_16960.yaml	CultureMech:006546	MEDIUM 820 MODIFIED FOR DSM 16960	0	no ingredients
-30	bacterial/micronutrient_solution_sl8_medium_1128.yaml	CultureMech:004804	Micronutrient solution SL8 (medium 1128)	0	no ingredients
 30	bacterial/middlebrook_7h10_agar.yaml	CultureMech:004805	Middlebrook 7H10 agar	0	no ingredients
 30	bacterial/modified_am5_medium.yaml	CultureMech:003007	MODIFIED AM5 MEDIUM	27	placeholder ingredient text; no pH and no temperature
-30	bacterial/modified_hoagland_trace_element_solution_medium_867.yaml	CultureMech:004283	Modified hoagland trace element solution (medium 867)	0	no ingredients
 30	bacterial/mueller_hinton_broth.yaml	CultureMech:005193	Mueller-Hinton broth	0	no ingredients
 30	bacterial/nutrient_broth_oxoid_medium_948.yaml	CultureMech:004822	Nutrient broth (Oxoid) (medium 948)	0	no ingredients
 30	bacterial/pelobacter_medium.yaml	CultureMech:005242	PELOBACTER medium	0	no ingredients
-30	bacterial/phosphate_buffer_10x_medium_1341.yaml	CultureMech:004285	Phosphate buffer (10x) (medium 1341)	0	no ingredients
-30	bacterial/phosphate_buffer_medium_878.yaml	CultureMech:004823	Phosphate buffer (medium 878)	0	no ingredients
-30	bacterial/phosphate_buffer_medium_921.yaml	CultureMech:004286	Phosphate buffer (medium 921)	0	no ingredients
-30	bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml	CultureMech:004287	Phosphate buffer (pH 6.8, see medium 1132)	0	no ingredients
-30	bacterial/phosphate_buffer_ph_7_2.yaml	CultureMech:004824	Phosphate buffer pH 7.2	0	no ingredients
-30	bacterial/phosphate_solution_medium_1191.yaml	CultureMech:004825	Phosphate solution (medium 1191)	0	no ingredients
 30	bacterial/pplo_broth.yaml	CultureMech:005654	PPLO broth	0	no ingredients
-30	bacterial/salt_solution_medium_852.yaml	CultureMech:004831	salt solution (medium 852)	0	no ingredients
-30	bacterial/seven_vitamin_solution_medium_1332.yaml	CultureMech:004835	Seven Vitamin solution (medium 1332)	0	no ingredients
 30	bacterial/soil_extract_medium_98.yaml	CultureMech:004991	Soil extract (medium 98)	0	no ingredients
-30	bacterial/solution_b_medium_807.yaml	CultureMech:006084	Solution B (medium 807)	0	no ingredients
 30	bacterial/spirochaeta_aurantia_medium.yaml	CultureMech:004195	SPIROCHAETA AURANTIA medium	0	no ingredients
 30	bacterial/spirochaeta_isovalerica_medium.yaml	CultureMech:004701	SPIROCHAETA ISOVALERICA medium	0	no ingredients
 30	bacterial/sporomusa_silvacetica_medium.yaml	CultureMech:006435	SPOROMUSA SILVACETICA medium	0	no ingredients
 30	bacterial/syfac_medium.yaml	CultureMech:003181	SYFAC MEDIUM	22	placeholder ingredient text; no pH and no temperature
 30	bacterial/synthetic_sea_water_medium_79.yaml	CultureMech:004839	Synthetic sea water (medium 79)	0	no ingredients
-30	bacterial/trace_element_solution_medium_1007.yaml	CultureMech:004296	Trace element solution (medium 1007)	0	no ingredients
-30	bacterial/trace_element_solution_medium_1180.yaml	CultureMech:004303	Trace element solution (medium 1180)	0	no ingredients
-30	bacterial/trace_element_solution_medium_1190.yaml	CultureMech:005000	Trace element solution (medium 1190)	0	no ingredients
-30	bacterial/trace_element_solution_medium_1396.yaml	CultureMech:004853	Trace Element solution (medium 1396)	0	no ingredients
-30	bacterial/trace_element_solution_medium_1403.yaml	CultureMech:004309	Trace element solution (medium 1403)	0	no ingredients
-30	bacterial/trace_element_solution_medium_333.yaml	CultureMech:004314	Trace element solution (medium 333)	0	no ingredients
-30	bacterial/trace_element_solution_medium_737.yaml	CultureMech:004323	Trace element solution (medium 737)	0	no ingredients
-30	bacterial/trace_element_solution_medium_918.yaml	CultureMech:004326	Trace element solution (medium 918)	0	no ingredients
-30	bacterial/trace_element_solution_medium_922.yaml	CultureMech:004328	Trace element solution (medium 922)	0	no ingredients
-30	bacterial/trace_element_solution_medium_929.yaml	CultureMech:004330	Trace element solution (medium 929)	0	no ingredients
-30	bacterial/trace_element_solution_medium_996.yaml	CultureMech:004334	Trace element solution (medium 996)	0	no ingredients
-30	bacterial/trace_element_solution_sl_11_medium_784.yaml	CultureMech:004869	Trace element solution SL-11 (medium 784)	0	no ingredients
-30	bacterial/trace_element_solution_sl_12_b.yaml	CultureMech:004338	Trace element solution SL-12 B	0	no ingredients
-30	bacterial/trace_element_solution_sl_8.yaml	CultureMech:004342	Trace element solution SL-8	0	no ingredients
-30	bacterial/trace_element_solution_sl_9_medium_828.yaml	CultureMech:004343	Trace element solution SL-9 (medium 828)	0	no ingredients
-30	bacterial/trace_element_solution_sla.yaml	CultureMech:004335	Trace element solution (SLA)	0	no ingredients
-30	bacterial/trace_elements_sl_12.yaml	CultureMech:004880	Trace elements SL-12	0	no ingredients
 30	bacterial/varunavibrio_medium.yaml	CultureMech:002290	VARUNAVIBRIO MEDIUM	23	placeholder ingredient text; no pH and no temperature
-30	bacterial/vitamin_mixture_medium_484.yaml	CultureMech:004359	Vitamin mixture (medium 484)	0	no ingredients
-30	bacterial/vitamin_solution_ca_medium_87a.yaml	CultureMech:004976	Vitamin solution CA (medium 87a)	0	no ingredients
-30	bacterial/vitamin_solution_medium_559.yaml	CultureMech:004963	Vitamin solution (medium 559)	0	no ingredients
 30	bacterial/xb45_xb90_pb90_2_medium.yaml	CultureMech:006693	XB45/XB90/PB90-2 MEDIUM	0	no ingredients
 30	specialized/dv_base_medium_no_mo.yaml	CultureMech:015517	Dv base medium no Mo	2	only 2 ingredient(s); no media_term (untraceable to a source catalogue); no pH and no temperature
 30	specialized/dv_base_medium_no_w.yaml	CultureMech:015519	Dv base medium no W	2	only 2 ingredient(s); no media_term (untraceable to a source catalogue); no pH and no temperature

--- a/data/normalized_yaml/algae/chapman_andresens_modified_pringsheims_solution.yaml
+++ b/data/normalized_yaml/algae/chapman_andresens_modified_pringsheims_solution.yaml
@@ -1,6 +1,7 @@
 id: CultureMech:000062
 name: chapman_andresens_modified_pringsheims_solution
 category: algae
+record_kind: SOLUTION
 medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/100x_vitamin_solution_medium_1398.yaml
+++ b/data/normalized_yaml/bacterial/100x_vitamin_solution_medium_1398.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004994
 name: 100x_vitamin_solution_medium_1398
 original_name: 100x Vitamin solution (medium 1398)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/10_x_m9_salts.yaml
+++ b/data/normalized_yaml/bacterial/10_x_m9_salts.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004267
 name: 10_x_m9_salts
 original_name: 10 x M9 salts
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/50_x_pye.yaml
+++ b/data/normalized_yaml/bacterial/50_x_pye.yaml
@@ -2,6 +2,7 @@ id: CultureMech:006514
 name: 50_x_pye
 original_name: 50 x PYE
 category: bacterial
+record_kind: SOLUTION
 medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/50x_heterotrophic_basal_salts_solution_medium_1190.yaml
+++ b/data/normalized_yaml/bacterial/50x_heterotrophic_basal_salts_solution_medium_1190.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004779
 name: 50x_heterotrophic_basal_salts_solution_medium_1190
 original_name: 50x Heterotrophic basal salts solution (medium 1190)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/KOMODO_3018_H3P-Vitamin_solution_medium_428.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3018_H3P-Vitamin_solution_medium_428.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004797
 name: h3p_vitamin_solution_medium_428
 original_name: H3P-Vitamin solution (medium 428)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/KOMODO_3071_Trace_element_solution_medium_155.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3071_Trace_element_solution_medium_155.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004857
 name: trace_element_solution_medium_155
 original_name: Trace element solution (medium 155)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/KOMODO_3077_Trace_element_solution_medium_84.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3077_Trace_element_solution_medium_84.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004863
 name: trace_element_solution_medium_84
 original_name: Trace element solution (medium 84)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/KOMODO_3087_Trace_element_solution_SL-8.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3087_Trace_element_solution_SL-8.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004873
 name: trace_element_solution_sl_8
 original_name: Trace element solution SL-8
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/amino_acid_solution_medium_78.yaml
+++ b/data/normalized_yaml/bacterial/amino_acid_solution_medium_78.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004780
 name: amino_acid_solution_medium_78
 original_name: Amino acid solution (medium 78)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_from_a_marine_aquarium_salts_mixture.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005655
 name: artificial_sea_water_from_a_marine_aquarium_salts_mixture
 original_name: Artificial sea water from a marine aquarium salts mixture
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/basal_salts_solution_medium_791.yaml
+++ b/data/normalized_yaml/bacterial/basal_salts_solution_medium_791.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004792
 name: basal_salts_solution_medium_791
 original_name: Basal salts solution (medium 791)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/chelated_iron_solution_medium_737.yaml
+++ b/data/normalized_yaml/bacterial/chelated_iron_solution_medium_737.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004268
 name: chelated_iron_solution_medium_737
 original_name: Chelated iron solution (medium 737)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/chelated_iron_solution_medium_748.yaml
+++ b/data/normalized_yaml/bacterial/chelated_iron_solution_medium_748.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004793
 name: chelated_iron_solution_medium_748
 original_name: Chelated Iron solution (medium 748)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/co_factors_solution_medium_843.yaml
+++ b/data/normalized_yaml/bacterial/co_factors_solution_medium_843.yaml
@@ -2,6 +2,7 @@ id: CultureMech:006083
 name: co_factors_solution_medium_843
 original_name: Co-factors solution (medium 843)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_119.yaml
+++ b/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_119.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004794
 name: fatty_acid_mixture_medium_119
 original_name: Fatty acid mixture (medium 119)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_328.yaml
+++ b/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_328.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004795
 name: fatty_acid_mixture_medium_328
 original_name: Fatty acid mixture (medium 328)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_436.yaml
+++ b/data/normalized_yaml/bacterial/fatty_acid_mixture_medium_436.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004796
 name: fatty_acid_mixture_medium_436
 original_name: Fatty acid mixture (medium 436)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/ferric_quinate_solution_medium_380.yaml
+++ b/data/normalized_yaml/bacterial/ferric_quinate_solution_medium_380.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004272
 name: ferric_quinate_solution_medium_380
 original_name: Ferric Quinate Solution (medium 380)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/h3p_vitamin_solution_medium_428.yaml
+++ b/data/normalized_yaml/bacterial/h3p_vitamin_solution_medium_428.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004397
 name: h3p_vitamin_solution_medium_428
 original_name: H3P-vitamin solution (medium 428)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/haemin_solution_medium_104.yaml
+++ b/data/normalized_yaml/bacterial/haemin_solution_medium_104.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004798
 name: haemin_solution_medium_104
 original_name: Haemin solution (medium 104)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml
+++ b/data/normalized_yaml/bacterial/hanks_balanced_salt_solution_bss_medium_1078.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004800
 name: hanks_balanced_salt_solution_bss_medium_1078
 original_name: Hank's balanced salt solution (BSS, medium 1078)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/heavy_metal_solution_medium_867.yaml
+++ b/data/normalized_yaml/bacterial/heavy_metal_solution_medium_867.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004273
 name: heavy_metal_solution_medium_867
 original_name: Heavy metal solution (medium 867)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/inorganic_salt_solution_medium_754.yaml
+++ b/data/normalized_yaml/bacterial/inorganic_salt_solution_medium_754.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004801
 name: inorganic_salt_solution_medium_754
 original_name: Inorganic salt solution (medium 754)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/lip_solution_medium_391.yaml
+++ b/data/normalized_yaml/bacterial/lip_solution_medium_391.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004802
 name: lip_solution_medium_391
 original_name: LIP-solution (medium 391)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/micronutrient_solution_sl8_medium_1128.yaml
+++ b/data/normalized_yaml/bacterial/micronutrient_solution_sl8_medium_1128.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004804
 name: micronutrient_solution_sl8_medium_1128
 original_name: Micronutrient solution SL8 (medium 1128)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/min_e_base_10x.yaml
+++ b/data/normalized_yaml/bacterial/min_e_base_10x.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004275
 name: min_e_base_10x
 original_name: MIN E - Base (10x)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_salt_solution_2xw_medium_391.yaml
+++ b/data/normalized_yaml/bacterial/mineral_salt_solution_2xw_medium_391.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004806
 name: mineral_salt_solution_2xw_medium_391
 original_name: Mineral salt solution "2xW" (medium 391)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml
+++ b/data/normalized_yaml/bacterial/mineral_salts_solution_for_liquid_medium_medium_1396.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004987
 name: mineral_salts_solution_for_liquid_medium_medium_1396
 original_name: Mineral salts solution for liquid medium (medium 1396)
 category: bacterial
+record_kind: SOLUTION
 medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_salts_solution_for_solid_medium_medium_1396.yaml
+++ b/data/normalized_yaml/bacterial/mineral_salts_solution_for_solid_medium_medium_1396.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004989
 name: mineral_salts_solution_for_solid_medium_medium_1396
 original_name: Mineral salts solution for solid medium (medium 1396)
 category: bacterial
+record_kind: SOLUTION
 medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_1_medium_165.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_1_medium_165.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004278
 name: mineral_solution_1_medium_165
 original_name: Mineral solution 1 (medium 165)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_2_medium_1033.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_2_medium_1033.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004815
 name: mineral_solution_2_medium_1033
 original_name: Mineral solution 2 (medium 1033)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_2_medium_165.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_2_medium_165.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004279
 name: mineral_solution_2_medium_165
 original_name: Mineral solution 2 (medium 165)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_2_medium_203.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_2_medium_203.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004997
 name: mineral_solution_2_medium_203
 original_name: Mineral solution 2 (medium 203)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_2_medium_404.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_2_medium_404.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004816
 name: mineral_solution_2_medium_404
 original_name: Mineral solution 2 (medium 404)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_2_medium_436.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_2_medium_436.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004817
 name: mineral_solution_2_medium_436
 original_name: Mineral solution 2 (medium 436)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_a_medium_492.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_a_medium_492.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004280
 name: mineral_solution_a_medium_492
 original_name: Mineral solution A (medium 492)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_b_medium_492.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_b_medium_492.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004281
 name: mineral_solution_b_medium_492
 original_name: Mineral solution B (medium 492)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_c_medium_492.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_c_medium_492.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004282
 name: mineral_solution_c_medium_492
 original_name: Mineral solution C (medium 492)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_212.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_212.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005195
 name: mineral_solution_medium_212
 original_name: Mineral solution (medium 212)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_317.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_317.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004818
 name: mineral_solution_medium_317
 original_name: Mineral solution (medium 317)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_321.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_321.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004810
 name: mineral_solution_medium_321
 original_name: Mineral solution (medium 321)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_328.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_328.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004811
 name: mineral_solution_medium_328
 original_name: Mineral solution (medium 328)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_330.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_330.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004812
 name: mineral_solution_medium_330
 original_name: Mineral solution (medium 330)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/mineral_solution_medium_335.yaml
+++ b/data/normalized_yaml/bacterial/mineral_solution_medium_335.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004813
 name: mineral_solution_medium_335
 original_name: Mineral solution (medium 335)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/modified_hoagland_trace_element_solution_medium_867.yaml
+++ b/data/normalized_yaml/bacterial/modified_hoagland_trace_element_solution_medium_867.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004283
 name: modified_hoagland_trace_element_solution_medium_867
 original_name: Modified hoagland trace element solution (medium 867)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/na_sesquicarbonate_solution_medium_31.yaml
+++ b/data/normalized_yaml/bacterial/na_sesquicarbonate_solution_medium_31.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004819
 name: na_sesquicarbonate_solution_medium_31
 original_name: Na-sesquicarbonate solution (medium 31)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_buffer_10x_medium_1341.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_buffer_10x_medium_1341.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004285
 name: phosphate_buffer_10x_medium_1341
 original_name: Phosphate buffer (10x) (medium 1341)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_buffer_medium_878.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_buffer_medium_878.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004823
 name: phosphate_buffer_medium_878
 original_name: Phosphate buffer (medium 878)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_buffer_medium_921.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_buffer_medium_921.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004286
 name: phosphate_buffer_medium_921
 original_name: Phosphate buffer (medium 921)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_buffer_ph_6_8_see_medium_1132.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004287
 name: phosphate_buffer_ph_6_8_see_medium_1132
 original_name: Phosphate buffer (pH 6.8, see medium 1132)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_buffer_ph_7_2.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_buffer_ph_7_2.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004824
 name: phosphate_buffer_ph_7_2
 original_name: Phosphate buffer pH 7.2
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_solution_medium_1191.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_solution_medium_1191.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004825
 name: phosphate_solution_medium_1191
 original_name: Phosphate solution (medium 1191)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/phosphate_solution_medium_791.yaml
+++ b/data/normalized_yaml/bacterial/phosphate_solution_medium_791.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004826
 name: phosphate_solution_medium_791
 original_name: Phosphate solution (medium 791)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salt_base_solution_medium_88.yaml
+++ b/data/normalized_yaml/bacterial/salt_base_solution_medium_88.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005194
 name: salt_base_solution_medium_88
 original_name: Salt base solution (medium 88)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salt_solution_medium_104.yaml
+++ b/data/normalized_yaml/bacterial/salt_solution_medium_104.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004828
 name: salt_solution_medium_104
 original_name: salt solution (medium 104)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salt_solution_medium_1191.yaml
+++ b/data/normalized_yaml/bacterial/salt_solution_medium_1191.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004829
 name: salt_solution_medium_1191
 original_name: salt solution (medium 1191)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salt_solution_medium_58.yaml
+++ b/data/normalized_yaml/bacterial/salt_solution_medium_58.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004830
 name: salt_solution_medium_58
 original_name: salt solution (medium 58)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salt_solution_medium_852.yaml
+++ b/data/normalized_yaml/bacterial/salt_solution_medium_852.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004831
 name: salt_solution_medium_852
 original_name: salt solution (medium 852)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/salts_solution_medium_1139.yaml
+++ b/data/normalized_yaml/bacterial/salts_solution_medium_1139.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004833
 name: salts_solution_medium_1139
 original_name: salts solution (medium 1139)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/sea_water_salts_solution_medium_958.yaml
+++ b/data/normalized_yaml/bacterial/sea_water_salts_solution_medium_958.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004834
 name: sea_water_salts_solution_medium_958
 original_name: Sea water salts solution (medium 958)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/selenite_tungstate_solution_medium_385.yaml
+++ b/data/normalized_yaml/bacterial/selenite_tungstate_solution_medium_385.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004289
 name: selenite_tungstate_solution_medium_385
 original_name: Selenite/tungstate solution (medium 385)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/seven_vitamin_solution_medium_1332.yaml
+++ b/data/normalized_yaml/bacterial/seven_vitamin_solution_medium_1332.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004835
 name: seven_vitamin_solution_medium_1332
 original_name: Seven Vitamin solution (medium 1332)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/seven_vitamins_solution_medium_503.yaml
+++ b/data/normalized_yaml/bacterial/seven_vitamins_solution_medium_503.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004290
 name: seven_vitamins_solution_medium_503
 original_name: Seven vitamins solution (medium 503)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_1_10x_nms_salts_medium_921.yaml
+++ b/data/normalized_yaml/bacterial/solution_1_10x_nms_salts_medium_921.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004291
 name: solution_1_10x_nms_salts_medium_921
 original_name: Solution 1 (10x NMS salts) (medium 921)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_a_medium_1267.yaml
+++ b/data/normalized_yaml/bacterial/solution_a_medium_1267.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005221
 name: solution_a_medium_1267
 original_name: Solution A (medium 1267)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_a_medium_1275.yaml
+++ b/data/normalized_yaml/bacterial/solution_a_medium_1275.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005222
 name: solution_a_medium_1275
 original_name: Solution A, medium 1275
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_a_medium_858.yaml
+++ b/data/normalized_yaml/bacterial/solution_a_medium_858.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005220
 name: solution_a_medium_858
 original_name: Solution A (medium 858)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_b_medium_1275.yaml
+++ b/data/normalized_yaml/bacterial/solution_b_medium_1275.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005223
 name: solution_b_medium_1275
 original_name: Solution B, medium 1275
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_b_medium_807.yaml
+++ b/data/normalized_yaml/bacterial/solution_b_medium_807.yaml
@@ -2,6 +2,7 @@ id: CultureMech:006084
 name: solution_b_medium_807
 original_name: Solution B (medium 807)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_c_medium_1275.yaml
+++ b/data/normalized_yaml/bacterial/solution_c_medium_1275.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005224
 name: solution_c_medium_1275
 original_name: Solution C, medium 1275
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_ii_medium_1308.yaml
+++ b/data/normalized_yaml/bacterial/solution_ii_medium_1308.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004836
 name: solution_ii_medium_1308
 original_name: solution II (medium 1308)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/solution_ii_medium_1398.yaml
+++ b/data/normalized_yaml/bacterial/solution_ii_medium_1398.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004837
 name: solution_ii_medium_1398
 original_name: solution II (medium 1398)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/stearate_solution_0_1_m_medium_517.yaml
+++ b/data/normalized_yaml/bacterial/stearate_solution_0_1_m_medium_517.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004295
 name: stearate_solution_0_1_m_medium_517
 original_name: Stearate solution (0.1 M) (medium 517)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/stock_solution_from_medium_756.yaml
+++ b/data/normalized_yaml/bacterial/stock_solution_from_medium_756.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004387
 name: stock_solution_from_medium_756
 original_name: Stock solution (from medium 756)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/stock_solution_medium_462.yaml
+++ b/data/normalized_yaml/bacterial/stock_solution_medium_462.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004398
 name: stock_solution_medium_462
 original_name: Stock solution (medium 462)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/sugar_stock_solution_medium_1245.yaml
+++ b/data/normalized_yaml/bacterial/sugar_stock_solution_medium_1245.yaml
@@ -2,6 +2,7 @@ id: CultureMech:006082
 name: sugar_stock_solution_medium_1245
 original_name: Sugar Stock Solution (medium 1245)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/thermus_macronutrients_10x_solution.yaml
+++ b/data/normalized_yaml/bacterial/thermus_macronutrients_10x_solution.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004841
 name: thermus_macronutrients_10x_solution
 original_name: Thermus macronutrients 10X solution
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/thermus_micronutrients_100x_solution.yaml
+++ b/data/normalized_yaml/bacterial/thermus_micronutrients_100x_solution.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004842
 name: thermus_micronutrients_100x_solution
 original_name: Thermus micronutrients 100X solution
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/thioglycolate_ascorbate_solution_medium_210.yaml
+++ b/data/normalized_yaml/bacterial/thioglycolate_ascorbate_solution_medium_210.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004844
 name: thioglycolate_ascorbate_solution_medium_210
 original_name: Thioglycolate-ascorbate solution (medium 210)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_a_medium_537.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_a_medium_537.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004865
 name: trace_element_solution_a_medium_537
 original_name: Trace element solution A (medium 537)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_b_medium_537.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_b_medium_537.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004867
 name: trace_element_solution_b_medium_537
 original_name: Trace element solution B (medium 537)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_from_medium_756.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_from_medium_756.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004388
 name: trace_element_solution_from_medium_756
 original_name: Trace element solution (from medium 756)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_ho_le_medium_668.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_ho_le_medium_668.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004868
 name: trace_element_solution_ho_le_medium_668
 original_name: Trace element solution Ho-le (medium 668)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1007.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1007.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004296
 name: trace_element_solution_medium_1007
 original_name: Trace element solution (medium 1007)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1072.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1072.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004847
 name: trace_element_solution_medium_1072
 original_name: Trace element solution (medium 1072)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1149.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1149.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004848
 name: trace_element_solution_medium_1149
 original_name: Trace element solution (medium 1149)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1156.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1156.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004302
 name: trace_element_solution_medium_1156
 original_name: Trace element solution (medium 1156)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1165.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1165.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004849
 name: trace_element_solution_medium_1165
 original_name: Trace element solution (medium 1165)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1180.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1180.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004303
 name: trace_element_solution_medium_1180
 original_name: Trace element solution (medium 1180)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1181.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1181.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004304
 name: trace_element_solution_medium_1181
 original_name: Trace element solution (medium 1181)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1190.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1190.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005000
 name: trace_element_solution_medium_1190
 original_name: Trace element solution (medium 1190)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_124.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_124.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004850
 name: trace_element_solution_medium_124
 original_name: Trace element solution (medium 124)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1282.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1282.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004852
 name: trace_element_solution_medium_1282
 original_name: Trace element solution (medium 1282)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_131.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_131.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004308
 name: trace_element_solution_medium_131
 original_name: Trace element solution (medium 131)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1396.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1396.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004853
 name: trace_element_solution_medium_1396
 original_name: Trace Element solution (medium 1396)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_1403.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_1403.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004309
 name: trace_element_solution_medium_1403
 original_name: Trace element solution (medium 1403)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_150a.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_150a.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004312
 name: trace_element_solution_medium_150a
 original_name: Trace element solution (medium 150a)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_155.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_155.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004399
 name: trace_element_solution_medium_155
 original_name: Trace element solution (medium 155)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_158.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_158.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004858
 name: trace_element_solution_medium_158
 original_name: Trace element solution (medium 158)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_333.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_333.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004314
 name: trace_element_solution_medium_333
 original_name: Trace element solution (medium 333)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_463.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_463.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004315
 name: trace_element_solution_medium_463
 original_name: Trace element solution (medium 463)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_463a.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_463a.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004316
 name: trace_element_solution_medium_463a
 original_name: Trace element solution (medium 463a)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_533.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_533.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004317
 name: trace_element_solution_medium_533
 original_name: Trace element solution (medium 533)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_534.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_534.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004318
 name: trace_element_solution_medium_534
 original_name: Trace element solution (medium 534)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_632.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_632.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004320
 name: trace_element_solution_medium_632
 original_name: Trace element solution (medium 632)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_652.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_652.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004860
 name: trace_element_solution_medium_652
 original_name: Trace element solution (medium 652)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_705.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_705.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004862
 name: trace_element_solution_medium_705
 original_name: Trace element solution (medium 705)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_737.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_737.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004323
 name: trace_element_solution_medium_737
 original_name: Trace element solution (medium 737)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_84.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_84.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004401
 name: trace_element_solution_medium_84
 original_name: Trace element solution (medium 84)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_878.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_878.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004864
 name: trace_element_solution_medium_878
 original_name: Trace element solution (medium 878)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_918.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_918.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004326
 name: trace_element_solution_medium_918
 original_name: Trace element solution (medium 918)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_921.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_921.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004327
 name: trace_element_solution_medium_921
 original_name: Trace element solution (medium 921)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_922.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_922.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004328
 name: trace_element_solution_medium_922
 original_name: Trace element solution (medium 922)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_929.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_929.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004330
 name: trace_element_solution_medium_929
 original_name: Trace element solution (medium 929)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_976.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_976.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004332
 name: trace_element_solution_medium_976
 original_name: Trace element solution (medium 976)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_medium_996.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_medium_996.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004334
 name: trace_element_solution_medium_996
 original_name: Trace element solution (medium 996)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl12_medium_998.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl12_medium_998.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004870
 name: trace_element_solution_sl12_medium_998
 original_name: Trace element solution SL12 (medium 998)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl7.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl7.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004871
 name: trace_element_solution_sl7
 original_name: Trace element solution SL7
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl8_medium_1119.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl8_medium_1119.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004874
 name: trace_element_solution_sl8_medium_1119
 original_name: Trace element solution SL8 (medium 1119)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_10_b.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_10_b.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004337
 name: trace_element_solution_sl_10_b
 original_name: Trace element solution SL-10 B
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_10_medium_320.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_10_medium_320.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004336
 name: trace_element_solution_sl_10_medium_320
 original_name: Trace element solution SL-10 (medium 320)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_11_medium_784.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_11_medium_784.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004869
 name: trace_element_solution_sl_11_medium_784
 original_name: Trace element solution SL-11 (medium 784)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_12_b.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_12_b.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004338
 name: trace_element_solution_sl_12_b
 original_name: Trace element solution SL-12 B
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_6_medium_457.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_6_medium_457.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004340
 name: trace_element_solution_sl_6_medium_457
 original_name: Trace element solution SL-6 (medium 457)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_7_medium_660.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_7_medium_660.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004341
 name: trace_element_solution_sl_7_medium_660
 original_name: Trace element solution SL-7 (medium 660)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_7_medium_941.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_7_medium_941.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004872
 name: trace_element_solution_sl_7_medium_941
 original_name: Trace element solution SL-7 (medium 941)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_8.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_8.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004342
 name: trace_element_solution_sl_8
 original_name: Trace element solution SL-8
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sl_9_medium_828.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sl_9_medium_828.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004343
 name: trace_element_solution_sl_9_medium_828
 original_name: Trace element solution SL-9 (medium 828)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_element_solution_sla.yaml
+++ b/data/normalized_yaml/bacterial/trace_element_solution_sla.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004335
 name: trace_element_solution_sla
 original_name: Trace element solution (SLA)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_elements_sl_12.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_sl_12.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004880
 name: trace_elements_sl_12
 original_name: Trace elements SL-12
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_elements_solution_medium_1280.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_solution_medium_1280.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004883
 name: trace_elements_solution_medium_1280
 original_name: Trace elements solution (medium 1280)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_metals_500x_medium_1341.yaml
+++ b/data/normalized_yaml/bacterial/trace_metals_500x_medium_1341.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004347
 name: trace_metals_500x_medium_1341
 original_name: Trace Metals (500x) (medium 1341)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_metals_solution_medium_802.yaml
+++ b/data/normalized_yaml/bacterial/trace_metals_solution_medium_802.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004884
 name: trace_metals_solution_medium_802
 original_name: Trace metals solution (medium 802)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_mineral_solution_medium_1000.yaml
+++ b/data/normalized_yaml/bacterial/trace_mineral_solution_medium_1000.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004351
 name: trace_mineral_solution_medium_1000
 original_name: Trace mineral solution (medium 1000)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_mineral_solution_medium_1121.yaml
+++ b/data/normalized_yaml/bacterial/trace_mineral_solution_medium_1121.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004353
 name: trace_mineral_solution_medium_1121
 original_name: Trace mineral solution (medium 1121)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_mineral_solution_medium_997.yaml
+++ b/data/normalized_yaml/bacterial/trace_mineral_solution_medium_997.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004355
 name: trace_mineral_solution_medium_997
 original_name: Trace mineral solution (medium 997)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_salt_solution_medium_609.yaml
+++ b/data/normalized_yaml/bacterial/trace_salt_solution_medium_609.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005191
 name: trace_salt_solution_medium_609
 original_name: Trace salt solution (medium 609)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_salt_solution_medium_856.yaml
+++ b/data/normalized_yaml/bacterial/trace_salt_solution_medium_856.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004885
 name: trace_salt_solution_medium_856
 original_name: Trace salt solution (medium 856)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/trace_salts_solution_medium_978.yaml
+++ b/data/normalized_yaml/bacterial/trace_salts_solution_medium_978.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004938
 name: trace_salts_solution_medium_978
 original_name: Trace salts solution (medium 978)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/tyc_solution_medium_391.yaml
+++ b/data/normalized_yaml/bacterial/tyc_solution_medium_391.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004992
 name: tyc_solution_medium_391
 original_name: TYC-solution (medium 391)
 category: bacterial
+record_kind: SOLUTION
 medium_type: COMPLEX
 composition_type: UNDEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_b12_solution_medium_867.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_b12_solution_medium_867.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004356
 name: vitamin_b12_solution_medium_867
 original_name: Vitamin B12 solution (medium 867)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_b_solution_medium_978.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_b_solution_medium_978.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004940
 name: vitamin_b_solution_medium_978
 original_name: Vitamin B solution (medium 978)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_k1_solution_medium_104.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_k1_solution_medium_104.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004941
 name: vitamin_k1_solution_medium_104
 original_name: Vitamin K1 solution (medium 104)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_mixture_medium_1001.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_mixture_medium_1001.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004358
 name: vitamin_mixture_medium_1001
 original_name: Vitamin mixture (medium 1001)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_mixture_medium_484.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_mixture_medium_484.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004359
 name: vitamin_mixture_medium_484
 original_name: Vitamin mixture (medium 484)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_mixture_medium_619.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_mixture_medium_619.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004360
 name: vitamin_mixture_medium_619
 original_name: Vitamin mixture (medium 619)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_7_medium_842.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_7_medium_842.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004975
 name: vitamin_solution_7_medium_842
 original_name: Vitamin solution 7 (medium 842)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_according_to_wolin_and_coauthors.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004384
 name: vitamin_solution_according_to_wolin_and_coauthors
 original_name: Vitamin solution according to Wolin and coauthors
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_b_medium_253.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_b_medium_253.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004942
 name: vitamin_solution_b_medium_253
 original_name: Vitamin solution (B) (medium 253)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_ca_medium_87a.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_ca_medium_87a.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004976
 name: vitamin_solution_ca_medium_87a
 original_name: Vitamin solution CA (medium 87a)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_double_conc_medium_621.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_double_conc_medium_621.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004943
 name: vitamin_solution_double_conc_medium_621
 original_name: Vitamin solution (double conc.) (medium 621)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1072.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1072.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004945
 name: vitamin_solution_medium_1072
 original_name: Vitamin solution (medium 1072)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1116.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1116.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004361
 name: vitamin_solution_medium_1116
 original_name: Vitamin solution (medium 1116)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1121.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1121.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004362
 name: vitamin_solution_medium_1121
 original_name: Vitamin solution (medium 1121)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1131.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1131.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004363
 name: vitamin_solution_medium_1131
 original_name: Vitamin solution (medium 1131)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1149.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1149.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004946
 name: vitamin_solution_medium_1149
 original_name: Vitamin solution (medium 1149)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1165.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1165.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004947
 name: vitamin_solution_medium_1165
 original_name: Vitamin solution (medium 1165)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1183.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1183.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004954
 name: vitamin_solution_medium_1183
 original_name: Vitamin solution (medium 1183)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1191.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1191.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004955
 name: vitamin_solution_medium_1191
 original_name: Vitamin solution (medium 1191)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_124.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_124.yaml
@@ -2,6 +2,7 @@ id: CultureMech:005001
 name: vitamin_solution_medium_124
 original_name: Vitamin solution (medium 124)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1263.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1263.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004956
 name: vitamin_solution_medium_1263
 original_name: Vitamin solution (medium 1263)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1275.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1275.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004364
 name: vitamin_solution_medium_1275
 original_name: Vitamin solution (medium 1275)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1282.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1282.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004957
 name: vitamin_solution_medium_1282
 original_name: Vitamin solution (medium 1282)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1306.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1306.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004958
 name: vitamin_solution_medium_1306
 original_name: Vitamin solution (medium 1306)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_131.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_131.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004365
 name: vitamin_solution_medium_131
 original_name: Vitamin solution (medium 131)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1315.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1315.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004366
 name: vitamin_solution_medium_1315
 original_name: Vitamin solution (medium 1315)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_141.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_141.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004367
 name: vitamin_solution_medium_141
 original_name: Vitamin solution (medium 141)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1426.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1426.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004959
 name: vitamin_solution_medium_1426
 original_name: Vitamin solution (medium 1426)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_1457.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_1457.yaml
@@ -2,6 +2,7 @@ id: CultureMech:006516
 name: vitamin_solution_medium_1457
 original_name: Vitamin solution (medium 1457)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_148.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_148.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004369
 name: vitamin_solution_medium_148
 original_name: Vitamin solution (medium 148)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_212.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_212.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004960
 name: vitamin_solution_medium_212
 original_name: Vitamin solution (medium 212)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_315.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_315.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004370
 name: vitamin_solution_medium_315
 original_name: Vitamin solution (medium 315)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_322.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_322.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004961
 name: vitamin_solution_medium_322
 original_name: Vitamin solution (medium 322)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_461.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_461.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004371
 name: vitamin_solution_medium_461
 original_name: Vitamin solution (medium 461)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_463.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_463.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004372
 name: vitamin_solution_medium_463
 original_name: Vitamin solution (medium 463)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_463a.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_463a.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004373
 name: vitamin_solution_medium_463a
 original_name: Vitamin solution (medium 463a)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_473.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_473.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004374
 name: vitamin_solution_medium_473
 original_name: Vitamin solution (medium 473)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_521.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_521.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004962
 name: vitamin_solution_medium_521
 original_name: Vitamin solution (medium 521)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_559.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_559.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004963
 name: vitamin_solution_medium_559
 original_name: Vitamin solution (medium 559)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_589.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_589.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004967
 name: vitamin_solution_medium_589
 original_name: Vitamin solution (medium 589)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_598.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_598.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004944
 name: vitamin_solution_medium_598
 original_name: Vitamin solution (medium 598)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_600.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_600.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004394
 name: vitamin_solution_medium_600
 original_name: Vitamin solution (medium 600)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_600a.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_600a.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004969
 name: vitamin_solution_medium_600a
 original_name: Vitamin solution (medium 600a)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_602.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_602.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004970
 name: vitamin_solution_medium_602
 original_name: Vitamin solution (medium 602)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_603.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_603.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004375
 name: vitamin_solution_medium_603
 original_name: Vitamin solution (medium 603)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_628.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_628.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004968
 name: vitamin_solution_medium_628
 original_name: Vitamin solution (medium 628)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_651.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_651.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004971
 name: vitamin_solution_medium_651
 original_name: Vitamin solution (medium 651)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_663.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_663.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004972
 name: vitamin_solution_medium_663
 original_name: Vitamin solution (medium 663)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_78.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_78.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004973
 name: vitamin_solution_medium_78
 original_name: Vitamin solution (medium 78)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_791.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_791.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004974
 name: vitamin_solution_medium_791
 original_name: Vitamin solution (medium 791)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_867.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_867.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004376
 name: vitamin_solution_medium_867
 original_name: Vitamin solution (medium 867)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_908.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_908.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004377
 name: vitamin_solution_medium_908
 original_name: Vitamin solution (medium 908)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_929.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_929.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004378
 name: vitamin_solution_medium_929
 original_name: Vitamin solution (medium 929)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_944.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_944.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004382
 name: vitamin_solution_medium_944
 original_name: Vitamin solution (medium 944)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_medium_951.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_medium_951.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004380
 name: vitamin_solution_medium_951
 original_name: Vitamin solution (medium 951)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_schlegel_medium_462.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_schlegel_medium_462.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004381
 name: vitamin_solution_schlegel_medium_462
 original_name: Vitamin solution (Schlegel, medium 462)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_v10.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_v10.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004385
 name: vitamin_solution_v10
 original_name: Vitamin solution V10
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamin_solution_va_medium_351.yaml
+++ b/data/normalized_yaml/bacterial/vitamin_solution_va_medium_351.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004383
 name: vitamin_solution_va_medium_351
 original_name: Vitamin solution (VA) (medium 351)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/vitamins_v7_solution_medium_998.yaml
+++ b/data/normalized_yaml/bacterial/vitamins_v7_solution_medium_998.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004978
 name: vitamins_v7_solution_medium_998
 original_name: Vitamins V7 solution (medium 998)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/volatile_fatty_acid_mixture_medium_330.yaml
+++ b/data/normalized_yaml/bacterial/volatile_fatty_acid_mixture_medium_330.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004979
 name: volatile_fatty_acid_mixture_medium_330
 original_name: Volatile fatty acid mixture (medium 330)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/data/normalized_yaml/bacterial/volatile_fatty_acid_solution_medium_909.yaml
+++ b/data/normalized_yaml/bacterial/volatile_fatty_acid_solution_medium_909.yaml
@@ -2,6 +2,7 @@ id: CultureMech:004980
 name: volatile_fatty_acid_solution_medium_909
 original_name: Volatile fatty acid solution (medium 909)
 category: bacterial
+record_kind: SOLUTION
 medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID

--- a/project.justfile
+++ b/project.justfile
@@ -187,6 +187,13 @@ audit-filename-collisions *args="":
 # Triage the media that carry no usable composition (#175). Report-only: the
 # obvious repair — resolving "X solution (medium N)" to medium N's composition —
 # would write a whole medium's recipe into a solution record. See the docstring.
+# Mark stock solutions that were imported as media records (#175). Asserts
+# `record_kind: SOLUTION` — a curated claim, not derived from the name at read
+# time, so it lands in a reviewable diff. Report-only without --apply.
+[group('Curation')]
+retype-solution-records *args="":
+    uv run --extra dev python scripts/retype_solution_records.py {{args}}
+
 [group('QC')]
 triage-missing-compositions *args="":
     uv run --extra dev python scripts/triage_missing_compositions.py {{args}}

--- a/scripts/record_kinds.py
+++ b/scripts/record_kinds.py
@@ -56,6 +56,33 @@ SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")
 RECORD_KIND_SOLUTION = "SOLUTION"
 
 
+def has_solution_shape(instance: Any) -> bool:
+    """True if the record is STRUCTURED as a SolutionRecipe.
+
+    Distinct from `is_solution_record`, and the distinction is load-bearing.
+
+    `is_solution_record` answers "should media-level audits and rankings skip
+    this?" — a question about what the record IS. This one answers "which schema
+    class does this record's SHAPE match?", which is what `validate_strict` needs.
+
+    The 202 records carrying a curated `record_kind: SOLUTION` (#175) are stock
+    solutions conceptually, but they were imported with MediaRecipe shape — `name`,
+    `original_name`, `ingredients` — not the `preferred_term` / `composition` /
+    `term` shape of a SolutionRecipe. Validating them as SolutionRecipe produced
+    606 spurious errors across exactly those 202 files.
+
+    So shape routing keys on the upstream `term.id` prefix only. A curated
+    assertion about what a record means cannot change what it structurally is.
+    """
+    if not isinstance(instance, dict):
+        return False
+    term = instance.get("term")
+    if not isinstance(term, dict):
+        return False
+    tid = term.get("id")
+    return isinstance(tid, str) and tid.startswith(SOLUTION_TERM_PREFIXES)
+
+
 def is_solution_record(instance: Any) -> bool:
     """True if `instance` is a standalone stock-solution record, not a medium.
 

--- a/scripts/record_kinds.py
+++ b/scripts/record_kinds.py
@@ -2,7 +2,7 @@
 """Structural classification of normalized_yaml records: medium vs stock solution.
 
 `data/normalized_yaml/bacterial/` holds two different kinds of record. Most are
-organism growth media. ~4,784 are standalone MediaDive stock-solution entries
+organism growth media. ~4,986 are standalone stock-solution entries
 (`Solution B`, `Main_sol_493`, `SL10_elements`, …) that carry a top-level
 `composition:` and `preferred_term:` instead of `name:`/`ingredients:`.
 
@@ -38,17 +38,40 @@ from typing import Any
 # same shape.
 SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")
 
+# A CURATED assertion, for solutions that carry no upstream solution id (#175).
+#
+# 202 records are stock solutions imported as media — "Trace element solution
+# (medium 929)", "Solution C, medium 1275", "10 x M9 salts". They have no
+# `mediadive.solution:` id to key on, and the id they DO carry cannot be reused:
+# their `mediadive.medium:N` values collide coincidentally with unrelated entries
+# in the solutions namespace, so `mediadive.medium:3145` ("100x Vitamin solution")
+# resolves to solution 3145, "SODIUM CHLORIDE". Only 3 of 202 have a
+# name-agreeing id; asserting the other 170 would record a false identity.
+#
+# So the kind is stated directly instead of inferred from a borrowed identifier.
+# This is deliberately NOT a name heuristic: the value is written once, by a
+# curation script, into a slot a human can review in the diff — whereas matching
+# "*solution*" at read time would silently reclassify any genuine medium that
+# happens to be named "Ringer's solution".
+RECORD_KIND_SOLUTION = "SOLUTION"
+
 
 def is_solution_record(instance: Any) -> bool:
     """True if `instance` is a standalone stock-solution record, not a medium.
 
-    Deliberately keyed on `term.id` rather than on the presence of `composition:`
-    or the absence of `ingredients:`: the id prefix is an explicit provenance
-    assertion, whereas shape heuristics would also catch malformed media records
-    and silently drop them from the research ranking.
+    Two signals, both EXPLICIT assertions rather than shape heuristics — the latter
+    would also catch malformed media records and silently drop them from the
+    research ranking:
+
+      * `term.id` prefix — an upstream provenance assertion (4,784 records).
+      * `record_kind: SOLUTION` — curated, for the 202 with no upstream id.
+      * `record_kind: SOLUTION` — a curated assertion, for solutions that have no
+        upstream solution id to point at (#175).
     """
     if not isinstance(instance, dict):
         return False
+    if str(instance.get("record_kind") or "") == RECORD_KIND_SOLUTION:
+        return True
     term = instance.get("term")
     if not isinstance(term, dict):
         return False

--- a/scripts/retype_solution_records.py
+++ b/scripts/retype_solution_records.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Mark stock solutions that were imported as media records (#175).
+
+202 records under `data/normalized_yaml/` are stock solutions, not media: "Trace
+element solution (medium 929)", "Solution C, medium 1275", "10 x M9 salts",
+"Vitamin mixture (medium 1001)". They came in through the KOMODO ModelSEED import,
+which **flattened** each solution's contents into its parent medium's ingredient
+list and left the solution itself as an empty stub — `KOMODO_1072_PSEUDO...` has no
+`solutions:` at all but lists `MnCl2 x 4 H2O`, `FeSO4 x 7 H2O` and `Biotin`
+directly, which is what upstream cites as "Trace element solution (see below)".
+
+So their composition is not missing from the corpus. It has been absorbed into the
+parent, and these are leftover stubs. They are not media with an absent recipe,
+and counting them as such overstated #175 by nearly half.
+
+## Why `record_kind` and not an id
+
+`is_solution_record()` normally keys on a `term.id` prefix, an upstream provenance
+assertion. These records have none, and the id they DO carry cannot be borrowed:
+their `mediadive.medium:N` values collide coincidentally with unrelated entries in
+the solutions namespace. `100x Vitamin solution` carries `mediadive.medium:3145`,
+and solution 3145 is "SODIUM CHLORIDE". Measured across all 202: **3** have a
+name-agreeing solution id, **170** would assert a false identity, 29 do not resolve
+at all.
+
+Writing `mediadive.solution:3145` onto a vitamin solution would be false chemistry
+of the #166 kind — plausible, well-formed, and wrong. So the kind is asserted
+directly in a slot a reviewer can see, rather than smuggled into a provenance
+field.
+
+## Why this is a script and not a read-time rule
+
+Matching "*solution*" while reading would silently reclassify any genuine medium
+named "Ringer's solution" or "Hank's balanced salt solution", and nobody would see
+it happen. Written once, by this script, the decision appears in a diff.
+
+Deleting these records was the alternative. It was rejected: their CultureMech ids
+appear in 16 tracked artifacts, and CultureMech ids are meant to be stable, so
+retirement creates dangling references while re-typing does not.
+
+Report-only by default.
+
+Usage::
+
+    just retype-solution-records
+    just retype-solution-records --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_kinds import RECORD_KIND_SOLUTION, is_solution_record  # noqa: E402
+from triage_missing_compositions import (  # noqa: E402
+    SOLUTION_NAMED,
+    has_no_usable_composition,
+)
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+
+
+def candidates(normalized: Path = NORMALIZED) -> list[tuple[Path, dict[str, Any]]]:
+    """Records that are named like a stock solution AND carry no composition.
+
+    BOTH conditions are required. A record named "...solution" that has a real
+    ingredient list is a medium as far as this corpus is concerned — Ringer's and
+    Hank's BSS are solutions by name but usable media by content, and re-typing
+    them would remove them from media audits that should still see them.
+    """
+    out = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(doc, dict) or is_solution_record(doc):
+            continue
+        if not has_no_usable_composition(doc):
+            continue
+        name = str(doc.get("original_name") or doc.get("name") or "")
+        if SOLUTION_NAMED.search(name):
+            out.append((path, doc))
+    return out
+
+
+def stamp(path: Path, doc: dict[str, Any]) -> bool:
+    """Insert `record_kind: SOLUTION`. Returns True if the file changed."""
+    text = path.read_text()
+    if re.search(r"^record_kind:", text, re.M):
+        return False
+    # After `category:` when present, else at the top — the id must stay first.
+    new, n = re.subn(r"^(category:.*)$", rf"\1\nrecord_kind: {RECORD_KIND_SOLUTION}",
+                     text, count=1, flags=re.M)
+    if not n:
+        new, n = re.subn(r"^(id:.*)$", rf"\1\nrecord_kind: {RECORD_KIND_SOLUTION}",
+                         text, count=1, flags=re.M)
+    if not n:
+        return False
+    path.write_text(new)
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--apply", action="store_true",
+                    help="Write record_kind: SOLUTION. Default is report-only.")
+    args = ap.parse_args(argv)
+
+    found = candidates(args.normalized_dir)
+    print(f"Stock solutions imported as media records: {len(found)}\n")
+    for path, doc in found[:25]:
+        print(f"  {str(path.relative_to(args.normalized_dir))[:50]:52s} "
+              f"{str(doc.get('original_name') or '')[:40]}")
+    if len(found) > 25:
+        print(f"  ... and {len(found) - 25} more")
+
+    if not args.apply:
+        print("\nReport only. Re-run with --apply to stamp record_kind: SOLUTION.")
+        return 0
+
+    written = sum(1 for path, doc in found if stamp(path, doc))
+    print(f"\nStamped {written} record(s) with record_kind: {RECORD_KIND_SOLUTION}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage_missing_compositions.py
+++ b/scripts/triage_missing_compositions.py
@@ -5,27 +5,30 @@ Classifies every record with nothing to work from, so the backlog can be attacke
 by cause rather than one record at a time. REPORT ONLY — see "the trap" below for
 why the obvious repair is not attempted.
 
-## The count is 428, not 463
+## The count is 226 — it was reported as 463, then 428
 
-The original issue measured `ingredients` alone. A stock-supplied component is
-recorded under `solutions`, so 35 records that look empty are not: they carry
-their whole composition there. The same oversight made 15 of 17 findings in #181
-false positives, so it is worth stating plainly — a record's composition lives in
-`ingredients` AND `solutions`, and any audit that reads one slot will invent a
-defect.
+Two corrections, both of which shrank the problem:
 
-## What the 428 are
+  463 -> 428  The original issue measured `ingredients` alone. A stock-supplied
+              component is recorded under `solutions`, and 35 records that look
+              empty carry their whole composition there. The same oversight made
+              15 of 17 findings in #181 false positives, so it is worth stating
+              plainly: a record's composition lives in `ingredients` AND
+              `solutions`, and any audit reading one slot will invent a defect.
 
-  327  KOMODO ModelSEED, no ingredients and no solutions
-  101  a single placeholder ingredient ("See source for composition")
+  428 -> 226  202 of the remainder were stock solutions imported as media, not
+              media at all. They now carry `record_kind: SOLUTION`, so
+              `is_solution_record()` excludes them (#175). Their contents were
+              flattened into their parent media by the KOMODO import, so nothing
+              is missing — the stubs are leftovers.
 
-**202 of the 428 are named like a stock solution rather than a medium** —
-"Trace element solution (medium 929)", "Solution C, medium 1275",
-"10 x M9 salts". These are not media missing a composition; they are solutions
-imported as media records. `record_kinds.is_solution_record()` does not catch them
-because it keys on a `term.id` prefix these records lack, deliberately: an id
-prefix is an explicit provenance assertion, whereas guessing from a name would
-also swallow genuine media.
+## What the remaining 226 are
+
+  126  KOMODO ModelSEED, no ingredients and no solutions
+  100  a single placeholder ingredient ("See source for composition")
+
+These are the genuine gap: media whose recipe the corpus does not hold. Unlike the
+202, no other record carries their composition.
 
 ## The trap — why 217 records are NOT auto-repairable
 

--- a/scripts/validate_strict.py
+++ b/scripts/validate_strict.py
@@ -42,19 +42,25 @@ DEFAULT_ROOTS = [_REPO_ROOT / "data" / "normalized_yaml" / sub
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from record_kinds import is_solution_record  # noqa: E402  -- shared medium/solution rule
+from record_kinds import has_solution_shape  # noqa: E402  -- shared medium/solution rule
 
 
 def infer_target_class(instance: dict) -> str:
     """Pick the right root class for this record.
 
     A standalone stock-solution record (e.g. mediadive_*_Main_sol_*.yaml)
-    is identified by its `term.id` prefix — see `record_kinds.is_solution_record`,
-    which is shared with the deep-research prioritizer so the two cannot drift
-    (#124). ~4,784 records look like SolutionDescriptors with their own id and
-    curation history, not full MediaRecipes. Everything else is MediaRecipe.
+    is identified by its `term.id` prefix — see `record_kinds.has_solution_shape`,
+    shared so this and the deep-research prioritizer cannot drift (#124). ~4,784
+    records look like SolutionDescriptors with their own id and curation history,
+    not full MediaRecipes. Everything else is MediaRecipe.
+
+    Deliberately `has_solution_shape`, NOT `is_solution_record`. The latter also
+    honours the curated `record_kind: SOLUTION` (#175), which says what a record
+    MEANS — but those 202 records were imported with MediaRecipe shape, so routing
+    them to SolutionRecipe produced 606 spurious errors. A curatorial assertion
+    cannot change what a record structurally is.
     """
-    return "SolutionRecipe" if is_solution_record(instance) else "MediaRecipe"
+    return "SolutionRecipe" if has_solution_shape(instance) else "MediaRecipe"
 
 # Per-worker singleton — built lazily after fork so the schema parses once per
 # worker process, not once per file.

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -250,6 +250,19 @@ classes:
         range: OrganismCultureTypeEnum
         recommended: true
 
+      record_kind:
+        description: >-
+          What kind of record this is: a growth MEDIUM, or a standalone stock
+          SOLUTION. Normally inferred from the `term.id` prefix
+          (`mediadive.solution:*`), and only stated explicitly for solutions that
+          carry no upstream solution identifier — 202 records imported from KOMODO
+          as media ("Trace element solution (medium 929)", "10 x M9 salts") whose
+          composition was flattened into their parent medium.
+          A curated assertion, written by `just retype-solution-records` and
+          reviewable in the diff. It is NOT derived from the name at read time:
+          matching "*solution*" would silently reclassify a genuine medium such as
+          Ringer's solution.
+        range: RecordKindEnum
       medium_type:
         description: >-
           DEPRECATED single-axis classification. Superseded by composition_type,
@@ -2107,6 +2120,18 @@ classes:
 # ================================================================
 
 enums:
+  RecordKindEnum:
+    description: >-
+      Whether a normalized_yaml record describes a growth medium or a standalone
+      stock solution. See the `record_kind` slot: this is stated only where the
+      `term.id` prefix cannot carry the distinction.
+    permissible_values:
+      MEDIUM:
+        description: A growth medium.
+      SOLUTION:
+        description: >-
+          A standalone stock solution (trace elements, vitamins, buffers). Excluded
+          from media-level audits and from the deep-research ranking.
   MediumTypeEnum:
     description: >-
       DEPRECATED single-axis classification of culture medium. It conflated three

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-07-30T21:23:00
+# Generation date: 2026-08-04T18:26:44
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -202,6 +202,7 @@ class MediaRecipe(YAMLRoot):
     target_organisms: Optional[Union[dict[Union[str, OrganismDescriptorPreferredTerm], Union[dict, "OrganismDescriptor"]], list[Union[dict, "OrganismDescriptor"]]]] = empty_dict()
     source_environment: Optional[Union[Union[dict, "SourceEnvironmentDescriptor"], list[Union[dict, "SourceEnvironmentDescriptor"]]]] = empty_list()
     organism_culture_type: Optional[Union[str, "OrganismCultureTypeEnum"]] = None
+    record_kind: Optional[Union[str, "RecordKindEnum"]] = None
     medium_type: Optional[Union[str, "MediumTypeEnum"]] = None
     composition_type: Optional[Union[str, "MediumCompositionTypeEnum"]] = None
     nutritional_class: Optional[Union[str, "MediumNutritionalClassEnum"]] = None
@@ -314,6 +315,9 @@ class MediaRecipe(YAMLRoot):
 
         if self.organism_culture_type is not None and not isinstance(self.organism_culture_type, OrganismCultureTypeEnum):
             self.organism_culture_type = OrganismCultureTypeEnum(self.organism_culture_type)
+
+        if self.record_kind is not None and not isinstance(self.record_kind, RecordKindEnum):
+            self.record_kind = RecordKindEnum(self.record_kind)
 
         if self.medium_type is not None and not isinstance(self.medium_type, MediumTypeEnum):
             self.medium_type = MediumTypeEnum(self.medium_type)
@@ -2581,6 +2585,23 @@ class Dataset(YAMLRoot):
 
 
 # Enumerations
+class RecordKindEnum(EnumDefinitionImpl):
+    """
+    Whether a normalized_yaml record describes a growth medium or a standalone stock solution. See the `record_kind`
+    slot: this is stated only where the `term.id` prefix cannot carry the distinction.
+    """
+    MEDIUM = PermissibleValue(
+        text="MEDIUM",
+        description="A growth medium.")
+    SOLUTION = PermissibleValue(
+        text="SOLUTION",
+        description="""A standalone stock solution (trace elements, vitamins, buffers). Excluded from media-level audits and from the deep-research ranking.""")
+
+    _defn = EnumDefinition(
+        name="RecordKindEnum",
+        description="""Whether a normalized_yaml record describes a growth medium or a standalone stock solution. See the `record_kind` slot: this is stated only where the `term.id` prefix cannot carry the distinction.""",
+    )
+
 class MediumTypeEnum(EnumDefinitionImpl):
     """
     DEPRECATED single-axis classification of culture medium. It conflated three orthogonal properties (composition,
@@ -3942,6 +3963,9 @@ slots.mediaRecipe__source_environment = Slot(uri=CULTUREMECH.source_environment,
 
 slots.mediaRecipe__organism_culture_type = Slot(uri=CULTUREMECH.organism_culture_type, name="mediaRecipe__organism_culture_type", curie=CULTUREMECH.curie('organism_culture_type'),
                    model_uri=CULTUREMECH.mediaRecipe__organism_culture_type, domain=None, range=Optional[Union[str, "OrganismCultureTypeEnum"]])
+
+slots.mediaRecipe__record_kind = Slot(uri=CULTUREMECH.record_kind, name="mediaRecipe__record_kind", curie=CULTUREMECH.curie('record_kind'),
+                   model_uri=CULTUREMECH.mediaRecipe__record_kind, domain=None, range=Optional[Union[str, "RecordKindEnum"]])
 
 slots.mediaRecipe__medium_type = Slot(uri=CULTUREMECH.medium_type, name="mediaRecipe__medium_type", curie=CULTUREMECH.curie('medium_type'),
                    model_uri=CULTUREMECH.mediaRecipe__medium_type, domain=None, range=Optional[Union[str, "MediumTypeEnum"]])

--- a/tests/test_missing_compositions.py
+++ b/tests/test_missing_compositions.py
@@ -43,7 +43,8 @@ def test_a_record_with_nothing_is_reported(tmc):
 
 
 def test_solutions_count_as_a_composition(tmc):
-    """#175 originally said 463; it is 428. A record whose composition lives in
+    """#175 originally said 463; it was 428, and is 226 once the mis-typed stock
+    solutions are excluded. A record whose composition lives in
     `solutions` is not empty — the same slot that made 15 of 17 findings in #181
     false positives."""
     rows = tmc.triage_parsed([_rec(
@@ -64,7 +65,8 @@ def test_a_real_composition_is_not_reported(tmc):
 
 
 def test_solution_named_records_are_flagged_as_mis_typed(tmc):
-    """202 of the 428 are stock solutions imported as media. They
+    """202 were stock solutions imported as media, now carrying
+    `record_kind: SOLUTION` so `is_solution_record()` excludes them. They
     are not media missing a recipe, and counting them as such overstates the
     data-quality problem."""
     rows = tmc.triage_parsed([_rec(
@@ -101,9 +103,10 @@ def test_solution_records_themselves_are_skipped(tmc):
 def test_corpus_baseline(tmc, corpus):
     normalized = REPO_ROOT / "data" / "normalized_yaml"
     rows = tmc.triage_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
-    assert len(rows) <= 428, (
+    assert len(rows) <= 226, (
         f"{len(rows)} records lack a composition, above the documented baseline of "
-        "428 — a new import dropped one, or the detector widened.")
+        "226 — a new import dropped one, or the detector widened. The figure was "
+        "428 before #175 re-typed 202 mis-imported stock solutions.")
 
 
 def test_the_solution_classifier_does_not_enumerate_reagents(tmc):

--- a/tests/test_retype_solution_records.py
+++ b/tests/test_retype_solution_records.py
@@ -1,0 +1,118 @@
+"""Tests for the solution re-typing (#175).
+
+The dangerous direction here is over-reach: re-typing a genuine medium removes it
+from every media-level audit, silently. Most of these pin what must NOT be
+re-typed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rt():
+    return _load("retype_solution_records")
+
+
+@pytest.fixture(scope="module")
+def rk():
+    return _load("record_kinds")
+
+
+def _write(d: Path, name: str, doc: dict):
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(yaml.dump(doc, sort_keys=False))
+
+
+def test_a_named_solution_with_no_composition_is_a_candidate(rt, tmp_path):
+    _write(tmp_path / "bacterial", "a.yaml", {
+        "id": "CultureMech:1", "name": "x",
+        "original_name": "Trace element solution (medium 929)",
+        "category": "bacterial", "ingredients": []})
+    assert len(rt.candidates(tmp_path)) == 1
+
+
+def test_a_named_solution_WITH_a_composition_is_left_alone(rt, tmp_path):
+    """Ringer's and Hank's BSS are solutions by name but usable media by content.
+    Re-typing them would drop them from audits that should still see them — so the
+    name alone is never sufficient."""
+    _write(tmp_path / "bacterial", "b.yaml", {
+        "id": "CultureMech:2", "name": "y",
+        "original_name": "Hank's balanced salt solution", "category": "bacterial",
+        "ingredients": [{"preferred_term": "NaCl"}, {"preferred_term": "KCl"}]})
+    assert rt.candidates(tmp_path) == []
+
+
+def test_an_empty_record_that_is_NOT_named_like_a_solution_is_left_alone(rt, tmp_path):
+    """The 126 genuinely-empty media. They are the real #175 gap and must stay
+    visible in the triage report."""
+    _write(tmp_path / "bacterial", "c.yaml", {
+        "id": "CultureMech:3", "name": "z",
+        "original_name": "DESULFOBACTERIUM ANILINI MEDIUM", "category": "bacterial",
+        "ingredients": []})
+    assert rt.candidates(tmp_path) == []
+
+
+def test_an_already_typed_solution_is_not_reprocessed(rt, tmp_path):
+    _write(tmp_path / "bacterial", "d.yaml", {
+        "id": "CultureMech:4", "record_kind": "SOLUTION",
+        "original_name": "Trace element solution (medium 929)",
+        "category": "bacterial", "ingredients": []})
+    assert rt.candidates(tmp_path) == []
+
+
+def test_stamping_is_idempotent(rt, tmp_path):
+    d = tmp_path / "bacterial"
+    _write(d, "e.yaml", {"id": "CultureMech:5", "name": "e",
+                         "original_name": "Vitamin solution (medium 951)",
+                         "category": "bacterial", "ingredients": []})
+    assert rt.main(["--normalized-dir", str(tmp_path), "--apply"]) == 0
+    once = (d / "e.yaml").read_text()
+    assert rt.main(["--normalized-dir", str(tmp_path), "--apply"]) == 0
+    assert (d / "e.yaml").read_text() == once
+    assert once.count("record_kind:") == 1
+
+
+def test_report_only_by_default(rt, tmp_path):
+    d = tmp_path / "bacterial"
+    _write(d, "f.yaml", {"id": "CultureMech:6", "name": "f",
+                         "original_name": "Trace element solution (medium 84)",
+                         "category": "bacterial", "ingredients": []})
+    before = (d / "f.yaml").read_text()
+    assert rt.main(["--normalized-dir", str(tmp_path)]) == 0
+    assert (d / "f.yaml").read_text() == before
+
+
+def test_record_kind_makes_is_solution_record_true(rk):
+    assert rk.is_solution_record({"record_kind": "SOLUTION"})
+    assert not rk.is_solution_record({"record_kind": "MEDIUM"})
+    assert not rk.is_solution_record({"name": "lb_broth"})
+
+
+def test_the_term_id_rule_still_works(rk):
+    """The curated assertion is additional, not a replacement — 4,784 records still
+    rely on the upstream prefix."""
+    assert rk.is_solution_record({"term": {"id": "mediadive.solution:4367"}})
+    assert rk.is_solution_record({"term": {"id": "MediaIngredientMech:1"}})
+
+
+def test_the_corpus_has_no_untyped_solution_stubs_left(rt):
+    """If this fails, `just retype-solution-records --apply` was not run."""
+    left = rt.candidates()
+    assert not left, f"{len(left)} stubs still untyped, e.g. {[p.name for p,_ in left[:5]]}"

--- a/tests/test_retype_solution_records.py
+++ b/tests/test_retype_solution_records.py
@@ -116,3 +116,33 @@ def test_the_corpus_has_no_untyped_solution_stubs_left(rt):
     """If this fails, `just retype-solution-records --apply` was not run."""
     left = rt.candidates()
     assert not left, f"{len(left)} stubs still untyped, e.g. {[p.name for p,_ in left[:5]]}"
+
+
+# --- shape vs meaning (the 606-error lesson) --------------------------------
+
+
+def test_a_curated_solution_does_not_have_solution_SHAPE(rk):
+    """`is_solution_record` answers "should media audits skip this?".
+    `has_solution_shape` answers "which schema class does this match?".
+
+    Conflating them routed 202 MediaRecipe-shaped records to SolutionRecipe and
+    produced 606 validation errors. A curatorial assertion about what a record
+    MEANS cannot change what it structurally IS.
+    """
+    stub = {"record_kind": "SOLUTION", "name": "x", "ingredients": []}
+    assert rk.is_solution_record(stub)
+    assert not rk.has_solution_shape(stub)
+
+
+def test_an_upstream_solution_is_both(rk):
+    up = {"term": {"id": "mediadive.solution:4367"}}
+    assert rk.is_solution_record(up) and rk.has_solution_shape(up)
+
+
+def test_validate_strict_routes_on_shape_not_meaning():
+    """Guard against re-merging the two: routing on `is_solution_record` here is
+    what broke validation."""
+    src = (REPO_ROOT / "scripts" / "validate_strict.py").read_text()
+    assert "has_solution_shape" in src
+    assert "is_solution_record(instance)" not in src, (
+        "validate_strict routes on meaning again; it must route on shape")


### PR DESCRIPTION
Implements the **re-type** decision.

## Why not delete

Their CultureMech ids appear in **16 tracked artifacts**, and those ids are meant
to be stable identifiers. Retirement creates dangling references; re-typing does
not.

## Why a new slot rather than a solution id

`is_solution_record()` keys on a `term.id` prefix — an upstream provenance
assertion. These 202 have none, and the id they *do* carry cannot be borrowed:
their `mediadive.medium:N` values collide **coincidentally** with unrelated
entries in the solutions namespace.

```
"100x Vitamin solution"  carries mediadive.medium:3145
mediadive solution 3145  is      "SODIUM CHLORIDE"
```

Measured across all 202:

| | |
|---|--:|
| id resolves **and** name agrees | 3 |
| id resolves, names **disagree** | 170 |
| id not in the solutions index | 29 |

Writing `mediadive.solution:3145` onto a vitamin solution is #166's failure mode
— plausible, well-formed, wrong. So `record_kind: SOLUTION` states the claim
**directly**, in a slot a reviewer sees in the diff, instead of smuggling a
curatorial judgement into a provenance field.

It is written **once by a script, never inferred at read time**. Matching
`*solution*` while reading would silently reclassify Ringer's or Hank's BSS, and
nobody would see it happen.

## Why these aren't media with a missing recipe

The KOMODO import **flattened** each solution's contents into its parent and left
the solution as an empty stub. `KOMODO_1072_PSEUDOALTEROMONAS_SPIRALIS_medium` has
no `solutions:` at all but lists `MnCl2 x 4 H2O`, `FeSO4 x 7 H2O`, `Biotin`
directly — which upstream cites as `Trace element solution (see below) 2.0ml`.
Nothing is missing; the stubs are leftovers.

## Scope

**202 files, 202 insertions, one line each.** No other change to any record.

```
media records    11,094 -> 10,892
solution records  4,784 ->  4,986
#175 backlog        428 ->    226
```

The 226 are the genuine gap — 126 empty, 100 placeholder-only. Unlike the 202, no
other record holds their composition.

## Verification

Canaried on one record before the batch: correct placement after `category:`,
recognised by `is_solution_record()`, still parses, idempotent on re-run.

Nine tests, most pinning what must **not** be re-typed — a named solution *with* a
real composition, and an empty record *not* named like a solution, both stay
untouched. Over-reach here removes records from every media audit silently.

Refs #175.