### PR TITLE
Give artifact_writers per-scope resolution so a shadowed name is not a write (#211)

### DIFF
--- a/scripts/artifact_writers.py
+++ b/scripts/artifact_writers.py
@@ -35,12 +35,15 @@ to follow, yields "unknown" rather than a guess. A wrong "yes" is worse than an
 honest "unknown", because the whole point is to stop asserting things that are not
 established.
 
-## Known limitation
+## Scope
 
-There is no scope analysis, so a local variable that shadows a module constant and
-writes somewhere else produces a false "yes". No script in this repo currently does
-that, and ten spot-checked attributions all held up, but it is a real hole —
-tracked in #211 rather than left to be discovered.
+Analysis is per-scope (#211). A name is resolved to the artifact only where it is
+actually bound to it: a function that reassigns a module constant's name to a
+different path *shadows* the constant, so a write there is not a write to the
+artifact. Module bindings flow INTO a function (that is how the `args.out` write
+finds `DEFAULT_OUT`), but a local rebinding to a non-artifact expression drops the
+name for the rest of that scope. Statements are processed in document order so the
+shadow takes effect before the write it guards.
 """
 
 from __future__ import annotations
@@ -50,67 +53,31 @@ from pathlib import Path
 
 WRITE_METHODS = {"write_text", "write_bytes", "write"}
 DUMP_FUNCS = {"dump", "safe_dump", "to_csv", "writerow", "writerows", "writeheader"}
+_SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
 
 
-class _Tracer(ast.NodeVisitor):
-    """Names bound to the artifact path, and names written through."""
+class _Scope:
+    """One lexical scope: which names resolve to the artifact here, and whether a
+    write to it happens. ``inherited`` seeds the names an enclosing scope bound to
+    the artifact; a local rebinding to a non-artifact expression removes one."""
 
-    def __init__(self, basename: str) -> None:
+    def __init__(self, basename: str, inherited: set[str]) -> None:
         self.basename = basename
-        self.bound: set[str] = set()
-        self.written: set[str] = set()
-        self._opened_from: dict[str, str] = {}  # handle name -> path name
+        self.bound: set[str] = set(inherited)
+        self.wrote = False
+        self.any_bound = False   # did any scope bind a NEW name to the artifact?
+        self._opened_from: dict[str, str] = {}   # handle name -> path name
+        # child (def/class) nodes with the bindings visible where they are defined
+        self.children: list[tuple[ast.AST, set[str]]] = []
 
-    # --- binding ---------------------------------------------------------
-    def _mentions(self, node: ast.AST) -> bool:
-        return any(isinstance(n, ast.Constant) and isinstance(n.value, str)
-                   and self.basename in n.value
-                   for n in ast.walk(node))
+    def _mentions(self, node: ast.AST | None) -> bool:
+        return node is not None and any(
+            isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and self.basename in n.value for n in ast.walk(node))
 
-    def visit_Assign(self, node: ast.Assign) -> None:
-        if node.value is not None and self._mentions(node.value):
-            for tgt in node.targets:
-                if isinstance(tgt, ast.Name):
-                    self.bound.add(tgt.id)
-        # handle = X.open(...) / open(X, ...)
-        self._track_handle(node)
-        # writer = csv.DictWriter(handle, ...) — the write goes through the writer
-        # object, so the chain handle -> writer must be followed or every
-        # DictWriter-based report looks unwritten.
-        self._track_writer_object(node)
-        self.generic_visit(node)
-
-    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        if node.value is not None and self._mentions(node.value) and isinstance(node.target, ast.Name):
-            self.bound.add(node.target.id)
-        self.generic_visit(node)
-
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        """Bind parameters whose DEFAULT is the artifact path.
-
-        `def collect(out: Path = DEFAULT_OUT)` is common here. Positional defaults
-        align to the LAST n parameters, so the pairing is done from the right;
-        getting it wrong would bind the wrong name and invent a writer.
-        """
-        args = node.args
-        positional = [a.arg for a in args.args]
-        for name, default in zip(positional[len(positional) - len(args.defaults):],
-                                 args.defaults, strict=True):
-            if self._mentions(default):
-                self.bound.add(name)
-        for kwarg, default in zip([a.arg for a in args.kwonlyargs],
-                                  args.kw_defaults, strict=True):
-            if default is not None and self._mentions(default):
-                self.bound.add(kwarg)
-        self.generic_visit(node)
-
-    # --- writing ---------------------------------------------------------
     def _root_name(self, node: ast.AST) -> str | None:
-        """The name a path expression resolves to.
-
-        `args.out` resolves to "out", not "args": the argparse dest is what the
-        binding pass records, since that is where the module constant ends up.
-        """
+        """The name a path expression resolves to. `args.out` resolves to "out"
+        (the argparse dest that carries the module constant), not "args"."""
         if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
             if node.attr in self.bound:
                 return node.attr
@@ -118,11 +85,66 @@ class _Tracer(ast.NodeVisitor):
             node = node.value
         return node.id if isinstance(node, ast.Name) else None
 
-    def _track_handle(self, node: ast.Assign) -> None:
-        call = node.value
-        target = node.targets[0] if node.targets else None
-        if not isinstance(call, ast.Call) or not isinstance(target, ast.Name):
+    # --- ordered, scope-respecting walk ----------------------------------
+    def run(self, body: list[ast.stmt]) -> tuple[bool, bool]:
+        """Process ``body`` in document order (descending into control flow but not
+        into nested def/class scopes), then recurse into those child scopes.
+        Returns ``(wrote, any_bound)`` aggregated over this scope and its children."""
+        for stmt in body:
+            self._walk(stmt)
+        wrote, any_bound = self.wrote, self.any_bound
+        for node, visible in self.children:
+            child_wrote, child_bound = _analyze_child(node, self.basename, visible)
+            wrote = wrote or child_wrote
+            any_bound = any_bound or child_bound
+        return wrote, any_bound
+
+    def _walk(self, node: ast.AST) -> None:
+        if isinstance(node, _SCOPE_NODES):
+            # A nested scope. Its parameter DEFAULTS are evaluated here, so record
+            # the def with the bindings currently visible; the child scope handles
+            # its own params and body.
+            self.children.append((node, set(self.bound)))
             return
+        if isinstance(node, ast.Assign):
+            self._on_assign(node)
+        elif isinstance(node, ast.AnnAssign):
+            self._on_annassign(node)
+        elif isinstance(node, ast.With):
+            for item in node.items:
+                if isinstance(item.context_expr, ast.Call) and isinstance(item.optional_vars, ast.Name):
+                    self._track_handle(item.optional_vars, item.context_expr)
+        elif isinstance(node, ast.Call):
+            self._on_call(node)
+        for child in ast.iter_child_nodes(node):
+            self._walk(child)
+
+    # --- binding ---------------------------------------------------------
+    def _on_assign(self, node: ast.Assign) -> None:
+        mentions = self._mentions(node.value)
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                if mentions:
+                    self.bound.add(tgt.id)
+                    self.any_bound = True
+                elif tgt.id in self.bound:
+                    # Rebound to something that is NOT the artifact: shadow it for
+                    # the rest of this scope (#211).
+                    self.bound.discard(tgt.id)
+                    self._opened_from.pop(tgt.id, None)
+        if isinstance(node.value, ast.Call) and node.targets and isinstance(node.targets[0], ast.Name):
+            self._track_handle(node.targets[0], node.value)
+            self._track_writer_object(node.targets[0], node.value)
+
+    def _on_annassign(self, node: ast.AnnAssign) -> None:
+        if isinstance(node.target, ast.Name):
+            if self._mentions(node.value):
+                self.bound.add(node.target.id)
+                self.any_bound = True
+            elif node.value is not None and node.target.id in self.bound:
+                self.bound.discard(node.target.id)
+
+    def _track_handle(self, target: ast.Name, call: ast.Call) -> None:
         path_name = mode = None
         if isinstance(call.func, ast.Attribute) and call.func.attr == "open":
             path_name = self._root_name(call.func.value)
@@ -137,31 +159,18 @@ class _Tracer(ast.NodeVisitor):
         if path_name and isinstance(mode, str) and ("w" in mode or "a" in mode):
             self._opened_from[target.id] = path_name
 
-    def _track_writer_object(self, node: ast.Assign) -> None:
-        call = node.value
-        target = node.targets[0] if node.targets else None
-        if not isinstance(call, ast.Call) or not isinstance(target, ast.Name):
-            return
+    def _track_writer_object(self, target: ast.Name, call: ast.Call) -> None:
         for arg in call.args:
             name = self._root_name(arg)
             if name and name in self._opened_from:
                 self._opened_from[target.id] = self._opened_from[name]
                 return
 
-    def visit_With(self, node: ast.With) -> None:
-        for item in node.items:
-            call = item.context_expr
-            if isinstance(call, ast.Call) and isinstance(item.optional_vars, ast.Name):
-                fake = ast.Assign(targets=[item.optional_vars], value=call)
-                self._track_handle(fake)
-        self.generic_visit(node)
-
-    def visit_Call(self, node: ast.Call) -> None:
+    def _on_call(self, node: ast.Call) -> None:
         func = node.func
-        # The dominant pattern in this repo: the path is a module constant used as
-        # an argparse default, and the write goes through `args.out`. Without this
-        # the tracer scored 1/6 on known cases, because the binding flows through
-        # argparse rather than through a direct assignment.
+        # Dominant pattern here: the path is a module constant used as an argparse
+        # default, and the write goes through `args.out`. The default resolves
+        # against the bindings visible at this point (module constant inherited).
         if isinstance(func, ast.Attribute) and func.attr == "add_argument":
             dest = None
             for arg in node.args:
@@ -178,20 +187,43 @@ class _Tracer(ast.NodeVisitor):
                         default_bound = True
             if dest and default_bound:
                 self.bound.add(dest)
+                self.any_bound = True
         if isinstance(func, ast.Attribute):
             if func.attr in WRITE_METHODS:
                 name = self._root_name(func.value)
-                if name:
-                    self.written.add(self._opened_from.get(name, name))
+                if name and self._opened_from.get(name, name) in self.bound:
+                    self.wrote = True
             elif func.attr in DUMP_FUNCS:
                 for arg in node.args:
                     name = self._root_name(arg)
-                    if name:
-                        self.written.add(self._opened_from.get(name, name))
+                    if name and self._opened_from.get(name, name) in self.bound:
+                        self.wrote = True
                 name = self._root_name(func.value)
-                if name and name in self._opened_from:
-                    self.written.add(self._opened_from[name])
-        self.generic_visit(node)
+                if name and name in self._opened_from and self._opened_from[name] in self.bound:
+                    self.wrote = True
+
+
+def _analyze_child(node: ast.AST, basename: str, inherited: set[str]) -> tuple[bool, bool]:
+    """Analyze a nested def/class/lambda scope, binding parameter defaults locally.
+    Returns ``(wrote, any_bound)``."""
+    scope = _Scope(basename, inherited)
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        args = node.args
+        positional = [a.arg for a in args.args]
+        for name, default in zip(positional[len(positional) - len(args.defaults):],
+                                 args.defaults, strict=True):
+            if scope._mentions(default):
+                scope.bound.add(name)
+                scope.any_bound = True
+            elif name in scope.bound:
+                scope.bound.discard(name)   # param shadows an inherited name
+        for kwarg, default in zip([a.arg for a in args.kwonlyargs], args.kw_defaults, strict=True):
+            if default is not None and scope._mentions(default):
+                scope.bound.add(kwarg)
+                scope.any_bound = True
+    # A lambda's body is a single expression, not a statement list.
+    body = node.body if isinstance(node.body, list) else [ast.Expr(value=node.body)]
+    return scope.run(body)
 
 
 def writes_artifact(source: str, basename: str) -> str:
@@ -200,13 +232,24 @@ def writes_artifact(source: str, basename: str) -> str:
         tree = ast.parse(source)
     except SyntaxError:
         return "unknown"
-    tracer = _Tracer(basename)
-    tracer.visit(tree)
-    if not tracer.bound:
-        # The path is not bound to a name we can follow. If the module writes
-        # nothing at all, "no" is still established; otherwise say so.
-        return "no" if not tracer.written else "unknown"
-    return "yes" if tracer.bound & tracer.written else "no"
+    wrote, any_bound = _Scope(basename, set()).run(tree.body)
+    if wrote:
+        return "yes"
+    if any_bound:
+        # The path was bound to a followable name and no write went through it.
+        return "no"
+    # The path is not bound to a name we can follow. If the module writes SOMETHING
+    # (through a path built too indirectly to trace) say "unknown" rather than "no",
+    # since it could be writing the artifact by a route we cannot see.
+    return "unknown" if _writes_something(tree) else "no"
+
+
+def _writes_something(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and node.func.attr in (WRITE_METHODS | DUMP_FUNCS):
+            return True
+    return False
 
 
 def classify_file(path: Path, basename: str) -> str:

--- a/tests/test_artifact_writers.py
+++ b/tests/test_artifact_writers.py
@@ -103,6 +103,33 @@ def load():
     assert aw.writes_artifact(src, "reg.tsv") == "no"
 
 
+def test_a_write_inside_control_flow_is_detected(aw):
+    """Per-scope analysis must still descend into if/for/while/try within a scope —
+    the write is rarely at the top of the function body."""
+    src = '''
+from pathlib import Path
+OUT = Path("data/report.tsv")
+def main(items):
+    for x in items:
+        if x:
+            OUT.write_text(str(x))
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
+def test_a_write_in_a_method_is_detected(aw):
+    """A class body is a scope and its methods are nested scopes; a module binding
+    must still reach a write in a method."""
+    src = '''
+from pathlib import Path
+OUT = Path("data/report.tsv")
+class Writer:
+    def run(self):
+        OUT.write_text("x")
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
 def test_unparseable_source_is_unknown_not_a_guess(aw):
     """A wrong "yes" is worse than an honest "unknown" — the point is to stop
     asserting things that are not established."""

--- a/tests/test_artifact_writers.py
+++ b/tests/test_artifact_writers.py
@@ -143,14 +143,10 @@ def test_the_manifest_separates_writes_from_mentions():
         "a reader is listed as a writer again (#209)")
 
 
-def test_shadowing_is_a_known_false_positive(aw):
-    """#211. Pinned as CURRENT behaviour, not as desired behaviour.
-
-    Without scope analysis a local rebinding of a module constant's name looks
-    like a write to the constant's path. No script here does this today. If a fix
-    lands, this test should flip to expecting "no" — it exists so the hole is
-    visible rather than forgotten.
-    """
+def test_a_shadowed_constant_is_not_a_write(aw):
+    """#211 fixed. A function that rebinds a module constant's name to a different
+    path and writes there is NOT writing the constant's artifact — per-scope
+    analysis with document-order shadowing catches it."""
     src = '''
 from pathlib import Path
 OUT = Path("data/report.tsv")
@@ -158,4 +154,33 @@ def unrelated():
     OUT = Path("/tmp/other.tsv")
     OUT.write_text("x")
 '''
+    assert aw.writes_artifact(src, "report.tsv") == "no"
+
+
+def test_a_write_before_the_shadow_still_counts(aw):
+    """Document order matters: a genuine write to the module constant, followed
+    later by a local rebinding, is still a write. The shadow only guards writes
+    after it, in its own scope."""
+    src = '''
+from pathlib import Path
+OUT = Path("data/report.tsv")
+def writer():
+    OUT.write_text("real")
+
+def unrelated():
+    OUT = Path("/tmp/other.tsv")
+    OUT.write_text("x")
+'''
     assert aw.writes_artifact(src, "report.tsv") == "yes"
+
+
+def test_a_parameter_can_shadow_an_inherited_binding(aw):
+    """A parameter reusing a constant's name, defaulting to something else, shadows
+    the module binding inside that function."""
+    src = '''
+from pathlib import Path
+OUT = Path("data/report.tsv")
+def helper(OUT=None):
+    OUT.write_text("x")
+'''
+    assert aw.writes_artifact(src, "report.tsv") == "no"


### PR DESCRIPTION
Closes #211.

## The bug
`writes_artifact` collected `bound` names and `written` names across the whole
module with **no scope separation**, so a local variable that shadows a module
constant and writes elsewhere produced a false "yes":

```python
OUT = Path("data/report.tsv")
def unrelated():
    OUT = Path("/tmp/other.tsv")   # shadows the constant
    OUT.write_text("x")            # -> report.tsv wrongly reported as written
```

That is the `writes` column — the one a curator trusts most to tell a current-view
artifact from a snapshot.

## The fix
Analysis is now **per-scope, in document order**:
- Module bindings flow *into* a function (so the dominant `args.out` →
  `DEFAULT_OUT` write still resolves).
- A local rebinding to a non-artifact expression **shadows** the name for the rest
  of that scope; a parameter can shadow an inherited binding too.
- `run` returns `(wrote, any_bound)`. The `any_bound` signal distinguishes an
  honest **unknown** (path never bound to a followable name, yet something is
  written) from **no** — replacing a separate heuristic that missed the
  argparse-`default=` pattern and mis-scored real writers.

## Verification
- The four adversarial cases from #211 now resolve correctly (shadow → `no`).
- **Every existing pattern test and all nine real-repo attributions still pass**
  (19/19), and `tests/test_derived_artifacts.py` + `tests/test_report_artifacts.py`
  are green.
- A fresh `derived_artifacts.tsv` is **byte-identical to main** — no real
  attribution moved; the fix only closes the hole.
- The #211 pin-test flips to expect `no`, plus two new scope tests
  (write-before-shadow still counts; a parameter can shadow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)