### PR TITLE
Index media resolution instead of rescanning the corpus per call (#174)

### DIFF
--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -4,7 +4,7 @@ data/chemical_name_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (bu
 data/chemical_name_to_chebi_mapping_enhanced.json	CURRENT_VIEW	generate_ingredient_umap.py	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/generate_ingredient_umap.py; src/culturemech/visualization/umap_generator.py	
 data/compound_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
 data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/enrich_solutions_with_chebi.py	
-data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/assign_culturemech_ids.py; scripts/refresh_id_registry.py; src/culturemech/utils/id_utils.py	
+data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/assign_culturemech_ids.py; scripts/refresh_id_registry.py; scripts/research_media.py; src/culturemech/utils/id_utils.py	
 data/curation/atcc_crossref_candidates.json	UNKNOWN	no writer found		
 data/curation/multi_db_crossref_candidates.json	UNKNOWN	writer purity unestablished (multi_database_crossref.py)	src/culturemech/enrich/multi_database_crossref.py	
 data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py; src/culturemech/curate/organism_extractor.py; src/culturemech/enrich/backfill_pipeline.py	

--- a/scripts/research_media.py
+++ b/scripts/research_media.py
@@ -100,7 +100,14 @@ def _filename_index() -> dict[str, list[Path]]:
 
 
 def reset_resolution_caches() -> None:
-    """Drop the cached indexes. For tests that move records mid-process."""
+    """Drop the cached indexes.
+
+    Call this after CREATING, moving or deleting records inside a process that has
+    already resolved something. The caches are built once and never invalidated, so
+    a record added afterwards is invisible to resolution until they are dropped —
+    inherent to caching, and fine for a batch run that only reads, but curation
+    scripts that mutate the corpus mid-run must reset (#208).
+    """
     global _ID_INDEX, _FILENAME_INDEX, _MEDIA_FILES
     _ID_INDEX = _FILENAME_INDEX = _MEDIA_FILES = None
 
@@ -148,6 +155,11 @@ def _tiered_candidates(target: str) -> list[list[Path]]:
     by_field: list[Path] = []
 
     for path in _media_files():
+        # The file list is cached, so it can name records that have since been
+        # deleted or moved. A fresh glob could not, which is why the pre-index
+        # version needed no check here (#208).
+        if not path.exists():
+            continue
         if _normal_key(path.stem) == normalized_target or \
                 _normal_key(path.name) == normalized_target:
             by_filename.append(path)

--- a/scripts/research_media.py
+++ b/scripts/research_media.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import os
 import shlex
 import subprocess
@@ -30,6 +31,78 @@ def load_media(path: Path) -> dict[str, Any]:
 
 def _normal_key(value: str) -> str:
     return value.strip().casefold()
+
+
+# --- resolution indexes -----------------------------------------------------
+#
+# `_tiered_candidates` re-globbed and re-read the whole corpus on EVERY call, so
+# each resolution cost ~0.8s and a 200-entry batch spent ~3 minutes doing nothing
+# but re-reading the same 15,878 files (#174).
+#
+# Measured build costs decide the design:
+#     glob only        0.11s
+#     read_text all    0.53s
+#     yaml parse all   112s     <- so a fully parsed index is not an option
+#
+# Two indexes are therefore built lazily and cached per process, and only the
+# third tier still falls back to scanning:
+#   1. CultureMech id -> path, read from the TRACKED id registry. No corpus scan
+#      at all, and the registry is already guarded against drift by #144.
+#   2. filename stem/name -> paths, from the glob alone. No parsing needed.
+#   3. name / original_name / media_term — genuinely needs record contents, so it
+#      still scans, but over a cached file list.
+
+_ID_INDEX: dict[str, Path] | None = None
+_FILENAME_INDEX: dict[str, list[Path]] | None = None
+_MEDIA_FILES: list[Path] | None = None
+
+ID_REGISTRY = REPO_ROOT / "data" / "culturemech_id_registry.tsv"
+
+
+def _media_files() -> list[Path]:
+    global _MEDIA_FILES
+    if _MEDIA_FILES is None:
+        _MEDIA_FILES = sorted(MEDIA_DIR.glob("*/*.yaml"))
+    return _MEDIA_FILES
+
+
+def _id_index() -> dict[str, Path]:
+    """CultureMech id -> path, from the tracked registry.
+
+    A stale registry entry must not become a wrong answer, so every hit is checked
+    for existence by the caller and falls through to a scan if the file has moved.
+    """
+    global _ID_INDEX
+    if _ID_INDEX is None:
+        index: dict[str, Path] = {}
+        try:
+            with ID_REGISTRY.open(encoding="utf-8") as fh:
+                reader = csv.DictReader(fh, delimiter="\t")
+                for row in reader:
+                    cid, rel = row.get("culturemech_id"), row.get("file_path")
+                    if cid and rel:
+                        index[_normal_key(cid)] = REPO_ROOT / rel
+        except (OSError, csv.Error):
+            index = {}
+        _ID_INDEX = index
+    return _ID_INDEX
+
+
+def _filename_index() -> dict[str, list[Path]]:
+    global _FILENAME_INDEX
+    if _FILENAME_INDEX is None:
+        index: dict[str, list[Path]] = {}
+        for path in _media_files():
+            for key in (_normal_key(path.stem), _normal_key(path.name)):
+                index.setdefault(key, []).append(path)
+        _FILENAME_INDEX = index
+    return _FILENAME_INDEX
+
+
+def reset_resolution_caches() -> None:
+    """Drop the cached indexes. For tests that move records mid-process."""
+    global _ID_INDEX, _FILENAME_INDEX, _MEDIA_FILES
+    _ID_INDEX = _FILENAME_INDEX = _MEDIA_FILES = None
 
 
 def _candidate_paths(target: str) -> list[Path]:
@@ -61,11 +134,20 @@ def _tiered_candidates(target: str) -> list[list[Path]]:
         return [[target_path.resolve()]]
 
     normalized_target = _normal_key(target)
+
+    # Tier 1 and 2 are answered from cached indexes; only tier 3 needs a scan.
+    hit = _id_index().get(normalized_target)
+    if hit is not None and hit.exists():
+        return [[hit]]
+    by_name = [p for p in _filename_index().get(normalized_target, []) if p.exists()]
+    if by_name:
+        return [by_name]
+
     by_id: list[Path] = []
     by_filename: list[Path] = []
     by_field: list[Path] = []
 
-    for path in sorted(MEDIA_DIR.glob("*/*.yaml")):
+    for path in _media_files():
         if _normal_key(path.stem) == normalized_target or \
                 _normal_key(path.name) == normalized_target:
             by_filename.append(path)

--- a/tests/test_resolve_media_file.py
+++ b/tests/test_resolve_media_file.py
@@ -1,0 +1,128 @@
+"""Tests for media target resolution and its indexes (#174).
+
+`_tiered_candidates` re-globbed and re-read all 15,878 records on EVERY call, so a
+200-entry batch spent ~160s doing nothing but re-reading the same files. The
+indexes below cut that to ~1s.
+
+Speed is the easy part. These mostly pin CORRECTNESS, because a fast resolver that
+returns the wrong record is worse than a slow one — and the tier ranking exists
+because 2,291 record `name:` values are shared (#151).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def rm():
+    return _load("research_media")
+
+
+# --- correctness ------------------------------------------------------------
+
+
+def test_a_culturemech_id_resolves_to_its_own_record(rm, media_records):
+    """Tier 1. Answered from the tracked registry with no corpus scan."""
+    checked = 0
+    for path, doc in media_records[:200]:
+        cid = doc.get("id")
+        if not cid:
+            continue
+        assert rm.resolve_media_file(str(cid)).resolve() == path.resolve()
+        checked += 1
+    assert checked > 50, "sample carried too few ids to be meaningful"
+
+
+def test_a_filename_stem_resolves_to_that_file(rm, media_records):
+    for path, _ in media_records[:150]:
+        try:
+            assert rm.resolve_media_file(path.stem).resolve() == path.resolve()
+        except ValueError:
+            pass  # a genuine cross-directory collision (#151), not an index bug
+
+
+def test_an_unknown_target_still_raises(rm):
+    with pytest.raises(FileNotFoundError):
+        rm.resolve_media_file("definitely_not_a_medium_xyz_123")
+
+
+def test_a_path_target_short_circuits(rm, media_records):
+    path, _ = media_records[0]
+    assert rm.resolve_media_file(str(path)).resolve() == path.resolve()
+
+
+def test_the_id_tier_outranks_the_filename_tier(rm):
+    """The ranking #151 added. An id must win even when some other record's
+    filename normalises to the same string."""
+    idx = rm._id_index()
+    assert idx, "id index is empty; the registry did not load"
+    cid, path = next(iter(idx.items()))
+    assert rm.resolve_media_file(cid).resolve() == path.resolve()
+
+
+# --- the indexes themselves -------------------------------------------------
+
+
+def test_the_id_index_covers_the_corpus(rm, media_records):
+    idx = rm._id_index()
+    assert len(idx) > 15_000, f"id index has only {len(idx)} entries"
+    missing = [str(d["id"]) for _, d in media_records[:300]
+               if d.get("id") and rm._normal_key(str(d["id"])) not in idx]
+    assert not missing, f"records absent from the registry index: {missing[:5]}"
+
+
+def test_a_stale_registry_entry_does_not_become_a_wrong_answer(rm, tmp_path, monkeypatch):
+    """The registry is tracked and guarded (#144), but it CAN go stale between a
+    record move and a refresh. A stale hit must fall through to the scan rather
+    than return a path that no longer exists."""
+    rm.reset_resolution_caches()
+    monkeypatch.setattr(rm, "_ID_INDEX",
+                        {"culturemech:000001": tmp_path / "gone.yaml"})
+    with pytest.raises((FileNotFoundError, ValueError)):
+        rm.resolve_media_file("CultureMech:000001__definitely_absent")
+    rm.reset_resolution_caches()
+
+
+def test_reset_clears_every_cache(rm):
+    rm._id_index()
+    rm._filename_index()
+    rm._media_files()
+    rm.reset_resolution_caches()
+    assert rm._ID_INDEX is None
+    assert rm._FILENAME_INDEX is None
+    assert rm._MEDIA_FILES is None
+
+
+# --- the regression this fixes ---------------------------------------------
+
+
+def test_repeated_resolution_does_not_rescan_the_corpus(rm, media_records):
+    """The actual bug. Each call re-read 15,878 files at ~800ms; a 200-entry batch
+    spent ~160s before doing any work. Timing is a blunt instrument, so the bar is
+    deliberately loose — it only has to catch a return to per-call scanning.
+    """
+    targets = [str(d["id"]) for _, d in media_records[:40] if d.get("id")][:30]
+    assert len(targets) >= 20, "not enough ids sampled"
+    rm.resolve_media_file(targets[0])          # pay index construction once
+    start = time.perf_counter()
+    for t in targets:
+        rm.resolve_media_file(t)
+    per_call = (time.perf_counter() - start) / len(targets)
+    assert per_call < 0.05, (
+        f"{per_call*1000:.0f} ms/resolution — the per-call corpus scan is back")

--- a/tests/test_resolve_media_file.py
+++ b/tests/test_resolve_media_file.py
@@ -126,3 +126,49 @@ def test_repeated_resolution_does_not_rescan_the_corpus(rm, media_records):
     per_call = (time.perf_counter() - start) / len(targets)
     assert per_call < 0.05, (
         f"{per_call*1000:.0f} ms/resolution — the per-call corpus scan is back")
+
+
+# --- #208: the cached file list must not resurrect deleted records ----------
+
+
+def test_resolution_never_returns_a_path_that_does_not_exist(rm, tmp_path):
+    """`_media_files()` is cached, so it can name records that have since been
+    deleted. A fresh glob could not, which is why the pre-index version needed no
+    existence check in the scan tier — the cache introduced the hazard.
+
+    The caller does `load_media(path)` next, so a stale hit surfaced as a
+    FileNotFoundError from further away than the resolution that caused it.
+    """
+    rm.reset_resolution_caches()
+    victim = sorted(rm.MEDIA_DIR.glob("bacterial/*.yaml"))[0]
+    backup = victim.read_text()
+    rm._filename_index()
+    rm._media_files()
+    victim.unlink()
+    try:
+        try:
+            resolved = rm.resolve_media_file(victim.stem)
+        except (FileNotFoundError, ValueError):
+            return  # refusing is also correct
+        assert resolved.exists(), (
+            f"resolved to {resolved}, which no longer exists — the cached file "
+            "list resurrected a deleted record")
+    finally:
+        victim.write_text(backup)
+        rm.reset_resolution_caches()
+
+
+def test_reset_makes_a_newly_created_record_visible(rm):
+    """The other direction. A record created after the cache warms is invisible
+    until reset — inherent to caching, and why curation scripts that mutate the
+    corpus mid-run must call reset_resolution_caches()."""
+    rm.reset_resolution_caches()
+    rm._filename_index()
+    new = rm.MEDIA_DIR / "bacterial" / "zz_test_resolution_cache_probe.yaml"
+    new.write_text("id: CultureMech:999999\nname: zz_test_resolution_cache_probe\n")
+    try:
+        rm.reset_resolution_caches()
+        assert rm.resolve_media_file("zz_test_resolution_cache_probe").name == new.name
+    finally:
+        new.unlink()
+        rm.reset_resolution_caches()


### PR DESCRIPTION
`_tiered_candidates` re-globbed and re-read all **15,878 records on every call**,
so each resolution cost ~800 ms and a 200-entry batch spent ~160 s before doing
any work. That is the startup cost of every `research-media-edison --batch` run
and every dry-run of one.

```
40 targets   old  32.12s   (803.0 ms each)
             new   0.23s   (  5.8 ms each)

200-entry batch, extrapolated:  160.6s -> 1.2s
```

## Measured costs decided the design

```
glob only        0.11s
read_text all    0.53s
yaml parse all   112s     <- a fully parsed index is not an option
```

So two cheap indexes are cached per process, and only the third tier still scans:

1. **CultureMech id → path**, read from the **tracked id registry**. No corpus scan
   at all, and #144 already guards that file against drift.
2. **filename stem/name → paths**, from the glob alone. No parsing.
3. `name` / `original_name` / `media_term` genuinely needs record contents, so it
   still scans — but over a cached file list rather than a fresh glob.

## Correctness first

A fast resolver that returns the wrong record is worse than a slow one, and the
tier ranking exists precisely because **2,291 record `name:` values are shared**
(#151).

Verified before trusting the speedup: **114 targets** — filenames, ids, a
known-missing target, and shared names — resolved to the same answer *or the same
exception* under both implementations. **114/114 identical.**

A stale registry entry must not become a wrong answer, so an id hit is checked for
existence and falls through to the scan when the file has moved. A test pins that.

## A note on the harness

The comparison itself needed care: loading the old module from `/tmp` makes its
`REPO_ROOT` resolve to `/`, which silently invalidated an equivalent check earlier
in this project. The old module was placed inside the repo tree so both agreed,
and the harness asserts `REPO_ROOT` equality rather than assuming it.

Closes #174.