### PR TITLE
Export chem_formula.hydration_states in __all__, and guard the API (#220)

### DIFF
--- a/scripts/chem_formula.py
+++ b/scripts/chem_formula.py
@@ -29,6 +29,7 @@ __all__ = [
     "parse_formula",
     "parse_ontology_formula",
     "compare_formulas",
+    "hydration_states",
     "build_formula_lookup",
 ]
 

--- a/tests/test_chem_formula_api.py
+++ b/tests/test_chem_formula_api.py
@@ -1,0 +1,53 @@
+"""Guard that chem_formula's public API stays declared in __all__ (#220).
+
+#216 added `hydration_states` — a public helper called from
+validate_id_label_correspondence.py — without adding it to `__all__`, so
+`from chem_formula import *` silently omitted it and linters read it as
+non-public. This pins the invariant so the next public function cannot slip the
+same way: every top-level `def` whose name does not start with `_` must appear in
+`__all__`.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+CHEM_FORMULA = REPO_ROOT / "scripts" / "chem_formula.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("chem_formula", CHEM_FORMULA)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["chem_formula"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _public_functions() -> list[str]:
+    tree = ast.parse(CHEM_FORMULA.read_text())
+    return [n.name for n in tree.body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and not n.name.startswith("_")]
+
+
+def test_hydration_states_is_exported():
+    assert "hydration_states" in _load().__all__
+
+
+def test_every_public_function_is_in_all():
+    exported = set(_load().__all__)
+    missing = [f for f in _public_functions() if f not in exported]
+    assert not missing, (
+        f"public function(s) missing from chem_formula.__all__: {missing}. Add them, "
+        "or prefix with _ if they are not part of the API (#220).")
+
+
+def test_all_only_names_things_that_exist():
+    mod = _load()
+    absent = [name for name in mod.__all__ if not hasattr(mod, name)]
+    assert not absent, f"__all__ lists names that do not exist: {absent}"


### PR DESCRIPTION
Closes #220.

#216 added `hydration_states` — a documented public helper called from
`validate_id_label_correspondence.py` and covered by tests — but did not add it to
`chem_formula.__all__`. Impact is cosmetic (every caller uses
`chem_formula.hydration_states(...)`, which works regardless), but `from
chem_formula import *` omitted it and linters can read it as non-public.

- Adds `hydration_states` to `__all__`.
- Adds a **recurrence guard** (`tests/test_chem_formula_api.py`): every top-level
  public `def` must be in `__all__`; `__all__` must only name things that exist.
  That is exactly the check that would have caught #216's omission.

`chem_formula.py` is the hub copy; spokes pick this up on their next vendored sync.
There is no local drift gate that blocks it, and the new test is CultureMech-specific.

- `pytest tests/test_chem_formula_api.py` → 3 passed; `from chem_formula import *`
  now includes `hydration_states`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)