### PR TITLE
Curate organism_culture_type=community on the DSMZ co-culture medium (#223)

### DIFF
--- a/data/normalized_yaml/archaea/medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397.yaml
+++ b/data/normalized_yaml/archaea/medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei_nbrc_100397.yaml
@@ -454,7 +454,10 @@ curation_history:
 - timestamp: '2026-06-08T23:19:46.921439+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-10T07:47:06.026168+00:00'
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
@@ -469,6 +472,13 @@ curation_history:
     Qiu 2004 (cited to Sekiguchi et al. 2000), and Qiu names the methanogen as DSM
     864 rather than NBRC 100397; treat both as evidence-backed but recipe-unverified.
     [added 2 organism(s), 0 variant(s)]'
+- timestamp: '2026-08-06T06:01:46.226804+00:00'
+  curator: coculture-community-curation-v1.0
+  action: SET_ORGANISM_CULTURE_TYPE
+  notes: 'Set community: syntrophic co-culture of Pelotomaculum sp. + Methanospirillum
+    hungatei grown together. Deferred from #142 (script does not guess community from
+    a keyword); resolved manually per #223.'
+  changes: Set organism_culture_type=community (was unset)
 solutions:
 - preferred_term: Vitamin solution*
   term:
@@ -506,6 +516,7 @@ solutions:
     unit: G_PER_L
   notes: See mediadive_30_Resazurin_solution.yaml for composition
   name: Unknown solution
+organism_culture_type: community
 target_organisms:
 - preferred_term: Pelotomaculum sp.
   term:


### PR DESCRIPTION
Closes #223 (follow-up from #142).

The #142 backfill set 39 records to `isolate` and deliberately left one for a
curator — `medium_for_co_culture_of_strain_jt_with_methanospirillum_hungatei` is a
**syntrophic co-culture** (*Pelotomaculum* sp. + *Methanospirillum hungatei* grown
together), i.e. `community`, not `isolate`. The backfill script does not assert
`community` from a name keyword; this resolves that one record manually with a
curation event.

- `linkml-validate -C MediaRecipe` → no issues.
- The #142 recurrence guard is unaffected (it excludes community-signal records).
- `just curate-organism-culture-type` now reports **0 to set, 0 left for a curator**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)