### PR TITLE
Backfill Fastidious Anaerobe Agar from MediaDive 1203; measure the rest (#239)

### DIFF
--- a/data/normalized_yaml/bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_3136_Fastidious_Anaerobe_Agar.yaml
@@ -14,8 +14,18 @@ media_term:
     id: komodo.medium:3136
     label: Fastidious Anaerobe Agar
 notes: 'Source: KOMODO ModelSEED | ID: 3136 | DSMZ Medium: 3136 (mediadive.medium:3136)
-  | Aerobic: No | SubMedium: Yes'
-ingredients: []
+  | Aerobic: No | SubMedium: Yes | MediaDive medium: 1203 (resolved; the ''3136''
+  above is the KOMODO id)'
+ingredients:
+- preferred_term: Horse blood
+  concentration:
+    value: '100'
+    unit: G_PER_L
+- preferred_term: Fastidious Anaerobe Agar
+  concentration:
+    value: '45.7'
+    unit: G_PER_L
+- preferred_term: Deionized water
 applications:
 - Microbial cultivation
 curation_history:
@@ -42,5 +52,12 @@ curation_history:
   notes: Media record has no ingredients and no solutions — no usable composition;
     flagged so the gap is not silent (#175).
   changes: 'Added data_quality_flags: incomplete_composition'
-data_quality_flags:
-- incomplete_composition
+- timestamp: '2026-08-07T05:25:54.947087+00:00'
+  curator: mediadive-composition-backfill-v1.0
+  action: BACKFILLED_COMPOSITION
+  notes: Backfilled 3 components from MediaDive medium 1203 (/rest/medium-composition/1203).
+    The record carried only the KOMODO id 3136; MediaDive 1203 is the same medium
+    — identical name and identical pH range 7.0-7.4. Cleared incomplete_composition
+    (#239).
+  changes: Added 3 ingredients from MediaDive 1203; removed incomplete_composition
+    flag

--- a/data/normalized_yaml/bacterial_index.json
+++ b/data/normalized_yaml/bacterial_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-06T22:50:10.594695+00:00",
+  "generated": "2026-08-07T05:26:32.979526+00:00",
   "category": "bacterial",
   "count": 14304,
   "recipes": {
@@ -8021,7 +8021,7 @@
     "CultureMech:004984": {
       "name": "fastidious_anaerobe_agar",
       "filename": "KOMODO_3136_Fastidious_Anaerobe_Agar.yaml",
-      "ingredient_count": 0,
+      "ingredient_count": 3,
       "id": "CultureMech:004984",
       "source_id": "komodo.medium:3136",
       "source": "KOMODO",

--- a/data/normalized_yaml/by_source_komodo_index.json
+++ b/data/normalized_yaml/by_source_komodo_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-06T22:51:52.016931+00:00",
+  "generated": "2026-08-07T05:28:18.842233+00:00",
   "source": "KOMODO",
   "count": 3637,
   "recipes": {
@@ -6108,7 +6108,7 @@
     "CultureMech:004984": {
       "name": "fastidious_anaerobe_agar",
       "filename": "KOMODO_3136_Fastidious_Anaerobe_Agar.yaml",
-      "ingredient_count": 0,
+      "ingredient_count": 3,
       "id": "CultureMech:004984",
       "source_id": "komodo.medium:3136",
       "source": "KOMODO",

--- a/data/normalized_yaml/recipe_index.json
+++ b/data/normalized_yaml/recipe_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-06T22:51:51.907477+00:00",
+  "generated": "2026-08-07T05:28:18.672700+00:00",
   "description": "Master index of all CultureMech recipes",
   "total_recipes": 15877,
   "categories": {
@@ -20831,7 +20831,7 @@
     "CultureMech:004984": {
       "name": "fastidious_anaerobe_agar",
       "filename": "KOMODO_3136_Fastidious_Anaerobe_Agar.yaml",
-      "ingredient_count": 0,
+      "ingredient_count": 3,
       "id": "CultureMech:004984",
       "source_id": "komodo.medium:3136",
       "source": "KOMODO",


### PR DESCRIPTION
Addresses #239 — and, importantly, **measures** how much of it is actually
recoverable, which turns out to be one record.

## The backfill
`KOMODO_3136_Fastidious_Anaerobe_Agar` carried only the KOMODO id **3136** (the
"DSMZ Medium: 3136" in its notes is the KOMODO/ModelSEED id, not a MediaDive id), so
the import never fetched a composition. **MediaDive medium 1203 is the same
medium** — identical name *and* identical pH range **7.0–7.4**, an independent
corroboration beyond name-matching — with 3 components:

| component | amount |
|---|---|
| Horse blood | 100 g/l |
| Fastidious Anaerobe Agar (base) | 45.7 g/l |
| Deionized water | — |

Backfilled those, recorded the resolved MediaDive id in `notes` so the mapping isn't
lost again, and cleared `incomplete_composition`. Regenerated only the **3** indexes
the record appears in (the other 9 differed by timestamp alone).

## Why this is one record, not a pipeline
Measured the whole empty set (225) against the **live** sources:

```
126  KOMODO id only  -> 7 unique MediaDive name matches, 1 numeric WITH composition
 40  JCM GRMD link   -> ALL 40 return JCM's 843-byte "Nothing found" page
 39  no medium id at all
 14  mediadive.medium id (J*/C* prefixed; composition endpoint 404s)
  3  DSMZ pdf link,  3 TOGO
```

119 of the 126 KOMODO records have **no MediaDive name match at all**, and the 40
JCM-linked media are a genuine upstream gap (those GRMD ids do not exist in the live
JCM catalogue). Name-matching the remainder is unsafe anyway — JCM `J806 "GS MEDIUM"`
collides with DSMZ `1397 "GS MEDIUM"` (37 components). So an automated backfill
recovers this single record; doing it by hand with verified evidence is the
proportionate response.

## Testing
- `linkml-validate -C MediaRecipe` → no issues.
- `pytest tests/test_recipe_indexes.py tests/test_flag_empty_composition.py
  tests/test_missing_compositions.py` → 42 passed.

Refs #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)