### PR TITLE
Guard recipe indexes against field-level drift, not just count/path (#238)

### DIFF
--- a/tests/test_recipe_indexes.py
+++ b/tests/test_recipe_indexes.py
@@ -126,7 +126,7 @@ def test_index_entries_match_freshly_extracted_metadata(corpus):
     never reached the index.
     """
     gen = _generator()
-    by_path = {path: doc for path, doc in corpus}
+    by_path = dict(corpus)
 
     stale: list[str] = []
     for index_path in CATEGORY_INDEXES:

--- a/tests/test_recipe_indexes.py
+++ b/tests/test_recipe_indexes.py
@@ -90,3 +90,60 @@ def test_every_yaml_in_the_directory_is_indexed(index_path: Path):
         f"{len(unindexed)} recipe(s) in {category_dir.name}/ are missing from "
         f"{index_path.name} (e.g. {unindexed[:3]}) — {STALE_HINT}"
     )
+
+
+# --- field-level drift (#238) ------------------------------------------------
+#
+# The guards above check the record SET — counts, paths, coverage. They all pass
+# while a per-entry FIELD is stale, which is what happened: #142/#223 backfilled
+# `organism_culture_type`, the indexes embed it, nobody regenerated them, and CI
+# said nothing until #237 regenerated for an unrelated reason.
+#
+# This recomputes each entry with the generator's own `extract_recipe_metadata`
+# (the function the indexes are built from, so the check cannot drift from the
+# definition) against the session-scoped corpus — no subprocess, no re-read. A full
+# `generate_recipe_indexes.py` run takes ~104s, too close to the 120s slow-test
+# budget to be a safe guard.
+
+
+def _generator():
+    import importlib.util
+    import sys as _sys
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_recipe_indexes", REPO_ROOT / "scripts" / "generate_recipe_indexes.py")
+    mod = importlib.util.module_from_spec(spec)
+    _sys.modules["generate_recipe_indexes"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_index_entries_match_freshly_extracted_metadata(corpus):
+    """Every committed index entry must equal what the generator would emit today.
+
+    Catches field-level drift a count/path check cannot see — a slot added or
+    changed on a record (organism_culture_type, medium_type, source_id, …) that
+    never reached the index.
+    """
+    gen = _generator()
+    by_path = {path: doc for path, doc in corpus}
+
+    stale: list[str] = []
+    for index_path in CATEGORY_INDEXES:
+        doc, category_dir = _load(index_path)
+        for entry in doc["recipes"].values():
+            record_path = category_dir / entry["filename"]
+            record = by_path.get(record_path)
+            if record is None:
+                continue  # a missing file is the path guard's job, not this one
+            fresh = gen.extract_recipe_metadata(record, record_path)
+            if fresh != entry:
+                differing = sorted(
+                    set(fresh) ^ set(entry)
+                    | {k for k in set(fresh) & set(entry) if fresh[k] != entry[k]})
+                stale.append(f"{index_path.name}:{entry['filename']} fields={differing}")
+
+    assert not stale, (
+        f"{len(stale)} index entry/entries differ from freshly extracted metadata "
+        f"(e.g. {stale[:3]}) — {STALE_HINT}"
+    )


### PR DESCRIPTION
Closes #238.

## The hole
The index guards checked the record **set** — counts, entry totals, filenames exist,
every file indexed. All of them pass while a per-entry **field** is stale. That is
exactly what happened: #142/#223 backfilled `organism_culture_type`, the indexes
embed it, nothing regenerated them, and CI stayed green until #237 regenerated for
an unrelated reason and swept the drift in.

## The guard
`test_index_entries_match_freshly_extracted_metadata`: every committed entry must
equal what **`extract_recipe_metadata`** emits for that record today — the
generator's own function, so the check cannot drift from the definition it guards.

It runs against the session-scoped `corpus` fixture rather than shelling out: a full
`generate_recipe_indexes.py` run takes **~104s**, too close to the 120s slow-test
budget to be a safe guard. Call duration is **0.46s**.

## Verified it bites
Injecting `organism_culture_type: community` into one fungal entry fails the test,
naming the exact file and field:

```
1 index entry/entries differ from freshly extracted metadata
(e.g. ["fungal_index.json:1_10_r2a_medium_modified_yeast_extract.yaml
       fields=['organism_culture_type']"]) — stale index — regenerate with
`just generate-indexes data/normalized_yaml`
```

The indexes as committed pass (they were regenerated current in #237).

- `pytest tests/test_recipe_indexes.py` → 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)