### PR TITLE
Flag 126 silently-empty media as incomplete_composition (#175)

### DIFF
--- a/data/normalized_yaml/archaea/KOMODO_131_METHANOBACTERIUM_THERMOAUTOTROPHICUM_MEDIUM.yaml
+++ b/data/normalized_yaml/archaea/KOMODO_131_METHANOBACTERIUM_THERMOAUTOTROPHICUM_MEDIUM.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOBACTERIUM THERMOAUTOTROPHICUM MEDIUM" to "methanobacterium_thermoautotrophicum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.351475+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/KOMODO_304_METHANOSARCINA_ACETIVORANS_medium.yaml
+++ b/data/normalized_yaml/archaea/KOMODO_304_METHANOSARCINA_ACETIVORANS_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOSARCINA ACETIVORANS medium" to "methanosarcina_acetivorans_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.358216+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/KOMODO_510_STYGIOLOBUS_medium.yaml
+++ b/data/normalized_yaml/archaea/KOMODO_510_STYGIOLOBUS_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''2.5-3.0'' -> {''min'': 2.5, ''max'': 3.0}'
+- timestamp: '2026-08-06T08:58:32.361497+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/aeropyrum_jxt_medium.yaml
+++ b/data/normalized_yaml/archaea/aeropyrum_jxt_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.0-7.2'' -> {''min'': 7.0, ''max'': 7.2}'
+- timestamp: '2026-08-06T08:58:32.362814+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/metallosphaera_medium.yaml
+++ b/data/normalized_yaml/archaea/metallosphaera_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METALLOSPHAERA medium" to "metallosphaera_medium" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.363922+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanocorpusculum_medium.yaml
+++ b/data/normalized_yaml/archaea/methanocorpusculum_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOCORPUSCULUM medium" to "methanocorpusculum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.365181+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanogenium_sp_medium.yaml
+++ b/data/normalized_yaml/archaea/methanogenium_sp_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOGENIUM SP. medium" to "methanogenium_sp_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.366253+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanolobus_ii_medium.yaml
+++ b/data/normalized_yaml/archaea/methanolobus_ii_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7'' -> {''min'': 6.8, ''max'': 7.0}'
+- timestamp: '2026-08-06T08:58:32.367202+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanosarcina_acetivorans_medium_replace_trimethylamine_hcl_with_methanol.yaml
+++ b/data/normalized_yaml/archaea/methanosarcina_acetivorans_medium_replace_trimethylamine_hcl_with_methanol.yaml
@@ -31,3 +31,11 @@ curation_history:
   notes: Normalized name from "METHANOSARCINA ACETIVORANS medium_replace_Trimethylamine-HCl_with_Methanol"
     to "methanosarcina_acetivorans_medium_replace_trimethylamine_hcl_with_methanol"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.368606+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanosarcina_frisia_medium.yaml
+++ b/data/normalized_yaml/archaea/methanosarcina_frisia_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7.0'' -> {''min'': 6.8, ''max'': 7.0}'
+- timestamp: '2026-08-06T08:58:32.369761+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanosarcina_thermophilic_medium.yaml
+++ b/data/normalized_yaml/archaea/methanosarcina_thermophilic_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "METHANOSARCINA (thermophilic) medium" to "methanosarcina_thermophilic_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.370913+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119.yaml
+++ b/data/normalized_yaml/archaea/methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119.yaml
@@ -35,3 +35,11 @@ curation_history:
   notes: Normalized name from "METHANOSARCINA (thermophilic) medium_replace_Rumen
     fluid, clarified_with_Sludge fluid (medium 119)" to "methanosarcina_thermophilic_medium_replace_rumen_fluid_clarified_with_sludge_fluid_medium_119"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.371946+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/archaea/thermophilic_methanosaeta_medium.yaml
+++ b/data/normalized_yaml/archaea/thermophilic_methanosaeta_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "THERMOPHILIC METHANOSAETA MEDIUM" to "thermophilic_methanosaeta_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.373074+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/4_times_concentrated_sea_water_medium_821.yaml
+++ b/data/normalized_yaml/bacterial/4_times_concentrated_sea_water_medium_821.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "4 times concentrated sea water (medium 821)" to "4_times_concentrated_sea_water_medium_821"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.374037+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/KOMODO_1254_NAUTILIA_NITRATIREDUCENS_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1254_NAUTILIA_NITRATIREDUCENS_MEDIUM.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "NAUTILIA NITRATIREDUCENS MEDIUM" to "nautilia_nitratireducens_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.375196+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/KOMODO_272_DESULFOVIBRIO_medium_choline.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_272_DESULFOVIBRIO_medium_choline.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO medium (choline)" to "desulfovibrio_medium_choline"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.376322+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.0-7.4'' -> {''min'': 7.0, ''max'': 7.4}'
+- timestamp: '2026-08-06T08:58:32.377425+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/KOMODO_7001_Trace_elements_medium_596.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_7001_Trace_elements_medium_596.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (medium 596)" to "trace_elements_medium_596"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.378465+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/KOMODO_787_ACETOBACTERIUM_DEHALOGENANS_medium.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_787_ACETOBACTERIUM_DEHALOGENANS_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ACETOBACTERIUM DEHALOGENANS medium" to "acetobacterium_dehalogenans_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.379545+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/acetobacterium_2_medium.yaml
+++ b/data/normalized_yaml/bacterial/acetobacterium_2_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ACETOBACTERIUM 2 medium" to "acetobacterium_2_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.380491+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/acetobacterium_carbinolicum_medium.yaml
+++ b/data/normalized_yaml/bacterial/acetobacterium_carbinolicum_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ACETOBACTERIUM CARBINOLICUM medium" to "acetobacterium_carbinolicum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.381777+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/acetobacterium_sp_komac1_medium.yaml
+++ b/data/normalized_yaml/bacterial/acetobacterium_sp_komac1_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ACETOBACTERIUM SP. KoMAc1 medium" to "acetobacterium_sp_komac1_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.382895+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/acetonema_medium.yaml
+++ b/data/normalized_yaml/bacterial/acetonema_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ACETONEMA medium" to "acetonema_medium" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.383827+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/anaerobic_acetoin_medium.yaml
+++ b/data/normalized_yaml/bacterial/anaerobic_acetoin_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ANAEROBIC ACETOIN medium" to "anaerobic_acetoin_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.384705+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/anaerobic_oxalate_medium.yaml
+++ b/data/normalized_yaml/bacterial/anaerobic_oxalate_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7.0'' -> {''min'': 6.8, ''max'': 7.0}'
+- timestamp: '2026-08-06T08:58:32.385839+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/anaerovibrio_burkinabensis_medium.yaml
+++ b/data/normalized_yaml/bacterial/anaerovibrio_burkinabensis_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7.2'' -> {''min'': 6.8, ''max'': 7.2}'
+- timestamp: '2026-08-06T08:58:32.386881+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_3_times_concentrated_medium_1137.yaml
@@ -30,3 +30,11 @@ curation_history:
   notes: Normalized name from "Artificial sea water, 3 times concentrated (medium
     1137)" to "artificial_sea_water_3_times_concentrated_medium_1137" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.387941+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_3_times_concentrated_medium_590.yaml
@@ -30,3 +30,11 @@ curation_history:
   notes: Normalized name from "Artificial sea water, 3 times concentrated (medium
     590)" to "artificial_sea_water_3_times_concentrated_medium_590" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.388952+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_1075.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_1075.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 1075)" to "artificial_sea_water_medium_1075"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.389983+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_246.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_246.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 246)" to "artificial_sea_water_medium_246"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.390937+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_343.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_343.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 343)" to "artificial_sea_water_medium_343"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.391878+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_405.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_405.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 405)" to "artificial_sea_water_medium_405"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.392821+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_600.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_600.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 600)" to "artificial_sea_water_medium_600"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.393747+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_600a.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_600a.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 600a)" to "artificial_sea_water_medium_600a"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.394662+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_sea_water_medium_607.yaml
+++ b/data/normalized_yaml/bacterial/artificial_sea_water_medium_607.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial sea water (medium 607)" to "artificial_sea_water_medium_607"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.395585+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_seawater_medium_1231.yaml
+++ b/data/normalized_yaml/bacterial/artificial_seawater_medium_1231.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''5.5-6.0'' -> {''min'': 5.5, ''max'': 6.0}'
+- timestamp: '2026-08-06T08:58:32.396501+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_seawater_medium_1326.yaml
+++ b/data/normalized_yaml/bacterial/artificial_seawater_medium_1326.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial seawater (medium 1326)" to "artificial_seawater_medium_1326"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.397553+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/artificial_tap_water_medium_1167.yaml
+++ b/data/normalized_yaml/bacterial/artificial_tap_water_medium_1167.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Artificial tap water (medium 1167)" to "artificial_tap_water_medium_1167"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.398530+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/bacto_middelbrook_7h11_agar_medium_911.yaml
+++ b/data/normalized_yaml/bacterial/bacto_middelbrook_7h11_agar_medium_911.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.4-6.8'' -> {''min'': 6.4, ''max'': 6.8}'
+- timestamp: '2026-08-06T08:58:32.399598+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/bacto_middelbrook_oadc_enrichment_medium_911.yaml
+++ b/data/normalized_yaml/bacterial/bacto_middelbrook_oadc_enrichment_medium_911.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Bacto Middelbrook OADC enrichment (medium 911)" to
     "bacto_middelbrook_oadc_enrichment_medium_911" for consistent matching
+- timestamp: '2026-08-06T08:58:32.400711+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/bbl_actinomyces_broth_medium_1029.yaml
+++ b/data/normalized_yaml/bacterial/bbl_actinomyces_broth_medium_1029.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "BBL Actinomyces broth (medium 1029)" to "bbl_actinomyces_broth_medium_1029"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.401650+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/blood_agar_base_from_difco_0045.yaml
+++ b/data/normalized_yaml/bacterial/blood_agar_base_from_difco_0045.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.2-7.6'' -> {''min'': 7.2, ''max'': 7.6}'
+- timestamp: '2026-08-06T08:58:32.402600+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/blood_agar_no_2_oxoid.yaml
+++ b/data/normalized_yaml/bacterial/blood_agar_no_2_oxoid.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.2-7.6'' -> {''min'': 7.2, ''max'': 7.6}'
+- timestamp: '2026-08-06T08:58:32.403779+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/bordet_gengou_agar_base.yaml
+++ b/data/normalized_yaml/bacterial/bordet_gengou_agar_base.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Bordet-Gengou-Agar-Base" to "bordet_gengou_agar_base"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.404937+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/brucella_broth_becton_dickinson.yaml
+++ b/data/normalized_yaml/bacterial/brucella_broth_becton_dickinson.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7.2'' -> {''min'': 6.8, ''max'': 7.2}'
+- timestamp: '2026-08-06T08:58:32.405890+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/casman_agar_base.yaml
+++ b/data/normalized_yaml/bacterial/casman_agar_base.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Casman-Agar-Base" to "casman_agar_base" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.407001+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/clostridium_estertheticum_medium.yaml
+++ b/data/normalized_yaml/bacterial/clostridium_estertheticum_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "CLOSTRIDIUM ESTERTHETICUM medium" to "clostridium_estertheticum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.407922+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/clostridium_longisporum_medium.yaml
+++ b/data/normalized_yaml/bacterial/clostridium_longisporum_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "CLOSTRIDIUM LONGISPORUM medium" to "clostridium_longisporum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.408881+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/clostridium_neopropionicum_medium.yaml
+++ b/data/normalized_yaml/bacterial/clostridium_neopropionicum_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "CLOSTRIDIUM NEOPROPIONICUM medium" to "clostridium_neopropionicum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.409823+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml
+++ b/data/normalized_yaml/bacterial/cmrl_1066_medium_10x_concentrated_gibco.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "CMRL-1066 medium (10x concentrated; GIBCO)" to "cmrl_1066_medium_10x_concentrated_gibco"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.410794+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/columbia_agar_base.yaml
+++ b/data/normalized_yaml/bacterial/columbia_agar_base.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.1-7.5'' -> {''min'': 7.1, ''max'': 7.5}'
+- timestamp: '2026-08-06T08:58:32.411946+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/corn_meal_agar_oxoid_cm103.yaml
+++ b/data/normalized_yaml/bacterial/corn_meal_agar_oxoid_cm103.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''5.8-6.2'' -> {''min'': 5.8, ''max'': 6.2}'
+- timestamp: '2026-08-06T08:58:32.413116+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/czapek_dox_agar_merck.yaml
+++ b/data/normalized_yaml/bacterial/czapek_dox_agar_merck.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.1-7.5'' -> {''min'': 7.1, ''max'': 7.5}'
+- timestamp: '2026-08-06T08:58:32.414221+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfobacterium_anilini_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfobacterium_anilini_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOBACTERIUM ANILINI MEDIUM" to "desulfobacterium_anilini_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.415297+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfococcus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfococcus_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOCOCCUS MEDIUM" to "desulfococcus_medium" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.416237+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfococcus_niacini_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfococcus_niacini_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOCOCCUS NIACINI MEDIUM" to "desulfococcus_niacini_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.417153+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfomicrobium_whb_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfomicrobium_whb_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOMICROBIUM WHB MEDIUM" to "desulfomicrobium_whb_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.418119+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfotomaculum_geothermicum_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfotomaculum_geothermicum_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOTOMACULUM GEOTHERMICUM MEDIUM" to "desulfotomaculum_geothermicum_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.419061+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfotomaculum_sp_medium_ii.yaml
+++ b/data/normalized_yaml/bacterial/desulfotomaculum_sp_medium_ii.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOTOMACULUM SP. MEDIUM II" to "desulfotomaculum_sp_medium_ii"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.420006+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_aespoeensis_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_aespoeensis_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.3-7.5'' -> {''min'': 7.3, ''max'': 7.5}'
+- timestamp: '2026-08-06T08:58:32.421073+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_alcoholovorans_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_alcoholovorans_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO ALCOHOLOVORANS medium" to "desulfovibrio_alcoholovorans_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.422270+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_alcoholovorans_medium_replace_desulfovibrio_medium_with_desulfobulbus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_alcoholovorans_medium_replace_desulfovibrio_medium_with_desulfobulbus_medium.yaml
@@ -34,3 +34,11 @@ curation_history:
   notes: Normalized name from "DESULFOVIBRIO ALCOHOLOVORANS medium_replace_DESULFOVIBRIO
     medium_with_DESULFOBULBUS MEDIUM" to "desulfovibrio_alcoholovorans_medium_replace_desulfovibrio_medium_with_desulfobulbus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.423328+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_baarsii_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_baarsii_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO BAARSII MEDIUM" to "desulfovibrio_baarsii_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.424482+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_carbinolicus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_carbinolicus_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO CARBINOLICUS medium" to "desulfovibrio_carbinolicus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.425493+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_giganteus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_giganteus_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO GIGANTEUS MEDIUM" to "desulfovibrio_giganteus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.426576+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_inopinatus_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_inopinatus_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO INOPINATUS MEDIUM" to "desulfovibrio_inopinatus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.427665+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_inopinatus_medium_replace_na_pyruvate_with_1_2_4_trihydroxybenzene.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_inopinatus_medium_replace_na_pyruvate_with_1_2_4_trihydroxybenzene.yaml
@@ -30,3 +30,11 @@ curation_history:
   notes: Normalized name from "DESULFOVIBRIO INOPINATUS MEDIUM_replace_Na-pyruvate_with_1,2,4-trihydroxybenzene"
     to "desulfovibrio_inopinatus_medium_replace_na_pyruvate_with_1_2_4_trihydroxybenzene"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.428679+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_sapovorans_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_sapovorans_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO SAPOVORANS MEDIUM" to "desulfovibrio_sapovorans_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.429895+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_shv_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_shv_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DESULFOVIBRIO SHV MEDIUM" to "desulfovibrio_shv_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.431005+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/desulfovibrio_sp_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_sp_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.8-7'' -> {''min'': 6.8, ''max'': 7.0}'
+- timestamp: '2026-08-06T08:58:32.431989+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/dmj_synthetic_seawater_medium_997.yaml
+++ b/data/normalized_yaml/bacterial/dmj_synthetic_seawater_medium_997.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DMJ synthetic seawater (medium 997)" to "dmj_synthetic_seawater_medium_997"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.433101+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/dsm_4156_b_and_dsm_4156.yaml
+++ b/data/normalized_yaml/bacterial/dsm_4156_b_and_dsm_4156.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "DSM 4156 B and DSM 4156" to "dsm_4156_b_and_dsm_4156"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.434113+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/for_dsm_2805.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_2805.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "For DSM 2805" to "for_dsm_2805" for consistent matching
+- timestamp: '2026-08-06T08:58:32.435088+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/for_dsm_3246.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_3246.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "For DSM 3246" to "for_dsm_3246" for consistent matching
+- timestamp: '2026-08-06T08:58:32.436501+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/for_dsm_3247.yaml
+++ b/data/normalized_yaml/bacterial/for_dsm_3247.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "For DSM 3247" to "for_dsm_3247" for consistent matching
+- timestamp: '2026-08-06T08:58:32.437551+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/for_s_buswellii_dsm_2612m.yaml
+++ b/data/normalized_yaml/bacterial/for_s_buswellii_dsm_2612m.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "For S. buswellii DSM 2612M" to "for_s_buswellii_dsm_2612m"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.438565+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/for_s_wolinii_dsm_2805m.yaml
+++ b/data/normalized_yaml/bacterial/for_s_wolinii_dsm_2805m.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "For S. wolinii DSM 2805M" to "for_s_wolinii_dsm_2805m"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.439518+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/glutarate_medium.yaml
+++ b/data/normalized_yaml/bacterial/glutarate_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "GLUTARATE medium" to "glutarate_medium" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.440457+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/ilyobacter_tartaricus_medium.yaml
+++ b/data/normalized_yaml/bacterial/ilyobacter_tartaricus_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "ILYOBACTER TARTARICUS MEDIUM" to "ilyobacter_tartaricus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.441432+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/isovitalex.yaml
+++ b/data/normalized_yaml/bacterial/isovitalex.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "Isovitalex" to "isovitalex" for consistent matching
+- timestamp: '2026-08-06T08:58:32.442644+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/mab1_medium.yaml
+++ b/data/normalized_yaml/bacterial/mab1_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "mAB1-MEDIUM" to "mab1_medium" for consistent matching
+- timestamp: '2026-08-06T08:58:32.443647+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml
+++ b/data/normalized_yaml/bacterial/marine_medium_synthetic_seawater_mix_medium_611.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Marine-Medium/Synthetic seawater-mix (medium 611)"
     to "marine_medium_synthetic_seawater_mix_medium_611" for consistent matching
+- timestamp: '2026-08-06T08:58:32.444636+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/marine_trace_elements_medium_511.yaml
+++ b/data/normalized_yaml/bacterial/marine_trace_elements_medium_511.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Marine trace elements (medium 511)" to "marine_trace_elements_medium_511"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.445783+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/medium_131_modified_for_dsm_6216.yaml
+++ b/data/normalized_yaml/bacterial/medium_131_modified_for_dsm_6216.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "MEDIUM 131 MODIFIED FOR DSM 6216" to "medium_131_modified_for_dsm_6216"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.446825+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/medium_777_modified_for_dsm_14980.yaml
+++ b/data/normalized_yaml/bacterial/medium_777_modified_for_dsm_14980.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "MEDIUM 777 MODIFIED FOR DSM 14980" to "medium_777_modified_for_dsm_14980"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.448172+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/medium_820_modified_for_dsm_16960.yaml
+++ b/data/normalized_yaml/bacterial/medium_820_modified_for_dsm_16960.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "MEDIUM 820 MODIFIED FOR DSM 16960" to "medium_820_modified_for_dsm_16960"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.449595+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/medium_md1_medium_9.yaml
+++ b/data/normalized_yaml/bacterial/medium_md1_medium_9.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "medium MD1 (medium 9)" to "medium_md1_medium_9" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.450731+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/metals_44_medium_590.yaml
+++ b/data/normalized_yaml/bacterial/metals_44_medium_590.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Metals 44 (medium 590)" to "metals_44_medium_590" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.451863+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/middlebrook_7h10_agar.yaml
+++ b/data/normalized_yaml/bacterial/middlebrook_7h10_agar.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.4-6.8'' -> {''min'': 6.4, ''max'': 6.8}'
+- timestamp: '2026-08-06T08:58:32.453012+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/mineral_mix_medium_1001.yaml
+++ b/data/normalized_yaml/bacterial/mineral_mix_medium_1001.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Mineral Mix (medium 1001)" to "mineral_mix_medium_1001"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.454275+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml
+++ b/data/normalized_yaml/bacterial/modified_mj_synthetic_sea_water_medium_1131.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Modified MJ synthetic sea water (medium 1131)" to "modified_mj_synthetic_sea_water_medium_1131"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.455675+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/mtp4_medium.yaml
+++ b/data/normalized_yaml/bacterial/mtp4_medium.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "MTP4 MEDIUM" to "mtp4_medium" for consistent matching
+- timestamp: '2026-08-06T08:58:32.456945+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/mueller_hinton_broth.yaml
+++ b/data/normalized_yaml/bacterial/mueller_hinton_broth.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Mueller-Hinton broth" to "mueller_hinton_broth" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.458152+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/nutrient_broth_difco.yaml
+++ b/data/normalized_yaml/bacterial/nutrient_broth_difco.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Nutrient broth (Difco)" to "nutrient_broth_difco" for
     consistent matching
+- timestamp: '2026-08-06T08:58:32.459131+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/nutrient_broth_oxoid_medium_948.yaml
+++ b/data/normalized_yaml/bacterial/nutrient_broth_oxoid_medium_948.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Nutrient broth (Oxoid) (medium 948)" to "nutrient_broth_oxoid_medium_948"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.460403+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pelobacter_acetylenicus_medium.yaml
+++ b/data/normalized_yaml/bacterial/pelobacter_acetylenicus_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PELOBACTER ACETYLENICUS MEDIUM" to "pelobacter_acetylenicus_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.461395+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pelobacter_medium.yaml
+++ b/data/normalized_yaml/bacterial/pelobacter_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PELOBACTER medium" to "pelobacter_medium" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.462632+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pelobacter_venetianus_fresh_water_medium.yaml
+++ b/data/normalized_yaml/bacterial/pelobacter_venetianus_fresh_water_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PELOBACTER VENETIANUS (fresh water) MEDIUM" to "pelobacter_venetianus_fresh_water_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.463760+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pelobacter_venetianus_marine_medium.yaml
+++ b/data/normalized_yaml/bacterial/pelobacter_venetianus_marine_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PELOBACTER VENETIANUS (marine) MEDIUM" to "pelobacter_venetianus_marine_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.464728+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pennassay_broth.yaml
+++ b/data/normalized_yaml/bacterial/pennassay_broth.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Pennassay Broth" to "pennassay_broth" for consistent
     matching
+- timestamp: '2026-08-06T08:58:32.465658+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/pplo_broth.yaml
+++ b/data/normalized_yaml/bacterial/pplo_broth.yaml
@@ -35,3 +35,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.6-8'' -> {''min'': 7.6, ''max'': 8.0}'
+- timestamp: '2026-08-06T08:58:32.466854+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/propionigenium_maris_medium.yaml
+++ b/data/normalized_yaml/bacterial/propionigenium_maris_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "PROPIONIGENIUM MARIS medium" to "propionigenium_maris_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.468509+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/rumen_fluid_clarified.yaml
+++ b/data/normalized_yaml/bacterial/rumen_fluid_clarified.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Rumen fluid, clarified" to "rumen_fluid_clarified"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.469778+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/sabouraud_2_glucose_bouillon_merck_108339.yaml
+++ b/data/normalized_yaml/bacterial/sabouraud_2_glucose_bouillon_merck_108339.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SABOURAUD-2% Glucose-Bouillon (Merck 108339)" to "sabouraud_2_glucose_bouillon_merck_108339"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.471124+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/salt_concentrate_medium_517.yaml
+++ b/data/normalized_yaml/bacterial/salt_concentrate_medium_517.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Salt concentrate (medium 517)" to "salt_concentrate_medium_517"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.472271+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/sb_sw_medium.yaml
+++ b/data/normalized_yaml/bacterial/sb_sw_medium.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "SB/SW MEDIUM" to "sb_sw_medium" for consistent matching
+- timestamp: '2026-08-06T08:58:32.473528+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/sludge_fluid_medium_119.yaml
+++ b/data/normalized_yaml/bacterial/sludge_fluid_medium_119.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Sludge fluid (medium 119)" to "sludge_fluid_medium_119"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.474530+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/soil_extract_medium_98.yaml
+++ b/data/normalized_yaml/bacterial/soil_extract_medium_98.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Soil extract (medium 98)" to "soil_extract_medium_98"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.475644+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/spirochaeta_aurantia_medium.yaml
+++ b/data/normalized_yaml/bacterial/spirochaeta_aurantia_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''7.0-7.3'' -> {''min'': 7.0, ''max'': 7.3}'
+- timestamp: '2026-08-06T08:58:32.476742+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/spirochaeta_isovalerica_medium.yaml
+++ b/data/normalized_yaml/bacterial/spirochaeta_isovalerica_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SPIROCHAETA ISOVALERICA medium" to "spirochaeta_isovalerica_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.478186+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/sporomusa_silvacetica_medium.yaml
+++ b/data/normalized_yaml/bacterial/sporomusa_silvacetica_medium.yaml
@@ -36,3 +36,11 @@ curation_history:
   curator: migrate_ph_range.py
   action: MIGRATED_PH_RANGE
   notes: 'ph_range ''6.5-6.7'' -> {''min'': 6.5, ''max'': 6.7}'
+- timestamp: '2026-08-06T08:58:32.479245+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/sse_double_concentrated_medium_1426.yaml
+++ b/data/normalized_yaml/bacterial/sse_double_concentrated_medium_1426.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SSE (double concentrated) (medium 1426)" to "sse_double_concentrated_medium_1426"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.480595+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/synthetic_sea_water_medium_79.yaml
+++ b/data/normalized_yaml/bacterial/synthetic_sea_water_medium_79.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Synthetic sea water (medium 79)" to "synthetic_sea_water_medium_79"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.481760+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/synthetic_seawater_2_x_conc_medium_795.yaml
+++ b/data/normalized_yaml/bacterial/synthetic_seawater_2_x_conc_medium_795.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Synthetic seawater (2 x conc.) (medium 795)" to "synthetic_seawater_2_x_conc_medium_795"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.482838+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/syntrophobacter_wolinii_medium.yaml
+++ b/data/normalized_yaml/bacterial/syntrophobacter_wolinii_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SYNTROPHOBACTER WOLINII medium" to "syntrophobacter_wolinii_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.483873+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/syntrophus_buswellii_ii_medium.yaml
+++ b/data/normalized_yaml/bacterial/syntrophus_buswellii_ii_medium.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SYNTROPHUS BUSWELLII II MEDIUM" to "syntrophus_buswellii_ii_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.484817+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/syntrophus_medium_sulfate_free.yaml
+++ b/data/normalized_yaml/bacterial/syntrophus_medium_sulfate_free.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "SYNTROPHUS medium - SULFATE FREE" to "syntrophus_medium_sulfate_free"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.485793+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml
+++ b/data/normalized_yaml/bacterial/thiobacillus_ferrooxidans_medium_with_tetrathionate.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "THIOBACILLUS FERROOXIDANS MEDIUM WITH TETRATHIONATE"
     to "thiobacillus_ferrooxidans_medium_with_tetrathionate" for consistent matching
+- timestamp: '2026-08-06T08:58:32.486871+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/trace_elements_medium_1108a.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_medium_1108a.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (medium 1108a)" to "trace_elements_medium_1108a"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.488041+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/trace_elements_medium_1147.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_medium_1147.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (medium 1147)" to "trace_elements_medium_1147"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.489193+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/trace_elements_medium_596.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_medium_596.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (medium 596)" to "trace_elements_medium_596"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.490252+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/trace_elements_medium_651.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_medium_651.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (medium 651)" to "trace_elements_medium_651"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.491207+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/trace_elements_pfennig_medium_1264.yaml
+++ b/data/normalized_yaml/bacterial/trace_elements_pfennig_medium_1264.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "Trace elements (Pfennig) (medium 1264)" to "trace_elements_pfennig_medium_1264"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.492132+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/true_blue_trace_elements_medium_748.yaml
+++ b/data/normalized_yaml/bacterial/true_blue_trace_elements_medium_748.yaml
@@ -29,3 +29,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "True Blue Trace Elements (medium 748)" to "true_blue_trace_elements_medium_748"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.493072+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/vitox.yaml
+++ b/data/normalized_yaml/bacterial/vitox.yaml
@@ -28,3 +28,11 @@ curation_history:
   curator: normalize_media_names_to_snake_case.py
   action: NAME_NORMALIZED
   notes: Normalized name from "Vitox" to "vitox" for consistent matching
+- timestamp: '2026-08-06T08:58:32.494170+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/data/normalized_yaml/bacterial/xb45_xb90_pb90_2_medium.yaml
+++ b/data/normalized_yaml/bacterial/xb45_xb90_pb90_2_medium.yaml
@@ -30,3 +30,11 @@ curation_history:
   action: NAME_NORMALIZED
   notes: Normalized name from "XB45/XB90/PB90-2 MEDIUM" to "xb45_xb90_pb90_2_medium"
     for consistent matching
+- timestamp: '2026-08-06T08:58:32.495305+00:00'
+  curator: curate_flag_empty_composition.py
+  action: FLAGGED_INCOMPLETE_COMPOSITION
+  notes: Media record has no ingredients and no solutions — no usable composition;
+    flagged so the gap is not silent (#175).
+  changes: 'Added data_quality_flags: incomplete_composition'
+data_quality_flags:
+- incomplete_composition

--- a/project.justfile
+++ b/project.justfile
@@ -233,6 +233,13 @@ curate-organism-culture-type *args="":
 curate-placeholder-composition *args="":
     uv run --extra dev python scripts/curate_placeholder_composition.py {{args}}
 
+# Flag media with no ingredients and no solutions as incomplete_composition (#175),
+# so a silently-empty record is visible rather than reading as complete. Does not
+# decide the record's fate (re-import / accept / retire). Report-only without --apply.
+[group('Curation')]
+curate-flag-empty-composition *args="":
+    uv run --extra dev python scripts/curate_flag_empty_composition.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/curate_flag_empty_composition.py
+++ b/scripts/curate_flag_empty_composition.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Flag media that carry no composition at all (#175).
+
+A media record with no `ingredients` AND no `solutions` has no usable composition —
+there is nothing to grow the organism in. `validate-strict` does not catch it
+(`ingredients` is not required), so these sit in the corpus reading as complete.
+226 media are in this state; 100 were just de-placeholdered (and already flagged),
+but 126 carry no `data_quality_flags` at all — silently empty.
+
+This stamps `incomplete_composition` on the unflagged ones so the gap is honest and
+visible (the review-need ranking and any downstream reader can see it). It is
+deliberately conservative: flagging records a value they lack, not deciding their
+fate. Whether a given record is recoverable (re-import from its source), acceptably
+empty, or spurious (a test fixture like test_medium_123 that should be retired) is a
+per-record curation decision this does not make.
+
+Report-only by default; `--apply` writes via record_io with a curation event.
+
+Usage::
+
+    just curate-flag-empty-composition
+    just curate-flag-empty-composition --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+from record_io import write_record  # noqa: E402
+from record_kinds import is_solution_record  # noqa: E402
+
+from culturemech.curate.curation_event import record_curation_event  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+INCOMPLETE = "incomplete_composition"
+
+
+def has_no_composition(doc: dict[str, Any]) -> bool:
+    ings = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
+    return not ings and not doc.get("solutions")
+
+
+def needs_flag(doc: dict[str, Any]) -> bool:
+    """A media record with no composition and no incomplete_composition flag."""
+    return (not is_solution_record(doc)
+            and has_no_composition(doc)
+            and INCOMPLETE not in (doc.get("data_quality_flags") or []))
+
+
+def scan_parsed(records) -> list[tuple[Path, dict[str, Any]]]:
+    return [(p, d) for p, d in records if isinstance(d, dict) and needs_flag(d)]
+
+
+def scan(normalized: Path) -> list[tuple[Path, dict[str, Any]]]:
+    records = []
+    for path in sorted(normalized.rglob("*.yaml")):
+        try:
+            records.append((path, yaml.safe_load(path.read_text(errors="replace"))))
+        except (yaml.YAMLError, OSError):
+            continue
+    return scan_parsed(records)
+
+
+def flag(doc: dict[str, Any]) -> bool:
+    if not needs_flag(doc):
+        return False
+    doc.setdefault("data_quality_flags", []).append(INCOMPLETE)
+    record_curation_event(
+        doc, curator="curate_flag_empty_composition.py",
+        action="FLAGGED_INCOMPLETE_COMPOSITION",
+        notes="Media record has no ingredients and no solutions — no usable "
+              "composition; flagged so the gap is not silent (#175).",
+        changes=f"Added data_quality_flags: {INCOMPLETE}")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    ap.add_argument("--apply", action="store_true",
+                    help="Write the flag. Default is report-only.")
+    args = ap.parse_args(argv)
+
+    affected = scan(args.normalized_dir)
+    print(f"{len(affected)} media with no composition and no incomplete_composition flag:")
+    for path, _doc in affected[:60]:
+        print(f"  {path.relative_to(args.normalized_dir)}")
+    if len(affected) > 60:
+        print(f"  ... and {len(affected) - 60} more")
+
+    if not args.apply:
+        print("\nReport only. Re-run with --apply to flag them.")
+        return 0
+
+    written = sum(1 for path, doc in affected if flag(doc) and write_record(path, doc))
+    print(f"\nFlagged {written} record(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_flag_empty_composition.py
+++ b/tests/test_flag_empty_composition.py
@@ -1,0 +1,62 @@
+"""Guard that no-composition media are flagged incomplete, not silent (#175).
+
+A media record with no ingredients and no solutions has no usable composition, yet
+validate-strict passes it. 126 such records carried no data_quality_flag at all;
+they were flagged incomplete_composition so the gap is visible. This pins that
+invariant and the classifier.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cfe():
+    return _load("curate_flag_empty_composition")
+
+
+def test_no_composition_detection(cfe):
+    assert cfe.has_no_composition({})
+    assert cfe.has_no_composition({"ingredients": []})
+    assert not cfe.has_no_composition({"ingredients": [{"preferred_term": "Agar"}]})
+    assert not cfe.has_no_composition({"solutions": [{"preferred_term": "Trace elements"}]})
+
+
+def test_needs_flag_only_when_unflagged_and_empty(cfe):
+    assert cfe.needs_flag({"ingredients": []})
+    assert not cfe.needs_flag({"ingredients": [],
+                               "data_quality_flags": ["incomplete_composition"]})
+    assert not cfe.needs_flag({"ingredients": [{"preferred_term": "Agar"}]})
+
+
+def test_flag_adds_flag_and_event(cfe):
+    doc = {"ingredients": []}
+    assert cfe.flag(doc) is True
+    assert "incomplete_composition" in doc["data_quality_flags"]
+    assert doc["curation_history"][-1]["action"] == "FLAGGED_INCOMPLETE_COMPOSITION"
+    # idempotent: a second pass does nothing
+    assert cfe.flag(doc) is False
+
+
+def test_every_empty_medium_is_flagged(cfe, media_records):
+    """Recurrence guard: a media record with no ingredients and no solutions must
+    carry the incomplete_composition flag, or a fresh import left a silent gap."""
+    silent = [str(p) for p, d in media_records if cfe.needs_flag(d)]
+    assert silent == [], (
+        f"{len(silent)} media have no composition and no incomplete_composition "
+        "flag; run `just curate-flag-empty-composition --apply`.")


### PR DESCRIPTION
Continues #175 (the no-composition media). After the placeholder cleanup (#233),
226 media have no usable composition (no ingredients, no solutions). 100 are
flagged; **126 carried no `data_quality_flag` at all** — silently empty, since
`validate-strict` does not require `ingredients`.

This stamps `incomplete_composition` on those 126 so the gap is visible to the
review-need ranking and any downstream reader, instead of reading as a complete
record.

**Conservative by design:** it labels the state, it does not decide the fate.
Whether a record is recoverable (re-import from its source), acceptably empty, or
spurious (a test fixture to retire, like `test_medium_123`) stays a per-record
decision — left open.

Adds `just curate-flag-empty-composition` (report/apply) and a **recurrence
guard**: every media record with no composition must carry the flag, so a fresh
import cannot land another silent gap.

## Testing
- `just curate-flag-empty-composition` → 0 remain (was 126).
- `pytest tests/test_flag_empty_composition.py` → 4 passed, incl. the corpus guard.
- `linkml-validate -C MediaRecipe` on changed records → no issues.
- The review-need scorer is unaffected (it intentionally does not read
  `data_quality_flags`); verified `test_review_need` still passes.

Refs #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)