### PR TITLE
Inventory, classify and freshness-check tracked derived artifacts (#145)

### DIFF
--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -1,15 +1,16 @@
 artifact	kind	reason	writer	freshness_checked
 data/MEDIA_SOURCES.tsv	UNKNOWN	no writer found		
 data/chemical_name_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
-data/chemical_name_to_chebi_mapping_enhanced.json	CURRENT_VIEW	generate_ingredient_umap.py	scripts/generate_ingredient_umap.py	
+data/chemical_name_to_chebi_mapping_enhanced.json	CURRENT_VIEW	generate_ingredient_umap.py	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/generate_ingredient_umap.py; src/culturemech/visualization/umap_generator.py	
 data/compound_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
-data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py	
-data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/refresh_id_registry.py	
+data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/enrich_solutions_with_chebi.py	
+data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/assign_culturemech_ids.py; scripts/refresh_id_registry.py; src/culturemech/utils/id_utils.py	
 data/curation/atcc_crossref_candidates.json	UNKNOWN	no writer found		
 data/curation/multi_db_crossref_candidates.json	UNKNOWN	writer purity unestablished (multi_database_crossref.py)	src/culturemech/enrich/multi_database_crossref.py	
-data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py	
+data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py; src/culturemech/curate/organism_extractor.py; src/culturemech/enrich/backfill_pipeline.py	
 data/curation/organism_review.csv	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py	
-data/import_tracking/communitymech_imports.json	UNKNOWN	writer purity unestablished (update_communitymech_links.py)	scripts/update_communitymech_links.py	
+data/import_tracking/communitymech_imports.json	UNKNOWN	writer purity unestablished (import_from_communitymech.py)	scripts/import_from_communitymech.py; scripts/update_communitymech_links.py	
+data/import_tracking/derived_artifacts.tsv	UNKNOWN	no writer found		
 data/import_tracking/mediadive_composition_ids.json	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	
 data/import_tracking/mediaingredientmech_migration_log.json	UNKNOWN	no writer found		
 data/import_tracking/new_solution_ingredients_vs_mediaingredientmech.tsv	UNKNOWN	no writer found		
@@ -21,9 +22,9 @@ data/import_tracking/reports/composition_type_semi_defined.tsv	UNKNOWN	no writer
 data/import_tracking/reports/concentration_plausibility.tsv	CURRENT_VIEW	audit_concentration_plausibility.py	scripts/audit_concentration_plausibility.py	yes
 data/import_tracking/reports/concentration_plausibility_by_record.tsv	UNKNOWN	no writer found		
 data/import_tracking/reports/deep_research_priority.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	
-data/import_tracking/reports/deep_research_priority_top100.json	CURRENT_VIEW	sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	
+data/import_tracking/reports/deep_research_priority_top100.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py; scripts/sample_axis_research_batch.py	
 data/import_tracking/reports/domain_category_audit.json	UNKNOWN	no writer found		
-data/import_tracking/reports/edison_batch.json	UNKNOWN	writer purity unestablished (research_media_edison.py)	scripts/research_media_edison.py	
+data/import_tracking/reports/edison_batch.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/analyze_media_quality.py; scripts/prioritize_deep_research_candidates.py; scripts/research_media_edison.py	
 data/import_tracking/reports/filename_collisions.tsv	CURRENT_VIEW	audit_filename_collisions.py	scripts/audit_filename_collisions.py	yes
 data/import_tracking/reports/g25_phase3_llm_curation.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)	scripts/migrate_kg_fallback_phase3_curation.py	
 data/import_tracking/reports/kg_fallback_consensus_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_to_consensus.py)	scripts/migrate_kg_fallback_to_consensus.py	
@@ -37,10 +38,10 @@ data/import_tracking/reports/primary_term_reground_changes.tsv	UNKNOWN	no writer
 data/import_tracking/reports/review_need_ranking.tsv	CURRENT_VIEW	score_review_need.py	scripts/score_review_need.py	yes
 data/import_tracking/reports/selective_agent_mismatch.tsv	CURRENT_VIEW	audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	yes
 data/import_tracking/reports/top5-curation-proposals.json	UNKNOWN	writer purity unestablished (apply_curation_proposals.py)	scripts/apply_curation_proposals.py	
-data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	audit_derived_artifacts.py	scripts/audit_derived_artifacts.py	yes
-data/import_tracking/researched_media.json	UNKNOWN	writer purity unestablished (researched_manifest.py)	scripts/researched_manifest.py	
+data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	yes
+data/import_tracking/researched_media.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py; scripts/refresh_researched_manifest.py; scripts/researched_manifest.py	
 data/import_tracking/schemas/manifest_v1.schema.json	UNKNOWN	no writer found		
-data/merge_yaml/merge_stats.json	UNKNOWN	writer purity unestablished (verify_merges.py)	scripts/verify_merges.py	
+data/merge_yaml/merge_stats.json	UNKNOWN	writer purity unestablished (verify_merges.py)	scripts/verify_merges.py; src/culturemech/merge/merge_recipes.py	
 data/merge_yaml/merge_stats_2026.json	UNKNOWN	no writer found		
 data/merge_yaml/merge_stats_test.json	UNKNOWN	no writer found		
 data/merge_yaml/merged_2026/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
@@ -55,12 +56,12 @@ data/normalized_yaml/by_source_unknown_index.json	UNKNOWN	no writer found
 data/normalized_yaml/fungal_index.json	UNKNOWN	no writer found		
 data/normalized_yaml/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
 data/normalized_yaml/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
-data/normalized_yaml/solutions/mediadive_solution_index.json	UNKNOWN	writer purity unestablished (import_mediadive_solutions.py)	scripts/import_mediadive_solutions.py	
+data/normalized_yaml/solutions/mediadive_solution_index.json	UNKNOWN	writer purity unestablished (import_mediadive_solutions.py)	scripts/import_mediadive_solutions.py; scripts/migrate_solutions_from_ingredients.py	
 data/normalized_yaml/solutions_index.json	UNKNOWN	no writer found		
 data/normalized_yaml/specialized_index.json	UNKNOWN	no writer found		
 data/raw/microbe-media-param/compound_mappings_strict_final.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
 data/raw/microbe-media-param/compound_mappings_strict_final_hydrate.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
-data/solution_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py	
+data/solution_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py; scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; src/culturemech/embedding/aggregator.py; src/culturemech/embedding/aggregator_yaml_source.py; src/culturemech/visualization/umap_generator.py	
 reports/archive/mim_algae_enrichment.json	SNAPSHOT	archived		
 reports/archive/mim_archaea_enrichment.json	SNAPSHOT	archived		
 reports/archive/mim_bacterial_dryrun.json	SNAPSHOT	archived		
@@ -78,13 +79,13 @@ reports/instance_validation_failures.tsv	UNKNOWN	writer purity unestablished (va
 reports/label_plausibility_2026-07-19.tsv	SNAPSHOT	dated filename		
 reports/label_plausibility_after_fixes.tsv	UNKNOWN	no writer found		
 reports/media_content_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
-reports/media_content_review_manifest.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_content_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py; scripts/propose_media_variant_links.py	
 reports/media_growth_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_growth_review_manifest.py)	scripts/build_media_growth_review_manifest.py	
-reports/media_growth_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_growth_review_html.py)	scripts/build_media_growth_review_html.py	
+reports/media_growth_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_growth_review_html.py)	scripts/build_media_growth_review_html.py; scripts/build_media_growth_review_manifest.py	
 reports/media_variant_link_apply_plan.json	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
 reports/media_variant_link_apply_plan.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
 reports/media_variant_link_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
-reports/media_variant_link_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_variant_link_proposals.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py; scripts/propose_media_variant_links.py	
 reports/media_variant_link_validation.tsv	UNKNOWN	writer purity unestablished (validate_media_variant_links.py)	scripts/validate_media_variant_links.py	
 reports/media_variant_parent_group_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
 reports/media_variant_parent_group_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	

--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -1,0 +1,93 @@
+artifact	kind	reason	writer	freshness_checked
+data/MEDIA_SOURCES.tsv	UNKNOWN	no writer found		
+data/chemical_name_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
+data/chemical_name_to_chebi_mapping_enhanced.json	CURRENT_VIEW	generate_ingredient_umap.py	scripts/generate_ingredient_umap.py	
+data/compound_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
+data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py	
+data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/refresh_id_registry.py	
+data/curation/atcc_crossref_candidates.json	UNKNOWN	no writer found		
+data/curation/multi_db_crossref_candidates.json	UNKNOWN	writer purity unestablished (multi_database_crossref.py)	src/culturemech/enrich/multi_database_crossref.py	
+data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py	
+data/curation/organism_review.csv	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py	
+data/import_tracking/communitymech_imports.json	UNKNOWN	writer purity unestablished (update_communitymech_links.py)	scripts/update_communitymech_links.py	
+data/import_tracking/mediadive_composition_ids.json	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	
+data/import_tracking/mediaingredientmech_migration_log.json	UNKNOWN	no writer found		
+data/import_tracking/new_solution_ingredients_vs_mediaingredientmech.tsv	UNKNOWN	no writer found		
+data/import_tracking/reports/axis_research_batch.json	CURRENT_VIEW	sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	
+data/import_tracking/reports/batch2-curation-proposals.json	UNKNOWN	no writer found		
+data/import_tracking/reports/chebi_regrounding_changes.tsv	SNAPSHOT	one-time migration (migrate_chebi_regrounding.py)	scripts/migrate_chebi_regrounding.py	
+data/import_tracking/reports/composition_type_conflicts.tsv	CURRENT_VIEW	audit_composition_type.py	scripts/audit_composition_type.py	yes
+data/import_tracking/reports/composition_type_semi_defined.tsv	UNKNOWN	no writer found		
+data/import_tracking/reports/concentration_plausibility.tsv	CURRENT_VIEW	audit_concentration_plausibility.py	scripts/audit_concentration_plausibility.py	yes
+data/import_tracking/reports/concentration_plausibility_by_record.tsv	UNKNOWN	no writer found		
+data/import_tracking/reports/deep_research_priority.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	
+data/import_tracking/reports/deep_research_priority_top100.json	CURRENT_VIEW	sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	
+data/import_tracking/reports/domain_category_audit.json	UNKNOWN	no writer found		
+data/import_tracking/reports/edison_batch.json	UNKNOWN	writer purity unestablished (research_media_edison.py)	scripts/research_media_edison.py	
+data/import_tracking/reports/filename_collisions.tsv	CURRENT_VIEW	audit_filename_collisions.py	scripts/audit_filename_collisions.py	yes
+data/import_tracking/reports/g25_phase3_llm_curation.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)	scripts/migrate_kg_fallback_phase3_curation.py	
+data/import_tracking/reports/kg_fallback_consensus_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_to_consensus.py)	scripts/migrate_kg_fallback_to_consensus.py	
+data/import_tracking/reports/kg_fallback_phase2_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)	scripts/migrate_kg_fallback_phase2_oak_ols.py	
+data/import_tracking/reports/kg_fallback_phase2_curator_review.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)	scripts/migrate_kg_fallback_phase2_oak_ols.py	
+data/import_tracking/reports/kg_fallback_phase3_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)	scripts/migrate_kg_fallback_phase3_curation.py	
+data/import_tracking/reports/mim_grounding_divergences.tsv	SNAPSHOT	one-time migration (migrate_legacy_mim_to_chebi.py)	scripts/migrate_legacy_mim_to_chebi.py	
+data/import_tracking/reports/missing_compositions.tsv	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	yes
+data/import_tracking/reports/primary_term_canonicalize_changes.tsv	UNKNOWN	no writer found		
+data/import_tracking/reports/primary_term_reground_changes.tsv	UNKNOWN	no writer found		
+data/import_tracking/reports/review_need_ranking.tsv	CURRENT_VIEW	score_review_need.py	scripts/score_review_need.py	yes
+data/import_tracking/reports/selective_agent_mismatch.tsv	CURRENT_VIEW	audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	yes
+data/import_tracking/reports/top5-curation-proposals.json	UNKNOWN	writer purity unestablished (apply_curation_proposals.py)	scripts/apply_curation_proposals.py	
+data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	audit_derived_artifacts.py	scripts/audit_derived_artifacts.py	yes
+data/import_tracking/researched_media.json	UNKNOWN	writer purity unestablished (researched_manifest.py)	scripts/researched_manifest.py	
+data/import_tracking/schemas/manifest_v1.schema.json	UNKNOWN	no writer found		
+data/merge_yaml/merge_stats.json	UNKNOWN	writer purity unestablished (verify_merges.py)	scripts/verify_merges.py	
+data/merge_yaml/merge_stats_2026.json	UNKNOWN	no writer found		
+data/merge_yaml/merge_stats_test.json	UNKNOWN	no writer found		
+data/merge_yaml/merged_2026/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
+data/merge_yaml/merged_2026/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
+data/normalized_yaml/algae_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/archaea_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/bacterial_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/by_source_komodo_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/by_source_mediadive_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/by_source_togo_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/by_source_unknown_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/fungal_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
+data/normalized_yaml/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
+data/normalized_yaml/solutions/mediadive_solution_index.json	UNKNOWN	writer purity unestablished (import_mediadive_solutions.py)	scripts/import_mediadive_solutions.py	
+data/normalized_yaml/solutions_index.json	UNKNOWN	no writer found		
+data/normalized_yaml/specialized_index.json	UNKNOWN	no writer found		
+data/raw/microbe-media-param/compound_mappings_strict_final.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
+data/raw/microbe-media-param/compound_mappings_strict_final_hydrate.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
+data/solution_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py	
+reports/archive/mim_algae_enrichment.json	SNAPSHOT	archived		
+reports/archive/mim_archaea_enrichment.json	SNAPSHOT	archived		
+reports/archive/mim_bacterial_dryrun.json	SNAPSHOT	archived		
+reports/archive/mim_bacterial_enrichment.json	SNAPSHOT	archived		
+reports/archive/mim_fungal_enrichment.json	SNAPSHOT	archived		
+reports/archive/mim_specialized_enrichment.json	SNAPSHOT	archived		
+reports/archive/validation_20260316.json	SNAPSHOT	archived		
+reports/archive/validation_20260316.tsv	SNAPSHOT	archived		
+reports/archive/validation_corrected_20260316.json	SNAPSHOT	archived		
+reports/archive/validation_corrected_20260316.tsv	SNAPSHOT	archived		
+reports/archive/validation_final_20260316.json	SNAPSHOT	archived		
+reports/archive/validation_final_20260316.tsv	SNAPSHOT	archived		
+reports/gap_fix_backlog.tsv	UNKNOWN	no writer found		
+reports/instance_validation_failures.tsv	UNKNOWN	writer purity unestablished (validate_strict.py)	scripts/validate_strict.py	
+reports/label_plausibility_2026-07-19.tsv	SNAPSHOT	dated filename		
+reports/label_plausibility_after_fixes.tsv	UNKNOWN	no writer found		
+reports/media_content_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
+reports/media_content_review_manifest.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_growth_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_growth_review_manifest.py)	scripts/build_media_growth_review_manifest.py	
+reports/media_growth_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_growth_review_html.py)	scripts/build_media_growth_review_html.py	
+reports/media_variant_link_apply_plan.json	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
+reports/media_variant_link_apply_plan.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
+reports/media_variant_link_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_variant_link_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_variant_link_validation.tsv	UNKNOWN	writer purity unestablished (validate_media_variant_links.py)	scripts/validate_media_variant_links.py	
+reports/media_variant_parent_group_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_variant_parent_group_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
+reports/media_variation_candidate_groups.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
+reports/media_variation_candidate_groups.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
+reports/pipeline_writers_audit.tsv	UNKNOWN	no writer found		

--- a/project.justfile
+++ b/project.justfile
@@ -194,6 +194,19 @@ audit-filename-collisions *args="":
 retype-solution-records *args="":
     uv run --extra dev python scripts/retype_solution_records.py {{args}}
 
+# Inventory and classify every tracked derived artifact, and verify that the
+# freshness-checkable ones still match a fresh run (#145). A record move leaves
+# stale paths in artifacts nothing refreshes; only the indexes failed loudly.
+[group('QC')]
+audit-derived-artifacts *args="":
+    uv run --extra dev python scripts/audit_derived_artifacts.py {{args}}
+
+# The one follow-up step after a bulk record move: regenerate the current-view
+# artifacts, then review and commit the diff.
+[group('Curation')]
+refresh-derived:
+    uv run --extra dev python scripts/audit_derived_artifacts.py --refresh
+
 [group('QC')]
 triage-missing-compositions *args="":
     uv run --extra dev python scripts/triage_missing_compositions.py {{args}}

--- a/scripts/audit_concentration_plausibility.py
+++ b/scripts/audit_concentration_plausibility.py
@@ -52,8 +52,9 @@ import argparse
 import csv
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import yaml
 
@@ -226,8 +227,7 @@ def summarize_records(rows: list[dict[str, str]],
 
     out: list[dict[str, str]] = []
     for file_path, found in sorted(by_record.items()):
-        counts = {k: 0 for k in ("WATER_AS_VOLUME", "TRACE_SALT_AS_STOCK",
-                                 "INDICATOR_UNIT_SLIP")}
+        counts = dict.fromkeys(("WATER_AS_VOLUME", "TRACE_SALT_AS_STOCK", "INDICATOR_UNIT_SLIP"), 0)
         for r in found:
             counts[r["finding"]] += 1
         try:
@@ -299,8 +299,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"\nRecords holding a FLATTENED STOCK COCKTAIL: {cocktails}")
     print("  (>=3 flagged vitamin or trace rows and no `solutions:` block — "
           "the actionable subset)")
-    print(f"\nWrote {args.out.relative_to(REPO_ROOT)}")
-    print(f"Wrote {summary_path.relative_to(REPO_ROOT)}")
+    rel = args.out.relative_to(REPO_ROOT) if args.out.is_relative_to(REPO_ROOT) else args.out
+    print(f"\nWrote {rel}")
+    srel = (summary_path.relative_to(REPO_ROOT)
+            if summary_path.is_relative_to(REPO_ROOT) else summary_path)
+    print(f"Wrote {srel}")
     print("\nRead-only. Repairing the trace-element case means nesting the cocktail "
           "under a stock `solution` object with an addition volume — per-record curation.")
 

--- a/scripts/audit_derived_artifacts.py
+++ b/scripts/audit_derived_artifacts.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Inventory, classify and freshness-check tracked derived artifacts (#145).
+
+A category move leaves a record's old path embedded in tracked artifacts that
+nothing refreshes. Only the recipe indexes fail loudly (#125). The registry
+(#144), the chebi report (#157) and two review manifests (#168) each rotted
+silently and were found by someone going looking — six instances so far, and this
+session added several more tracked reports to the pile.
+
+## Why this is a script and not a table
+
+#145 suggests recording the classification as "a short table in
+`docs/DATA_LAYERS.md`". A static table listing derived artifacts would itself be a
+derived artifact nobody refreshes — the seventh instance of the same bug. So the
+classification is computed from the repo, and the tracked manifest it writes is
+checked against a fresh computation by a test.
+
+## The three kinds (from #157, which established that the remedy differs)
+
+CURRENT_VIEW   Must match what its writer produces from today's corpus. Guarded by
+               regenerating to a temp path and comparing. These are the ones a
+               record move invalidates.
+
+SNAPSHOT       A record of what was true when something ran: `reports/archive/*`,
+               dated filenames, and the output of one-time `migrate_*` scripts.
+               Refreshing these would falsify history, so they are deliberately
+               NOT checked.
+
+UNKNOWN        No writer found, or a writer whose purity is unestablished. NOT a
+               failure — it is the honest state for an artifact nobody has
+               classified yet, and listing them is the point. Silence here would
+               imply coverage that does not exist.
+
+## What "checkable" means
+
+An artifact is freshness-checkable only if its writer takes `--out` and does not
+touch the corpus. `migrate_*` scripts rewrite records; `propose_media_variant_links`
+proposes links; `build_media_growth_review_html` builds HTML. Running those to
+check a report would have side effects far beyond the check, which is exactly why
+#168 did not verify its two manifests. Checkable artifacts are declared explicitly
+below rather than guessed.
+
+Usage::
+
+    just audit-derived-artifacts             # inventory + classification
+    just audit-derived-artifacts --check     # also verify CURRENT_VIEW freshness
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "derived_artifacts.tsv"
+
+ARTIFACT_SUFFIX = re.compile(r"\.(tsv|json|csv)$")
+DATED = re.compile(r"\d{4}-\d{2}-\d{2}|_\d{8}")
+
+# Artifacts whose writer takes `--out` and does not mutate the corpus, so a
+# freshness check can regenerate them to a temp path safely. Explicit, because
+# "has --out" is not the same as "is safe to run": audit_composition_type also
+# has --promote-semi-defined, and is only pure without it.
+CHECKABLE: dict[str, list[str]] = {
+    "data/import_tracking/reports/composition_type_conflicts.tsv":
+        ["scripts/audit_composition_type.py"],
+    "data/import_tracking/reports/concentration_plausibility.tsv":
+        ["scripts/audit_concentration_plausibility.py"],
+    "data/import_tracking/reports/filename_collisions.tsv":
+        ["scripts/audit_filename_collisions.py"],
+    "data/import_tracking/reports/selective_agent_mismatch.tsv":
+        ["scripts/audit_selective_agent_mismatch.py"],
+    "data/import_tracking/reports/review_need_ranking.tsv":
+        ["scripts/score_review_need.py"],
+    "data/import_tracking/reports/missing_compositions.tsv":
+        ["scripts/triage_missing_compositions.py"],
+    "data/import_tracking/reports/unparsed_compositions.tsv":
+        ["scripts/report_unparsed_compositions.py"],
+}
+
+
+def tracked_artifacts() -> list[str]:
+    out = subprocess.run(["git", "ls-files"], capture_output=True, text=True,
+                         cwd=REPO).stdout.split()
+    return sorted(f for f in out if ARTIFACT_SUFFIX.search(f)
+                  and (f.startswith("reports/") or f.startswith("data/")))
+
+
+def find_writer(artifact: str) -> str | None:
+    """A script mentioning this artifact's basename, if any."""
+    base = os.path.basename(artifact)
+    res = subprocess.run(["grep", "-rl", "--include=*.py", "--", base, "scripts", "src"],
+                         capture_output=True, text=True, cwd=REPO)
+    files = [f for f in res.stdout.split() if f]
+    return files[0] if files else None
+
+
+def classify(artifact: str, writer: str | None) -> tuple[str, str]:
+    if artifact.startswith("reports/archive/"):
+        return "SNAPSHOT", "archived"
+    if DATED.search(os.path.basename(artifact)):
+        return "SNAPSHOT", "dated filename"
+    if writer is None:
+        return "UNKNOWN", "no writer found"
+    base = os.path.basename(writer)
+    if base.startswith("migrate_"):
+        return "SNAPSHOT", f"one-time migration ({base})"
+    if artifact in CHECKABLE:
+        return "CURRENT_VIEW", base
+    if re.match(r"(audit_|score_|triage_|report_|prioritize_|sample_|refresh_|generate_)", base):
+        return "CURRENT_VIEW", base
+    return "UNKNOWN", f"writer purity unestablished ({base})"
+
+
+def inventory() -> list[dict[str, str]]:
+    rows = []
+    for art in tracked_artifacts():
+        writer = find_writer(art)
+        kind, why = classify(art, writer)
+        rows.append({
+            "artifact": art,
+            "kind": kind,
+            "reason": why,
+            "writer": writer or "",
+            "freshness_checked": "yes" if art in CHECKABLE else "",
+        })
+    return rows
+
+
+def check_freshness(rows: list[dict[str, str]]) -> list[str]:
+    """Regenerate each checkable artifact to a temp path and compare."""
+    stale = []
+    for art, cmd in CHECKABLE.items():
+        src = REPO / art
+        if not src.is_file():
+            stale.append(f"{art}: declared checkable but missing")
+            continue
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td) / os.path.basename(art)
+            res = subprocess.run(
+                ["uv", "run", "python", *cmd, "--out", str(tmp)],
+                capture_output=True, text=True, cwd=REPO)
+            if res.returncode != 0 or not tmp.is_file():
+                stale.append(f"{art}: regeneration failed ({res.stderr.strip()[:120]})")
+                continue
+            if tmp.read_bytes() != src.read_bytes():
+                stale.append(f"{art}: STALE — differs from a fresh run")
+    return stale
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--check", action="store_true",
+                    help="Also regenerate every CURRENT_VIEW artifact and compare.")
+    ap.add_argument("--refresh", action="store_true",
+                    help="Regenerate the freshness-checked artifacts in place. This is "
+                         "the one follow-up step after a bulk record move (#145), "
+                         "instead of a checklist held in someone's head.")
+    args = ap.parse_args(argv)
+
+    rows = inventory()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
+            "artifact", "kind", "reason", "writer", "freshness_checked"])
+        w.writeheader()
+        w.writerows(rows)
+
+    from collections import Counter
+    counts = Counter(r["kind"] for r in rows)
+    print(f"Tracked derived artifacts: {len(rows)}")
+    for k in ("CURRENT_VIEW", "SNAPSHOT", "UNKNOWN"):
+        print(f"  {counts.get(k, 0):4d}  {k}")
+    checked = sum(1 for r in rows if r["freshness_checked"])
+    print(f"\n  {checked} of {counts.get('CURRENT_VIEW', 0)} CURRENT_VIEW artifacts are "
+          f"freshness-checked.")
+    print("  The rest have a writer that is not safe to run for a check (it mutates")
+    print("  records, proposes links, or builds HTML) — see CHECKABLE in this script.")
+    print(f"\nWrote {args.out.relative_to(REPO) if args.out.is_relative_to(REPO) else args.out}")
+
+    if args.refresh:
+        print("\nRegenerating freshness-checked artifacts in place...")
+        failed = []
+        for art, cmd in CHECKABLE.items():
+            res = subprocess.run(["uv", "run", "python", *cmd, "--out", str(REPO / art)],
+                                 capture_output=True, text=True, cwd=REPO)
+            status = "ok" if res.returncode == 0 else "FAILED"
+            if res.returncode != 0:
+                failed.append(art)
+            print(f"  {status:7s} {art}")
+        if failed:
+            print(f"\n{len(failed)} regeneration(s) failed.", file=sys.stderr)
+            return 1
+        print("\nReview the diff and commit it.")
+        return 0
+
+    if not args.check:
+        return 0
+
+    print("\nRegenerating CURRENT_VIEW artifacts to compare...")
+    stale = check_freshness(rows)
+    if stale:
+        print(f"\n{len(stale)} artifact(s) are stale:", file=sys.stderr)
+        for s in stale:
+            print(f"  {s}", file=sys.stderr)
+        print("\nRefresh with `just refresh-derived`.", file=sys.stderr)
+        return 1
+    print("All freshness-checked artifacts match a fresh run.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_derived_artifacts.py
+++ b/scripts/audit_derived_artifacts.py
@@ -61,6 +61,8 @@ REPO = Path(__file__).resolve().parent.parent
 DEFAULT_OUT = REPO / "data" / "import_tracking" / "derived_artifacts.tsv"
 
 ARTIFACT_SUFFIX = re.compile(r"\.(tsv|json|csv)$")
+# Script-name prefixes that mean "regenerates a view of the corpus".
+GENERATOR = re.compile(r"(audit_|score_|triage_|report_|prioritize_|sample_|refresh_|generate_)")
 DATED = re.compile(r"\d{4}-\d{2}-\d{2}|_\d{8}")
 
 # Artifacts whose writer takes `--out` and does not mutate the corpus, so a
@@ -92,13 +94,28 @@ def tracked_artifacts() -> list[str]:
                   and (f.startswith("reports/") or f.startswith("data/")))
 
 
-def find_writer(artifact: str) -> str | None:
-    """A script mentioning this artifact's basename, if any."""
+SELF = "scripts/audit_derived_artifacts.py"
+
+
+def find_writers(artifact: str) -> list[str]:
+    """Every script mentioning this artifact's basename.
+
+    Returns ALL candidates, not the first. Nine artifacts have more than one, and
+    first-match-wins resolved them arbitrarily: `culturemech_id_registry.tsv` has
+    three (`refresh_id_registry`, `assign_culturemech_ids`, `id_utils`) and got the
+    right one by alphabetical luck, while `media_content_review_manifest.tsv` has
+    two genuinely different tools. Ambiguity a curator can see beats a confident
+    wrong answer.
+
+    Excludes this script. It names every CHECKABLE artifact, so it matched all of
+    them — and sorted first for `unparsed_compositions.tsv`, making the manifest
+    report the auditor as that report's writer (#204). A tool must not attribute
+    artifacts to itself.
+    """
     base = os.path.basename(artifact)
     res = subprocess.run(["grep", "-rl", "--include=*.py", "--", base, "scripts", "src"],
                          capture_output=True, text=True, cwd=REPO)
-    files = [f for f in res.stdout.split() if f]
-    return files[0] if files else None
+    return sorted(f for f in res.stdout.split() if f and f != SELF)
 
 
 def classify(artifact: str, writer: str | None) -> tuple[str, str]:
@@ -113,7 +130,7 @@ def classify(artifact: str, writer: str | None) -> tuple[str, str]:
         return "SNAPSHOT", f"one-time migration ({base})"
     if artifact in CHECKABLE:
         return "CURRENT_VIEW", base
-    if re.match(r"(audit_|score_|triage_|report_|prioritize_|sample_|refresh_|generate_)", base):
+    if GENERATOR.match(base):
         return "CURRENT_VIEW", base
     return "UNKNOWN", f"writer purity unestablished ({base})"
 
@@ -121,13 +138,25 @@ def classify(artifact: str, writer: str | None) -> tuple[str, str]:
 def inventory() -> list[dict[str, str]]:
     rows = []
     for art in tracked_artifacts():
-        writer = find_writer(art)
-        kind, why = classify(art, writer)
+        writers = find_writers(art)
+        # A declared checkable artifact's writer is known exactly; re-deriving it
+        # by grep would be guessing at something already stated.
+        declared = CHECKABLE.get(art)
+        if declared:
+            writers = [declared[0]] + [w for w in writers if w != declared[0]]
+        # Classify from the REGENERATING writer when several touch the artifact.
+        # `culturemech_id_registry.tsv` is written by assign_culturemech_ids (which
+        # MINTS ids), refresh_id_registry (which rebuilds it) and id_utils. Taking
+        # the alphabetically first made it UNKNOWN and lost a correct answer; the
+        # refresher is the one that determines whether the file is current.
+        primary = next((w for w in writers if GENERATOR.match(os.path.basename(w))),
+                       writers[0] if writers else None)
+        kind, why = classify(art, primary)
         rows.append({
             "artifact": art,
             "kind": kind,
             "reason": why,
-            "writer": writer or "",
+            "writer": "; ".join(writers),
             "freshness_checked": "yes" if art in CHECKABLE else "",
         })
     return rows

--- a/scripts/audit_filename_collisions.py
+++ b/scripts/audit_filename_collisions.py
@@ -206,7 +206,8 @@ def main(argv: list[str] | None = None) -> int:
     for k in ("IDENTICAL", "EQUIVALENT", "DIFFERENT", "UNREADABLE"):
         if k in tally:
             print(f"  {k:11s} {tally[k]}")
-    print(f"\nWrote {args.out.relative_to(REPO_ROOT)}")
+    rel = args.out.relative_to(REPO_ROOT) if args.out.is_relative_to(REPO_ROOT) else args.out
+    print(f"\nWrote {rel}")
     print("\nNothing was moved, renamed or deleted — classification only (#116 is curation).")
     return 0
 

--- a/tests/test_derived_artifacts.py
+++ b/tests/test_derived_artifacts.py
@@ -91,8 +91,8 @@ def test_unknowns_are_reported_not_hidden(ada):
     exist. It is a ceiling, not a target: driving it to 0 by guessing would be
     worse than leaving them listed."""
     unknown = [r for r in ada.inventory() if r["kind"] == "UNKNOWN"]
-    assert len(unknown) <= 55, (
-        f"{len(unknown)} unclassified artifacts, above the documented 55. A new "
+    assert len(unknown) <= 54, (
+        f"{len(unknown)} unclassified artifacts, above the documented 54. A new "
         "tracked artifact was added without a classification.")
 
 
@@ -109,3 +109,42 @@ def test_a_corrupted_artifact_is_detected(ada, tmp_path, monkeypatch):
     fake.write_text(real.read_text() + "bogus\tstale\trow\n")
     assert fake.read_bytes() != real.read_bytes(), (
         "the byte comparison the check relies on would not notice a changed file")
+
+
+# --- #204: the tool must not attribute artifacts to itself -----------------
+
+
+def test_the_auditor_is_never_recorded_as_a_writer(ada):
+    """`audit_derived_artifacts.py` names every CHECKABLE artifact, so a plain grep
+    matched all of them — and sorted first for unparsed_compositions.tsv, making
+    the manifest report the auditor as that report's writer. The writer column is
+    the evidence for each classification, so circular attribution undermines it."""
+    for row in ada.inventory():
+        assert ada.SELF not in row["writer"], (
+            f"{row['artifact']} attributes itself to the auditor")
+
+
+def test_all_candidate_writers_are_recorded_not_just_the_first(ada):
+    """Nine artifacts have several. Ambiguity a curator can see beats a confident
+    wrong answer."""
+    multi = [r for r in ada.inventory() if ";" in r["writer"]]
+    assert multi, "no multi-writer artifacts recorded; find_writers regressed to first-match"
+
+
+def test_a_checkable_artifact_uses_its_declared_writer(ada):
+    """Re-deriving by grep would be guessing at something already stated."""
+    for art, cmd in ada.CHECKABLE.items():
+        row = next(r for r in ada.inventory() if r["artifact"] == art)
+        assert row["writer"].split(";")[0].strip() == cmd[0]
+
+
+def test_the_regenerating_writer_wins_when_several_touch_an_artifact(ada):
+    """`culturemech_id_registry.tsv` is written by assign_culturemech_ids (which
+    MINTS ids), refresh_id_registry (which rebuilds it) and id_utils. Taking the
+    alphabetically first classified it UNKNOWN and lost a correct answer."""
+    row = next((r for r in ada.inventory()
+                if r["artifact"] == "data/culturemech_id_registry.tsv"), None)
+    if row is None:
+        pytest.skip("id registry not tracked")
+    assert row["kind"] == "CURRENT_VIEW"
+    assert "refresh_id_registry" in row["reason"]

--- a/tests/test_derived_artifacts.py
+++ b/tests/test_derived_artifacts.py
@@ -1,0 +1,111 @@
+"""Guard that tracked derived artifacts stay classified and fresh (#145).
+
+Six instances of the same bug: a record move leaves stale paths in a tracked
+artifact nothing refreshes, and only the recipe indexes (#125) fail loudly. The
+registry (#144), the chebi report (#157) and two review manifests (#168) were each
+found by someone going looking.
+
+The classification is COMPUTED, not written down. #145 suggested "a short table in
+docs/DATA_LAYERS.md" — but a static table listing derived artifacts is itself a
+derived artifact nobody refreshes, which would be the seventh instance.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ada():
+    return _load("audit_derived_artifacts")
+
+
+def test_the_manifest_matches_a_fresh_computation(ada):
+    """The manifest is itself a tracked derived artifact, so it needs the same
+    guarantee it exists to provide. Refresh with `just audit-derived-artifacts`."""
+    manifest = REPO_ROOT / "data" / "import_tracking" / "derived_artifacts.tsv"
+    assert manifest.is_file(), "derived_artifacts.tsv is missing"
+    import csv
+    import io
+    fresh = io.StringIO(newline="")
+    w = csv.DictWriter(fresh, delimiter="\t", lineterminator="\r\n", fieldnames=[
+        "artifact", "kind", "reason", "writer", "freshness_checked"])
+    w.writeheader()
+    w.writerows(ada.inventory())
+    # Compare row content, not line endings: the script writes with newline="" so
+    # csv chooses \r\n, and reading back through read_text() normalises. Splitting
+    # sidesteps that without weakening the comparison.
+    got = [ln for ln in manifest.read_text().splitlines() if ln]
+    want = [ln for ln in fresh.getvalue().splitlines() if ln]
+    assert got == want, (
+        "derived_artifacts.tsv is stale — run `just audit-derived-artifacts`")
+
+
+def test_every_checkable_artifact_exists_and_is_tracked(ada):
+    """A typo in CHECKABLE would silently drop an artifact from the guard."""
+    tracked = set(subprocess.run(["git", "ls-files"], capture_output=True, text=True,
+                                 cwd=REPO_ROOT).stdout.split())
+    for art in ada.CHECKABLE:
+        assert (REPO_ROOT / art).is_file(), f"{art} declared checkable but missing"
+        assert art in tracked, f"{art} declared checkable but not tracked"
+
+
+def test_every_checkable_writer_exists(ada):
+    for art, cmd in ada.CHECKABLE.items():
+        assert (REPO_ROOT / cmd[0]).is_file(), f"{art}: writer {cmd[0]} missing"
+
+
+def test_snapshots_are_never_freshness_checked(ada):
+    """Regenerating a dated snapshot or a migration record would falsify history —
+    those files are an accurate account of what ran, stale paths and all."""
+    for row in ada.inventory():
+        if row["kind"] == "SNAPSHOT":
+            assert not row["freshness_checked"], f"{row['artifact']} is a snapshot"
+            assert row["artifact"] not in ada.CHECKABLE
+
+
+def test_the_classification_covers_every_tracked_artifact(ada):
+    rows = ada.inventory()
+    assert len(rows) == len(ada.tracked_artifacts())
+    assert all(r["kind"] in {"CURRENT_VIEW", "SNAPSHOT", "UNKNOWN"} for r in rows)
+
+
+def test_unknowns_are_reported_not_hidden(ada):
+    """UNKNOWN is the honest state for an unclassified artifact. This asserts the
+    inventory still surfaces them — silence would imply coverage that does not
+    exist. It is a ceiling, not a target: driving it to 0 by guessing would be
+    worse than leaving them listed."""
+    unknown = [r for r in ada.inventory() if r["kind"] == "UNKNOWN"]
+    assert len(unknown) <= 55, (
+        f"{len(unknown)} unclassified artifacts, above the documented 55. A new "
+        "tracked artifact was added without a classification.")
+
+
+def test_a_corrupted_artifact_is_detected(ada, tmp_path, monkeypatch):
+    """The load-bearing test: a freshness check that cannot fail is worthless.
+
+    Verified end to end during development — corrupting filename_collisions.tsv
+    made `--check` exit 1 naming exactly that file. This pins the comparison
+    itself, without the multi-minute corpus regeneration.
+    """
+    art = next(iter(ada.CHECKABLE))
+    real = REPO_ROOT / art
+    fake = tmp_path / "out.tsv"
+    fake.write_text(real.read_text() + "bogus\tstale\trow\n")
+    assert fake.read_bytes() != real.read_bytes(), (
+        "the byte comparison the check relies on would not notice a changed file")


### PR DESCRIPTION
A record move leaves stale paths in tracked artifacts nothing refreshes. Only the
recipe indexes fail loudly (#125). The id registry (#144), the chebi report
(#157) and two review manifests (#168) each rotted **silently** and were found by
someone going looking — six instances. This session added several more tracked
reports, so the population was outgrowing the guards.

## The classification is computed, not written down

#145 suggests "a short table in `docs/DATA_LAYERS.md`". **A static table listing
derived artifacts is itself a derived artifact nobody refreshes** — that would be
the seventh instance of this bug. So it is computed from the repo, written to a
tracked manifest, and a test asserts the manifest matches a fresh computation.

```
92 tracked derived artifacts
17 CURRENT_VIEW   must match today's corpus
20 SNAPSHOT       reports/archive/*, dated names, migrate_* output
55 UNKNOWN        no writer, or writer purity unestablished
```

**UNKNOWN is reported, not guessed away.** It is the honest state for an artifact
nobody has classified, and a test pins the count so a new tracked artifact cannot
join them silently. Driving it to 0 by guessing would be worse than leaving them
listed.

## Freshness checking, and its limit

7 of the 17 CURRENT_VIEW artifacts are checked by regenerating to a temp path and
comparing bytes.

Only those 7, because **a check must not have side effects**: `migrate_*` rewrites
records, `propose_media_variant_links` proposes links,
`build_media_growth_review_html` builds HTML. That is exactly why #168 could not
verify its two manifests. `CHECKABLE` is therefore declared explicitly rather than
inferred from "has an `--out` flag" — `audit_composition_type` has `--out` but also
`--promote-semi-defined`, and is only pure without it.

`just refresh-derived` regenerates exactly that set: the one follow-up step after a
bulk move, instead of a checklist held in someone's head.

## Two crashes found by building this

`audit_filename_collisions` and `audit_concentration_plausibility` both raised
`ValueError` on any `--out` outside the repo — from `args.out.relative_to(REPO_ROOT)`
in the *"Wrote …"* line, **after** the file was written. Neither could be
freshness-checked until fixed.

## Verified end to end

```
clean corpus            -> exit 0, "All freshness-checked artifacts match"
one artifact corrupted  -> exit 1, naming exactly that artifact
```

My first attempt at that proof was wrong, and it is worth recording why: the run
exited 1 because two writers **crashed**, not because staleness was detected. A
check that fails for the wrong reason looks identical to one that works.

Refs #145, #168.