### PR TITLE
Gate flattened stock cocktails in CI (#150)

### DIFF
--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -1,0 +1,62 @@
+name: concentration-plausibility
+
+# Gate for #150: stops a fresh import re-flattening a stock solution inline.
+#
+# #118 asked for an audit AND a corpus repair; #135 shipped the audit only, and
+# nothing has since stopped the defect being reintroduced. The corpus backlog
+# (3,914 records, 579 flattened cocktails) is NOT fixed by this workflow — the
+# baselines hold the line while it is worked through, per the --max-allowed
+# convention already used by check-chebi-grounding.
+#
+# The cocktail count is the sharper of the two baselines. A raw row count drifts
+# with corpus size; a new flattened cocktail is a specific defect shape that an
+# import has reintroduced.
+
+on:
+  pull_request:
+    # Scoped to normalized_yaml: the detectors read only that tree. merge_yaml is
+    # derived from it, so a defect introduced *only* in merge_yaml would not be
+    # caught here — same caveat as chebi-consistency.
+    paths:
+      - 'data/normalized_yaml/**'
+      - 'scripts/audit_concentration_plausibility.py'
+      - 'project.justfile'
+      - '.github/workflows/concentration-plausibility.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: concentration-plausibility-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plausibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Check concentration plausibility
+        run: just audit-concentration-plausibility
+
+      - name: Upload plausibility report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: concentration-plausibility-report
+          path: |
+            data/import_tracking/reports/concentration_plausibility.tsv
+            data/import_tracking/reports/concentration_plausibility_by_record.tsv

--- a/project.justfile
+++ b/project.justfile
@@ -225,7 +225,7 @@ audit-selective-agent-mismatch *args="":
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py \
-        --max-allowed 11540 {{args}}
+        --max-allowed 11540 --max-cocktails 579 {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/scripts/audit_concentration_plausibility.py
+++ b/scripts/audit_concentration_plausibility.py
@@ -258,6 +258,11 @@ def main(argv: list[str] | None = None) -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
     ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--max-cocktails", type=int, default=None,
+                    help="Exit 1 if more than N records hold a FLATTENED STOCK "
+                         "COCKTAIL. The sharper gate: a raw row count drifts with "
+                         "corpus size, whereas a new cocktail is a specific defect "
+                         "shape a fresh import has reintroduced (#150).")
     ap.add_argument("--max-allowed", type=int, default=None,
                     help="Exit non-zero when flagged rows exceed this baseline. Gates "
                          "NEW defects without blocking on the existing backlog — the "
@@ -307,12 +312,18 @@ def main(argv: list[str] | None = None) -> int:
     print("\nRead-only. Repairing the trace-element case means nesting the cocktail "
           "under a stock `solution` object with an addition volume — per-record curation.")
 
+    failed = False
     if args.max_allowed is not None and len(rows) > args.max_allowed:
         print(f"\nFAIL: {len(rows)} implausible concentration rows > baseline "
               f"{args.max_allowed}. A new import or edit has introduced rows beyond the "
               f"known backlog; see the report for which records.", file=sys.stderr)
-        return 1
-    return 0
+        failed = True
+    if args.max_cocktails is not None and cocktails > args.max_cocktails:
+        print(f"\nFAIL: {cocktails} records hold a flattened stock cocktail > baseline "
+              f"{args.max_cocktails}. An import has landed a stock solution inline "
+              f"again; see `flattened_cocktail` in the by-record report.", file=sys.stderr)
+        failed = True
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -189,6 +189,9 @@ def test_stock_solution_records_are_excluded(corpus_findings):
 
 
 CONCENTRATION_BACKLOG_BASELINE = 11_540
+# The sharper baseline (#150): a raw row count drifts with corpus size, whereas a
+# new flattened cocktail is a specific defect shape an import has reintroduced.
+COCKTAIL_BASELINE = 579
 
 
 def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings):
@@ -247,3 +250,48 @@ def test_justfile_baseline_matches_the_test_baseline():
         f"project.justfile gates at {match.group(1)} but this file baselines at "
         f"{CONCENTRATION_BACKLOG_BASELINE}; lower both together"
     )
+
+
+# --- the prevention gate (#150) ---------------------------------------------
+
+
+def test_the_cocktail_baseline_matches_the_justfile(acp):
+    """Same drift guard as the row baseline: two copies of a number meant to
+    change must be lowered together (#170)."""
+    import re
+    justfile = (REPO_ROOT / "project.justfile").read_text()
+    block = justfile.split("audit-concentration-plausibility", 1)[1][:400]
+    match = re.search(r"--max-cocktails\s+(\d+)", block)
+    assert match, "the recipe no longer passes --max-cocktails; the sharper gate is off"
+    assert int(match.group(1)) == COCKTAIL_BASELINE, (
+        f"justfile gates cocktails at {match.group(1)} but this file baselines at "
+        f"{COCKTAIL_BASELINE}; lower both together")
+
+
+def test_the_gate_baselines_match_the_current_corpus(acp, media_records):
+    """#118 asked for an audit AND a repair; #135 shipped the audit, and nothing
+    stopped the defect being reintroduced for another 15 issues.
+
+    These baselines hold the line while the 3,914-record backlog is worked
+    through. They must track the corpus: a baseline above the real count is a gate
+    that cannot fail.
+    """
+    rows = acp.audit_parsed(media_records)
+    rows_baseline = CONCENTRATION_BACKLOG_BASELINE
+    assert len(rows) <= rows_baseline, (
+        f"{len(rows)} rows exceeds the gate baseline {rows_baseline}")
+    # A baseline far above the real count cannot fail, which is worse than no gate.
+    assert rows_baseline - len(rows) <= 200, (
+        f"gate baseline {rows_baseline} is {rows_baseline - len(rows)} above the "
+        "actual count — tighten it or it will never fire")
+    assert COCKTAIL_BASELINE > 0
+
+
+def test_the_gate_is_wired_into_ci():
+    """A --max-allowed flag nobody runs is not a gate. The audit carried one for
+    15 issues without ever being invoked."""
+    wf = REPO_ROOT / ".github" / "workflows" / "concentration-plausibility.yaml"
+    assert wf.is_file(), "no workflow runs the plausibility gate"
+    text = wf.read_text()
+    assert "just audit-concentration-plausibility" in text
+    assert "data/normalized_yaml/**" in text, "gate not triggered by corpus edits"


### PR DESCRIPTION
#118 asked for an audit **and** a corpus repair. #135 shipped the audit and said so
outright — *"Does NOT close #118; the corpus repair remains"* — and #118 was closed
anyway. Fifteen issues later the corpus is still wrong and nothing stops a fresh
import reintroducing the same shape.

#150 calls prevention the highest-leverage item, ahead of the repair itself,
because without it any sweep decays. This is that.

## What was actually missing

The audit already carried `--max-allowed 11540` and the recipe already passed it.
Missing were a **CI workflow to run it** and a gate on the **specific defect
shape**.

`--max-cocktails`, baselined at **579**, is the sharper of the two. A raw row count
drifts with corpus size; a flattened stock cocktail — three or more stock-strength
trace/vitamin rows with no `solutions:` block — is a specific thing an import has
done again.

## Verified by injecting one

Three trace salts at stock strength into `lb_broth`:

```
cocktails  579 -> 580     FAIL
rows     11540 -> 11544   FAIL
exit 1
```

Corpus restored, re-checked clean, exit 0.

The first attempt at that proof used values *below* the 1 G_PER_L threshold, so
only one row flagged and the gate correctly did nothing — my test data was wrong,
not the gate.

## A mistake worth recording

My first version **removed `--max-allowed` from the recipe** and put both baselines
in a new `check-` recipe — weakening an existing gate while believing I was adding
one. I had grepped for the recipe *name*, seen one line, and concluded it wasn't
wired without reading the body.

`test_justfile_baseline_matches_the_test_baseline` caught it, which is precisely
what that test exists for (#170: two copies of a number meant to change). Now one
recipe carries both flags, and the cocktail baseline has the same drift guard.

## Scope

The **3,914-record backlog is not repaired here.** The baselines hold the line
while it is worked through, per the convention `check-chebi-grounding` already
uses.

Separately worth knowing for the repair: I checked feasibility, and **183 of 216
matched cocktails have their addition volume upstream** in `data/raw/togo`
(`Trace mineral solution … 1 ml`). So the repair is recoverable from tracked data
rather than invented — which was the reason to hesitate.

Refs #150.