### PR TITLE
Split HYDRATE_RELAXED into three directional hydration verdicts

### DIFF
--- a/scripts/chem_formula.py
+++ b/scripts/chem_formula.py
@@ -255,3 +255,56 @@ def compare_formulas(label: str, ontology_formula: str) -> str | None:
     if ws and set(ws) == set(gs):
         return "SUBSCRIPTS_LOST"
     return "CONFLICT"
+
+
+def _label_water_units(text: str) -> int:
+    """Waters of hydration written in a label string; 0 when none is stated.
+
+    Mirrors the tail/dot hydrate handling ``parse_formula`` applies, so it reads
+    the same count that folded into the element multiset: "NiCl2 x 6 H2O" -> 6,
+    "MnSO4 x H2O" -> 1 (the ``x`` is the separator, count implied), "MgSO4" -> 0.
+    A variable multiplier ("VOSO4·xH2O") never reaches here -- ``parse_formula``
+    returns None for it, so ``compare_formulas`` is None and the caller stops.
+    """
+    s = str(text or "").strip()
+    total = 0
+    m = _HYDRATE_TAIL_RE.search(s)
+    if m:
+        total += int(m.group(1) or 1)
+        s = s[: m.start()].strip().rstrip(".·・")
+    m = _HYDRATE_DOT_RE.match(s)
+    if m:
+        total += int(m.group(2) or 1)
+    return total
+
+
+def hydration_states(label: str, ontology_formula: str) -> tuple[int, int] | None:
+    """Waters of hydration on each side of a ``HYDRATE_RELAXED`` pair.
+
+    Returns ``(label_waters, term_waters)`` when the label and the ontology
+    formula share a non-water skeleton and differ ONLY by water of hydration;
+    None when that is not the case, so the caller keeps the old tolerant pass.
+
+    The term's molecular formula may fold its waters into the H/O totals
+    ("H14MgO11S") or spell them out ("Cl2Mn.4H2O") -- either way the folded
+    OXYGEN difference between the two multisets is the difference in waters
+    (each H2O contributes H2 O1), and the label's own stated count anchors that
+    difference to an absolute pair. A difference that is not a whole number of
+    waters (dH != 2·dO, e.g. an -OH vs -H structural change) is refused.
+    """
+    want = parse_formula(label)
+    got = parse_ontology_formula(ontology_formula)
+    if not want or not got:
+        return None
+    ws, gs = _skeleton(want), _skeleton(got)
+    if not ws or ws != gs:
+        return None
+    d_h = want.get("H", 0) - got.get("H", 0)
+    d_o = want.get("O", 0) - got.get("O", 0)
+    if d_o == 0 or d_h != 2 * d_o:
+        return None
+    label_w = _label_water_units(label)
+    term_w = label_w - d_o
+    if term_w < 0:
+        return None                       # inconsistent counts -- refuse to guess
+    return label_w, term_w

--- a/scripts/validate_id_label_correspondence.py
+++ b/scripts/validate_id_label_correspondence.py
@@ -146,7 +146,16 @@ _ERROR_VERDICTS = {
 # Reported, actionable, but NOT fatal: the grounding is correct and only the
 # label lost its subscript glyphs upstream ("NaCO3" for Na2CO3). Repairing the
 # name is a data-cleanup task, not a mapping error, so it must not fail enforce.
-_WARN_VERDICTS = {"LABEL_SUBSCRIPTS_LOST"}
+# The label's element skeleton matches the term's but the waters of hydration
+# differ. All three are the same MAPPING_SEMANTICS.md Section 3 collapse seen
+# from different sides — reported for curation, never fatal (a hydrate grounded
+# to its anhydrous parent is a defensible interim mapping).
+_HYDRATION_VERDICTS = {
+    "HYDRATE_ON_ANHYDROUS_TERM",   # label has water, term has none
+    "ANHYDROUS_ON_HYDRATE_TERM",   # term has water, label has none
+    "HYDRATION_STATE_MISMATCH",    # both have water, different amounts
+}
+_WARN_VERDICTS = {"LABEL_SUBSCRIPTS_LOST"} | _HYDRATION_VERDICTS
 
 # Path segments under which a `term`/`chebi_term` label-waiver does NOT apply:
 # organism (NCBITaxon) and environment (ENVO) groundings must carry the canonical
@@ -406,8 +415,30 @@ def _plausibility_verdict(
 
     if formula and chem_formula.looks_like_formula(label):
         cmp = chem_formula.compare_formulas(label, formula)
-        if cmp in ("MATCH", "HYDRATE_RELAXED"):
-            return "OK_ID_ONLY", f"formula {cmp.lower()}"
+        if cmp == "MATCH":
+            return "OK_ID_ONLY", "formula match"
+        if cmp == "HYDRATE_RELAXED":
+            # Skeletons agree but the water counts differ. That is symmetric, so
+            # a single "label has extra water" verdict asserts the opposite of
+            # the facts half the time. Split it by comparing the waters on each
+            # side; when the split is not decidable, keep the tolerant pass.
+            states = chem_formula.hydration_states(label, formula)
+            if states is None:
+                return "OK_ID_ONLY", "formula hydrate_relaxed"
+            label_w, term_w = states
+            if term_w == 0:
+                return "HYDRATE_ON_ANHYDROUS_TERM", (
+                    f"label states {label_w} water(s) of hydration that "
+                    f"'{canonical or formula}' (anhydrous) lacks — ground to a "
+                    "hydrate-specific term, or mint cas:<hydrate CAS> with a "
+                    "narrowMatch to this parent (MAPPING_SEMANTICS.md Section 3)")
+            if label_w == 0:
+                return "ANHYDROUS_ON_HYDRATE_TERM", (
+                    f"term carries {term_w} water(s) of hydration the anhydrous "
+                    "label lacks — ground to the anhydrous term instead")
+            return "HYDRATION_STATE_MISMATCH", (
+                f"label states {label_w} water(s), term states {term_w} — ground "
+                "to the term whose hydration state the label actually names")
         if cmp == "SUBSCRIPTS_LOST":
             # Correct grounding, damaged label — flag for name repair, not as a
             # mapping error.
@@ -849,16 +880,20 @@ def run(config_path: Path, report_path: Path | None) -> int:
                 # residuals of exactly the kind the allow-list exists for — a
                 # correct grounding the heuristic cannot see is correct
                 # ("soy peptone" on FOODON "vegetable protein, hydrolyzed"
-                # shares no word) — so they are waivable too. Structural errors
-                # (UNKNOWN_PREFIX, ADAPTER_ERROR, MISSING_*) remain unwaivable.
+                # shares no word) — so they are waivable too. The three
+                # _HYDRATION_VERDICTS are the same kind of curator-judgeable
+                # residual (a hydrate grounded to its anhydrous parent when no
+                # hydrate term exists yet), so a curator gets the same escape
+                # hatch. Structural errors (UNKNOWN_PREFIX, ADAPTER_ERROR,
+                # MISSING_*) remain unwaivable.
                 # ID_OUT_OF_RANGE explicitly signals a foreign identifier
                 # wearing an OBO prefix (e.g. PubChem CID as CHEBI:) — that's
                 # the one class the allow-list must NOT cover; a curator who
                 # really wants to keep such an id should add its true prefix
                 # to `ignored_prefixes` instead.
                 if rec["verdict"] in (
-                    "MISMATCH", "ID_NOT_FOUND", "IMPLAUSIBLE_LABEL",
-                    "LABEL_SUBSCRIPTS_LOST",
+                    {"MISMATCH", "ID_NOT_FOUND", "IMPLAUSIBLE_LABEL",
+                     "LABEL_SUBSCRIPTS_LOST"} | _HYDRATION_VERDICTS
                 ) and (curie, normalize(label)) in exceptions:
                     rec["verdict"] = "OK_EXCEPTION"
                 counts[rec["verdict"]] = counts.get(rec["verdict"], 0) + 1
@@ -889,6 +924,9 @@ def run(config_path: Path, report_path: Path | None) -> int:
         "IMPLAUSIBLE_LABEL",
         "ID_OUT_OF_RANGE",
         "LABEL_SUBSCRIPTS_LOST",
+        "HYDRATE_ON_ANHYDROUS_TERM",
+        "ANHYDROUS_ON_HYDRATE_TERM",
+        "HYDRATION_STATE_MISMATCH",
         "SKIPPED_NO_ADAPTER",
         "SKIPPED_EMPTY_ADAPTER",
     ):

--- a/tests/test_id_label_plausibility.py
+++ b/tests/test_id_label_plausibility.py
@@ -78,12 +78,33 @@ def _classify(label: str, curie: str, **kw):
 @pytest.mark.parametrize("label,curie", [
     ("Distilled water", "CHEBI:15377"),   # shares the word "water"
     ("KH2PO4", "CHEBI:63036"),            # formula matches exactly
-    ("MnCl2 x 4 H2O", "CHEBI:86368"),     # formula matches exactly
-    ("NiCl2 x 6 H2O", "CHEBI:34887"),     # hydrate → anhydrous parent, tolerated
+    ("MnCl2 x 4 H2O", "CHEBI:86368"),     # formula matches exactly (right hydrate)
     ("H2O", "CHEBI:15377"),               # matches a synonym
 ])
 def test_curator_labels_still_pass(label, curie):
     assert _classify(label, curie) == "OK_ID_ONLY"
+
+
+@pytest.mark.parametrize("label,curie,verdict", [
+    # label has waters the term lacks — the case #242 set out to surface. The
+    # remedy is a hydrate-specific term or a cas: mint, NOT accepting it silently.
+    ("NiCl2 x 6 H2O", "CHEBI:34887", "HYDRATE_ON_ANHYDROUS_TERM"),
+    # term is a hydrate, the label is anhydrous — a DIFFERENT substance, whose
+    # remedy (the anhydrous term) is the opposite of the case above.
+    ("MnCl2", "CHEBI:86368", "ANHYDROUS_ON_HYDRATE_TERM"),
+    # both are hydrates, but of different states.
+    ("MnCl2 x 6 H2O", "CHEBI:86368", "HYDRATION_STATE_MISMATCH"),
+])
+def test_hydration_state_is_split_by_which_side_carries_water(label, curie, verdict):
+    """`compare_formulas` returns HYDRATE_RELAXED symmetrically; a single
+    "label has extra water" verdict is right only a third of the time (#242)."""
+    assert _classify(label, curie) == verdict
+
+
+def test_hydration_verdicts_are_non_blocking():
+    """All three are curation signals, never enforce failures."""
+    assert mod._HYDRATION_VERDICTS <= mod._WARN_VERDICTS
+    assert not (mod._HYDRATION_VERDICTS & mod._ERROR_VERDICTS)
 
 
 @pytest.mark.parametrize("label,curie", [
@@ -141,6 +162,33 @@ def test_default_waiver_mode_is_unchanged():
 ])
 def test_formula_comparison(label, formula, expected):
     assert chem.compare_formulas(label, formula) == expected
+
+
+@pytest.mark.parametrize("label,formula,expected", [
+    # (label_waters, term_waters). Term formula folded ("Cl2Ni") or spelled
+    # out (".4H2O") — the oxygen delta plus the label's own count recover both.
+    ("NiCl2 x 6 H2O", "Cl2Ni", (6, 0)),
+    ("MnCl2", "Cl2Mn.4H2O", (0, 4)),
+    ("MnCl2 x 6 H2O", "Cl2Mn.4H2O", (6, 4)),
+    ("MnCl2 x H2O", "Cl2Mn.4H2O", (1, 4)),          # implied monohydrate
+    # not a hydration question: exact match, and an element conflict.
+    ("MnCl2 x 4 H2O", "Cl2Mn.4H2O", None),          # MATCH, no water gap
+    ("KI", "Cl2Ni", None),                          # skeletons differ
+])
+def test_hydration_states_reads_water_on_each_side(label, formula, expected):
+    assert chem.hydration_states(label, formula) == expected
+
+
+@pytest.mark.parametrize("label,expected", [
+    ("NiCl2 x 6 H2O", 6),
+    ("CuSO4·5H2O", 5),
+    ("Na2MoO4. 2H2O", 2),
+    ("MnSO4 x H2O", 1),     # x is the separator, monohydrate
+    ("MgSO4", 0),           # anhydrous
+    ("glucose", 0),
+])
+def test_label_water_units(label, expected):
+    assert chem._label_water_units(label) == expected
 
 
 def test_roman_oxidation_state_parses():


### PR DESCRIPTION
Lands the hydration-verdict redesign that `CultureBotAI/MediaIngredientMech#242` scoped. It must land here (the hub) first because `validate_id_label_correspondence.py`, `chem_formula.py`, and `test_id_label_plausibility.py` are vendored byte-identical into the spokes; the spokes then bump `.vendored_canon_ref`.

## Why a redesign, not a relocation

`chem_formula.compare_formulas` returns `HYDRATE_RELAXED` whenever the non-water **skeleton** matches and the full counts don't. That is **symmetric**, so the obvious "label carries extra water" verdict is wrong half the time:

| label | term | reality |
|---|---|---|
| `NiCl2 x 6 H2O` | nickel dichloride (anhydrous) | label has water ✅ the wanted case |
| `MgSO4` | magnesium sulfate **hepta**hydrate | **term** has water |
| `MnSO4 x 4 H2O` | manganese(II) sulfate **hexa**hydrate | different states |

The first wants a hydrate term or `cas:` mint; the last two want a **different term**. A single verdict prescribes the wrong remedy for two of three.

## What this does

Three verdicts, chosen by the water count on each side:

- `HYDRATE_ON_ANHYDROUS_TERM` — label has water, term has none
- `ANHYDROUS_ON_HYDRATE_TERM` — term has water, label has none
- `HYDRATION_STATE_MISMATCH` — both have water, different amounts

`chem_formula.hydration_states(label, formula)` recovers `(label_waters, term_waters)` robustly: the folded **oxygen delta** between the two multisets is the water difference — correct whether the ontology formula folds waters into H/O (`H14MgO11S`) or spells them out (`Cl2Mn.4H2O`) — anchored to an absolute pair by the label's own stated count. A gap that isn't a whole number of waters (`dH ≠ 2·dO`, e.g. an –OH vs –H structural difference) is refused, so the old tolerant pass is preserved when the split can't be decided.

All three:
- start in `_WARN_VERDICTS` (non-blocking — a hydrate on its anhydrous parent is a defensible interim mapping),
- are waivable through the `exceptions` allow-list (the escape hatch #242 noted was missing),
- appear in the hardcoded summary loop (else invisible to `just validate-products`).

## Tests

`test_id_label_plausibility.py`: the three directions end-to-end through `classify`, `hydration_states`/`_label_water_units` units, and a guard that the verdicts are non-blocking. The prior `NiCl2 x 6 H2O → OK_ID_ONLY` case moved from "still passes" to `HYDRATE_ON_ANHYDROUS_TERM` — that reclassification is the point. 52 pass.

Refs `CultureBotAI/MediaIngredientMech#242`, #238.