### PR TITLE
Propose (never apply) how to nest the 579 flattened cocktails (#150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,8 @@ reports/media_variation_candidate_groups.json
 reports/media_growth_review_manifest.tsv
 reports/media_growth_review_manifest.json
 reports/media_growth_review_manifest_summary.md
+
+# Cocktail-nesting proposal worklist: a regenerable diagnostic for the #150 repair,
+# not a tracked artifact. Regenerate with `just propose-cocktail-nesting`.
+data/import_tracking/reports/cocktail_nesting_proposals.tsv
+data/import_tracking/reports/cocktail_nesting_proposals.json

--- a/project.justfile
+++ b/project.justfile
@@ -240,6 +240,15 @@ curate-placeholder-composition *args="":
 curate-flag-empty-composition *args="":
     uv run --extra dev python scripts/curate_flag_empty_composition.py {{args}}
 
+# Propose (never apply) how to nest each of the 579 flattened stock cocktails under
+# a solution with an addition volume (#150). Recovers the volume from the record's
+# own preparation_steps/notes where possible; marks the rest MANUAL. Emits a curator
+# worklist, edits nothing — the addition volume is judgement-heavy and a wrong one
+# corrupts a real recipe.
+[group('QC')]
+propose-cocktail-nesting *args="":
+    uv run --extra dev python scripts/propose_cocktail_nesting.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/propose_cocktail_nesting.py
+++ b/scripts/propose_cocktail_nesting.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Propose (never apply) how to nest each flattened stock cocktail (#150).
+
+A "flattened cocktail" is a stock trace/vitamin solution whose components were
+written straight into a medium's `ingredients:` at their stock-solution strength
+(e.g. ZnSO4 22 G_PER_L), instead of nested under a `solutions:` object added at a
+small volume. Read as final per-litre values those magnitudes are implausible;
+the fix is structural — move the cocktail under a stock solution with an addition
+volume, so `stock_conc x volume/1000` gives the real final concentration.
+
+The audit (`audit_concentration_plausibility`) already finds the 579 records. The
+missing, judgement-heavy piece is the **addition volume**, and a wrong volume
+silently corrupts a real recipe. So this tool does NOT edit anything. It:
+
+  1. Detects each flattened cocktail and its flagged component rows.
+  2. Tries to recover the addition volume from the record's OWN preparation_steps /
+     notes (e.g. "add 1 ml of trace element solution per litre") — recovered from
+     tracked data, never invented (#166).
+  3. Emits a per-record proposal: the components to nest, the recovered volume (with
+     the sentence it came from) or `MANUAL` when none is confidently found, and the
+     proposed nested-solution shape.
+
+Apply nothing here. The output is a worklist for a curator to review and apply,
+which is what a volume-sensitive structural repair needs.
+
+Usage::
+
+    just propose-cocktail-nesting               # summary + write the proposal TSV/JSON
+    just propose-cocktail-nesting --top 20       # also print the first 20 proposals
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+import audit_concentration_plausibility as acp  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "cocktail_nesting_proposals.tsv"
+
+# A CANDIDATE addition volume: an amount in ml sitting next to a
+# trace/vitamin/element solution word, AND in an addition context — an "add"-type
+# verb or a per-litre phrase nearby. The context requirement cuts obvious false
+# positives (a volume in "...except vitamins..." or in an unrelated comment). Even
+# so these are candidates a curator must verify against `volume_evidence`, never
+# auto-applied — which is the whole point of this being a proposal.
+_SOLUTION_WORD = r"(?:trace|vitamin|element|mineral|selenite|tungstate|SL-?\d+|metal)s?[\w \-]*?(?:solution|elements?)?"
+_VOL = r"(\d+(?:\.\d+)?)\s*(?:ml|millilit(?:er|re)s?)\b"
+_NEAR_VOL = re.compile(rf"(?:{_SOLUTION_WORD}[^.]{{0,40}}?({_VOL}))|(?:({_VOL})[^.]{{0,40}}?{_SOLUTION_WORD})", re.I)
+_ADD_CONTEXT = re.compile(r"\b(?:add|added|adding|supplement|per\s+lit(?:er|re)|/\s*l\b|per\s+l\b)", re.I)
+
+
+def recover_volume(doc: dict[str, Any]) -> tuple[str, str]:
+    """(candidate_volume_ml, evidence_sentence) recovered from the record itself, or
+    ("", ""). Requires an addition context in the sentence to avoid grabbing a volume
+    that is merely near a solution word."""
+    sentences: list[str] = []
+    for step in doc.get("preparation_steps") or []:
+        if isinstance(step, dict) and step.get("description"):
+            sentences.append(str(step["description"]))
+    if doc.get("notes"):
+        sentences.append(str(doc["notes"]))
+    for s in sentences:
+        if not _ADD_CONTEXT.search(s):
+            continue
+        m = _NEAR_VOL.search(s)
+        if m:
+            vol = next(g for g in m.groups() if g and re.fullmatch(r"\d+(?:\.\d+)?", g))
+            return vol, s.strip()[:160]
+    return "", ""
+
+
+def cocktail_components(rows: list[dict[str, str]], file_path: str) -> list[dict[str, str]]:
+    """The flagged trace/vitamin rows for one record — the components to nest."""
+    return [{"ingredient": r["ingredient"], "value": r["value"], "unit": r["unit"],
+             "finding": r["finding"]}
+            for r in rows if r["file_path"] == file_path
+            and r["finding"] in ("TRACE_SALT_AS_STOCK", "INDICATOR_UNIT_SLIP")]
+
+
+def build_proposals() -> list[dict[str, Any]]:
+    rows = acp.audit(NORMALIZED)
+    summary = acp.summarize_records(rows, NORMALIZED)
+    cocktail_paths = [s["file_path"] for s in summary if s["flattened_cocktail"] == "yes"]
+    proposals = []
+    for fp in sorted(cocktail_paths):
+        try:
+            doc = yaml.safe_load((NORMALIZED / fp).read_text(errors="replace")) or {}
+        except (yaml.YAMLError, OSError):
+            doc = {}
+        comps = cocktail_components(rows, fp)
+        vol, evidence = recover_volume(doc)
+        proposals.append({
+            "file_path": fp,
+            "record_id": str(doc.get("id") or ""),
+            "n_components": len(comps),
+            "components": "; ".join(f"{c['ingredient']}={c['value']}{c['unit']}" for c in comps),
+            "candidate_volume_ml": vol,
+            "volume_source": "preparation_steps/notes" if vol else "MANUAL",
+            "volume_evidence": evidence,
+            # The proposed nested shape (curator applies): the flagged components move
+            # under one solution added at candidate_volume_ml per litre.
+            "proposed_solution": json.dumps({
+                "preferred_term": "Trace/vitamin stock (nested from flattened ingredients)",
+                "addition_volume": {"value": vol or "TBD", "unit": "MILLILITERS_PER_LITER"},
+                "composition": [{"preferred_term": c["ingredient"],
+                                 "concentration": {"value": c["value"], "unit": c["unit"]}}
+                                for c in comps],
+            }),
+        })
+    return proposals
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--top", type=int, default=0, help="Also print the first N proposals.")
+    args = ap.parse_args(argv)
+
+    proposals = build_proposals()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    cols = ["file_path", "record_id", "n_components", "components",
+            "candidate_volume_ml", "volume_source", "volume_evidence", "proposed_solution"]
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=cols)
+        w.writeheader()
+        w.writerows(proposals)
+    args.out.with_suffix(".json").write_text(json.dumps(proposals, indent=2) + "\n")
+
+    recoverable = [p for p in proposals if p["candidate_volume_ml"]]
+    print(f"Flattened cocktails proposed: {len(proposals)}")
+    print(f"  candidate addition volume found in the record (verify vs evidence): {len(recoverable)}")
+    print(f"  volume MANUAL (needs a curator / an external source): {len(proposals) - len(recoverable)}")
+    print(f"\nProposal only — NOTHING is applied. Review {args.out.relative_to(REPO)} and apply per record.")
+    for p in proposals[:args.top]:
+        print(f"\n  {p['file_path']}  ({p['n_components']} components, vol={p['candidate_volume_ml'] or 'MANUAL'})")
+        if p["volume_evidence"]:
+            print(f"    evidence: {p['volume_evidence']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cocktail_nesting.py
+++ b/tests/test_cocktail_nesting.py
@@ -1,0 +1,77 @@
+"""Unit-test the pure pieces of the cocktail-nesting PROPOSAL tool (#150).
+
+The tool never edits the corpus — it emits a worklist. What has logic worth pinning
+is the addition-volume recovery: it must find a volume only in a genuine addition
+context, and stay silent otherwise, because a fabricated volume corrupts a real
+recipe (the whole reason the repair is a proposal, not an auto-apply).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def pcn():
+    return _load("propose_cocktail_nesting")
+
+
+def _doc(*sentences):
+    return {"preparation_steps": [{"description": s} for s in sentences]}
+
+
+def test_recovers_a_genuine_addition_volume(pcn):
+    vol, evidence = pcn.recover_volume(_doc("Autoclave and add 1.0 ml/l vitamin solution."))
+    assert vol == "1.0"
+    assert "vitamin solution" in evidence
+
+
+def test_recovers_from_a_ml_solution_phrase(pcn):
+    vol, _ = pcn.recover_volume(_doc("Combine solutions A, B, C and add 1 ml trace element solution."))
+    assert vol == "1"
+
+
+def test_a_volume_without_addition_context_is_not_recovered(pcn):
+    """'except vitamins ... adjust to 20 ml' is not an addition of the cocktail."""
+    vol, _ = pcn.recover_volume(_doc("Mix ingredients except vitamins, then adjust to 20 ml final."))
+    assert vol == ""
+
+
+def test_no_volume_at_all_is_silent(pcn):
+    assert pcn.recover_volume(_doc("Adjust pH to 7.0 and autoclave.")) == ("", "")
+
+
+def test_notes_are_also_searched(pcn):
+    vol, _ = pcn.recover_volume({"notes": "Add 10 ml trace elements per litre after autoclaving."})
+    assert vol == "10"
+
+
+def test_cocktail_components_selects_only_flagged_trace_and_vitamin_rows(pcn):
+    rows = [
+        {"file_path": "a.yaml", "finding": "TRACE_SALT_AS_STOCK", "ingredient": "ZnSO4",
+         "value": "22", "unit": "G_PER_L"},
+        {"file_path": "a.yaml", "finding": "INDICATOR_UNIT_SLIP", "ingredient": "Biotin",
+         "value": "0.02", "unit": "G_PER_L"},
+        {"file_path": "a.yaml", "finding": "WATER_AS_VOLUME", "ingredient": "Water",
+         "value": "1000", "unit": "G_PER_L"},
+        {"file_path": "b.yaml", "finding": "TRACE_SALT_AS_STOCK", "ingredient": "MnCl2",
+         "value": "5", "unit": "G_PER_L"},
+    ]
+    comps = pcn.cocktail_components(rows, "a.yaml")
+    names = [c["ingredient"] for c in comps]
+    assert names == ["ZnSO4", "Biotin"]          # trace + indicator, this file only
+    assert "Water" not in names                    # WATER_AS_VOLUME is not a cocktail component


### PR DESCRIPTION
Advances #150 with a **non-destructive proposal tool** (per the "dry-run proposal
only" direction). It does not touch the corpus.

## Why a proposal, not a repair
The audit already finds the 579 flattened stock cocktails. The missing piece is
each one's **addition volume**, and a wrong volume silently corrupts a real recipe
(`stock_conc x volume/1000` is the real final concentration). So this emits a
curator worklist rather than editing recipes.

## What `just propose-cocktail-nesting` produces
Per cocktail record: the flagged trace/vitamin components to nest, a **candidate**
addition volume recovered from the record's own `preparation_steps`/`notes` (in a
genuine "add N ml … solution per litre" context — never invented, #166) with the
evidence sentence, or `MANUAL`, plus the proposed nested-solution shape.

Of 579: ~15 yield a candidate volume, 564 are `MANUAL`. The candidates deliberately
still surface false positives (a volume next to "methanol", a pH step) — each
visible in `volume_evidence` — which is exactly why a curator verifies and applies
per record. The volume is the risky part, so it stays a reviewed step.

## Notes
- The proposal report is gitignored (regenerable diagnostic, not a tracked artifact).
- Unit tests pin the volume recovery (requires an addition context; silent
  otherwise) and component selection — 6 passed.
- `just propose-cocktail-nesting` verified to change **0** corpus files.

Refs #150. The actual per-record application remains a curator step over this worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)