### PR TITLE
Repair the DSMZ 309 neomycin composition and gate the defect at zero (#181)

### DIFF
--- a/data/normalized_yaml/bacterial/KOMODO_309_NEOMYCIN_AGAR.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_309_NEOMYCIN_AGAR.yaml
@@ -40,6 +40,12 @@ ingredients:
   concentration:
     value: '4'
     unit: G_PER_L
+- preferred_term: Neomycin
+  concentration:
+    value: '1.0'
+    unit: MG_PER_ML
+  notes: Selective agent; recovered from the DSMZ Medium 309 source duplicate (neomycin_agar),
+    which states 1.0 mg/ml.
 applications:
 - Microbial cultivation
 curation_history:
@@ -69,6 +75,12 @@ curation_history:
   notes: 'Replaced 1 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T05:34:58.048209+00:00'
+  curator: curate_selective_agent.py
+  action: ADDED_SELECTIVE_AGENT
+  notes: Added neomycin 1.0 mg/ml, recovered from the record's own preparation_steps
+    / source duplicate (#181)
+  changes: Added ingredient Neomycin (1.0 MG_PER_ML)
 parent_media:
   path: data/normalized_yaml/bacterial/neomycin_agar.yaml
   relationship: SOURCE_DUPLICATE

--- a/data/normalized_yaml/bacterial/neomycin_agar.yaml
+++ b/data/normalized_yaml/bacterial/neomycin_agar.yaml
@@ -39,6 +39,12 @@ ingredients:
   concentration:
     value: '4'
     unit: G_PER_L
+- preferred_term: Neomycin
+  concentration:
+    value: '1.0'
+    unit: MG_PER_ML
+  notes: Selective agent; added aseptically to a final concentration of 1.0 mg/ml
+    per preparation step 2.
 preparation_steps:
 - step_number: 1
   action: ADJUST_PH
@@ -71,6 +77,12 @@ curation_history:
   notes: 'Replaced 1 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-06T05:34:58.042742+00:00'
+  curator: curate_selective_agent.py
+  action: ADDED_SELECTIVE_AGENT
+  notes: Added neomycin 1.0 mg/ml, recovered from the record's own preparation_steps
+    / source duplicate (#181)
+  changes: Added ingredient Neomycin (1.0 MG_PER_ML)
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_309_NEOMYCIN_AGAR.yaml
   relationship: SOURCE_DUPLICATE

--- a/scripts/audit_selective_agent_mismatch.py
+++ b/scripts/audit_selective_agent_mismatch.py
@@ -22,17 +22,21 @@ was not defective; the VIEW of it was partial, and this script reproduced the sa
 partial view before concluding the corpus was broken.
 
 `composition_terms()` therefore spans `ingredients`, `solutions`, and the nested
-`solutions[].composition`. Current baseline: **2** records, both DSMZ Medium 309
-reached via two sources. Neither has a `solutions` entry, and the local mediadive
-extraction of medium 309 lacks the neomycin too — so the gap is upstream, not in
-this import, and is not locally recoverable.
+`solutions[].composition`. Current baseline: **0** records. The last two were both
+DSMZ Medium 309 (neomycin agar); its concentration turned out to be locally
+recoverable after all — the record's own `preparation_steps` state "add neomycin to
+a final concentration of 1.0 mg/ml" — so neomycin was added as an ingredient and
+its source-duplicate matched (#181). `composition_terms()` intentionally does NOT
+scan `preparation_steps`: prose there is not a structured component, and the right
+fix is to lift the agent into `ingredients`, not to teach the audit to accept prose.
 
 ## REPORT ONLY
 
-Recovering a lost concentration needs the upstream record, and a plausible guess
-that round-trips and validates is still false chemistry (#166). Where the source
-kept a concentration in the NAME ("LB + 50 ug/ml Kanamycin medium"), it is
-surfaced in `named_conc` for a curator — surfaced, not applied.
+Recovering a lost concentration needs a value that is actually recorded — the
+record's own name or preparation steps — not a plausible guess, which even when it
+round-trips and validates is still false chemistry (#166). Where the source kept a
+concentration in the NAME ("LB + 50 ug/ml Kanamycin medium"), it is surfaced in
+`named_conc` for a curator — surfaced, not applied.
 
 ## Traps, each hit while building this
 
@@ -52,7 +56,7 @@ surfaced in `named_conc` for a curator — surfaced, not applied.
 Usage::
 
     just audit-selective-agent-mismatch
-    just audit-selective-agent-mismatch --max-allowed 2    # current baseline
+    just audit-selective-agent-mismatch --max-allowed 0    # current baseline (regression gate)
 """
 
 from __future__ import annotations

--- a/tests/test_selective_agent_mismatch.py
+++ b/tests/test_selective_agent_mismatch.py
@@ -145,10 +145,11 @@ def test_corpus_count_matches_the_documented_baseline(aud, corpus):
     """
     normalized = REPO_ROOT / "data" / "normalized_yaml"
     rows = aud.audit_parsed([(str(p.relative_to(normalized)), d) for p, d in corpus])
-    assert len(rows) <= 2, (
-        f"{len(rows)} records now mismatch, above the documented baseline of 2. "
-        "Either a new defect landed or the agent list grew — update both the gate "
-        "and #181.")
+    assert len(rows) == 0, (
+        f"{len(rows)} records name a listed selective agent absent from their "
+        "composition, above the baseline of 0 (the DSMZ 309 pair was repaired in "
+        "#181). A new import reintroduced the defect, or the agent list grew; add "
+        "the agent from the record's own name/preparation_steps, or file it.")
 
 
 # --- #188: the concentration must belong to ITS agent ----------------------


### PR DESCRIPTION
Closes #181.

## What was left
The 13-record list in the issue was stale; once the audit learned to scan
`solutions` (#187/#193), only **2** records remained — both DSMZ Medium 309
(neomycin agar). The audit's docstring called the gap "upstream, not locally
recoverable."

## It was recoverable
`neomycin_agar` states, in its own `preparation_steps`:

> Aseptically add neomycin to a final concentration of **1.0 mg/ml** of medium.

So the value was recorded, not lost. This adds **Neomycin (1.0 MG_PER_ML)** as an
ingredient on that record and on its exact source duplicate (`KOMODO_309`),
recovered from tracked data rather than invented (respecting #166).

- **Left ungrounded** — "Neomycin" has no verified CHEBI mapping and the record's
  other ingredients (Beef extract, Peptone, …) carry none either; the grounding
  pipeline can key it later. No id guess.
- **The audit still won't scan `preparation_steps`** — prose is not a structured
  component; the correct fix is to lift the agent into `ingredients`, which is what
  this does.

## Gated at zero
The corpus count is now **0**, so the guard tightens from `<= 2` to `== 0` — a
regression gate for the known-agent family. A fresh import naming a listed agent it
omits now fails the pytest suite (which is in CI), so no separate workflow is needed.

## Testing
- `just audit-selective-agent-mismatch` → 0 affected records.
- `linkml-validate -C MediaRecipe` on both records → no issues.
- `pytest tests/test_selective_agent_mismatch.py` → 19 passed (incl. the tightened
  corpus guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)