### PR TITLE
Backfill organism_culture_type on records that name target_organisms (#142)

### DIFF
--- a/data/normalized_yaml/algae/2asw.yaml
+++ b/data/normalized_yaml/algae/2asw.yaml
@@ -49,6 +49,11 @@ curation_history:
   curator: primary-term-regrounding-v1.0
   action: Re-grounded wrong primary term id (OAK-verified)
   notes: 1 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.481264+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 4 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: CCAP:2ASW
 - reference: https://www.ccap.ac.uk/wp-content/uploads/MR_2ASW.pdf
@@ -218,6 +223,7 @@ variants:
     supports: SUPPORT
     explanation: Tsuji et al. report Chaetoceros gracilis UTEX LB2658 growth and carbon-concentrating-mechanism
       experiments in modified F/2ASW with defined sodium manipulations.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Dunaliella salina
   term:

--- a/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
@@ -65,7 +65,8 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
+  description: 'Important Notes To Consider: The quality of water, including natural
+    seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
@@ -121,21 +122,26 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial Seawater Medium" to "artificial_seawater_medium"
     for consistent matching
+- timestamp: '2026-08-06T00:58:02.491431+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:artificial-seawater-medium
 - reference: https://utex.org/products/artificial-seawater-medium
 original_name: Artificial Seawater Medium
 variants:
 - name: modified_artificial_seawater_hemiaulus_richelia_symbiosis
-  description: Modified artificial seawater medium used for growth of Hemiaulus
-    hauckii with its Richelia intracellularis endosymbiont.
+  description: Modified artificial seawater medium used for growth of Hemiaulus hauckii
+    with its Richelia intracellularis endosymbiont.
   modifications:
   - Use a modified artificial seawater medium.
   - Culture the Hemiaulus hauckii and Richelia intracellularis symbiotic unit.
-  - Use nitrogen-free medium with N2 as the sole nitrogen source for reported
-    maximum growth rates.
-  purpose: Capture growth of a diatom-cyanobacterium symbiosis under a modified
-    artificial seawater medium variant.
+  - Use nitrogen-free medium with N2 as the sole nitrogen source for reported maximum
+    growth rates.
+  purpose: Capture growth of a diatom-cyanobacterium symbiosis under a modified artificial
+    seawater medium variant.
   evidence:
   - reference: PMID:33083143
     supports: SUPPORT
@@ -151,23 +157,24 @@ variants:
   - Use artificial seawater medium as the base.
   - Supplement with nitrogen and phosphorus sources.
   - Add HEPES buffer when improved overall growth is needed.
-  purpose: Capture seawater-based cultivation of the freshwater cyanobacterium
-    Synechocystis sp. PCC 6803.
+  purpose: Capture seawater-based cultivation of the freshwater cyanobacterium Synechocystis
+    sp. PCC 6803.
   evidence:
   - reference: PMID:25954257
     supports: SUPPORT
     snippet: The Synechocystis wild-type strain grew well in an artificial seawater
       (ASW) medium supplemented with nitrogen and phosphorus sources.
-    explanation: Literature evidence supports an artificial-seawater variant for
-      Synechocystis sp. PCC 6803 growth.
+    explanation: Literature evidence supports an artificial-seawater variant for Synechocystis
+      sp. PCC 6803 growth.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Hemiaulus hauckii
   term:
     id: NCBITaxon:426650
     label: Hemiaulus hauckii
   growth_metrics:
-  - measurement_conditions: Modified artificial seawater medium; nitrogen-free
-      medium with N2 as the sole nitrogen source.
+  - measurement_conditions: Modified artificial seawater medium; nitrogen-free medium
+      with N2 as the sole nitrogen source.
     evidence:
     - reference: PMID:33083143
       supports: SUPPORT
@@ -184,10 +191,10 @@ target_organisms:
   - reference: PMID:33083143
     supports: SUPPORT
     snippet: We document the influence of light and nutrients on nitrogen fixation
-      and growth rates of the host diatom Hemiaulus hauckii Grunow together with
-      its diazotrophic endosymbiont Richelia intracellularis Schmidt
-    explanation: Literature evidence identifies Richelia intracellularis as the
-      diazotrophic endosymbiont in the cultured Hemiaulus-Richelia symbiosis.
+      and growth rates of the host diatom Hemiaulus hauckii Grunow together with its
+      diazotrophic endosymbiont Richelia intracellularis Schmidt
+    explanation: Literature evidence identifies Richelia intracellularis as the diazotrophic
+      endosymbiont in the cultured Hemiaulus-Richelia symbiosis.
 - preferred_term: Synechocystis sp. PCC 6803
   term:
     id: NCBITaxon:1148
@@ -200,6 +207,6 @@ target_organisms:
       supports: SUPPORT
       snippet: The Synechocystis wild-type strain grew well in an artificial seawater
         (ASW) medium supplemented with nitrogen and phosphorus sources.
-      explanation: Literature evidence directly reports growth of Synechocystis
-        sp. PCC 6803 in supplemented artificial seawater medium.
+      explanation: Literature evidence directly reports growth of Synechocystis sp.
+        PCC 6803 in supplemented artificial seawater medium.
     is_max_attainment: false

--- a/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
@@ -129,6 +129,11 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-06T00:58:02.497461+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:bold-basal-medium
 - reference: https://utex.org/products/bold-basal-medium
@@ -159,6 +164,7 @@ variants:
       (BBM)'
     explanation: The paper explicitly used BBM as one of three media for the Scenedesmus
       quadricauda CPCC-158 growth experiment.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Scenedesmus quadricauda
   term:

--- a/data/normalized_yaml/algae/Bristol_Medium.yaml
+++ b/data/normalized_yaml/algae/Bristol_Medium.yaml
@@ -40,7 +40,8 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
+  description: 'Important Notes To Consider: The quality of water, including natural
+    seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
@@ -95,23 +96,30 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Bristol Medium" to "bristol_medium" for consistent
     matching
+- timestamp: '2026-08-06T00:58:02.502002+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:bristol-medium
 - reference: https://utex.org/products/bristol-medium
 original_name: Bristol Medium
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Chlorella pyrenoidosa
   term:
     id: NCBITaxon:3077
     label: Chlorella vulgaris
   growth_metrics:
-  - measurement_conditions: Commercial Bristol medium comparator in settled and
-      activated sewage growth study.
+  - measurement_conditions: Commercial Bristol medium comparator in settled and activated
+      sewage growth study.
     evidence:
     - reference: PMID:15092268
       supports: SUPPORT
-      snippet: Good growth was obtained in both types of wastewater and the algal production
-        was comparable to and even higher than that found in commercial Bristol medium.
-      explanation: Literature evidence supports qualitative growth of Chlorella
-        pyrenoidosa on commercial Bristol medium as a comparator.
+      snippet: Good growth was obtained in both types of wastewater and the algal
+        production was comparable to and even higher than that found in commercial
+        Bristol medium.
+      explanation: Literature evidence supports qualitative growth of Chlorella pyrenoidosa
+        on commercial Bristol medium as a comparator.
     is_max_attainment: false

--- a/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
+++ b/data/normalized_yaml/algae/CCAP_TAP Medium.yaml
@@ -57,6 +57,11 @@ curation_history:
   action: BACKFILLED_SOURCE_ENVIRONMENT
   notes: added=2 env(s) from CommunityMech
   source: CommunityMech (environment_term + culturemech_id linkage)
+- timestamp: '2026-08-06T00:58:02.505628+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: CCAP:TAP
 - reference: https://www.ccap.ac.uk/wp-content/uploads/MR_TAP.pdf
@@ -208,6 +213,7 @@ data_quality_flags:
 - ingredients_curated
 - curation_method:automated_expert_mapping
 original_name: TAP Medium
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Chlorella vulgaris
   term:

--- a/data/normalized_yaml/algae/F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/F_2_Medium.yaml
@@ -45,7 +45,8 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
+  description: 'Important Notes To Consider: The quality of water, including natural
+    seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
@@ -103,74 +104,80 @@ curation_history:
 - timestamp: '2026-05-09T14:15:00-07:00'
   curator: culturemech-agentic-curation
   action: ADDED_GROWTH_EVIDENCE
-  notes: Added strain-specific F/2ASW and modified F/2ASW growth evidence from
-    Falcon report review and primary literature metadata.
+  notes: Added strain-specific F/2ASW and modified F/2ASW growth evidence from Falcon
+    report review and primary literature metadata.
+- timestamp: '2026-08-06T00:58:02.514496+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 4 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:f-2-medium
 - reference: https://utex.org/products/f-2-medium
 - reference: DOI:10.1104/pp.18.00453
-  title: Plasma-membrane-type aquaporins from marine diatoms function as CO2/NH3
-    channels and provide photoprotection
+  title: Plasma-membrane-type aquaporins from marine diatoms function as CO2/NH3 channels
+    and provide photoprotection
   authors: Matsui, H.; Hopkinson, B.; Nakajima, K.; Matsuda, Y.
   year: 2018
-  notes: PubMed PMID 30076224; source reports Phaeodactylum tricornutum UTEX
-    642 and Thalassiosira pseudonana CCMP1335 cultivation in F/2ASW.
+  notes: PubMed PMID 30076224; source reports Phaeodactylum tricornutum UTEX 642 and
+    Thalassiosira pseudonana CCMP1335 cultivation in F/2ASW.
 - reference: DOI:10.1007/s10126-021-10037-4
-  title: Characterization of a CO2-Concentrating Mechanism with Low Sodium
-    Dependency in the Centric Diatom Chaetoceros gracilis
+  title: Characterization of a CO2-Concentrating Mechanism with Low Sodium Dependency
+    in the Centric Diatom Chaetoceros gracilis
   authors: Tsuji, Y.; Kusi-Appiah, G.; Kozai, N.; Fukuda, Y.; Yamano, T.; Fukuzawa,
     H.
   year: 2021
-  notes: PubMed PMID 34109463; source reports Chaetoceros gracilis UTEX LB2658
-    growth experiments in modified F/2ASW.
+  notes: PubMed PMID 34109463; source reports Chaetoceros gracilis UTEX LB2658 growth
+    experiments in modified F/2ASW.
 original_name: F/2 Medium
 variants:
 - name: n_replete_second_stage_tetraselmis_marina
-  description: F/2 culture followed by nitrogen-replete second-stage cultivation
-    for enhanced biomass and lipid productivity of Tetraselmis marina.
+  description: F/2 culture followed by nitrogen-replete second-stage cultivation for
+    enhanced biomass and lipid productivity of Tetraselmis marina.
   modifications:
   - Grow cells in F/2 medium for seven days as the first stage.
   - Shift to a nitrogen-replete second stage with 4.41 mM NaNO3 for three days.
-  purpose: Capture a study-specific F/2-derived nitrogen repletion variant used
-    to increase Tetraselmis marina biomass and lipid productivity.
+  purpose: Capture a study-specific F/2-derived nitrogen repletion variant used to
+    increase Tetraselmis marina biomass and lipid productivity.
   evidence:
   - reference: PMID:28456040
     supports: SUPPORT
     snippet: After second stage of cultivation of T. marina for further 3-days under
       N-replete condition (4.41mM NaNO3) increased biomass concentration of 1900mg/L
       and lipid content of 50% were observed
-    explanation: Literature evidence describes a nitrogen-replete second-stage
-      variant after initial F/2 cultivation.
+    explanation: Literature evidence describes a nitrogen-replete second-stage variant
+      after initial F/2 cultivation.
 - name: f_2asw_diatom_culture
-  description: F/2 artificial seawater culture conditions used for marine diatom
-    maintenance and transformation studies.
+  description: F/2 artificial seawater culture conditions used for marine diatom maintenance
+    and transformation studies.
   modifications:
   - Use artificial seawater supplemented with half-strength Guillard f solution.
-  - Maintain cultures at 20 deg C under continuous illumination at 30-75 umol
-    photons m-2 s-1.
+  - Maintain cultures at 20 deg C under continuous illumination at 30-75 umol photons
+    m-2 s-1.
   - Aerate cultures with ambient air or 1% CO2 depending on the experiment.
-  purpose: Represent F/2ASW as a study-specific F/2 medium implementation for
-    marine diatoms.
+  purpose: Represent F/2ASW as a study-specific F/2 medium implementation for marine
+    diatoms.
   evidence:
   - reference: DOI:10.1104/pp.18.00453
     supports: SUPPORT
-    explanation: Matsui et al. define F/2ASW as artificial seawater plus
-      half-strength Guillard f solution and report use with Phaeodactylum
-      tricornutum UTEX 642 and Thalassiosira pseudonana CCMP1335.
+    explanation: Matsui et al. define F/2ASW as artificial seawater plus half-strength
+      Guillard f solution and report use with Phaeodactylum tricornutum UTEX 642 and
+      Thalassiosira pseudonana CCMP1335.
 - name: modified_f_2asw_sodium_response
-  description: Modified F/2 artificial seawater used for sodium and CO2 response
-    experiments with Chaetoceros gracilis.
+  description: Modified F/2 artificial seawater used for sodium and CO2 response experiments
+    with Chaetoceros gracilis.
   modifications:
   - Supplement F/2ASW with 10 nM sodium selenite and 0.1 mM sodium metasilicate.
   - Adjust sodium concentration by altering NaCl addition to the basal medium.
   - Vary CO2 availability to distinguish sodium-dependent growth effects.
-  purpose: Capture an experimental F/2ASW variant used to study carbon
-    concentrating mechanism physiology.
+  purpose: Capture an experimental F/2ASW variant used to study carbon concentrating
+    mechanism physiology.
   evidence:
   - reference: DOI:10.1007/s10126-021-10037-4
     supports: SUPPORT
-    explanation: Tsuji et al. report Chaetoceros gracilis UTEX LB2658 growth
-      experiments using a modified F/2ASW formulation.
+    explanation: Tsuji et al. report Chaetoceros gracilis UTEX LB2658 growth experiments
+      using a modified F/2ASW formulation.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Tetraselmis marina
   term:
@@ -182,10 +189,10 @@ target_organisms:
     - reference: PMID:28456040
       supports: SUPPORT
       snippet: When the cells were grown in F/2-medium for seven days in the first
-        stage, the carotenoid and lipid contents, and productivity were 44g/kg
-        (DW), 27% and 31mg/L/d, respectively.
-      explanation: Literature evidence states that Tetraselmis marina cells were
-        grown in F/2 medium for seven days.
+        stage, the carotenoid and lipid contents, and productivity were 44g/kg (DW),
+        27% and 31mg/L/d, respectively.
+      explanation: Literature evidence states that Tetraselmis marina cells were grown
+        in F/2 medium for seven days.
     is_max_attainment: false
   - measurement_conditions: F/2 first stage followed by three-day N-replete second
       stage with 4.41 mM NaNO3.
@@ -204,56 +211,55 @@ target_organisms:
     label: Phaeodactylum tricornutum CCAP 1055/1
   strain: UTEX 642
   growth_metrics:
-  - measurement_conditions: F/2ASW at 20 deg C, continuous illumination of
-      30-75 umol photons m-2 s-1, and aeration with ambient air or 1% CO2;
-      reported mid-log harvest OD730 0.2-0.3.
+  - measurement_conditions: F/2ASW at 20 deg C, continuous illumination of 30-75 umol
+      photons m-2 s-1, and aeration with ambient air or 1% CO2; reported mid-log harvest
+      OD730 0.2-0.3.
     evidence:
     - reference: DOI:10.1104/pp.18.00453
       supports: SUPPORT
-      explanation: Matsui et al. explicitly report Phaeodactylum tricornutum
-        UTEX 642 cultivation in F/2ASW.
+      explanation: Matsui et al. explicitly report Phaeodactylum tricornutum UTEX
+        642 cultivation in F/2ASW.
     is_max_attainment: false
   evidence:
   - reference: DOI:10.1104/pp.18.00453
     supports: SUPPORT
-    explanation: The publication supports the organism-medium relationship for
-      the F/2ASW variant of this parent F/2 medium record.
+    explanation: The publication supports the organism-medium relationship for the
+      F/2ASW variant of this parent F/2 medium record.
 - preferred_term: Thalassiosira pseudonana
   term:
     id: NCBITaxon:296543
     label: Thalassiosira pseudonana CCMP1335
   strain: CCMP1335
   growth_metrics:
-  - measurement_conditions: F/2ASW at 20 deg C, continuous illumination of
-      30-75 umol photons m-2 s-1, and aeration with ambient air or 1% CO2;
-      reported mid-log harvest OD730 0.1-0.15.
+  - measurement_conditions: F/2ASW at 20 deg C, continuous illumination of 30-75 umol
+      photons m-2 s-1, and aeration with ambient air or 1% CO2; reported mid-log harvest
+      OD730 0.1-0.15.
     evidence:
     - reference: DOI:10.1104/pp.18.00453
       supports: SUPPORT
-      explanation: Matsui et al. explicitly report Thalassiosira pseudonana
-        CCMP1335 cultivation in F/2ASW.
+      explanation: Matsui et al. explicitly report Thalassiosira pseudonana CCMP1335
+        cultivation in F/2ASW.
     is_max_attainment: false
   evidence:
   - reference: DOI:10.1104/pp.18.00453
     supports: SUPPORT
-    explanation: The source supports growth on the F/2ASW variant for the same
-      strain represented by NCBI Taxonomy ID 296543 and reference assembly
-      GCF_000149405.2.
+    explanation: The source supports growth on the F/2ASW variant for the same strain
+      represented by NCBI Taxonomy ID 296543 and reference assembly GCF_000149405.2.
 - preferred_term: Chaetoceros gracilis
   strain: UTEX LB2658
   growth_metrics:
-  - measurement_conditions: Modified F/2ASW supplemented with sodium selenite
-      and sodium metasilicate; sodium concentration adjusted by NaCl addition
-      and CO2 availability varied.
+  - measurement_conditions: Modified F/2ASW supplemented with sodium selenite and
+      sodium metasilicate; sodium concentration adjusted by NaCl addition and CO2
+      availability varied.
     evidence:
     - reference: DOI:10.1007/s10126-021-10037-4
       supports: SUPPORT
-      explanation: Tsuji et al. report growth and CO2-concentrating mechanism
-        experiments for Chaetoceros gracilis UTEX LB2658 using modified F/2ASW.
+      explanation: Tsuji et al. report growth and CO2-concentrating mechanism experiments
+        for Chaetoceros gracilis UTEX LB2658 using modified F/2ASW.
     is_max_attainment: false
   evidence:
   - reference: DOI:10.1007/s10126-021-10037-4
     supports: SUPPORT
-    explanation: The study identifies the UTEX LB2658 strain and modified
-      F/2ASW growth conditions; the UTEX strain page separately lists this strain
-      as a liquid-culture Chaetoceros gracilis accession.
+    explanation: The study identifies the UTEX LB2658 strain and modified F/2ASW growth
+      conditions; the UTEX strain page separately lists this strain as a liquid-culture
+      Chaetoceros gracilis accession.

--- a/data/normalized_yaml/algae/Spirulina_Medium.yaml
+++ b/data/normalized_yaml/algae/Spirulina_Medium.yaml
@@ -20,7 +20,8 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
+  description: 'Important Notes To Consider: The quality of water, including natural
+    seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
@@ -75,6 +76,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Spirulina Medium" to "spirulina_medium" for consistent
     matching
+- timestamp: '2026-08-06T00:58:02.521300+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:spirulina-medium
 - reference: https://utex.org/products/spirulina-medium
@@ -87,30 +93,31 @@ variants:
   - Use effluent from biogas production as the nutrient source.
   - Compare biomass composition and pigment production with conventional Spirulina
     medium.
-  purpose: Capture a study-specific Spirulina medium alternative using biogas
-    effluent as recycled nutrients.
+  purpose: Capture a study-specific Spirulina medium alternative using biogas effluent
+    as recycled nutrients.
   evidence:
   - reference: PMID:28025700
     supports: SUPPORT
     snippet: The effluent from the biogas process was tested as a nutrient source
-      during cultivation of the protein-rich and edible microalgae Spirulina
-      (Arthrospira platensis) and compared with conventional Spirulina medium.
-    explanation: Literature evidence describes an effluent-based medium variant
-      compared with the conventional Spirulina parent medium.
+      during cultivation of the protein-rich and edible microalgae Spirulina (Arthrospira
+      platensis) and compared with conventional Spirulina medium.
+    explanation: Literature evidence describes an effluent-based medium variant compared
+      with the conventional Spirulina parent medium.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Arthrospira platensis
   term:
     id: NCBITaxon:118562
     label: Limnospira platensis
   growth_metrics:
-  - measurement_conditions: Conventional Spirulina medium control compared with
-      effluent-based medium during Arthrospira platensis cultivation.
+  - measurement_conditions: Conventional Spirulina medium control compared with effluent-based
+      medium during Arthrospira platensis cultivation.
     evidence:
     - reference: PMID:28025700
       supports: SUPPORT
-      snippet: Equal biomass production was observed until late exponential phase and
-        no significant differences could be observed between the treatments in protein
-        amount, amino acid composition, and total lipid concentration.
+      snippet: Equal biomass production was observed until late exponential phase
+        and no significant differences could be observed between the treatments in
+        protein amount, amino acid composition, and total lipid concentration.
       explanation: Literature evidence reports biomass production for Arthrospira
         platensis in conventional Spirulina medium and effluent-based medium.
     is_max_attainment: false

--- a/data/normalized_yaml/algae/TAP_Medium.yaml
+++ b/data/normalized_yaml/algae/TAP_Medium.yaml
@@ -30,7 +30,8 @@ ingredients:
 preparation_steps:
 - step_number: 1
   action: MIX
-  description: 'Important Notes To Consider: The quality of water, including natural seawater, is important.'
+  description: 'Important Notes To Consider: The quality of water, including natural
+    seawater, is important.'
 - step_number: 2
   action: MIX
   description: The term 'dH2O' generally refers to distilled, deionized, distilled/deionized
@@ -84,6 +85,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "TAP Medium" to "tap_medium" for consistent matching
+- timestamp: '2026-08-06T00:58:02.525354+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 2 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 references:
 - reference: UTEX:tap-medium
 - reference: https://utex.org/products/tap-medium
@@ -105,8 +111,8 @@ variants:
     explanation: Literature evidence supports a TAP medium co-culture variant for
       Chlorella vulgaris and Delftia sp.
 - name: ab_wsf_tap_derived_chlorella_sorokiniana
-  description: Acetate-based water-soluble fertilizer medium developed from TAP
-    for Chlorella sorokiniana cultivation.
+  description: Acetate-based water-soluble fertilizer medium developed from TAP for
+    Chlorella sorokiniana cultivation.
   modifications:
   - Replace TAP trace and macroelements with water-soluble fertilizer.
   - Replace Tris in TAP medium with HAc-NaAc for pH balance.
@@ -119,8 +125,9 @@ variants:
     snippet: To address these problems, a novel acetate-based water-soluble fertilizer
       (Ab-WSF) was developed on the basis of TAP media, where the trace and macroelements
       in TAP were replaced by water-soluble fertilizer (WSF).
-    explanation: Literature evidence describes a TAP-derived formulation variant
-      for Chlorella sorokiniana cultivation.
+    explanation: Literature evidence describes a TAP-derived formulation variant for
+      Chlorella sorokiniana cultivation.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Chlorella vulgaris
   term:
@@ -152,14 +159,14 @@ target_organisms:
       explanation: Literature evidence uses TAP as the comparator medium for Chlorella
         sorokiniana cultivation.
     is_max_attainment: false
-  - measurement_conditions: TAP-derived Ab-WSF variant in twelve-liter Chlorella
-      sorokiniana culture.
+  - measurement_conditions: TAP-derived Ab-WSF variant in twelve-liter Chlorella sorokiniana
+      culture.
     evidence:
     - reference: PMID:40484141
       supports: SUPPORT
       snippet: The biomass concentration, volumetric productivity and areal productivity
-        were 4.5 g/L, 0.6 g/L/d, and 9.0 g/m2/d, which were 50.0 %, 36.0 % and
-        49.8 % greater than those obtained with TAP, respectively.
-      explanation: Literature evidence reports quantitative biomass/productivity
-        for a TAP-derived Ab-WSF variant and compares results with TAP.
+        were 4.5 g/L, 0.6 g/L/d, and 9.0 g/m2/d, which were 50.0 %, 36.0 % and 49.8
+        % greater than those obtained with TAP, respectively.
+      explanation: Literature evidence reports quantitative biomass/productivity for
+        a TAP-derived Ab-WSF variant and compares results with TAP.
     is_max_attainment: false

--- a/data/normalized_yaml/algae/bg11.yaml
+++ b/data/normalized_yaml/algae/bg11.yaml
@@ -131,8 +131,8 @@ source_data:
   notes: 'database_id: BG11; url: https://github.com/CultureBotAI/CultureBotHT'
 variants:
 - name: nitrate_replete_bg11_nostoc_linckia
-  description: BG11 nitrate-replete condition used for Nostoc linckia growth and
-    biomass productivity comparison with nitrate-free BG110.
+  description: BG11 nitrate-replete condition used for Nostoc linckia growth and biomass
+    productivity comparison with nitrate-free BG110.
   modifications:
   - Use BG11 medium with nitrate present.
   - Compare with BG110 medium lacking nitrate.
@@ -141,18 +141,18 @@ variants:
   - reference: PMID:36550226
     supports: SUPPORT
     snippet: Cultures grown in BG11 accumulated more cell biomass reaching a dry weight
-      of 1.65 ± 0.06 g L-1, compared to 0.92 ± 0.01 g L-1 in BG110 after 240 h
-      of culture.
-    explanation: Literature evidence reports higher biomass and productivity of
-      Nostoc linckia in BG11 than nitrate-free BG110.
+      of 1.65 ± 0.06 g L-1, compared to 0.92 ± 0.01 g L-1 in BG110 after 240 h of
+      culture.
+    explanation: Literature evidence reports higher biomass and productivity of Nostoc
+      linckia in BG11 than nitrate-free BG110.
 - name: bg11_synechococcus_ucp002
-  description: BG-11 cultivation condition for unaxenic Synechococcus sp. UCP002
-    isolated from the Peruvian Amazon Basin.
+  description: BG-11 cultivation condition for unaxenic Synechococcus sp. UCP002 isolated
+    from the Peruvian Amazon Basin.
   modifications:
   - Culture Synechococcus sp. UCP002 in BG-11 medium.
   - Use standardized growth-parameter and biochemical-profile measurements.
-  purpose: Capture strain-specific BG-11 growth and genome-context evidence for
-    Synechococcus sp. UCP002.
+  purpose: Capture strain-specific BG-11 growth and genome-context evidence for Synechococcus
+    sp. UCP002.
   evidence:
   - reference: PMID:36437912
     supports: SUPPORT
@@ -166,15 +166,15 @@ variants:
   modifications:
   - Use BG-11 medium under photoautotrophic cultivation.
   - Compare air and 2% CO2 gas conditions.
-  purpose: Capture strain-level BG-11 growth evidence for Scenedesmus obliquus
-    ABC-009, currently mapped by NCBI to Tetradesmus obliquus.
+  purpose: Capture strain-level BG-11 growth evidence for Scenedesmus obliquus ABC-009,
+    currently mapped by NCBI to Tetradesmus obliquus.
   evidence:
   - reference: PMID:34584038
     supports: SUPPORT
     snippet: photoautotrophic mode using BG-11 medium with air or 2% CO2 and heterotrophic
       mode using YM medium.
-    explanation: Literature evidence directly states that strain ABC-009 was
-      evaluated under photoautotrophic BG-11 cultivation conditions.
+    explanation: Literature evidence directly states that strain ABC-009 was evaluated
+      under photoautotrophic BG-11 cultivation conditions.
 curation_history:
 - timestamp: '2026-03-18T04:31:12.439728+00:00'
   curator: import_from_culturebotht.py
@@ -184,24 +184,30 @@ curation_history:
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID
   notes: 'Assigned stable identifier: CultureMech:015450'
+- timestamp: '2026-08-06T00:58:02.530976+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 data_quality_flags:
 - has_unmapped_ingredients
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Nostoc linckia
   term:
     id: NCBITaxon:92942
     label: Nostoc linckia
   growth_metrics:
-  - measurement_conditions: BG11 nitrate-replete medium after 240 h of culture;
-      compared with nitrate-free BG110.
+  - measurement_conditions: BG11 nitrate-replete medium after 240 h of culture; compared
+      with nitrate-free BG110.
     evidence:
     - reference: PMID:36550226
       supports: SUPPORT
-      snippet: Cultures grown in BG11 accumulated more cell biomass reaching a dry weight
-        of 1.65 ± 0.06 g L-1, compared to 0.92 ± 0.01 g L-1 in BG110 after 240 h
-        of culture.
-      explanation: Literature evidence reports biomass accumulation of Nostoc
-        linckia in BG11.
+      snippet: Cultures grown in BG11 accumulated more cell biomass reaching a dry
+        weight of 1.65 ± 0.06 g L-1, compared to 0.92 ± 0.01 g L-1 in BG110 after
+        240 h of culture.
+      explanation: Literature evidence reports biomass accumulation of Nostoc linckia
+        in BG11.
     is_max_attainment: false
 - preferred_term: Synechococcus sp. UCP002
   strain: UCP002
@@ -216,10 +222,10 @@ target_organisms:
     evidence:
     - reference: PMID:36437912
       supports: SUPPORT
-      snippet: Synechococcus sp. UCP002 had a specific growth rate of 0.086 ± 0.008 μ
-        and a doubling time of 8.08 ± 0.78 h.
-      explanation: Literature evidence reports growth rate and doubling time for
-        Synechococcus sp. UCP002 cultured in BG-11 medium.
+      snippet: Synechococcus sp. UCP002 had a specific growth rate of 0.086 ± 0.008
+        μ and a doubling time of 8.08 ± 0.78 h.
+      explanation: Literature evidence reports growth rate and doubling time for Synechococcus
+        sp. UCP002 cultured in BG-11 medium.
     is_max_attainment: false
   evidence:
   - reference: PMID:36437912
@@ -234,23 +240,22 @@ target_organisms:
     id: NCBITaxon:3088
     label: Tetradesmus obliquus
   growth_metrics:
-  - measurement_conditions: Photoautotrophic BG-11 medium cultivation with air
-      or 2% CO2 for the strain reported in the source as Scenedesmus obliquus
-      ABC-009.
+  - measurement_conditions: Photoautotrophic BG-11 medium cultivation with air or
+      2% CO2 for the strain reported in the source as Scenedesmus obliquus ABC-009.
     growth_mode: BATCH
     evidence:
     - reference: PMID:34584038
       supports: SUPPORT
-      snippet: Scenedesmus obliquus ABC-009 is a microalgal strain that accumulates large
-        amounts of lutein, particularly when subjected to growth-limiting conditions.
-      explanation: Literature evidence identifies the strain studied under BG-11
-        photoautotrophic cultivation; NCBI nuccore record MG971386.1 links strain
-        ABC-009 to the accepted taxonomy Tetradesmus obliquus, but it is a partial
-        marker sequence rather than a genome assembly.
+      snippet: Scenedesmus obliquus ABC-009 is a microalgal strain that accumulates
+        large amounts of lutein, particularly when subjected to growth-limiting conditions.
+      explanation: Literature evidence identifies the strain studied under BG-11 photoautotrophic
+        cultivation; NCBI nuccore record MG971386.1 links strain ABC-009 to the accepted
+        taxonomy Tetradesmus obliquus, but it is a partial marker sequence rather
+        than a genome assembly.
     - reference: PMID:34584038
       supports: SUPPORT
-      snippet: While the cell concentrations of the cultures grown under BG-11 and CO2
-        were largely similar to those grown in YM medium
-      explanation: Literature evidence reports cell concentrations for the BG-11
-        plus CO2 condition relative to YM medium.
+      snippet: While the cell concentrations of the cultures grown under BG-11 and
+        CO2 were largely similar to those grown in YM medium
+      explanation: Literature evidence reports cell concentrations for the BG-11 plus
+        CO2 condition relative to YM medium.
     is_max_attainment: false

--- a/data/normalized_yaml/archaea/archaeoglobus_medium_dsm_399.yaml
+++ b/data/normalized_yaml/archaea/archaeoglobus_medium_dsm_399.yaml
@@ -357,6 +357,11 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.538197+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: Trace Elements Solution
   term:
@@ -367,6 +372,7 @@ solutions:
     unit: G_PER_L
   notes: See mediadive_6129_Trace_elements_solution.yaml for composition
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Archaeoglobus fulgidus
   term:

--- a/data/normalized_yaml/archaea/ignicoccus_medium_for_dsm_18386.yaml
+++ b/data/normalized_yaml/archaea/ignicoccus_medium_for_dsm_18386.yaml
@@ -255,6 +255,11 @@ curation_history:
     / DSMZ 897) is cited transitively (Paper 2007 / Huber 2000), so exact recipe identity
     is unverified; organism links are to the recognizable Ignicoccus-medium family.
     [added 3 organism(s), 2 variant(s)]'
+- timestamp: '2026-08-06T00:58:02.548599+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: SrCl2 x 6 H2O solution (0.1% w/v)
   composition: []
@@ -271,6 +276,7 @@ solutions:
   notes: 'Role: Mineral source; Properties: Solution, Defined component, Inorganic
     compound'
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Ignicoccus hospitalis
   term:
@@ -304,8 +310,8 @@ target_organisms:
       family (extra NaHCO3, SrCl2.6H2O, KI and different S0/Na2S vs parent). Curate
       against the half_sme_s0_ignicoccus variant rather than asserting identity with
       the parent. | Identifiers: DSM 13165T; NZ_CP006867'
-    snippet: Ignicoccus pacificus LPC33, DSM 13166T • Ignicoccus islandicus Kol8, DSM
-      13165T
+    snippet: Ignicoccus pacificus LPC33, DSM 13166T • Ignicoccus islandicus Kol8,
+      DSM 13165T
 - preferred_term: Ignicoccus pacificus
   term:
     id: NCBITaxon:114376
@@ -337,10 +343,10 @@ variants:
   - reference: doi:10.5283/epub.34741
     supports: SUPPORT
     explanation: Koschnitzki 2017 prints the formulation and strain list.
-    snippet: '½ SME+S0 medium for all Ignicoccus representatives (Paper et al., 2007)
-      Substance Amount Concentration SME 500 ml ½ x KH2PO4 0.5 g 3.7 mM (NH4)2SO4 0.25
-      g 1.9 mM NaHCO3 0.16 g 1.9 mM Resazurin (0.1 %) 1 ml 0.0001 % Na2S x 7-9 H2O 0.5
-      g 2.1 mM ddH2O ad 1000 ml'
+    snippet: ½ SME+S0 medium for all Ignicoccus representatives (Paper et al., 2007)
+      Substance Amount Concentration SME 500 ml ½ x KH2PO4 0.5 g 3.7 mM (NH4)2SO4
+      0.25 g 1.9 mM NaHCO3 0.16 g 1.9 mM Resazurin (0.1 %) 1 ml 0.0001 % Na2S x 7-9
+      H2O 0.5 g 2.1 mM ddH2O ad 1000 ml
 - name: half_sme_ignicoccus_plus_0_1pct_yeast_extract
   relationship: SUPPLEMENTED_VARIANT
   description: Mixotrophic version of 1/2 SME-Ignicoccus medium with 0.1% (w/v) yeast

--- a/data/normalized_yaml/archaea/methanosarcina_medium.yaml
+++ b/data/normalized_yaml/archaea/methanosarcina_medium.yaml
@@ -431,6 +431,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.560977+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Methanosarcina acetivorans
   term:

--- a/data/normalized_yaml/archaea/pyrococcus_medium.yaml
+++ b/data/normalized_yaml/archaea/pyrococcus_medium.yaml
@@ -362,6 +362,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.570714+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Pyrococcus furiosus
   term:

--- a/data/normalized_yaml/archaea/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
+++ b/data/normalized_yaml/archaea/sulfolobus_medium_anaerobic_for_dsm_2162.yaml
@@ -286,6 +286,11 @@ curation_history:
     strain with a genuinely anaerobic (MBSY + Na2S + H2/CO2) formulation and is the
     closest to the parent, though its basal recipe is also cited transitively. [added
     6 organism(s), 2 variant(s)]'
+- timestamp: '2026-08-06T00:58:02.579053+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 6 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: Allen’s trace element solution
   composition: []
@@ -293,6 +298,7 @@ solutions:
     value: '10'
     unit: G_PER_L
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Acidianus brierleyi
   term:
@@ -303,9 +309,9 @@ target_organisms:
   evidence:
   - reference: doi:10.1128/mbio.01033-24
     supports: SUPPORT
-    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NOT verified on
-      the anaerobic parent (no Na2S/N2 reported); aerobic vented-bottle cultivation.
-      | Identifiers: DSM 3772; DSM 1651'
+    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant.
+      NOT verified on the anaerobic parent (no Na2S/N2 reported); aerobic vented-bottle
+      cultivation. | Identifiers: DSM 3772; DSM 1651'
 - preferred_term: Metallosphaera hakonensis
   term:
     id: NCBITaxon:79601
@@ -317,16 +323,17 @@ target_organisms:
   evidence:
   - reference: doi:10.1128/mbio.01033-24
     supports: SUPPORT
-    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. Differs from anaerobic
-      parent: NH4Cl vs (NH4)2SO4, no Na2S, no N2 phase. | Identifiers: DSM 7519'
+    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant.
+      Differs from anaerobic parent: NH4Cl vs (NH4)2SO4, no Na2S, no N2 phase. | Identifiers:
+      DSM 7519'
 - preferred_term: Metallosphaera prunae
   scoped_to_variant: aerobic_brocks_salts_dsm88_sulfur_yeast_extract
   strain: RON 12/II, DSM 10039
   evidence:
   - reference: doi:10.1128/mbio.01033-24
     supports: SUPPORT
-    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NOT the anaerobic
-      parent formulation. | Identifiers: DSM 10039'
+    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant.
+      NOT the anaerobic parent formulation. | Identifiers: DSM 10039'
 - preferred_term: Sulfurisphaera ohwakuensis
   term:
     id: NCBITaxon:69656
@@ -336,8 +343,8 @@ target_organisms:
   evidence:
   - reference: doi:10.1128/mbio.01033-24
     supports: SUPPORT
-    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. Vented bottles;
-      not anaerobic parent. | Identifiers: DSM 12421'
+    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant.
+      Vented bottles; not anaerobic parent. | Identifiers: DSM 12421'
 - preferred_term: Sulfurisphaera tokodaii
   term:
     id: NCBITaxon:111955
@@ -347,8 +354,9 @@ target_organisms:
   evidence:
   - reference: doi:10.1128/mbio.01033-24
     supports: SUPPORT
-    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant. NH4Cl, no Na2S,
-      vented bottles; not the anaerobic parent. | Identifiers: DSM 16993'
+    explanation: 'Scoped to the aerobic_brocks_salts_dsm88_sulfur_yeast_extract variant.
+      NH4Cl, no Na2S, vented bottles; not the anaerobic parent. | Identifiers: DSM
+      16993'
 - preferred_term: Sulfodiicoccus acidiphilus
   term:
     id: NCBITaxon:1670455
@@ -363,8 +371,8 @@ target_organisms:
     explanation: 'Closest match to the anaerobic parent of all DSM 2162 candidates
       (genuinely anaerobic: Na2S + reduced + H2/CO2). Basal MBS recipe is cited transitively,
       so exact identity is plausible but not provable from this source; scoped to
-      the reduced_anaerobic_mbsy_h2_co2 variant. | Identifiers: JCM 31740T; InaCC Ar79T;
-      16S LC061218; 23S LC176656'
+      the reduced_anaerobic_mbsy_h2_co2 variant. | Identifiers: JCM 31740T; InaCC
+      Ar79T; 16S LC061218; 23S LC176656'
     snippet: Strain HS-1T grown in modified Brock's basal salt medium with yeast extract
       (MBSY); anaerobic tests used MBSY reduced with Na2S (0.5 g/L) + resazurin (1
       mg/L), headspace H2/CO2 (80:20, 100 kPa), optional 10 g/L elemental sulfur.

--- a/data/normalized_yaml/archaea/sulfolobus_medium_for_dsm_5348.yaml
+++ b/data/normalized_yaml/archaea/sulfolobus_medium_for_dsm_5348.yaml
@@ -274,6 +274,11 @@ curation_history:
     found it grows on a plain Brock''s basal-salts medium (a distinct medium family,
     not the DSM-88 formulation captured here) that warrants its own record, not an
     addition here. [added 2 organism(s), 1 variant(s)]'
+- timestamp: '2026-08-06T00:58:02.588077+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 2 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: Allen’s trace element solution
   composition: []
@@ -281,6 +286,7 @@ solutions:
     value: '10'
     unit: G_PER_L
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Metallosphaera sedula
   term:
@@ -296,9 +302,9 @@ target_organisms:
       DSM 5348 type strain (exact parent match). Full DSMZ 88 recipe is referenced
       by name rather than printed; parent formulation is inherited from this record.
       | Identifiers: DSM 5348T; GenBank CP000682; RefSeq NC_009440.1'
-    snippet: 'Cells (DSMZ 5348) were grown aerobically at 70°C in an orbital shaking
+    snippet: Cells (DSMZ 5348) were grown aerobically at 70°C in an orbital shaking
       oil bath at 70 rpm on DSMZ 88 medium (pH 2), supplemented with 0.1% yeast extract
-      (YE).'
+      (YE).
 - preferred_term: Sulfuracidifex metallicus
   term:
     id: NCBITaxon:47303

--- a/data/normalized_yaml/archaea/sulfolobus_medium_for_dsm_9790.yaml
+++ b/data/normalized_yaml/archaea/sulfolobus_medium_for_dsm_9790.yaml
@@ -262,12 +262,17 @@ curation_history:
   action: ANNOTATED
   changes: target_organisms
   notes: 'Added Picrophilus oshimae strain DSM 9790, per the DSMZ catalogue entry
-    (via BacDive record 11901): DSMZ Medium 88, growth yes, 55 C. Resolves issue
-    #119 as no-rename - ''Sulfolobus Medium'' is DSMZ''s own name for Medium 88 and
-    ''(For DSM 9790)'' is accurate TOGO provenance. Metallosphaera sedula
-    deliberately NOT added here: it belongs to the sibling record
-    CultureMech:008908 ''Sulfolobus Medium (For DSM 5348)'' (TOGO M2320), where it
-    is already curated.'
+    (via BacDive record 11901): DSMZ Medium 88, growth yes, 55 C. Resolves issue #119
+    as no-rename - ''Sulfolobus Medium'' is DSMZ''s own name for Medium 88 and ''(For
+    DSM 9790)'' is accurate TOGO provenance. Metallosphaera sedula deliberately NOT
+    added here: it belongs to the sibling record CultureMech:008908 ''Sulfolobus Medium
+    (For DSM 5348)'' (TOGO M2320), where it is already curated.'
+- timestamp: '2026-08-06T00:58:02.597066+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Picrophilus oshimae
   term:
@@ -277,17 +282,16 @@ target_organisms:
   evidence:
   - reference: https://www.dsmz.de/collection/catalogue/details/culture/DSM-9790
     supports: SUPPORT
-    explanation: 'DSMZ catalogue entry for DSM 9790, relayed by BacDive strain
-      record 11901 (bacdive.dsmz.de/strain/11901), which lists culture medium
-      ''SULFOLOBUS MEDIUM (DSMZ Medium 88)'' with growth: yes at 55 C and links to
-      mediadive.dsmz.de/medium/88. That is the medium this record transcribes (TOGO
-      M2323 -> DSMZ_Medium88.pdf), and DSM 9790 is the strain the record is named
-      for. TAXONOMY: DSM 9790 was described as the Picrophilus torridus type strain
-      (Zillig et al. 1996), but NCBI has since synonymized P. torridus with
-      P. oshimae - NCBITaxon:46632 carries ''Picrophilus torridus'' as a related
-      synonym, and the former strain id NCBITaxon:263820 (''Picrophilus torridus
-      DSM 9790'') is now an alternative id of NCBITaxon:1122961. Curated to the
-      current species term, with the strain designation preserved above.'
+    explanation: 'DSMZ catalogue entry for DSM 9790, relayed by BacDive strain record
+      11901 (bacdive.dsmz.de/strain/11901), which lists culture medium ''SULFOLOBUS
+      MEDIUM (DSMZ Medium 88)'' with growth: yes at 55 C and links to mediadive.dsmz.de/medium/88.
+      That is the medium this record transcribes (TOGO M2323 -> DSMZ_Medium88.pdf),
+      and DSM 9790 is the strain the record is named for. TAXONOMY: DSM 9790 was described
+      as the Picrophilus torridus type strain (Zillig et al. 1996), but NCBI has since
+      synonymized P. torridus with P. oshimae - NCBITaxon:46632 carries ''Picrophilus
+      torridus'' as a related synonym, and the former strain id NCBITaxon:263820 (''Picrophilus
+      torridus DSM 9790'') is now an alternative id of NCBITaxon:1122961. Curated
+      to the current species term, with the strain designation preserved above.'
 solutions:
 - preferred_term: Allen’s trace element solution
   composition: []

--- a/data/normalized_yaml/bacterial/KOMODO_1078_FRIIS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1078_FRIIS_medium.yaml
@@ -272,6 +272,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 1 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.606017+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Mycoplasma hyopneumoniae
   term:

--- a/data/normalized_yaml/bacterial/KOMODO_11_MRS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_11_MRS_medium.yaml
@@ -284,6 +284,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.616265+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Heyndrickxia coagulans
   term:

--- a/data/normalized_yaml/bacterial/KOMODO_429_COLUMBIA_BLOOD_AGAR.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_429_COLUMBIA_BLOOD_AGAR.yaml
@@ -241,6 +241,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 1 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.630191+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Staphylococcus saccharolyticus
   term:

--- a/data/normalized_yaml/bacterial/KOMODO_761_HALOTHERMOTHRIX_ORENII.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_761_HALOTHERMOTHRIX_ORENII.yaml
@@ -313,6 +313,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.637595+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Halothermothrix orenii
   term:

--- a/data/normalized_yaml/bacterial/TOGO_M1308_Methylotroph_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1308_Methylotroph_Medium.yaml
@@ -255,6 +255,11 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.647301+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 2 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: Trace element solution (see Medium [M278])
   composition:
@@ -384,6 +389,7 @@ solutions:
     value: '2'
     unit: G_PER_L
   preparation_notes: 'Role: Mineral source'
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Methylosinus sp. Ce-a6
   term:

--- a/data/normalized_yaml/bacterial/TOGO_M1547_Marine_Agar_2216.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1547_Marine_Agar_2216.yaml
@@ -79,6 +79,12 @@ curation_history:
   notes: 'Replaced 1 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T00:58:02.661292+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Sneathiella glossodoripedis
   term:

--- a/data/normalized_yaml/bacterial/TOGO_M1663_Thermus_Medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M1663_Thermus_Medium.yaml
@@ -108,6 +108,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T00:58:02.669574+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Thermus thermophilus HB27
   term:

--- a/data/normalized_yaml/bacterial/TOGO_M2314_LB_medium.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M2314_LB_medium.yaml
@@ -11,30 +11,26 @@ ingredients:
     value: '10.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium
-      (Luria-Bertani, Miller formulation)
+    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium (Luria-Bertani,
+      Miller formulation)
     catalog_number: Multiple (L3522 Sigma, 244520 BD)
-    product_url:
-      https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
-  notes: Pancreatic digest of casein providing amino acids, peptides, and
-    nitrogen; Constituent of LB Medium (Luria-Bertani, Miller formulation)
-    commercial product. Original FOODON mapping was FOODON:03316428 tryptone.
-    Exact synonyms from source normalization were pancreatic digest of casein
-    and casein peptone.
+    product_url: https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
+  notes: Pancreatic digest of casein providing amino acids, peptides, and nitrogen;
+    Constituent of LB Medium (Luria-Bertani, Miller formulation) commercial product.
+    Original FOODON mapping was FOODON:03316428 tryptone. Exact synonyms from source
+    normalization were pancreatic digest of casein and casein peptone.
 - preferred_term: Yeast extract
   concentration:
     value: '5.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium
-      (Luria-Bertani, Miller formulation)
+    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium (Luria-Bertani,
+      Miller formulation)
     catalog_number: Multiple (L3522 Sigma, 244520 BD)
-    product_url:
-      https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
-  notes: Autodigest of Saccharomyces cerevisiae providing vitamins, amino acids,
-    and trace elements; Constituent of LB Medium (Luria-Bertani, Miller
-    formulation) commercial product. Original FOODON mapping was FOODON:00002960
-    yeast extract.
+    product_url: https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
+  notes: Autodigest of Saccharomyces cerevisiae providing vitamins, amino acids, and
+    trace elements; Constituent of LB Medium (Luria-Bertani, Miller formulation) commercial
+    product. Original FOODON mapping was FOODON:00002960 yeast extract.
 - preferred_term: Sodium chloride
   term:
     id: CHEBI:26710
@@ -43,14 +39,13 @@ ingredients:
     value: '10.0'
     unit: G_PER_L
   supplier_catalog:
-    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium
-      (Luria-Bertani, Miller formulation)
+    supplier_name: Multiple suppliers (Difco, Sigma, etc.) LB Medium (Luria-Bertani,
+      Miller formulation)
     catalog_number: Multiple (L3522 Sigma, 244520 BD)
-    product_url:
-      https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
-  notes: Maintains osmotic equilibrium (Miller formulation); Constituent of LB
-    Medium (Luria-Bertani, Miller formulation) commercial product. Exact
-    synonyms from source normalization were NaCl and table salt.
+    product_url: https://www.laboratorynotes.com/preparation-of-luria-bertani-lb-miller-broth/
+  notes: Maintains osmotic equilibrium (Miller formulation); Constituent of LB Medium
+    (Luria-Bertani, Miller formulation) commercial product. Exact synonyms from source
+    normalization were NaCl and table salt.
 media_term:
   preferred_term: TOGO Medium M2314
   term:
@@ -76,11 +71,11 @@ applications:
 references:
 - reference: PMID:16628448
   year: 2006
-  notes: Primary literature source reporting growth of Escherichia coli MG1655
-    on LB medium and monitoring nutrient utilization during batch culture.
+  notes: Primary literature source reporting growth of Escherichia coli MG1655 on
+    LB medium and monitoring nutrient utilization during batch culture.
 - reference: NCBI:GCF_000005845.2
-  notes: NCBI RefSeq assembly ASM584v2 for Escherichia coli str. K-12 substr.
-    MG1655; BioSample SAMN02604091.
+  notes: NCBI RefSeq assembly ASM584v2 for Escherichia coli str. K-12 substr. MG1655;
+    BioSample SAMN02604091.
 curation_history:
 - timestamp: '2026-01-27T06:35:56.329102Z'
   curator: togo-import
@@ -97,9 +92,15 @@ curation_history:
 - timestamp: '2026-05-05T00:00:00Z'
   curator: literature_review_manual
   action: ADDED_GROWTH_EVIDENCE
-  notes: Added strain-specific Escherichia coli K-12 MG1655 growth evidence on
-    LB medium from PMID:16628448.
+  notes: Added strain-specific Escherichia coli K-12 MG1655 growth evidence on LB
+    medium from PMID:16628448.
+- timestamp: '2026-08-06T00:58:02.675642+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 kg_microbe_match: mediadive.medium:74
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Escherichia coli K-12 MG1655
   term:
@@ -110,36 +111,34 @@ target_organisms:
   - GCF_000005845.2
   strain: K-12 MG1655
   growth_metrics:
-  - measurement_conditions: LB medium batch culture; source monitored
-      utilization of sugars, alcohols, and organic acids with transcriptional
-      microarrays and associated nutrient utilization with the highest growth
-      rate phase.
+  - measurement_conditions: LB medium batch culture; source monitored utilization
+      of sugars, alcohols, and organic acids with transcriptional microarrays and
+      associated nutrient utilization with the highest growth rate phase.
     evidence:
     - reference: PMID:16628448
       supports: SUPPORT
-      snippet: Utilization of these nutrients associated with the highest growth
-        rate of the culture was followed by simultaneous induction of enzymes
-        involved in assimilation of a large group of other carbon sources
-        including D-mannose, melibiose, D-galactose, L-fucose, L-rhamnose,
-        D-mannitol, amino sugars, trehalose, L-arabinose, glycerol, and lactate.
-      explanation: The article title and abstract directly identify growth of
-        Escherichia coli MG1655 on LB medium. The CultureMech record is LB
-        Miller liquid medium, so this is modeled as exact-parent evidence rather
-        than a variant.
+      snippet: Utilization of these nutrients associated with the highest growth rate
+        of the culture was followed by simultaneous induction of enzymes involved
+        in assimilation of a large group of other carbon sources including D-mannose,
+        melibiose, D-galactose, L-fucose, L-rhamnose, D-mannitol, amino sugars, trehalose,
+        L-arabinose, glycerol, and lactate.
+      explanation: The article title and abstract directly identify growth of Escherichia
+        coli MG1655 on LB medium. The CultureMech record is LB Miller liquid medium,
+        so this is modeled as exact-parent evidence rather than a variant.
     is_max_attainment: false
   evidence:
   - reference: PMID:16628448
     supports: SUPPORT
-    explanation: The source title states growth of Escherichia coli MG1655 on LB
-      medium and the abstract discusses the growth-rate phase of that culture.
+    explanation: The source title states growth of Escherichia coli MG1655 on LB medium
+      and the abstract discusses the growth-rate phase of that culture.
   - reference: NCBI:GCF_000005845.2
     supports: SUPPORT
-    explanation: NCBI lists RefSeq assembly GCF_000005845.2 and BioSample
-      SAMN02604091 for Escherichia coli str. K-12 substr. MG1655.
+    explanation: NCBI lists RefSeq assembly GCF_000005845.2 and BioSample SAMN02604091
+      for Escherichia coli str. K-12 substr. MG1655.
 variant_children:
 - path: data/normalized_yaml/bacterial/lb_0_1x.yaml
   relationship: CONCENTRATION_VARIANT
   id: CultureMech:015465
   name: LB_0.1x
-  notes: LB 0.1x decreases tryptone from 10 g/L to 1 g/L, yeast extract from 5
-    g/L to 0.5 g/L, and sodium chloride from 10 g/L to 0.5 g/L.
+  notes: LB 0.1x decreases tryptone from 10 g/L to 1 g/L, yeast extract from 5 g/L
+    to 0.5 g/L, and sodium chloride from 10 g/L to 0.5 g/L.

--- a/data/normalized_yaml/bacterial/TOGO_M540_Brucella_Broth.yaml
+++ b/data/normalized_yaml/bacterial/TOGO_M540_Brucella_Broth.yaml
@@ -140,6 +140,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T00:58:02.679509+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Helicobacter pylori
   term:

--- a/data/normalized_yaml/bacterial/acidiphilium_medium.yaml
+++ b/data/normalized_yaml/bacterial/acidiphilium_medium.yaml
@@ -123,6 +123,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.684483+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Acidiphilium cryptum
   term:

--- a/data/normalized_yaml/bacterial/bacto_marine_broth_difco_2216_for_dsm_11879.yaml
+++ b/data/normalized_yaml/bacterial/bacto_marine_broth_difco_2216_for_dsm_11879.yaml
@@ -249,6 +249,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.688443+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 6 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Cellulophaga algicola
   term:

--- a/data/normalized_yaml/bacterial/beijerinckia_medium_lmg_18.yaml
+++ b/data/normalized_yaml/bacterial/beijerinckia_medium_lmg_18.yaml
@@ -153,6 +153,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.698129+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Beijerinckia lactocogenes
   strain: NTCC 38849

--- a/data/normalized_yaml/bacterial/bg11.yaml
+++ b/data/normalized_yaml/bacterial/bg11.yaml
@@ -260,6 +260,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.702712+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Synechocystis sp. PCC 6803
   term:

--- a/data/normalized_yaml/bacterial/caldicellulosiruptor_medium_for_dsm_10319.yaml
+++ b/data/normalized_yaml/bacterial/caldicellulosiruptor_medium_for_dsm_10319.yaml
@@ -290,6 +290,11 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.710815+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 9 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 high_metal: true
 solutions:
 - preferred_term: Na-resazurin solution (0.1% w/v)
@@ -315,6 +320,7 @@ solutions:
     unit: G_PER_L
   notes: See mediadive_4178_Trace_element_solution_SL-10.yaml for composition
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Caldicellulosiruptor bescii
   term:

--- a/data/normalized_yaml/bacterial/caulobacter_medium.yaml
+++ b/data/normalized_yaml/bacterial/caulobacter_medium.yaml
@@ -104,6 +104,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T00:58:02.723427+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Caulobacter sp. K31
   term:

--- a/data/normalized_yaml/bacterial/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.yaml
+++ b/data/normalized_yaml/bacterial/chopped_meat_medium_atcc_1490_with_formate_and_fumarate_atcc_9733.yaml
@@ -239,6 +239,11 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 1 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.728451+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 7 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 solutions:
 - preferred_term: Formate and Fumarate Solution
   composition: []
@@ -264,6 +269,7 @@ solutions:
     unit: G_PER_L
   notes: See mediadive_2227_Vitamin_K1_solution.yaml for composition
   name: Unknown solution
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Bacteroides ureolyticus
   strain: ATCC 33387

--- a/data/normalized_yaml/bacterial/desulfovibrio_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_medium.yaml
@@ -160,6 +160,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.739443+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Desulfovibrio intestinalis
   term:

--- a/data/normalized_yaml/bacterial/geobacter_sulfurreducens_medium.yaml
+++ b/data/normalized_yaml/bacterial/geobacter_sulfurreducens_medium.yaml
@@ -391,6 +391,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.743865+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Geobacter sulfurreducens
   term:

--- a/data/normalized_yaml/bacterial/nutrient_broth.yaml
+++ b/data/normalized_yaml/bacterial/nutrient_broth.yaml
@@ -40,8 +40,8 @@ source_data:
   notes: 'database_id: nutrient broth; url: https://github.com/CultureBotAI/CultureBotHT'
 variants:
 - name: nutrient_broth_mycolicibacterium_cosmeticum_dm11_25c
-  description: Nutrient broth growth condition for Mycolicibacterium cosmeticum
-    strain DM-11 at 25 C.
+  description: Nutrient broth growth condition for Mycolicibacterium cosmeticum strain
+    DM-11 at 25 C.
   modifications:
   - Use Mycolicibacterium cosmeticum strain DM-11 as the target strain.
   - Incubate at 25 C.
@@ -50,10 +50,10 @@ variants:
   evidence:
   - reference: PMID:16461697
     supports: SUPPORT
-    snippet: The strain, designated strain DM-11, grew optimally at 25 degrees C
-      and had a doubling time of 29.2 h.
-    explanation: Literature evidence supports a strain-specific 25 C growth
-      condition variant under the parent Nutrient Broth record.
+    snippet: The strain, designated strain DM-11, grew optimally at 25 degrees C and
+      had a doubling time of 29.2 h.
+    explanation: Literature evidence supports a strain-specific 25 C growth condition
+      variant under the parent Nutrient Broth record.
 curation_history:
 - timestamp: '2026-03-18T04:31:15.467479+00:00'
   curator: import_from_culturebotht.py
@@ -67,8 +67,14 @@ curation_history:
   curator: literature_review_apply
   action: ADDED_GROWTH_EVIDENCE
   notes: organisms_added=1 metrics_added=1 genomes_added=0
+- timestamp: '2026-08-06T00:58:02.756697+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 data_quality_flags: []
 kg_microbe_match: mediadive.medium:681
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Mycolicibacterium cosmeticum
   term:

--- a/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
+++ b/data/normalized_yaml/bacterial/rhodobacter_sphaeroides_medium.yaml
@@ -239,6 +239,12 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-06T00:58:02.759218+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Rhodobacter sphaeroides
   term:

--- a/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
+++ b/data/normalized_yaml/bacterial/tryptic_soy_broth.yaml
@@ -188,6 +188,7 @@ variants:
     explanation: Smith and Zahnley report the study-specific TSBWD variant and the
       starch/maltose supplement levels used for Arthrobacter psychrolactophilus ATCC
       700733 growth.
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Arthrobacter psychrolactophilus
   term:
@@ -257,6 +258,11 @@ curation_history:
   notes: 'Replaced 1 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T00:58:02.767130+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 source_environment:
 - preferred_term: rhizosphere
   term:

--- a/data/normalized_yaml/specialized/bhis.yaml
+++ b/data/normalized_yaml/specialized/bhis.yaml
@@ -72,8 +72,8 @@ variants:
   modifications:
   - Incubate BHIS broth anaerobically for Brachyspira growth.
   - Source reports growth at 37 to 42 degrees C.
-  purpose: Capture strain-specific BHIS growth evidence under the parent BHIS
-    broth record.
+  purpose: Capture strain-specific BHIS growth evidence under the parent BHIS broth
+    record.
   evidence:
   - reference: PMID:8573497
     supports: SUPPORT
@@ -91,8 +91,14 @@ curation_history:
   curator: culturemech-id-assigner-v1.0
   action: Assigned CultureMech ID
   notes: 'Assigned stable identifier: CultureMech:015493'
+- timestamp: '2026-08-06T00:58:02.774578+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 data_quality_flags:
 - has_unmapped_ingredients
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Brachyspira pilosicoli
   term:
@@ -105,14 +111,14 @@ target_organisms:
   growth_metrics:
   - doubling_time_minutes: 60.0
     temperature_celsius: 37.0
-    measurement_conditions: BHIS broth; source reports 1 to 2 h doubling time,
-      maximum cell density of 2 x 10(9) cells per ml, and growth at 37 to 42
-      degrees C.
+    measurement_conditions: BHIS broth; source reports 1 to 2 h doubling time, maximum
+      cell density of 2 x 10(9) cells per ml, and growth at 37 to 42 degrees C.
     evidence:
     - reference: PMID:8573497
       supports: SUPPORT
-      snippet: In BHIS broth, P43/6/78T cells had a doubling time of 1 to 2 h and grew
-        to a maximum cell density of 2 x 10(9) cells per ml at 37 to 42 degrees C.
+      snippet: In BHIS broth, P43/6/78T cells had a doubling time of 1 to 2 h and
+        grew to a maximum cell density of 2 x 10(9) cells per ml at 37 to 42 degrees
+        C.
       explanation: Auto-curated from specialized media review; the source reports
         quantitative growth of Brachyspira pilosicoli P43/6/78T in BHIS broth.
     is_max_attainment: false

--- a/data/normalized_yaml/specialized/m9.yaml
+++ b/data/normalized_yaml/specialized/m9.yaml
@@ -69,20 +69,19 @@ source_data:
   notes: 'database_id: M9; url: https://github.com/CultureBotAI/CultureBotHT'
 variants:
 - name: modified_m9_high_density_e_coli_expression
-  description: Modified M9 condition for high-density Escherichia coli protein
-    expression cultures.
+  description: Modified M9 condition for high-density Escherichia coli protein expression
+    cultures.
   modifications:
   - Use modified M9 medium and optimized growth conditions.
   - Grow Escherichia coli to high culture density.
-  purpose: Capture high-density modified-M9 growth evidence under the parent M9
-    record.
+  purpose: Capture high-density modified-M9 growth evidence under the parent M9 record.
   evidence:
   - reference: PMID:27709314
     supports: SUPPORT
-    snippet: Using a modified M9 medium and optimized growth conditions, we were
-      able to grow cells in linear log phase to an OD600 of up to 10.
-    explanation: Literature evidence supports modeling the modified high-density
-      M9 condition as a variant under the parent M9 record.
+    snippet: Using a modified M9 medium and optimized growth conditions, we were able
+      to grow cells in linear log phase to an OD600 of up to 10.
+    explanation: Literature evidence supports modeling the modified high-density M9
+      condition as a variant under the parent M9 record.
 curation_history:
 - timestamp: '2026-03-18T04:31:12.887972+00:00'
   curator: import_from_culturebotht.py
@@ -100,8 +99,14 @@ curation_history:
   curator: literature_review_apply
   action: ADDED_GROWTH_EVIDENCE
   notes: organisms_added=0 metrics_added=1 genomes_added=0
+- timestamp: '2026-08-06T00:58:02.778967+00:00'
+  curator: curate_organism_culture_type.py
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
+  changes: Set organism_culture_type=isolate (was unset)
 data_quality_flags:
 - has_unmapped_ingredients
+organism_culture_type: isolate
 target_organisms:
 - preferred_term: Escherichia coli
   term:

--- a/project.justfile
+++ b/project.justfile
@@ -218,6 +218,14 @@ triage-missing-compositions *args="":
 curate-medium-type *args="":
     uv run --extra dev python scripts/curate_medium_type.py {{args}}
 
+# Backfill organism_culture_type (isolate vs community) on records that name
+# target_organisms (#142). recommended:, so validate-strict never flags the gap.
+# Sets `isolate` where specific strains are named; leaves community signals for a
+# curator. Report-only without --apply.
+[group('Curation')]
+curate-organism-culture-type *args="":
+    uv run --extra dev python scripts/curate_organism_culture_type.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/curate_organism_culture_type.py
+++ b/scripts/curate_organism_culture_type.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Backfill organism_culture_type on records that name target_organisms (#142).
+
+`organism_culture_type` distinguishes a pure-isolate medium (`isolate`) from one
+targeting a mixed community (`community`). It is `recommended:`, not `required:`,
+so `validate-strict` never flags its absence — and it is unset on 40 of the 50
+records that name a target organism.
+
+## Why it is inferable, and where the line is
+
+The enum defines `isolate` as "Pure culture of one or more specific strains" and
+`community` as a "Mixed/consortium culture of multiple organisms". The distinction
+is the NATURE of the target, not the count: a record naming seven specific gut
+strains is still an isolate medium (each grown as a pure culture), while a record
+targeting an unnamed consortium/enrichment is a community. So a record whose
+target_organisms are specific named strains/species is `isolate`; only a
+consortium/community/enrichment descriptor is `community`.
+
+This pass sets `isolate` on records whose targets are specific strains and carry
+no community/consortium signal. A record with such a signal is **left for a
+curator**, not guessed — the enum's `community` value should be a read assertion,
+not an inference from a keyword. (As of #142 no such record exists among the 40,
+so every one is set to `isolate`; the guard is for future imports.)
+
+## What this does NOT change
+
+`kgx_export` does not currently read this slot — it emits one `grows_in_medium`
+edge per organism regardless (see kgx_export.py). Populating the slot is correct
+curation data (yaml_updater already writes it, and it is the natural qualifier a
+future organism↔medium edge would carry), but it does not by itself alter the
+exported graph today. The issue's claim that isolate and community media "export
+identically" is aspirational, not current behaviour.
+
+Report-only by default; `--apply` writes via record_io (minimal diff) and records
+a curation event.
+
+Usage::
+
+    just curate-organism-culture-type            # report
+    just curate-organism-culture-type --apply     # stamp `isolate`
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_io import write_record  # noqa: E402
+
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+SCHEMA = REPO / "src" / "culturemech" / "schema" / "culturemech.yaml"
+
+# A target described as a mixed/consortium/environmental culture rather than a
+# specific strain. Such a record is reported for a curator, never auto-set: the
+# `community` value must be asserted, not guessed from a keyword. The `[\s_-]?`
+# between words matters — record names are slugged with underscores, so a
+# `co_culture` medium would slip past a plain `co-?culture` (as one did in #142).
+_SEP = r"[\s_-]?"
+COMMUNITY_SIGNAL = re.compile(
+    r"consorti|communit|microbiom|microbiota|\bsludge\b|metagenom|"
+    # `co` + sep + `cult` catches co-culture AND co-cultivation, in either the
+    # spaced, hyphenated or underscored (slugged name) form — the separator was
+    # the #142 slip, and the stem must not exclude co-cultivation.
+    rf"co{_SEP}cult|mixed{_SEP}cultur|enrichment{_SEP}cultur|"
+    rf"environmental{_SEP}sample|\brumen\b",
+    re.I,
+)
+
+
+def organism_names(doc: dict[str, Any]) -> list[str]:
+    """Every human-readable name in target_organisms.
+
+    Each entry is either a bare string or a dict carrying `preferred_term` /
+    `name` (the evidence-bearing form). Both shapes appear in the corpus.
+    """
+    names: list[str] = []
+    for org in doc.get("target_organisms") or []:
+        if isinstance(org, dict):
+            names.append(str(org.get("preferred_term") or org.get("name") or ""))
+        else:
+            names.append(str(org))
+    return names
+
+
+def classify(doc: dict[str, Any]) -> tuple[str | None, str]:
+    """Return (value_to_set, reason). value is None when the record should be
+    left untouched — already set, no target_organisms, or a community signal a
+    curator must resolve."""
+    if not doc.get("target_organisms"):
+        return None, "no target_organisms"
+    if doc.get("organism_culture_type"):
+        return None, "already set"
+    names = organism_names(doc)
+    blob = " ".join(names) + " " + str(doc.get("name", ""))
+    if COMMUNITY_SIGNAL.search(blob):
+        return None, "community/consortium signal — leave for a curator"
+    n = len([x for x in names if x])
+    return "isolate", f"{n} specific strain(s) named; no community signal"
+
+
+def _set_before(doc: dict[str, Any], key: str, value: Any, before: str) -> dict[str, Any]:
+    """Return a new dict with `key: value` inserted immediately before `before`,
+    preserving order otherwise, so the diff places the slot next to the organisms
+    it describes rather than appending it after the curation history."""
+    out: dict[str, Any] = {}
+    for k, v in doc.items():
+        if k == before:
+            out[key] = value
+        if k != key:
+            out[k] = v
+    if key not in out:  # `before` absent for some reason: fall back to append
+        out[key] = value
+    return out
+
+
+def scan_parsed(records) -> list[tuple[Path, dict[str, Any], str]]:
+    """Records needing a value, from already-parsed (path, doc) pairs. Split out so
+    the corpus test can reuse a session-scoped fixture instead of re-parsing ~15.9k
+    files (#191)."""
+    out = []
+    for path, doc in records:
+        if not isinstance(doc, dict):
+            continue
+        value, _reason = classify(doc)
+        if value is not None:
+            out.append((path, doc, value))
+    return out
+
+
+def community_signal_records(records) -> list[tuple[Path, list[str]]]:
+    """Records with target_organisms, no culture type, and a community signal —
+    the ones this script deliberately does not touch."""
+    out = []
+    for path, doc in records:
+        if not isinstance(doc, dict):
+            continue
+        value, reason = classify(doc)
+        if value is None and reason.startswith("community"):
+            out.append((path, organism_names(doc)))
+    return out
+
+
+def scan(normalized: Path) -> tuple[list, list]:
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(errors="replace"))
+        except (yaml.YAMLError, OSError):
+            continue
+        records.append((path, doc))
+    return scan_parsed(records), community_signal_records(records)
+
+
+def apply_value(path: Path, doc: dict[str, Any], value: str) -> bool:
+    """Stamp the slot next to target_organisms, record a curation event, write."""
+    n = len([x for x in organism_names(doc) if x])
+    doc = _set_before(doc, "organism_culture_type", value, before="target_organisms")
+    record_curation_event(
+        doc,
+        curator="curate_organism_culture_type.py",
+        action="SET_ORGANISM_CULTURE_TYPE",
+        notes=f"Inferred {value}: {n} specific strain(s) named, no community signal (#142)",
+        changes=f"Set organism_culture_type={value} (was unset)",
+    )
+    return write_record(path, doc)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--apply", action="store_true",
+                    help="Write the inferred value. Default is report-only.")
+    args = ap.parse_args(argv)
+
+    to_set, community = scan(args.normalized_dir)
+
+    print(f"{len(to_set)} record(s) with target_organisms but no organism_culture_type "
+          f"are inferable as `isolate`:")
+    for path, _doc, value in to_set[:60]:
+        print(f"  {str(path.relative_to(args.normalized_dir))[:56]:58s} -> {value}")
+    if len(to_set) > 60:
+        print(f"  ... and {len(to_set) - 60} more")
+
+    if community:
+        print(f"\n{len(community)} record(s) carry a community/consortium signal and are "
+              f"LEFT for a curator (not guessed):")
+        for path, names in community:
+            print(f"  {str(path.relative_to(args.normalized_dir))[:56]:58s} {names}")
+
+    if not args.apply:
+        print("\nReport only. Re-run with --apply to stamp `isolate`.")
+        return 0
+
+    written = 0
+    for path, doc, value in to_set:
+        if apply_value(path, doc, value):
+            written += 1
+    print(f"\nStamped {written} record(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/curate_organism_culture_type.py
+++ b/scripts/curate_organism_culture_type.py
@@ -104,6 +104,10 @@ def classify(doc: dict[str, Any]) -> tuple[str | None, str]:
     if COMMUNITY_SIGNAL.search(blob):
         return None, "community/consortium signal — leave for a curator"
     n = len([x for x in names if x])
+    if n == 0:
+        # Entries present but none carry a name — `isolate` would be a guess about
+        # a record we cannot actually read. Leave it for a curator.
+        return None, "target_organisms present but no organism name — leave for a curator"
     return "isolate", f"{n} specific strain(s) named; no community signal"
 
 

--- a/tests/test_organism_culture_type.py
+++ b/tests/test_organism_culture_type.py
@@ -76,6 +76,14 @@ def test_already_set_and_no_organisms_are_skipped(oct):
     assert oct.classify({"name": "no organisms here"})[0] is None
 
 
+def test_nameless_organism_entries_are_left_for_a_curator(oct):
+    """target_organisms present but no readable name is not evidence of an isolate;
+    `isolate` there would be a guess about an unreadable record."""
+    value, reason = oct.classify({"target_organisms": [{"strain": "x"}, {}]})
+    assert value is None
+    assert "no organism name" in reason
+
+
 def test_slot_is_placed_before_target_organisms(oct):
     doc = {"name": "x", "category": "bacterial",
            "target_organisms": [{"preferred_term": "E. coli"}],

--- a/tests/test_organism_culture_type.py
+++ b/tests/test_organism_culture_type.py
@@ -1,0 +1,100 @@
+"""Guard the organism_culture_type backfill and its recurrence (#142).
+
+`organism_culture_type` is `recommended:`, so validate-strict never flags a record
+that names target_organisms but leaves it unset. This backfilled the 40 such
+records: 39 to `isolate` (specific strains named), and one syntrophic co-culture
+left for a curator. These tests pin the inference and guard against a fresh import
+reintroducing the gap.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def oct():
+    return _load("curate_organism_culture_type")
+
+
+def test_specific_strains_are_isolate(oct):
+    doc = {"target_organisms": [{"preferred_term": "Escherichia coli", "strain": "K-12"}]}
+    value, _ = oct.classify(doc)
+    assert value == "isolate"
+
+
+def test_multiple_named_strains_are_still_isolate(oct):
+    """The enum is `Pure culture of one or more specific strains` — count is not
+    the axis. Seven named gut strains is an isolate medium, not a community."""
+    doc = {"target_organisms": [{"preferred_term": n} for n in
+                                ["Bacteroides ureolyticus", "Prevotella bivia",
+                                 "Fusobacterium nucleatum"]]}
+    assert oct.classify(doc)[0] == "isolate"
+
+
+@pytest.mark.parametrize("name", [
+    "medium_for_co_culture_of_strain_jt",      # underscore — the #142 slip
+    "medium for co-culture of strain jt",       # hyphen
+    "medium for co culture of strain jt",       # space
+    "cocultivation medium",                     # closed-up (cocultur)
+])
+def test_coculture_is_left_for_a_curator(oct, name):
+    """A co-culture is a community case; the separator between `co` and `culture`
+    must not decide whether it is caught (it did in #142). None of these may be
+    auto-set to isolate."""
+    doc = {"name": name, "target_organisms": [{"preferred_term": "Pelotomaculum sp."},
+                                              {"preferred_term": "Methanospirillum hungatei"}]}
+    value, reason = oct.classify(doc)
+    assert value is None
+    assert reason.startswith("community")
+
+
+@pytest.mark.parametrize("signal", ["consortium", "microbial community",
+                                     "activated sludge", "rumen fluid", "microbiome"])
+def test_community_signals_are_left_for_a_curator(oct, signal):
+    doc = {"name": f"{signal} medium", "target_organisms": [{"preferred_term": "mixed"}]}
+    assert oct.classify(doc)[0] is None
+
+
+def test_already_set_and_no_organisms_are_skipped(oct):
+    assert oct.classify({"target_organisms": [{"preferred_term": "E. coli"}],
+                         "organism_culture_type": "isolate"})[0] is None
+    assert oct.classify({"name": "no organisms here"})[0] is None
+
+
+def test_slot_is_placed_before_target_organisms(oct):
+    doc = {"name": "x", "category": "bacterial",
+           "target_organisms": [{"preferred_term": "E. coli"}],
+           "ingredients": []}
+    out = oct._set_before(doc, "organism_culture_type", "isolate", before="target_organisms")
+    keys = list(out.keys())
+    assert keys.index("organism_culture_type") == keys.index("target_organisms") - 1
+    assert out["organism_culture_type"] == "isolate"
+    # every original key survives, none duplicated
+    assert set(keys) == set(doc) | {"organism_culture_type"}
+
+
+def test_no_inferable_record_is_left_unset(oct, corpus):
+    """Recurrence guard (#142): after the backfill, no record that names specific
+    strains should still be missing organism_culture_type. A fresh import that
+    reintroduces the shape fails here. Community-signal records are excluded — the
+    script deliberately leaves those for a curator, so they are not in this set."""
+    pending = oct.scan_parsed(corpus)
+    assert pending == [], (
+        "records name target_organisms (specific strains) but lack "
+        f"organism_culture_type: {[str(p) for p, _d, _v in pending]}. "
+        "Run `just curate-organism-culture-type --apply`.")


### PR DESCRIPTION
Closes #142.

## Problem
`organism_culture_type` (isolate vs community) is `recommended:`, not `required:`,
so `validate-strict` never flagged that **40 of the 50** records naming a target
organism left it unset.

## What this does
- Adds `just curate-organism-culture-type` — report-only by default; `--apply`
  writes via `record_io` (minimal diff) and records a curation event.
- **Stamps `isolate` on 39 records.** The enum defines `isolate` as "Pure culture
  of one or more specific strains" — the axis is the *nature* of the target, not
  the count, so a record naming seven specific gut strains is still an isolate
  medium. All 39 name specific strains/species.
- **Leaves 1 record for a curator:** the syntrophic co-culture
  `medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei` (*Pelotomaculum*
  sp. + *Methanospirillum hungatei* grown together). `community` should be a read
  assertion, not a keyword guess, so the script reports it rather than setting it.
- **Recurrence guard:** `test_no_inferable_record_is_left_unset` fails if a fresh
  import names specific strains without the slot — the gap cannot silently return.

## A bug caught before applying
The community-signal detector first missed the co-culture record because its name
is slugged `co_culture` (underscore) and the regex only allowed `co-?culture`. The
separator between `co` and `cult` must not decide whether a co-culture is caught;
the stem is now `co[\s_-]?cult`, covering co-culture / co culture / co_culture /
co-cultivation, with a parametrized regression test.

## Correcting the issue's impact claim
The issue says `kgx_export` reads this slot and that isolate/community media
"export identically" without it. **`kgx_export` does not currently read it** — it
emits one `grows_in_medium` edge per organism regardless (kgx_export.py:105).
Populating the slot is correct curation data (`yaml_updater` already writes it, and
it is the natural qualifier a future organism↔medium edge would carry), but it does
not change the exported graph today.

## Diff note
16 of the 39 records also had long `notes`/`snippet` lines re-wrapped to the corpus
width convention — the one-time normalization `record_io` performs on records a
previous `width=120` run had reflowed (#141). Semantically lossless.

## Testing
- `pytest tests/test_organism_culture_type.py` — 14 passed (incl. corpus recurrence guard).
- `linkml-validate -C MediaRecipe` on changed records — no issues.
- `just curate-organism-culture-type` — reports 0 to-set, 1 left-for-curator (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)