### PR TITLE
One writer for corpus records, so curation diffs show only what changed (#141)

### DIFF
--- a/scripts/apply_edison_results.py
+++ b/scripts/apply_edison_results.py
@@ -8,11 +8,15 @@ Usage:
 """
 
 import argparse
+import sys
 import yaml
 import json
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from record_io import write_record  # noqa: E402
 
 
 def load_recipe(file_path: Path) -> Dict[str, Any]:
@@ -27,9 +31,9 @@ def save_recipe(file_path: Path, recipe: Dict[str, Any], dry_run: bool = False):
         print(f"[DRY RUN] Would write to: {file_path}")
         return
 
-    with open(file_path, 'w', encoding='utf-8') as f:
-        yaml.dump(recipe, f, default_flow_style=False, sort_keys=False,
-                 allow_unicode=True, width=120)
+    # Shared writer: `width=120` re-wrapped every long scalar in the file, so half
+    # of PR #140's diff was churn in untouched `notes:` (#141).
+    write_record(file_path, recipe)
 
 
 def apply_description(recipe: Dict[str, Any], description: str) -> List[str]:

--- a/scripts/apply_ingredient_roles.py
+++ b/scripts/apply_ingredient_roles.py
@@ -59,6 +59,9 @@ from typing import Any
 
 import yaml
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from record_io import write_record  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_YAML_DIR = REPO_ROOT / "data" / "normalized_yaml"
 
@@ -283,9 +286,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.limit is not None and recipes_written >= args.limit:
             continue
 
-        with open(yaml_path, "w", encoding="utf-8") as f:
-            yaml.dump(recipe, f, default_flow_style=False, sort_keys=False,
-                      allow_unicode=True, width=120)
+        # Shared writer: `width=120` re-wrapped every long scalar in the file, so
+        # half of PR #140's diff was churn in untouched `notes:` (#141).
+        write_record(yaml_path, recipe)
         recipes_written += 1
         if args.verbose:
             print(f"WROTE {yaml_path.relative_to(args.yaml_dir)}: {fields_changed}")

--- a/scripts/import_jcm_grmd.py
+++ b/scripts/import_jcm_grmd.py
@@ -62,7 +62,8 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-import yaml
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from record_io import dump_record  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 NORMALIZED_DIR = REPO_ROOT / "data" / "normalized_yaml"
@@ -408,7 +409,9 @@ def main(argv: list[str] | None = None) -> int:
 
         fname = f"JCM_J{grmd}_{re.sub(r'[^A-Za-z0-9]+', '_', rec['original_name']).strip('_')[:80]}.yaml"
         out_path = args.out_dir / fname
-        yaml_text = yaml.safe_dump(rec, sort_keys=False, allow_unicode=True, width=100)
+        # Corpus convention is PyYAML's default width; width=100 created records
+        # that every later curation pass would re-wrap (#141).
+        yaml_text = dump_record(rec)
 
         if args.dry_run:
             print(f"\n[DRY RUN] GRMD={grmd} -> {out_path.relative_to(REPO_ROOT)}  "

--- a/scripts/record_io.py
+++ b/scripts/record_io.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""One way to write a corpus record, so curation diffs show only what changed (#141).
+
+Writing a record back with `yaml.dump(..., width=120)` re-wraps EVERY long string
+in the file, not just the field being edited. PR #140 added one organism and one
+curation event and produced 47 added lines, 24 of them pure re-wrapping of
+untouched `notes:`. Roughly half the diff was noise — semantically lossless, but
+it buries the actual change exactly where a reviewer needs to see it, and it
+scales badly on a bulk apply.
+
+## Why `width=120` specifically
+
+The corpus was written with PyYAML's DEFAULT width. Measured over 300 random
+records, round-tripping load->dump gives:
+
+    default (width 80)   279/300 byte-identical
+    width=120              2/300
+    width=100              3/300
+    width=4096             2/300
+    sort_keys=True         0/300
+
+So the corpus convention is simply PyYAML's default, and passing `width=120`
+is what causes the churn. Dropping it is the whole fix.
+
+## Why not ruamel
+
+`ruamel.yaml` was added as a dependency for this in #153 and is the usual answer
+for round-trip-preserving YAML. It does not help here: no configuration of it
+reproduces this corpus. Best measured was width=80 at 7/300 byte-identical, versus
+279/300 for plain PyYAML defaults, because ruamel also differs in quoting and
+indentation. Two scripts already use it; they are not made worse by this module,
+but it is not the route to a clean diff.
+
+## The residual 7%
+
+About 21 of 300 records still differ under the default config. Those are records a
+PREVIOUS width=120 run already reflowed — their `notes:` lines are longer than the
+corpus convention allows. Rewriting them normalises the damage, which is a
+one-time correction rather than new churn.
+
+Usage::
+
+    from record_io import dump_record, write_record
+
+    write_record(path, doc)          # writes only if the text actually changed
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# PyYAML's defaults, stated explicitly so the absence of `width` is visibly
+# deliberate rather than an oversight someone will "fix" by adding width=120 back.
+DUMP_KWARGS: dict[str, Any] = {
+    "default_flow_style": False,
+    "sort_keys": False,      # record key order is meaningful; sorting rewrites every file
+    "allow_unicode": True,
+    # NO width: the corpus convention is PyYAML's default (80). See module docstring.
+}
+
+
+def dump_record(doc: dict[str, Any]) -> str:
+    """Serialize a record using the corpus's own formatting convention."""
+    return yaml.dump(doc, **DUMP_KWARGS)
+
+
+def write_record(path: Path, doc: dict[str, Any]) -> bool:
+    """Write `doc` to `path`. Returns True if the file changed.
+
+    Skips the write when the serialization is identical to what is already there,
+    so a no-op curation pass leaves no mtime churn and no diff at all.
+    """
+    text = dump_record(doc)
+    try:
+        if path.read_text() == text:
+            return False
+    except OSError:
+        pass
+    path.write_text(text)
+    return True

--- a/scripts/record_io.py
+++ b/scripts/record_io.py
@@ -72,12 +72,24 @@ def write_record(path: Path, doc: dict[str, Any]) -> bool:
 
     Skips the write when the serialization is identical to what is already there,
     so a no-op curation pass leaves no mtime churn and no diff at all.
+
+    The comparison is done in BYTES. Reading as text raised UnicodeDecodeError on
+    a record that is not valid UTF-8 — and that is not hypothetical: every corpus
+    reader here uses `errors="replace"` precisely because some records do not
+    decode cleanly, so a curation script would have crashed partway through a
+    batch instead of repairing the file (#206). Comparing bytes sidesteps decoding
+    entirely and is closer to what the check actually means.
+
+    Creates the parent directory: this writer is also used to create new records
+    (`import_jcm_grmd`), not only to edit existing ones.
     """
     text = dump_record(doc)
+    data = text.encode("utf-8")
     try:
-        if path.read_text() == text:
+        if path.read_bytes() == data:
             return False
     except OSError:
         pass
-    path.write_text(text)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
     return True

--- a/tests/test_record_io.py
+++ b/tests/test_record_io.py
@@ -122,3 +122,35 @@ def test_no_corpus_writer_passes_a_width_override():
     assert not offenders, (
         "these scripts write corpus records with a width override, which reflows "
         f"every long scalar: {offenders}. Use `record_io.write_record`.")
+
+
+# --- #206: the comparison must not depend on decoding ----------------------
+
+
+def test_a_record_that_is_not_valid_utf8_is_rewritten_not_raised_on(rio, tmp_path):
+    """`except OSError` did not catch UnicodeDecodeError, which is a ValueError.
+
+    Not hypothetical: every corpus reader here uses `errors="replace"` precisely
+    because some records do not decode cleanly, so a curation script would have
+    crashed partway through a batch rather than repairing the file.
+    """
+    p = tmp_path / "b.yaml"
+    p.write_bytes(b"\xff\xfe\x00binary")
+    assert rio.write_record(p, {"id": "CultureMech:1"}) is True
+    assert p.read_text().startswith("id: CultureMech:1")
+
+
+def test_a_missing_parent_directory_is_created(rio, tmp_path):
+    """This writer also CREATES records (import_jcm_grmd), not only edits them."""
+    p = tmp_path / "nested" / "deeper" / "r.yaml"
+    assert rio.write_record(p, {"id": "CultureMech:2"}) is True
+    assert p.is_file()
+
+
+def test_the_no_op_check_survives_unicode(rio, tmp_path):
+    """Byte comparison must still recognise an unchanged non-ASCII record."""
+    p = tmp_path / "u.yaml"
+    doc = {"id": "CultureMech:3", "name": "Müller-Hinton · agar ≥99%"}
+    rio.write_record(p, doc)
+    assert rio.write_record(p, doc) is False
+    assert "Müller" in p.read_text()

--- a/tests/test_record_io.py
+++ b/tests/test_record_io.py
@@ -1,0 +1,124 @@
+"""Guard that curation scripts write records without reflowing them (#141).
+
+`yaml.dump(..., width=120)` re-wraps every long scalar in a file, not just the
+field being edited. PR #140 added one organism and one curation event and produced
+47 added lines, 24 of them churn in untouched `notes:`. Semantically lossless, but
+it buries the real change exactly where a reviewer needs to see it.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import random
+import re
+import sys
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rio():
+    return _load("record_io")
+
+
+def test_no_width_override(rio):
+    """The whole fix. `width` absent means PyYAML's default (80), which is the
+    corpus convention: 279/300 records round-trip byte-identically under it, and
+    2/300 under width=120."""
+    assert "width" not in rio.DUMP_KWARGS
+
+
+def test_keys_are_not_sorted(rio):
+    """sort_keys=True round-tripped 0/300 records — it rewrites every file."""
+    assert rio.DUMP_KWARGS["sort_keys"] is False
+
+
+def test_dump_round_trips_the_corpus(rio, media_records):
+    """The load-bearing measurement. A writer that reflows is the defect.
+
+    Not 100%: some records were already reflowed by a past width=120 run, so their
+    `notes:` exceed the corpus convention. Rewriting those normalises the damage.
+    """
+    sample = random.Random(3).sample(media_records, min(300, len(media_records)))
+    identical = sum(1 for path, _ in sample
+                    if rio.dump_record(yaml.safe_load(path.read_text(errors="replace")))
+                    == path.read_text(errors="replace"))
+    assert identical / len(sample) > 0.85, (
+        f"only {identical}/{len(sample)} records round-trip byte-identically; the "
+        "dump config has drifted from the corpus convention")
+
+
+def test_write_record_is_a_no_op_when_nothing_changed(rio, tmp_path):
+    p = tmp_path / "r.yaml"
+    doc = {"id": "CultureMech:1", "name": "x", "notes": "y" * 200}
+    rio.write_record(p, doc)
+    first = p.read_text()
+    mtime = p.stat().st_mtime_ns
+    assert rio.write_record(p, doc) is False
+    assert p.read_text() == first and p.stat().st_mtime_ns == mtime
+
+
+def test_write_record_reports_a_real_change(rio, tmp_path):
+    p = tmp_path / "r.yaml"
+    rio.write_record(p, {"id": "CultureMech:1", "name": "x"})
+    assert rio.write_record(p, {"id": "CultureMech:1", "name": "y"}) is True
+
+
+def test_a_long_note_is_not_rewrapped_by_an_unrelated_edit(rio, tmp_path):
+    """The #141 scenario end to end: append a field, and the untouched long note
+    must not move."""
+    p = tmp_path / "r.yaml"
+    note = ("Source: KOMODO ModelSEED | ID: 378 | DSMZ Medium: 378 "
+            "(mediadive.medium:378) | Aerobic: No | Notes: a fairly long trailing note")
+    doc = {"id": "CultureMech:1", "name": "x", "notes": note}
+    rio.write_record(p, doc)
+    before = p.read_text().splitlines()
+    doc["applications"] = "Microbial cultivation"
+    rio.write_record(p, doc)
+    after = p.read_text().splitlines()
+    note_before = [ln for ln in before if "KOMODO" in ln or "Aerobic" in ln]
+    note_after = [ln for ln in after if "KOMODO" in ln or "Aerobic" in ln]
+    assert note_before == note_after, "the untouched note was re-wrapped"
+    assert len(after) == len(before) + 1
+
+
+# --- the regression guard ---------------------------------------------------
+
+
+def test_no_corpus_writer_passes_a_width_override():
+    """The specific mistake. `apply_curation_proposals.py` already carried a
+    comment warning against it, and two sibling scripts did it anyway — a comment
+    is not a guard."""
+    # PyYAML's default is 80, so stating it explicitly is equivalent and harmless.
+    # Anything else re-wraps.
+    CORPUS_DEFAULT = 80
+    # Scripts that dump YAML but not corpus records. Listed with the reason, so an
+    # addition here is a visible claim rather than a silent exemption.
+    NOT_CORPUS_RECORDS = {
+        "research_media_edison.py": "writes research/*-meta.yaml, not corpus records",
+    }
+    offenders = []
+    for path in (REPO_ROOT / "scripts").glob("*.py"):
+        if path.name == "record_io.py" or path.name in NOT_CORPUS_RECORDS:
+            continue
+        text = path.read_text(errors="replace")
+        if "normalized_yaml" not in text:
+            continue
+        for m in re.finditer(r"yaml\.(?:safe_)?dump\([^)]*width\s*=\s*(\d+)", text, re.S):
+            if int(m.group(1)) != CORPUS_DEFAULT:
+                offenders.append(f"{path.name}: width={m.group(1)}")
+    assert not offenders, (
+        "these scripts write corpus records with a width override, which reflows "
+        f"every long scalar: {offenders}. Use `record_io.write_record`.")


### PR DESCRIPTION
PR #140 added one organism and one curation event and produced **47 added lines,
24 of them pure re-wrapping of untouched `notes:`**. Half the diff was noise —
semantically lossless, but it buries the real change exactly where a reviewer
needs to see it, and it scales badly on a bulk apply.

## The cause is one keyword argument

Measured over 300 random records, load → dump byte-identity:

| dump config | identical |
|---|--:|
| **PyYAML default (80)** | **279/300** |
| `width=120` | 2/300 |
| `width=100` | 3/300 |
| `width=4096` | 2/300 |
| `sort_keys=True` | 0/300 |

The corpus convention is simply PyYAML's default. Dropping `width=120` is the
whole fix. `record_io.DUMP_KWARGS` states the absence deliberately, so nobody
"fixes" it by adding the override back.

## ruamel is not the answer, despite being a dependency added for exactly this

`ruamel.yaml` came in with #153 and the comment *"curation scripts must not reflow
records"*. **No configuration of it reproduces this corpus** — best measured was
`width=80` at **7/300** byte-identical, versus 279/300 for plain PyYAML defaults,
because ruamel also differs in quoting and indentation. Recorded in the module
docstring so nobody re-runs that experiment.

## Changes

- **`scripts/record_io.py`** — `dump_record` / `write_record`. The latter skips the
  write when serialization is unchanged, so a no-op pass leaves no diff and no
  mtime churn.
- **`apply_edison_results.py`**, **`apply_ingredient_roles.py`** — migrated off
  `width=120`.
- **`import_jcm_grmd.py`** — was creating *new* records at `width=100`,
  non-conforming from birth, so every later curation pass would re-wrap them.

## The guard

`apply_curation_proposals.py` **already carried a comment** warning against a width
override, and two sibling scripts did it anyway. A comment is not a guard.

The test treats `width=80` as equivalent (it *is* the default) and allowlists
`research_media_edison.py`, which dumps research meta rather than corpus records —
with the reason inline, so any addition is a visible claim rather than a silent
exemption.

## Verified

```
187/200 records round-trip byte-identically through dump_record
write_record on an unchanged record -> False, mtime untouched
corpus files changed by this PR      -> 0
```

The remaining 13 were already reflowed by a past `width=120` run; rewriting them
normalises the damage.

Closes #141.