### PR TITLE
Separate artifacts a script writes from ones it merely mentions (#209)

### DIFF
--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -1,94 +1,94 @@
-artifact	kind	reason	writer	freshness_checked
-data/MEDIA_SOURCES.tsv	UNKNOWN	no writer found		
-data/chemical_name_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
-data/chemical_name_to_chebi_mapping_enhanced.json	CURRENT_VIEW	generate_ingredient_umap.py	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/generate_ingredient_umap.py; src/culturemech/visualization/umap_generator.py	
-data/compound_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	
-data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/enrich_solutions_with_chebi.py	
-data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/assign_culturemech_ids.py; scripts/refresh_id_registry.py; scripts/research_media.py; src/culturemech/utils/id_utils.py	
-data/curation/atcc_crossref_candidates.json	UNKNOWN	no writer found		
-data/curation/multi_db_crossref_candidates.json	UNKNOWN	writer purity unestablished (multi_database_crossref.py)	src/culturemech/enrich/multi_database_crossref.py	
-data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py; src/culturemech/curate/organism_extractor.py; src/culturemech/enrich/backfill_pipeline.py	
-data/curation/organism_review.csv	UNKNOWN	writer purity unestablished (curation_validator.py)	src/culturemech/curate/curation_validator.py	
-data/import_tracking/communitymech_imports.json	UNKNOWN	writer purity unestablished (import_from_communitymech.py)	scripts/import_from_communitymech.py; scripts/update_communitymech_links.py	
-data/import_tracking/derived_artifacts.tsv	UNKNOWN	no writer found		
-data/import_tracking/mediadive_composition_ids.json	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	
-data/import_tracking/mediaingredientmech_migration_log.json	UNKNOWN	no writer found		
-data/import_tracking/new_solution_ingredients_vs_mediaingredientmech.tsv	UNKNOWN	no writer found		
-data/import_tracking/reports/axis_research_batch.json	CURRENT_VIEW	sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	
-data/import_tracking/reports/batch2-curation-proposals.json	UNKNOWN	no writer found		
-data/import_tracking/reports/chebi_regrounding_changes.tsv	SNAPSHOT	one-time migration (migrate_chebi_regrounding.py)	scripts/migrate_chebi_regrounding.py	
-data/import_tracking/reports/composition_type_conflicts.tsv	CURRENT_VIEW	audit_composition_type.py	scripts/audit_composition_type.py	yes
-data/import_tracking/reports/composition_type_semi_defined.tsv	UNKNOWN	no writer found		
-data/import_tracking/reports/concentration_plausibility.tsv	CURRENT_VIEW	audit_concentration_plausibility.py	scripts/audit_concentration_plausibility.py	yes
-data/import_tracking/reports/concentration_plausibility_by_record.tsv	UNKNOWN	no writer found		
-data/import_tracking/reports/deep_research_priority.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	
-data/import_tracking/reports/deep_research_priority_top100.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py; scripts/sample_axis_research_batch.py	
-data/import_tracking/reports/domain_category_audit.json	UNKNOWN	no writer found		
-data/import_tracking/reports/edison_batch.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/analyze_media_quality.py; scripts/prioritize_deep_research_candidates.py; scripts/research_media_edison.py	
-data/import_tracking/reports/filename_collisions.tsv	CURRENT_VIEW	audit_filename_collisions.py	scripts/audit_filename_collisions.py	yes
-data/import_tracking/reports/g25_phase3_llm_curation.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)	scripts/migrate_kg_fallback_phase3_curation.py	
-data/import_tracking/reports/kg_fallback_consensus_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_to_consensus.py)	scripts/migrate_kg_fallback_to_consensus.py	
-data/import_tracking/reports/kg_fallback_phase2_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)	scripts/migrate_kg_fallback_phase2_oak_ols.py	
-data/import_tracking/reports/kg_fallback_phase2_curator_review.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)	scripts/migrate_kg_fallback_phase2_oak_ols.py	
-data/import_tracking/reports/kg_fallback_phase3_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)	scripts/migrate_kg_fallback_phase3_curation.py	
-data/import_tracking/reports/mim_grounding_divergences.tsv	SNAPSHOT	one-time migration (migrate_legacy_mim_to_chebi.py)	scripts/migrate_legacy_mim_to_chebi.py	
-data/import_tracking/reports/missing_compositions.tsv	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	yes
-data/import_tracking/reports/primary_term_canonicalize_changes.tsv	UNKNOWN	no writer found		
-data/import_tracking/reports/primary_term_reground_changes.tsv	UNKNOWN	no writer found		
-data/import_tracking/reports/review_need_ranking.tsv	CURRENT_VIEW	score_review_need.py	scripts/score_review_need.py	yes
-data/import_tracking/reports/selective_agent_mismatch.tsv	CURRENT_VIEW	audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	yes
-data/import_tracking/reports/top5-curation-proposals.json	UNKNOWN	writer purity unestablished (apply_curation_proposals.py)	scripts/apply_curation_proposals.py	
-data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	yes
-data/import_tracking/researched_media.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py; scripts/refresh_researched_manifest.py; scripts/researched_manifest.py	
-data/import_tracking/schemas/manifest_v1.schema.json	UNKNOWN	no writer found		
-data/merge_yaml/merge_stats.json	UNKNOWN	writer purity unestablished (verify_merges.py)	scripts/verify_merges.py; src/culturemech/merge/merge_recipes.py	
-data/merge_yaml/merge_stats_2026.json	UNKNOWN	no writer found		
-data/merge_yaml/merge_stats_test.json	UNKNOWN	no writer found		
-data/merge_yaml/merged_2026/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
-data/merge_yaml/merged_2026/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
-data/normalized_yaml/algae_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/archaea_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/bacterial_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/by_source_komodo_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/by_source_mediadive_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/by_source_togo_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/by_source_unknown_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/fungal_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
-data/normalized_yaml/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py	scripts/generate_recipe_indexes.py	
-data/normalized_yaml/solutions/mediadive_solution_index.json	UNKNOWN	writer purity unestablished (import_mediadive_solutions.py)	scripts/import_mediadive_solutions.py; scripts/migrate_solutions_from_ingredients.py	
-data/normalized_yaml/solutions_index.json	UNKNOWN	no writer found		
-data/normalized_yaml/specialized_index.json	UNKNOWN	no writer found		
-data/raw/microbe-media-param/compound_mappings_strict_final.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
-data/raw/microbe-media-param/compound_mappings_strict_final_hydrate.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)	src/culturemech/import/chemical_mappings.py	
-data/solution_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py; scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; src/culturemech/embedding/aggregator.py; src/culturemech/embedding/aggregator_yaml_source.py; src/culturemech/visualization/umap_generator.py	
-reports/archive/mim_algae_enrichment.json	SNAPSHOT	archived		
-reports/archive/mim_archaea_enrichment.json	SNAPSHOT	archived		
-reports/archive/mim_bacterial_dryrun.json	SNAPSHOT	archived		
-reports/archive/mim_bacterial_enrichment.json	SNAPSHOT	archived		
-reports/archive/mim_fungal_enrichment.json	SNAPSHOT	archived		
-reports/archive/mim_specialized_enrichment.json	SNAPSHOT	archived		
-reports/archive/validation_20260316.json	SNAPSHOT	archived		
-reports/archive/validation_20260316.tsv	SNAPSHOT	archived		
-reports/archive/validation_corrected_20260316.json	SNAPSHOT	archived		
-reports/archive/validation_corrected_20260316.tsv	SNAPSHOT	archived		
-reports/archive/validation_final_20260316.json	SNAPSHOT	archived		
-reports/archive/validation_final_20260316.tsv	SNAPSHOT	archived		
-reports/gap_fix_backlog.tsv	UNKNOWN	no writer found		
-reports/instance_validation_failures.tsv	UNKNOWN	writer purity unestablished (validate_strict.py)	scripts/validate_strict.py	
-reports/label_plausibility_2026-07-19.tsv	SNAPSHOT	dated filename		
-reports/label_plausibility_after_fixes.tsv	UNKNOWN	no writer found		
-reports/media_content_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
-reports/media_content_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py; scripts/propose_media_variant_links.py	
-reports/media_growth_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_growth_review_manifest.py)	scripts/build_media_growth_review_manifest.py	
-reports/media_growth_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_growth_review_html.py)	scripts/build_media_growth_review_html.py; scripts/build_media_growth_review_manifest.py	
-reports/media_variant_link_apply_plan.json	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
-reports/media_variant_link_apply_plan.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	
-reports/media_variant_link_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
-reports/media_variant_link_proposals.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py; scripts/propose_media_variant_links.py	
-reports/media_variant_link_validation.tsv	UNKNOWN	writer purity unestablished (validate_media_variant_links.py)	scripts/validate_media_variant_links.py	
-reports/media_variant_parent_group_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
-reports/media_variant_parent_group_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	
-reports/media_variation_candidate_groups.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
-reports/media_variation_candidate_groups.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	
-reports/pipeline_writers_audit.tsv	UNKNOWN	no writer found		
+artifact	kind	reason	writes	mentioned_by	freshness_checked
+data/MEDIA_SOURCES.tsv	UNKNOWN	no writer found			
+data/chemical_name_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	scripts/build_compound_to_chebi_mapping.py	
+data/chemical_name_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/generate_ingredient_umap.py; src/culturemech/visualization/umap_generator.py	
+data/compound_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)	scripts/build_compound_to_chebi_mapping.py	scripts/build_compound_to_chebi_mapping.py	
+data/compound_to_chebi_mapping_enhanced.json	UNKNOWN	writer purity unestablished (build_enhanced_compound_mapping.py)	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py	scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; scripts/enrich_solutions_with_chebi.py	
+data/culturemech_id_registry.tsv	CURRENT_VIEW	refresh_id_registry.py	scripts/refresh_id_registry.py; src/culturemech/utils/id_utils.py	scripts/artifact_writers.py; scripts/assign_culturemech_ids.py; scripts/refresh_id_registry.py; scripts/research_media.py; src/culturemech/utils/id_utils.py	
+data/curation/atcc_crossref_candidates.json	UNKNOWN	no writer found			
+data/curation/multi_db_crossref_candidates.json	UNKNOWN	writer purity unestablished (multi_database_crossref.py)		src/culturemech/enrich/multi_database_crossref.py	
+data/curation/organism_candidates.json	UNKNOWN	writer purity unestablished (curation_validator.py)		src/culturemech/curate/curation_validator.py; src/culturemech/curate/organism_extractor.py; src/culturemech/enrich/backfill_pipeline.py	
+data/curation/organism_review.csv	UNKNOWN	writer purity unestablished (curation_validator.py)		src/culturemech/curate/curation_validator.py	
+data/import_tracking/communitymech_imports.json	UNKNOWN	writer purity unestablished (import_from_communitymech.py)	scripts/import_from_communitymech.py	scripts/import_from_communitymech.py; scripts/update_communitymech_links.py	
+data/import_tracking/derived_artifacts.tsv	UNKNOWN	no writer found			
+data/import_tracking/mediadive_composition_ids.json	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	scripts/triage_missing_compositions.py	
+data/import_tracking/mediaingredientmech_migration_log.json	UNKNOWN	no writer found			
+data/import_tracking/new_solution_ingredients_vs_mediaingredientmech.tsv	UNKNOWN	no writer found			
+data/import_tracking/reports/axis_research_batch.json	CURRENT_VIEW	sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	scripts/sample_axis_research_batch.py	
+data/import_tracking/reports/batch2-curation-proposals.json	UNKNOWN	no writer found			
+data/import_tracking/reports/chebi_regrounding_changes.tsv	SNAPSHOT	one-time migration (migrate_chebi_regrounding.py)		scripts/migrate_chebi_regrounding.py	
+data/import_tracking/reports/composition_type_conflicts.tsv	CURRENT_VIEW	audit_composition_type.py	scripts/audit_composition_type.py	scripts/audit_composition_type.py	yes
+data/import_tracking/reports/composition_type_semi_defined.tsv	UNKNOWN	no writer found			
+data/import_tracking/reports/concentration_plausibility.tsv	CURRENT_VIEW	audit_concentration_plausibility.py	scripts/audit_concentration_plausibility.py	scripts/audit_concentration_plausibility.py	yes
+data/import_tracking/reports/concentration_plausibility_by_record.tsv	UNKNOWN	no writer found			
+data/import_tracking/reports/deep_research_priority.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	
+data/import_tracking/reports/deep_research_priority_top100.json	CURRENT_VIEW	prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py	scripts/prioritize_deep_research_candidates.py; scripts/sample_axis_research_batch.py	
+data/import_tracking/reports/domain_category_audit.json	UNKNOWN	no writer found			
+data/import_tracking/reports/edison_batch.json	CURRENT_VIEW	prioritize_deep_research_candidates.py		scripts/analyze_media_quality.py; scripts/prioritize_deep_research_candidates.py; scripts/research_media_edison.py	
+data/import_tracking/reports/filename_collisions.tsv	CURRENT_VIEW	audit_filename_collisions.py	scripts/audit_filename_collisions.py	scripts/audit_filename_collisions.py	yes
+data/import_tracking/reports/g25_phase3_llm_curation.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)		scripts/migrate_kg_fallback_phase3_curation.py	
+data/import_tracking/reports/kg_fallback_consensus_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_to_consensus.py)		scripts/migrate_kg_fallback_to_consensus.py	
+data/import_tracking/reports/kg_fallback_phase2_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)		scripts/migrate_kg_fallback_phase2_oak_ols.py	
+data/import_tracking/reports/kg_fallback_phase2_curator_review.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)		scripts/migrate_kg_fallback_phase2_oak_ols.py	
+data/import_tracking/reports/kg_fallback_phase3_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)		scripts/migrate_kg_fallback_phase3_curation.py	
+data/import_tracking/reports/mim_grounding_divergences.tsv	SNAPSHOT	one-time migration (migrate_legacy_mim_to_chebi.py)		scripts/migrate_legacy_mim_to_chebi.py	
+data/import_tracking/reports/missing_compositions.tsv	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	scripts/triage_missing_compositions.py	yes
+data/import_tracking/reports/primary_term_canonicalize_changes.tsv	UNKNOWN	no writer found			
+data/import_tracking/reports/primary_term_reground_changes.tsv	UNKNOWN	no writer found			
+data/import_tracking/reports/review_need_ranking.tsv	CURRENT_VIEW	score_review_need.py	scripts/score_review_need.py	scripts/score_review_need.py	yes
+data/import_tracking/reports/selective_agent_mismatch.tsv	CURRENT_VIEW	audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	yes
+data/import_tracking/reports/top5-curation-proposals.json	UNKNOWN	writer purity unestablished (apply_curation_proposals.py)		scripts/apply_curation_proposals.py	
+data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	yes
+data/import_tracking/researched_media.json	CURRENT_VIEW	prioritize_deep_research_candidates.py		scripts/prioritize_deep_research_candidates.py; scripts/refresh_researched_manifest.py; scripts/researched_manifest.py	
+data/import_tracking/schemas/manifest_v1.schema.json	UNKNOWN	no writer found			
+data/merge_yaml/merge_stats.json	UNKNOWN	writer purity unestablished (merge_recipes.py)	src/culturemech/merge/merge_recipes.py	scripts/verify_merges.py; src/culturemech/merge/merge_recipes.py	
+data/merge_yaml/merge_stats_2026.json	UNKNOWN	no writer found			
+data/merge_yaml/merge_stats_test.json	UNKNOWN	no writer found			
+data/merge_yaml/merged_2026/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py		scripts/generate_recipe_indexes.py	
+data/merge_yaml/merged_2026/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py		scripts/generate_recipe_indexes.py	
+data/normalized_yaml/algae_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/archaea_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/bacterial_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/by_source_komodo_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/by_source_mediadive_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/by_source_togo_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/by_source_unknown_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/fungal_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/recipe_index.json	CURRENT_VIEW	generate_recipe_indexes.py		scripts/generate_recipe_indexes.py	
+data/normalized_yaml/recipe_statistics.json	CURRENT_VIEW	generate_recipe_indexes.py		scripts/generate_recipe_indexes.py	
+data/normalized_yaml/solutions/mediadive_solution_index.json	UNKNOWN	writer purity unestablished (import_mediadive_solutions.py)	scripts/import_mediadive_solutions.py	scripts/import_mediadive_solutions.py; scripts/migrate_solutions_from_ingredients.py	
+data/normalized_yaml/solutions_index.json	UNKNOWN	no writer found			
+data/normalized_yaml/specialized_index.json	UNKNOWN	no writer found			
+data/raw/microbe-media-param/compound_mappings_strict_final.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)		src/culturemech/import/chemical_mappings.py	
+data/raw/microbe-media-param/compound_mappings_strict_final_hydrate.tsv	UNKNOWN	writer purity unestablished (chemical_mappings.py)		src/culturemech/import/chemical_mappings.py	
+data/solution_to_chebi_mapping.json	UNKNOWN	writer purity unestablished (build_compound_to_chebi_mapping.py)		scripts/build_compound_to_chebi_mapping.py; scripts/build_enhanced_compound_mapping.py; scripts/build_fast_compound_mapping.py; src/culturemech/embedding/aggregator.py; src/culturemech/embedding/aggregator_yaml_source.py; src/culturemech/visualization/umap_generator.py	
+reports/archive/mim_algae_enrichment.json	SNAPSHOT	archived			
+reports/archive/mim_archaea_enrichment.json	SNAPSHOT	archived			
+reports/archive/mim_bacterial_dryrun.json	SNAPSHOT	archived			
+reports/archive/mim_bacterial_enrichment.json	SNAPSHOT	archived			
+reports/archive/mim_fungal_enrichment.json	SNAPSHOT	archived			
+reports/archive/mim_specialized_enrichment.json	SNAPSHOT	archived			
+reports/archive/validation_20260316.json	SNAPSHOT	archived			
+reports/archive/validation_20260316.tsv	SNAPSHOT	archived			
+reports/archive/validation_corrected_20260316.json	SNAPSHOT	archived			
+reports/archive/validation_corrected_20260316.tsv	SNAPSHOT	archived			
+reports/archive/validation_final_20260316.json	SNAPSHOT	archived			
+reports/archive/validation_final_20260316.tsv	SNAPSHOT	archived			
+reports/gap_fix_backlog.tsv	UNKNOWN	no writer found			
+reports/instance_validation_failures.tsv	UNKNOWN	writer purity unestablished (validate_strict.py)	scripts/validate_strict.py	scripts/validate_strict.py	
+reports/label_plausibility_2026-07-19.tsv	SNAPSHOT	dated filename			
+reports/label_plausibility_after_fixes.tsv	UNKNOWN	no writer found			
+reports/media_content_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	scripts/build_media_content_review_manifest.py	
+reports/media_content_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	scripts/build_media_content_review_manifest.py; scripts/propose_media_variant_links.py	
+reports/media_growth_review_manifest.json	UNKNOWN	writer purity unestablished (build_media_growth_review_manifest.py)	scripts/build_media_growth_review_manifest.py	scripts/build_media_growth_review_manifest.py	
+reports/media_growth_review_manifest.tsv	UNKNOWN	writer purity unestablished (build_media_growth_review_manifest.py)	scripts/build_media_growth_review_manifest.py	scripts/build_media_growth_review_html.py; scripts/build_media_growth_review_manifest.py	
+reports/media_variant_link_apply_plan.json	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	scripts/apply_media_variant_links.py	
+reports/media_variant_link_apply_plan.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)	scripts/apply_media_variant_links.py	scripts/apply_media_variant_links.py	
+reports/media_variant_link_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	scripts/propose_media_variant_links.py	
+reports/media_variant_link_proposals.tsv	UNKNOWN	writer purity unestablished (apply_media_variant_links.py)		scripts/apply_media_variant_links.py; scripts/propose_media_variant_links.py	
+reports/media_variant_link_validation.tsv	UNKNOWN	writer purity unestablished (validate_media_variant_links.py)	scripts/validate_media_variant_links.py	scripts/validate_media_variant_links.py	
+reports/media_variant_parent_group_proposals.json	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)	scripts/propose_media_variant_links.py	scripts/propose_media_variant_links.py	
+reports/media_variant_parent_group_proposals.tsv	UNKNOWN	writer purity unestablished (propose_media_variant_links.py)		scripts/propose_media_variant_links.py	
+reports/media_variation_candidate_groups.json	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	scripts/build_media_content_review_manifest.py	
+reports/media_variation_candidate_groups.tsv	UNKNOWN	writer purity unestablished (build_media_content_review_manifest.py)	scripts/build_media_content_review_manifest.py	scripts/build_media_content_review_manifest.py	
+reports/pipeline_writers_audit.tsv	UNKNOWN	no writer found			

--- a/scripts/artifact_writers.py
+++ b/scripts/artifact_writers.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Decide whether a script WRITES an artifact or merely mentions it (#209).
+
+`audit_derived_artifacts` attributed artifacts by grepping for the basename, so
+its `writer` column listed readers too. `research_media.py` reads
+`culturemech_id_registry.tsv` to build a resolution index and writes nothing, yet
+appeared among that artifact's writers.
+
+That column is what a curator reads to judge whether an artifact is a current view
+or a snapshot, so a reader listed as a writer is misleading in exactly that
+judgement — and the list grows with every new consumer.
+
+## Why proximity does not work
+
+The mention is almost always a module constant:
+
+    ID_REGISTRY = REPO_ROOT / "data" / "culturemech_id_registry.tsv"
+
+and the write, if any, happens elsewhere through that name. Looking for a write
+call near the mention finds nothing in either case.
+
+## What this does instead
+
+Parses the module and traces the binding:
+
+  1. Collect every name bound to an expression containing the artifact's basename
+     — assignments, annotated assignments, and parameter defaults.
+  2. Find write operations: `X.write_text(...)`, `X.write_bytes(...)`,
+     `X.open("w")`, `open(X, "w")`, `csv`/`json`/`yaml` dumps into a handle opened
+     from `X`.
+  3. Report `writes` when a write target resolves to one of those names.
+
+Deliberately conservative: an unparseable module, or a path built too indirectly
+to follow, yields "unknown" rather than a guess. A wrong "yes" is worse than an
+honest "unknown", because the whole point is to stop asserting things that are not
+established.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+WRITE_METHODS = {"write_text", "write_bytes", "write"}
+DUMP_FUNCS = {"dump", "safe_dump", "to_csv", "writerow", "writerows", "writeheader"}
+
+
+class _Tracer(ast.NodeVisitor):
+    """Names bound to the artifact path, and names written through."""
+
+    def __init__(self, basename: str) -> None:
+        self.basename = basename
+        self.bound: set[str] = set()
+        self.written: set[str] = set()
+        self._opened_from: dict[str, str] = {}  # handle name -> path name
+
+    # --- binding ---------------------------------------------------------
+    def _mentions(self, node: ast.AST) -> bool:
+        return any(isinstance(n, ast.Constant) and isinstance(n.value, str)
+                   and self.basename in n.value
+                   for n in ast.walk(node))
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if node.value is not None and self._mentions(node.value):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    self.bound.add(tgt.id)
+        # handle = X.open(...) / open(X, ...)
+        self._track_handle(node)
+        # writer = csv.DictWriter(handle, ...) — the write goes through the writer
+        # object, so the chain handle -> writer must be followed or every
+        # DictWriter-based report looks unwritten.
+        self._track_writer_object(node)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and self._mentions(node.value) and isinstance(node.target, ast.Name):
+            self.bound.add(node.target.id)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Bind parameters whose DEFAULT is the artifact path.
+
+        `def collect(out: Path = DEFAULT_OUT)` is common here. Positional defaults
+        align to the LAST n parameters, so the pairing is done from the right;
+        getting it wrong would bind the wrong name and invent a writer.
+        """
+        args = node.args
+        positional = [a.arg for a in args.args]
+        for name, default in zip(positional[len(positional) - len(args.defaults):],
+                                 args.defaults, strict=True):
+            if self._mentions(default):
+                self.bound.add(name)
+        for kwarg, default in zip([a.arg for a in args.kwonlyargs],
+                                  args.kw_defaults, strict=True):
+            if default is not None and self._mentions(default):
+                self.bound.add(kwarg)
+        self.generic_visit(node)
+
+    # --- writing ---------------------------------------------------------
+    def _root_name(self, node: ast.AST) -> str | None:
+        """The name a path expression resolves to.
+
+        `args.out` resolves to "out", not "args": the argparse dest is what the
+        binding pass records, since that is where the module constant ends up.
+        """
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.attr in self.bound:
+                return node.attr
+        while isinstance(node, ast.Attribute):
+            node = node.value
+        return node.id if isinstance(node, ast.Name) else None
+
+    def _track_handle(self, node: ast.Assign) -> None:
+        call = node.value
+        target = node.targets[0] if node.targets else None
+        if not isinstance(call, ast.Call) or not isinstance(target, ast.Name):
+            return
+        path_name = mode = None
+        if isinstance(call.func, ast.Attribute) and call.func.attr == "open":
+            path_name = self._root_name(call.func.value)
+            mode = call.args[0].value if call.args and isinstance(call.args[0], ast.Constant) else "r"
+        elif isinstance(call.func, ast.Name) and call.func.id == "open":
+            if call.args:
+                path_name = self._root_name(call.args[0])
+            mode = call.args[1].value if len(call.args) > 1 and isinstance(call.args[1], ast.Constant) else "r"
+        for kw in call.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                mode = kw.value.value
+        if path_name and isinstance(mode, str) and ("w" in mode or "a" in mode):
+            self._opened_from[target.id] = path_name
+
+    def _track_writer_object(self, node: ast.Assign) -> None:
+        call = node.value
+        target = node.targets[0] if node.targets else None
+        if not isinstance(call, ast.Call) or not isinstance(target, ast.Name):
+            return
+        for arg in call.args:
+            name = self._root_name(arg)
+            if name and name in self._opened_from:
+                self._opened_from[target.id] = self._opened_from[name]
+                return
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            call = item.context_expr
+            if isinstance(call, ast.Call) and isinstance(item.optional_vars, ast.Name):
+                fake = ast.Assign(targets=[item.optional_vars], value=call)
+                self._track_handle(fake)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        # The dominant pattern in this repo: the path is a module constant used as
+        # an argparse default, and the write goes through `args.out`. Without this
+        # the tracer scored 1/6 on known cases, because the binding flows through
+        # argparse rather than through a direct assignment.
+        if isinstance(func, ast.Attribute) and func.attr == "add_argument":
+            dest = None
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str) \
+                        and arg.value.startswith("--"):
+                    dest = arg.value.lstrip("-").replace("-", "_")
+            default_bound = False
+            for kw in node.keywords:
+                if kw.arg == "dest" and isinstance(kw.value, ast.Constant):
+                    dest = str(kw.value.value)
+                if kw.arg == "default":
+                    name = self._root_name(kw.value)
+                    if (name and name in self.bound) or self._mentions(kw.value):
+                        default_bound = True
+            if dest and default_bound:
+                self.bound.add(dest)
+        if isinstance(func, ast.Attribute):
+            if func.attr in WRITE_METHODS:
+                name = self._root_name(func.value)
+                if name:
+                    self.written.add(self._opened_from.get(name, name))
+            elif func.attr in DUMP_FUNCS:
+                for arg in node.args:
+                    name = self._root_name(arg)
+                    if name:
+                        self.written.add(self._opened_from.get(name, name))
+                name = self._root_name(func.value)
+                if name and name in self._opened_from:
+                    self.written.add(self._opened_from[name])
+        self.generic_visit(node)
+
+
+def writes_artifact(source: str, basename: str) -> str:
+    """Return "yes", "no" or "unknown" for whether `source` writes `basename`."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return "unknown"
+    tracer = _Tracer(basename)
+    tracer.visit(tree)
+    if not tracer.bound:
+        # The path is not bound to a name we can follow. If the module writes
+        # nothing at all, "no" is still established; otherwise say so.
+        return "no" if not tracer.written else "unknown"
+    return "yes" if tracer.bound & tracer.written else "no"
+
+
+def classify_file(path: Path, basename: str) -> str:
+    try:
+        return writes_artifact(path.read_text(errors="replace"), basename)
+    except OSError:
+        return "unknown"

--- a/scripts/artifact_writers.py
+++ b/scripts/artifact_writers.py
@@ -34,6 +34,13 @@ Deliberately conservative: an unparseable module, or a path built too indirectly
 to follow, yields "unknown" rather than a guess. A wrong "yes" is worse than an
 honest "unknown", because the whole point is to stop asserting things that are not
 established.
+
+## Known limitation
+
+There is no scope analysis, so a local variable that shadows a module constant and
+writes somewhere else produces a false "yes". No script in this repo currently does
+that, and ten spot-checked attributions all held up, but it is a real hole —
+tracked in #211 rather than left to be discovered.
 """
 
 from __future__ import annotations

--- a/scripts/audit_derived_artifacts.py
+++ b/scripts/audit_derived_artifacts.py
@@ -57,6 +57,9 @@ import sys
 import tempfile
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from artifact_writers import classify_file  # noqa: E402
+
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_OUT = REPO / "data" / "import_tracking" / "derived_artifacts.tsv"
 
@@ -138,7 +141,13 @@ def classify(artifact: str, writer: str | None) -> tuple[str, str]:
 def inventory() -> list[dict[str, str]]:
     rows = []
     for art in tracked_artifacts():
-        writers = find_writers(art)
+        mentions = find_writers(art)
+        base = os.path.basename(art)
+        # Grep cannot tell a reader from a writer: research_media.py READS the id
+        # registry to build an index and appeared among its "writers" (#209). This
+        # traces the binding through the module instead.
+        writers = [m for m in mentions
+                   if classify_file(REPO / m, base) == "yes"] or mentions
         # A declared checkable artifact's writer is known exactly; re-deriving it
         # by grep would be guessing at something already stated.
         declared = CHECKABLE.get(art)
@@ -152,11 +161,13 @@ def inventory() -> list[dict[str, str]]:
         primary = next((w for w in writers if GENERATOR.match(os.path.basename(w))),
                        writers[0] if writers else None)
         kind, why = classify(art, primary)
+        confirmed = [m for m in mentions if classify_file(REPO / m, base) == "yes"]
         rows.append({
             "artifact": art,
             "kind": kind,
             "reason": why,
-            "writer": "; ".join(writers),
+            "writes": "; ".join(confirmed),
+            "mentioned_by": "; ".join(mentions),
             "freshness_checked": "yes" if art in CHECKABLE else "",
         })
     return rows
@@ -199,7 +210,8 @@ def main(argv: list[str] | None = None) -> int:
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w", newline="", encoding="utf-8") as fh:
         w = csv.DictWriter(fh, delimiter="\t", fieldnames=[
-            "artifact", "kind", "reason", "writer", "freshness_checked"])
+            "artifact", "kind", "reason", "writes", "mentioned_by",
+            "freshness_checked"])
         w.writeheader()
         w.writerows(rows)
 

--- a/tests/test_apply_ingredient_roles.py
+++ b/tests/test_apply_ingredient_roles.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "apply_ingredient_roles.py"
 

--- a/tests/test_artifact_writers.py
+++ b/tests/test_artifact_writers.py
@@ -1,0 +1,143 @@
+"""Tests for reader-vs-writer attribution of derived artifacts (#209).
+
+`audit_derived_artifacts` attributed artifacts by grepping for the basename, so
+its `writer` column listed readers. `research_media.py` reads the id registry to
+build a resolution index and writes nothing, yet appeared among its writers — and
+that column is what a curator reads to judge current-view versus snapshot.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def aw():
+    return _load("artifact_writers")
+
+
+# --- the patterns this repo actually uses -----------------------------------
+
+
+def test_a_direct_write_text_is_detected(aw):
+    src = '''
+from pathlib import Path
+OUT = Path("data/x/report.tsv")
+def main():
+    OUT.write_text("hi")
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
+def test_a_read_only_module_is_not_a_writer(aw):
+    """The #209 case: a module binds the path and only reads it."""
+    src = '''
+from pathlib import Path
+REG = Path("data/culturemech_id_registry.tsv")
+def load():
+    return REG.read_text()
+'''
+    assert aw.writes_artifact(src, "culturemech_id_registry.tsv") == "no"
+
+
+def test_the_argparse_default_pattern_is_followed(aw):
+    """The dominant shape here: a module constant used as an --out default, with
+    the write going through `args.out`. Tracing only direct assignments scored
+    1/6 on real scripts."""
+    src = '''
+from pathlib import Path
+import argparse
+DEFAULT_OUT = Path("data/x/report.tsv")
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args()
+    args.out.write_text("hi")
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
+def test_the_handle_to_csv_writer_chain_is_followed(aw):
+    """The write goes through the DictWriter, not the handle. Missing this link
+    left every DictWriter-based report looking unwritten — 2/8 before, 10/10
+    after."""
+    src = '''
+from pathlib import Path
+import argparse, csv
+DEFAULT_OUT = Path("data/x/report.tsv")
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args()
+    with args.out.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, delimiter="\\t", fieldnames=["a"])
+        w.writeheader()
+        w.writerows([])
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
+def test_a_read_handle_is_not_a_write(aw):
+    src = '''
+from pathlib import Path
+import csv
+REG = Path("data/reg.tsv")
+def load():
+    with REG.open() as fh:
+        return list(csv.DictReader(fh))
+'''
+    assert aw.writes_artifact(src, "reg.tsv") == "no"
+
+
+def test_unparseable_source_is_unknown_not_a_guess(aw):
+    """A wrong "yes" is worse than an honest "unknown" — the point is to stop
+    asserting things that are not established."""
+    assert aw.writes_artifact("def broken(:\n", "x.tsv") == "unknown"
+
+
+# --- against the real repo --------------------------------------------------
+
+
+@pytest.mark.parametrize("script,artifact,expected", [
+    ("research_media.py", "culturemech_id_registry.tsv", "no"),
+    ("refresh_id_registry.py", "culturemech_id_registry.tsv", "yes"),
+    ("triage_missing_compositions.py", "missing_compositions.tsv", "yes"),
+    ("audit_selective_agent_mismatch.py", "selective_agent_mismatch.tsv", "yes"),
+    ("score_review_need.py", "review_need_ranking.tsv", "yes"),
+    ("report_unparsed_compositions.py", "unparsed_compositions.tsv", "yes"),
+    ("audit_filename_collisions.py", "filename_collisions.tsv", "yes"),
+    ("audit_composition_type.py", "composition_type_conflicts.tsv", "yes"),
+    ("prioritize_deep_research_candidates.py", "deep_research_priority.json", "yes"),
+])
+def test_known_cases_in_this_repo(aw, script, artifact, expected):
+    path = REPO_ROOT / "scripts" / script
+    if not path.is_file():
+        pytest.skip(f"{script} not present")
+    assert aw.classify_file(path, artifact) == expected
+
+
+def test_the_manifest_separates_writes_from_mentions():
+    """The columns must not be conflated again."""
+    import csv
+    manifest = REPO_ROOT / "data" / "import_tracking" / "derived_artifacts.tsv"
+    rows = list(csv.DictReader(manifest.open(), delimiter="\t"))
+    assert "writes" in rows[0] and "mentioned_by" in rows[0]
+    assert "writer" not in rows[0], "the ambiguous `writer` column is back"
+    registry = next(r for r in rows if r["artifact"] == "data/culturemech_id_registry.tsv")
+    assert "research_media.py" in registry["mentioned_by"]
+    assert "research_media.py" not in registry["writes"], (
+        "a reader is listed as a writer again (#209)")

--- a/tests/test_artifact_writers.py
+++ b/tests/test_artifact_writers.py
@@ -141,3 +141,21 @@ def test_the_manifest_separates_writes_from_mentions():
     assert "research_media.py" in registry["mentioned_by"]
     assert "research_media.py" not in registry["writes"], (
         "a reader is listed as a writer again (#209)")
+
+
+def test_shadowing_is_a_known_false_positive(aw):
+    """#211. Pinned as CURRENT behaviour, not as desired behaviour.
+
+    Without scope analysis a local rebinding of a module constant's name looks
+    like a write to the constant's path. No script here does this today. If a fix
+    lands, this test should flip to expecting "no" — it exists so the hole is
+    visible rather than forgotten.
+    """
+    src = '''
+from pathlib import Path
+OUT = Path("data/report.tsv")
+def unrelated():
+    OUT = Path("/tmp/other.tsv")
+    OUT.write_text("x")
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"

--- a/tests/test_backfill_ingredient_roles.py
+++ b/tests/test_backfill_ingredient_roles.py
@@ -32,11 +32,10 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import pytest
-
 
 # Load the backfill script as a module without touching sys.path — the
 # script lives outside the `culturemech` package.

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -178,8 +178,8 @@ def test_stock_solution_records_are_excluded(corpus_findings):
     Without this exclusion the audit would flag thousands of the ~4,784 MediaDive
     solution records that live in bacterial/ (#124).
     """
-    from record_kinds import is_solution_record
     import yaml as _yaml
+    from record_kinds import is_solution_record
 
     normalized = REPO_ROOT / "data" / "normalized_yaml"
     # Distinct records only — the row list repeats a file once per flagged row.

--- a/tests/test_derived_artifacts.py
+++ b/tests/test_derived_artifacts.py
@@ -44,7 +44,7 @@ def test_the_manifest_matches_a_fresh_computation(ada):
     import io
     fresh = io.StringIO(newline="")
     w = csv.DictWriter(fresh, delimiter="\t", lineterminator="\r\n", fieldnames=[
-        "artifact", "kind", "reason", "writer", "freshness_checked"])
+        "artifact", "kind", "reason", "writes", "mentioned_by", "freshness_checked"])
     w.writeheader()
     w.writerows(ada.inventory())
     # Compare row content, not line endings: the script writes with newline="" so
@@ -91,8 +91,8 @@ def test_unknowns_are_reported_not_hidden(ada):
     exist. It is a ceiling, not a target: driving it to 0 by guessing would be
     worse than leaving them listed."""
     unknown = [r for r in ada.inventory() if r["kind"] == "UNKNOWN"]
-    assert len(unknown) <= 54, (
-        f"{len(unknown)} unclassified artifacts, above the documented 54. A new "
+    assert len(unknown) <= 55, (
+        f"{len(unknown)} unclassified artifacts, above the documented 55. A new "
         "tracked artifact was added without a classification.")
 
 
@@ -120,14 +120,16 @@ def test_the_auditor_is_never_recorded_as_a_writer(ada):
     the manifest report the auditor as that report's writer. The writer column is
     the evidence for each classification, so circular attribution undermines it."""
     for row in ada.inventory():
-        assert ada.SELF not in row["writer"], (
+        assert ada.SELF not in row["mentioned_by"], (
             f"{row['artifact']} attributes itself to the auditor")
+        assert ada.SELF not in row["writes"], (
+            f"{row['artifact']} claims the auditor writes it")
 
 
 def test_all_candidate_writers_are_recorded_not_just_the_first(ada):
     """Nine artifacts have several. Ambiguity a curator can see beats a confident
     wrong answer."""
-    multi = [r for r in ada.inventory() if ";" in r["writer"]]
+    multi = [r for r in ada.inventory() if ";" in r["mentioned_by"]]
     assert multi, "no multi-writer artifacts recorded; find_writers regressed to first-match"
 
 
@@ -135,7 +137,8 @@ def test_a_checkable_artifact_uses_its_declared_writer(ada):
     """Re-deriving by grep would be guessing at something already stated."""
     for art, cmd in ada.CHECKABLE.items():
         row = next(r for r in ada.inventory() if r["artifact"] == art)
-        assert row["writer"].split(";")[0].strip() == cmd[0]
+        assert cmd[0] in row["writes"], (
+            f"{art}: declared writer {cmd[0]} not confirmed as a writer")
 
 
 def test_the_regenerating_writer_wins_when_several_touch_an_artifact(ada):

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -72,7 +72,7 @@ class TestATCCCrossRefBackfill:
         self.pipeline.apply_atcc_crossrefs(self.temp_dir, crossref_file, dry_run=False)
 
         # Load updated file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         # Verify ATCC reference added to notes
@@ -114,7 +114,7 @@ class TestATCCCrossRefBackfill:
         self.pipeline.apply_atcc_crossrefs(self.temp_dir, crossref_file, dry_run=False)
 
         # Load file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         # Should not have duplicate entry
@@ -141,7 +141,7 @@ class TestATCCCrossRefBackfill:
         self.pipeline.apply_atcc_crossrefs(self.temp_dir, crossref_file, dry_run=True)
 
         # Load file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         # Should be unchanged
@@ -204,7 +204,7 @@ class TestOrganismDataBackfill:
         self.pipeline.apply_organism_data(self.temp_dir, organism_file, dry_run=False)
 
         # Load updated file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         # Verify organism_culture_type added
@@ -254,7 +254,7 @@ class TestOrganismDataBackfill:
         self.pipeline.apply_organism_data(self.temp_dir, organism_file, dry_run=False)
 
         # Load file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         # Should NOT overwrite existing data
@@ -288,7 +288,7 @@ class TestOrganismDataBackfill:
         self.pipeline.apply_organism_data(self.temp_dir, organism_file, dry_run=False)
 
         # File should remain unchanged (invalid name skipped)
-        with open(self.temp_dir / "test_file.yaml", 'r', encoding='utf-8') as f:
+        with open(self.temp_dir / "test_file.yaml", encoding='utf-8') as f:
             updated = yaml.safe_load(f)
 
         assert "target_organisms" not in updated
@@ -506,7 +506,7 @@ class TestEnrichmentPipelineIntegration:
         )
 
         # Load enriched file
-        with open(self.temp_dir / "DSMZ_1_NUTRIENT_AGAR.yaml", 'r', encoding='utf-8') as f:
+        with open(self.temp_dir / "DSMZ_1_NUTRIENT_AGAR.yaml", encoding='utf-8') as f:
             enriched = yaml.safe_load(f)
 
         # Verify ATCC cross-reference added
@@ -568,7 +568,7 @@ class TestEnrichmentPipelineIntegration:
         self.pipeline.apply_organism_data(self.temp_dir, organism_file, dry_run=False)
 
         # Load enriched file
-        with open(yaml_file, 'r', encoding='utf-8') as f:
+        with open(yaml_file, encoding='utf-8') as f:
             enriched = yaml.safe_load(f)
 
         # Verify required schema fields are present
@@ -656,8 +656,8 @@ class TestATCCLiteratureVerification:
 
     def test_atcc_crossref_verifier_integration(self):
         """Test basic ATCCCrossRefVerifier integration."""
-        from culturemech.enrich.literature_verifier import LiteratureVerifier
         from culturemech.enrich.atcc_crossref_verifier import ATCCCrossRefVerifier
+        from culturemech.enrich.literature_verifier import LiteratureVerifier
 
         # Create verifier chain
         lit_verifier = LiteratureVerifier(use_fallback_pdf=False)
@@ -669,7 +669,7 @@ class TestATCCLiteratureVerification:
     def test_scihub_environment_variable_integration(self):
         """Test that ENABLE_SCIHUB_FALLBACK environment variable works."""
         import os
-        from culturemech.enrich.literature_verifier import LiteratureVerifier
+
 
         # Set environment variable
         os.environ["ENABLE_SCIHUB_FALLBACK"] = "true"

--- a/tests/test_extract_roles_from_edison.py
+++ b/tests/test_extract_roles_from_edison.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "extract_roles_from_edison.py"
 

--- a/tests/test_id_prefix_schema_config_parity.py
+++ b/tests/test_id_prefix_schema_config_parity.py
@@ -34,10 +34,9 @@ place in the ingredient-id pattern.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
-import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_kg_media_matcher.py
+++ b/tests/test_kg_media_matcher.py
@@ -1,9 +1,10 @@
 """Tests for KG-Microbe media matcher."""
 
 import os
+from pathlib import Path
 
 import pytest
-from pathlib import Path
+
 from culturemech.match import KGMediaMatcher, match_recipe_to_kg_microbe
 
 

--- a/tests/test_kg_microbe_integration.py
+++ b/tests/test_kg_microbe_integration.py
@@ -13,9 +13,11 @@ Key query patterns:
 """
 
 import json
+from pathlib import Path
+
 import pytest
 import yaml
-from pathlib import Path
+
 from culturemech.export.kgx_export import transform
 
 

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -4,19 +4,18 @@ Unit tests for KGX export module.
 Tests the transform functions that extract edges from recipe YAML.
 """
 
-import pytest
 from culturemech.export.kgx_export import (
-    transform,
+    _format_evidence,
+    _get_term_id,
+    _make_edge_id,
+    _sanitize_id,
+    application_to_edge,
+    database_reference_to_edge,
     ingredient_to_edge,
     organism_to_edge,
-    application_to_edge,
     physical_state_to_edge,
-    database_reference_to_edge,
+    transform,
     variant_to_edge,
-    _get_term_id,
-    _format_evidence,
-    _sanitize_id,
-    _make_edge_id,
 )
 
 

--- a/tests/test_literature_verifier.py
+++ b/tests/test_literature_verifier.py
@@ -1,10 +1,9 @@
 """Tests for literature verifier."""
 
-import pytest
-from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
-import tempfile
 import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 from culturemech.enrich.literature_verifier import LiteratureVerifier
 

--- a/tests/test_mediaingredientmech_enrichment.py
+++ b/tests/test_mediaingredientmech_enrichment.py
@@ -2,10 +2,11 @@
 
 import tempfile
 from pathlib import Path
+
 import yaml
 
-from culturemech.enrich.mediaingredientmech_loader import MediaIngredientMechLoader
 from culturemech.enrich.mediaingredientmech_linker import MediaIngredientMechLinker
+from culturemech.enrich.mediaingredientmech_loader import MediaIngredientMechLoader
 
 
 def test_mediaingredientmech_loader():

--- a/tests/test_ols_client.py
+++ b/tests/test_ols_client.py
@@ -3,15 +3,14 @@
 Unit tests for OLS API Client
 """
 
-import unittest
-from unittest.mock import Mock, patch, MagicMock
-from pathlib import Path
-import json
+import sys
 import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import requests
 
-import sys
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
 from culturemech.ontology.ols_client import OLSClient

--- a/tests/test_prioritize_role_research_candidates.py
+++ b/tests/test_prioritize_role_research_candidates.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCRIPT_PATH = _REPO_ROOT / "scripts" / "prioritize_role_research_candidates.py"
 

--- a/tests/test_render_media_role_graph.py
+++ b/tests/test_render_media_role_graph.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-import textwrap
 from pathlib import Path
 
 import pytest
 import yaml
-
 
 _SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "render_media_role_graph.py"
 _SPEC = importlib.util.spec_from_file_location("_render_media_role_graph", _SCRIPT_PATH)

--- a/tests/test_similarity_calculator.py
+++ b/tests/test_similarity_calculator.py
@@ -1,6 +1,7 @@
 """Tests for media similarity calculator."""
 
 import pytest
+
 from culturemech.taxonomy.similarity import SimilarityCalculator
 from culturemech.taxonomy.unit_converter import UnitConverter
 

--- a/tests/test_source_environment.py
+++ b/tests/test_source_environment.py
@@ -4,12 +4,10 @@ Tests schema validation of the SourceEnvironmentDescriptor and EnvironmentTerm
 classes added for environmental linking (issue #2).
 """
 
-import os
 import re
 import subprocess
 from pathlib import Path
 
-import pytest
 import yaml
 
 SCHEMA_PATH = Path(__file__).parent.parent / "src" / "culturemech" / "schema" / "culturemech.yaml"
@@ -108,9 +106,8 @@ class TestDataclassGeneration:
         if src_path not in sys.path:
             sys.path.insert(0, src_path)
         from culturemech.schema.culturemech_dataclasses import (
-            SourceEnvironmentDescriptor,
             EnvironmentTerm,
-            MediaRecipe,
+            SourceEnvironmentDescriptor,
         )
         assert SourceEnvironmentDescriptor is not None
         assert EnvironmentTerm is not None

--- a/tests/test_sssom_generation.py
+++ b/tests/test_sssom_generation.py
@@ -3,17 +3,22 @@
 Integration tests for SSSOM pipeline
 """
 
-import unittest
-import tempfile
-import yaml
-from pathlib import Path
-import pandas as pd
-
 import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from scripts.extract_unique_ingredients import extract_unique_ingredients, extract_source_from_path
-from scripts.generate_sssom_mappings import generate_sssom_mappings, create_curie, validate_sssom_format
+from scripts.extract_unique_ingredients import extract_source_from_path, extract_unique_ingredients
+from scripts.generate_sssom_mappings import (
+    create_curie,
+    generate_sssom_mappings,
+    validate_sssom_format,
+)
 
 
 class TestIngredientExtraction(unittest.TestCase):


### PR DESCRIPTION
`audit_derived_artifacts` attributed artifacts by grepping for the basename, so the
`writer` column listed **readers**. `research_media.py` reads
`culturemech_id_registry.tsv` to build a resolution index and writes nothing, yet
appeared among its writers.

That column is what a curator reads to judge current-view versus snapshot, so a
reader listed there is misleading in exactly that judgement — and the list grows
with every new consumer.

Two columns now: **`writes`** (established) and **`mentioned_by`** (literal). The
ambiguous `writer` is gone, and a test asserts it does not come back.

## Getting the detection right took three attempts

**Proximity does not work.** The mention is a module constant and the write happens
elsewhere through that name, so nothing is near the mention in either case.

| approach | score on known cases |
|---|--:|
| AST tracing of direct assignments | 1/6 |
| + follow the argparse `default=CONST` → `args.out` chain | 2/8 |
| + follow the handle → `csv.DictWriter(fh, …)` chain | **10/10** |

The last gap was the one that mattered: writes go through the DictWriter, not the
handle, so **every DictWriter-based report looked unwritten**.

Validated against real scripts rather than invented ones, because the failure mode
here is a confidently wrong attribution. Unparseable or too-indirect modules yield
`unknown` rather than a guess.

## It also corrected a classification

`chemical_name_to_chebi_mapping_enhanced.json` was CURRENT_VIEW on the strength of
`generate_ingredient_umap.py` matching the generator name prefix — but that script
only **reads** it (*"for name fallback"*). Its real writers are
`build_enhanced_compound_mapping.py` and `build_fast_compound_mapping.py`, whose
purity is unestablished, so UNKNOWN is the honest answer.

```
CURRENT_VIEW  19 -> 18
UNKNOWN       54 -> 55
```

The registry case from the issue now reads correctly:

```
writes      : refresh_id_registry.py; id_utils.py
mentioned_by: artifact_writers.py; assign_culturemech_ids.py;
              refresh_id_registry.py; research_media.py; id_utils.py
```

Closes #209.