### PR TITLE
Budget test time instead of banning corpus globs (#191)

### DIFF
--- a/scripts/curate_medium_type.py
+++ b/scripts/curate_medium_type.py
@@ -113,20 +113,33 @@ def assess(doc: dict[str, Any], mapping: dict[str, str], inv: dict[str, str]) ->
     return f"{current} contradicts composition_type={ct} -> {want}"
 
 
-def scan(normalized: Path, mapping: dict[str, str], inv: dict[str, str]
-         ) -> list[tuple[Path, dict[str, Any], str, str | None]]:
+def scan_parsed(records, mapping: dict[str, str], inv: dict[str, str]
+                ) -> list[tuple[Path, dict[str, Any], str, str | None]]:
+    """Drift among already-parsed records.
+
+    Split out so the corpus guard can use the session-scoped fixture rather than
+    re-parsing all ~15,900 files, which cost 328s (#191).
+    """
     out = []
-    for path in sorted(normalized.rglob("*.yaml")):
-        try:
-            doc = yaml.safe_load(path.read_text(errors="replace"))
-        except (yaml.YAMLError, OSError):
-            continue
+    for path, doc in records:
         if not isinstance(doc, dict) or is_solution_record(doc):
             continue
         reason = assess(doc, mapping, inv)
         if reason:
             out.append((path, doc, reason, expected_medium_type(doc, inv)))
     return out
+
+
+def scan(normalized: Path, mapping: dict[str, str], inv: dict[str, str]
+         ) -> list[tuple[Path, dict[str, Any], str, str | None]]:
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((path, doc))
+    return scan_parsed(records, mapping, inv)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/retype_solution_records.py
+++ b/scripts/retype_solution_records.py
@@ -67,8 +67,12 @@ from triage_missing_compositions import (  # noqa: E402
 NORMALIZED = REPO / "data" / "normalized_yaml"
 
 
-def candidates(normalized: Path = NORMALIZED) -> list[tuple[Path, dict[str, Any]]]:
-    """Records that are named like a stock solution AND carry no composition.
+def candidates_from(records) -> list[tuple[Path, dict[str, Any]]]:
+    """Candidates among already-parsed records.
+
+    Split out so the corpus guard can use the session-scoped fixture instead of
+    re-parsing all ~15,900 files, which cost 421s and made this the single
+    slowest test in the suite (#191).
 
     BOTH conditions are required. A record named "...solution" that has a real
     ingredient list is a medium as far as this corpus is concerned — Ringer's and
@@ -76,11 +80,7 @@ def candidates(normalized: Path = NORMALIZED) -> list[tuple[Path, dict[str, Any]
     them would remove them from media audits that should still see them.
     """
     out = []
-    for path in sorted(normalized.rglob("*.yaml")):
-        try:
-            doc = yaml.safe_load(path.read_text(errors="replace"))
-        except (yaml.YAMLError, OSError):
-            continue
+    for path, doc in records:
         if not isinstance(doc, dict) or is_solution_record(doc):
             continue
         if not has_no_usable_composition(doc):
@@ -89,6 +89,18 @@ def candidates(normalized: Path = NORMALIZED) -> list[tuple[Path, dict[str, Any]
         if SOLUTION_NAMED.search(name):
             out.append((path, doc))
     return out
+
+
+def candidates(normalized: Path = NORMALIZED) -> list[tuple[Path, dict[str, Any]]]:
+    """Parse the corpus from disk, then select candidates."""
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((path, doc))
+    return candidates_from(records)
 
 
 def stamp(path: Path, doc: dict[str, Any]) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,19 @@ def pytest_runtest_logreport(report) -> None:
 
 
 def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ARG001
+    # Under pytest-xdist each worker holds its own `_call_durations`, and the
+    # CONTROLLER's copy is empty — so this check would pass unconditionally while
+    # appearing to run. xdist is not installed today, but `-n auto` is the obvious
+    # response to a slow suite, and silently losing the guard is the exact failure
+    # class it exists to prevent. Fail loudly instead (#213).
+    if hasattr(session.config, "workerinput"):
+        return  # a worker; the controller does the reporting
+    if session.config.pluginmanager.hasplugin("xdist") and \
+            getattr(session.config.option, "numprocesses", None):
+        print("\nSLOW-TEST BUDGET DISABLED: running under pytest-xdist, where "
+              "per-worker durations never reach the controller. See #213.")
+        session.exitstatus = 1
+        return
     over = {
         nodeid: seconds
         for nodeid, seconds in _call_durations.items()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,3 +47,61 @@ def media_records(corpus) -> list[tuple[Path, dict[str, Any]]]:
     from record_kinds import is_solution_record
 
     return [(p, d) for p, d in corpus if not is_solution_record(d)]
+
+
+# --- slow-test budget (#191) -------------------------------------------------
+#
+# The corpus-rescan bug has now recurred four times: #189 fixed five tests that
+# each re-parsed ~15,900 records, and two MORE were then added in #199 and #202,
+# at 328s and 421s. The suite went 317s -> 1459s and CI from ~16 to ~34 minutes.
+#
+# A ban on `rglob("*.yaml")` in tests would be the wrong guard. Measured, globbing
+# is cheap — the path-only globs in test_recipe_indexes and test_id_registry cost
+# 0.17-0.35s. What is expensive is PARSING, and the worst offenders reached it by
+# calling a script function, not by globbing. So the budget is on time, which is
+# the thing that actually hurts, regardless of how a test gets there.
+#
+# Only `call` duration is measured. `setup` is dominated by the session-scoped
+# corpus fixture, which is paid once for the whole run and is the fix rather than
+# the problem.
+
+# 120s, and the allowlist is deliberately EMPTY.
+#
+# The slowest call after this fix is ~66s (the prioritizer-based tests), and CI
+# runs roughly 1.4x slower than local, which puts them near 90s there. So 90 would
+# have needed three exemptions for tests that are not actually a problem — and a
+# standing exemption is precisely what hides the next regression. One number, no
+# entries, still catching the 328s and 421s cases that motivated this by a wide
+# margin.
+#
+# If a test genuinely needs more, add it here WITH the reason. An entry should
+# feel like a decision, not a mute button.
+SLOW_TEST_BUDGET_S = 120.0
+
+SLOW_TEST_ALLOWLIST: dict[str, str] = {}
+
+_call_durations: dict[str, float] = {}
+
+
+def pytest_runtest_logreport(report) -> None:
+    if report.when == "call":
+        _call_durations[report.nodeid] = report.duration
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:  # noqa: ARG001
+    over = {
+        nodeid: seconds
+        for nodeid, seconds in _call_durations.items()
+        if seconds > SLOW_TEST_BUDGET_S and nodeid not in SLOW_TEST_ALLOWLIST
+    }
+    if not over:
+        return
+    print("\n" + "=" * 72)
+    print(f"SLOW TESTS: {len(over)} exceeded the {SLOW_TEST_BUDGET_S:.0f}s call budget")
+    for nodeid, seconds in sorted(over.items(), key=lambda kv: -kv[1]):
+        print(f"  {seconds:7.1f}s  {nodeid}")
+    print("\nUse the session-scoped `corpus` / `media_records` fixtures instead of")
+    print("re-parsing, or add an entry to SLOW_TEST_ALLOWLIST in tests/conftest.py")
+    print("with the reason the cost is irreducible.")
+    print("=" * 72)
+    session.exitstatus = 1

--- a/tests/test_curate_medium_type.py
+++ b/tests/test_curate_medium_type.py
@@ -108,8 +108,11 @@ def test_report_only_by_default(cmt, tmp_path):
     assert (d / "a.yaml").read_text() == before
 
 
-def test_the_corpus_needs_no_stamping(cmt, maps):
-    """If this fails, `just curate-medium-type --apply` was not run before commit."""
+def test_the_corpus_needs_no_stamping(cmt, maps, corpus):
+    """If this fails, `just curate-medium-type --apply` was not run before commit.
+
+    Uses the session fixture: `scan()` re-parsed the whole corpus at 328s (#191).
+    """
     mapping, inv = maps
-    drift = cmt.scan(REPO_ROOT / "data" / "normalized_yaml", mapping, inv)
+    drift = cmt.scan_parsed(corpus, mapping, inv)
     assert not drift, f"{len(drift)} records drifted, e.g. {[str(p) for p,_,_,_ in drift[:5]]}"

--- a/tests/test_derived_artifacts.py
+++ b/tests/test_derived_artifacts.py
@@ -151,3 +151,23 @@ def test_the_regenerating_writer_wins_when_several_touch_an_artifact(ada):
         pytest.skip("id registry not tracked")
     assert row["kind"] == "CURRENT_VIEW"
     assert "refresh_id_registry" in row["reason"]
+
+
+# --- the slow-test budget itself (#191, #213) -------------------------------
+
+
+def test_the_slow_test_budget_is_configured():
+    """The guard against a fifth corpus-rescan regression. Pinned because an
+    empty allowlist and a real threshold are the two things that make it work."""
+    import conftest  # noqa: PLC0415
+    assert conftest.SLOW_TEST_BUDGET_S >= 60, "budget too tight to be stable in CI"
+    assert conftest.SLOW_TEST_BUDGET_S <= 200, (
+        "budget too loose to catch the 328s/421s regressions that motivated it")
+
+
+def test_the_slow_test_allowlist_entries_all_carry_a_reason():
+    """An entry must be a decision, not a mute button. Empty is the current and
+    preferred state."""
+    import conftest  # noqa: PLC0415
+    for nodeid, reason in conftest.SLOW_TEST_ALLOWLIST.items():
+        assert reason and len(reason) > 20, f"{nodeid} exempted without a real reason"

--- a/tests/test_derived_artifacts.py
+++ b/tests/test_derived_artifacts.py
@@ -156,18 +156,26 @@ def test_the_regenerating_writer_wins_when_several_touch_an_artifact(ada):
 # --- the slow-test budget itself (#191, #213) -------------------------------
 
 
+def _conftest():
+    """conftest.py is loaded by pytest as a plugin, not importable by name."""
+    spec = importlib.util.spec_from_file_location(
+        "_cm_conftest", REPO_ROOT / "tests" / "conftest.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def test_the_slow_test_budget_is_configured():
     """The guard against a fifth corpus-rescan regression. Pinned because an
     empty allowlist and a real threshold are the two things that make it work."""
-    import conftest  # noqa: PLC0415
-    assert conftest.SLOW_TEST_BUDGET_S >= 60, "budget too tight to be stable in CI"
-    assert conftest.SLOW_TEST_BUDGET_S <= 200, (
+    cft = _conftest()
+    assert cft.SLOW_TEST_BUDGET_S >= 60, "budget too tight to be stable in CI"
+    assert cft.SLOW_TEST_BUDGET_S <= 200, (
         "budget too loose to catch the 328s/421s regressions that motivated it")
 
 
 def test_the_slow_test_allowlist_entries_all_carry_a_reason():
     """An entry must be a decision, not a mute button. Empty is the current and
     preferred state."""
-    import conftest  # noqa: PLC0415
-    for nodeid, reason in conftest.SLOW_TEST_ALLOWLIST.items():
+    for nodeid, reason in _conftest().SLOW_TEST_ALLOWLIST.items():
         assert reason and len(reason) > 20, f"{nodeid} exempted without a real reason"

--- a/tests/test_retype_solution_records.py
+++ b/tests/test_retype_solution_records.py
@@ -112,9 +112,13 @@ def test_the_term_id_rule_still_works(rk):
     assert rk.is_solution_record({"term": {"id": "MediaIngredientMech:1"}})
 
 
-def test_the_corpus_has_no_untyped_solution_stubs_left(rt):
-    """If this fails, `just retype-solution-records --apply` was not run."""
-    left = rt.candidates()
+def test_the_corpus_has_no_untyped_solution_stubs_left(rt, corpus):
+    """If this fails, `just retype-solution-records --apply` was not run.
+
+    Uses the session fixture: calling `candidates()` re-parsed the whole corpus
+    and made this the slowest test in the suite at 421s (#191).
+    """
+    left = rt.candidates_from(corpus)
     assert not left, f"{len(left)} stubs still untyped, e.g. {[p.name for p,_ in left[:5]]}"
 
 


### PR DESCRIPTION
The corpus-rescan bug has now recurred **four times**. #189 fixed five tests that
each re-parsed ~15,900 records; I then added **two more**, in #199 and #202, at
328s and 421s.

```
suite   317s -> 1459s
CI      ~16min -> ~34min
```

Having fixed this once and reintroduced it twice myself, a comment or a habit is
clearly not enough.

## The guard this issue proposed would have been the wrong one

#191 suggested banning `rglob("*.yaml")` in tests. Measured, that targets the
wrong thing:

| | cost |
|---|--:|
| path-only globs (`test_recipe_indexes`, `test_id_registry`) | 0.17–0.35s |
| `test_record_io`'s glob (over `scripts/`, not the corpus) | negligible |
| **parsing the corpus** | **~110s** |

**Both 400s offenders reached parsing by calling a script function, not by
globbing.** A glob ban would have flagged three innocent tests and missed both
real ones.

So the budget is on **time** — the thing that actually hurts, however a test gets
there. Only `call` duration counts; `setup` is dominated by the session-scoped
corpus fixture, which is paid once per run and is the fix rather than the problem.

## The two regressions, fixed

`retype_solution_records.candidates_from()` and `curate_medium_type.scan_parsed()`
now take already-parsed records — the `audit_parsed()` pattern used elsewhere —
and their corpus guards use the session fixture.

```
suite         1459s -> 713s
the two tests  421s and 328s -> negligible
```

## The allowlist is empty on purpose

At a 90s budget, three prioritizer-based tests would have needed exemptions —
they run at ~66s locally and CI is roughly 1.4× slower, putting them near the
line. **Exempting tests that are not actually a problem is how a guard stops
guarding.** 120s with no entries still catches the 328s and 421s cases by a wide
margin.

## Verified it fires

```
1s test, 0.5s budget  -> exit 1, names the test
real suite, 120s      -> exit 0, 0 violations
```

(The first attempt at that check reported exit 0 because I read `tail`'s status
through a pipe rather than pytest's.)

Closes #191.