### PR TITLE
Fetch authoritative cocktail addition volumes from MediaDive (#150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ reports/media_growth_review_manifest_summary.md
 # not a tracked artifact. Regenerate with `just propose-cocktail-nesting`.
 data/import_tracking/reports/cocktail_nesting_proposals.tsv
 data/import_tracking/reports/cocktail_nesting_proposals.json
+
+# MediaDive stock-solution volume cache for the #150 cocktail repair: a fetched
+# diagnostic, regenerable with `just fetch-mediadive-volumes`.
+data/import_tracking/reports/mediadive_solution_volumes.json

--- a/project.justfile
+++ b/project.justfile
@@ -249,6 +249,15 @@ curate-flag-empty-composition *args="":
 propose-cocktail-nesting *args="":
     uv run --extra dev python scripts/propose_cocktail_nesting.py {{args}}
 
+# Fetch authoritative stock-solution ADDITION volumes from MediaDive for the
+# flattened cocktails (#150). MediaDive states the volume as a structured
+# solution reference ("Wolfe's mineral elixir, 1 ml"), so it is read rather than
+# guessed from prose — 180 of 186 resolvable records get a real volume this way.
+# Read-only; run before `propose-cocktail-nesting` so the worklist carries them.
+[group('QC')]
+fetch-mediadive-volumes *args="":
+    uv run --extra dev python scripts/fetch_mediadive_solution_volumes.py {{args}}
+
 [group('QC')]
 audit-selective-agent-mismatch *args="":
     uv run --extra dev python scripts/audit_selective_agent_mismatch.py {{args}}

--- a/scripts/fetch_mediadive_solution_volumes.py
+++ b/scripts/fetch_mediadive_solution_volumes.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fetch authoritative stock-solution addition volumes from MediaDive (#150).
+
+The cocktail repair needs, per record, the volume at which a trace/vitamin stock is
+added to the medium. `propose_cocktail_nesting.py` could only scrape a candidate out
+of the record's own prose (15 of 579, several of them false positives), because that
+is all the corpus holds.
+
+MediaDive's `/rest/medium/{id}` has it exactly, and this is the endpoint that makes
+#150 tractable. Each medium returns `solutions[]`, and a solution's `recipe[]` may
+reference ANOTHER solution with the volume it contributes::
+
+    {"solution": "Wolfe's mineral elixir", "solution_id": 1605,
+     "amount": 1, "unit": "ml"}
+
+That "1 ml" is the addition volume — authoritative, not inferred. The referenced
+solution's own `recipe[]` is the cocktail's stock composition, and its `volume` is
+the volume the stock is PREPARED in (1000 ml), which is a different number and must
+not be mistaken for the addition volume. Conflating the two is the obvious way to
+get this wrong, so both are reported separately.
+
+Read-only: writes a JSON cache, never touches the corpus. Applying remains a
+reviewed step (see `propose_cocktail_nesting.py`).
+
+Usage::
+
+    just fetch-mediadive-volumes --limit 5      # canary a few
+    just fetch-mediadive-volumes                # all resolvable cocktails
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+NORMALIZED = REPO / "data" / "normalized_yaml"
+PROPOSALS = REPO / "data" / "import_tracking" / "reports" / "cocktail_nesting_proposals.tsv"
+DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "mediadive_solution_volumes.json"
+API = "https://mediadive.dsmz.de/rest/medium/{}"
+
+# A cocktail stock: trace elements, vitamins, mineral elixirs. Matching the
+# REFERENCED solution's name keeps a main-solution self-reference or a buffer out.
+COCKTAIL_NAME = re.compile(
+    r"trace|vitamin|elixir|mineral|selenite|tungstate|SL-?\d+|metal", re.I)
+
+
+def mediadive_id(doc: dict[str, Any]) -> str | None:
+    """The numeric MediaDive medium id this record resolves to, if any.
+
+    Only `mediadive.medium:<digits>[letter]` is accepted. A `komodo.medium:` id is
+    NOT a MediaDive id (they collide numerically — the KOMODO 3136 / MediaDive 1203
+    case in #239), and the J*/C*-prefixed ids are JCM/other catalogues whose
+    composition MediaDive does not serve.
+    """
+    mid = str(((doc.get("media_term") or {}).get("term") or {}).get("id") or "")
+    m = re.fullmatch(r"mediadive\.medium:(\d+[a-z]?)", mid)
+    return m.group(1) if m else None
+
+
+def fetch_medium(mid: str, timeout: int = 20) -> dict[str, Any] | None:
+    try:
+        with urllib.request.urlopen(API.format(mid), timeout=timeout) as r:
+            payload = json.load(r)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+    return payload.get("data") if payload.get("status") == 200 else None
+
+
+def extract_additions(medium: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every "solution X is added at N ml" reference in this medium.
+
+    Returns one entry per referenced cocktail solution, carrying BOTH volumes:
+    `addition_volume_ml` (what the medium takes) and `stock_prepared_in_ml` (what the
+    stock itself is made up to). The ratio of the two is what converts a stock
+    concentration to its real final concentration.
+    """
+    by_id = {s.get("id"): s for s in medium.get("solutions") or []}
+    out = []
+    for sol in medium.get("solutions") or []:
+        for item in sol.get("recipe") or []:
+            ref_id = item.get("solution_id")
+            ref_name = item.get("solution")
+            if not ref_id or not ref_name:
+                continue
+            if not COCKTAIL_NAME.search(str(ref_name)):
+                continue
+            if str(item.get("unit") or "").lower() != "ml":
+                continue          # a non-volume reference cannot give an addition volume
+            referenced = by_id.get(ref_id) or {}
+            out.append({
+                "parent_solution": sol.get("name"),
+                "solution_id": ref_id,
+                "solution_name": ref_name,
+                "addition_volume_ml": item.get("amount"),
+                "stock_prepared_in_ml": referenced.get("volume"),
+                "stock_components": [
+                    {"compound": r.get("compound"), "amount": r.get("amount"),
+                     "unit": r.get("unit"), "g_l": r.get("g_l")}
+                    for r in (referenced.get("recipe") or [])
+                    if r.get("compound")
+                ],
+            })
+    return out
+
+
+def cocktail_records() -> list[tuple[str, str]]:
+    """(file_path, mediadive_id) for flattened cocktails that resolve to MediaDive."""
+    if not PROPOSALS.is_file():
+        print(f"Run `just propose-cocktail-nesting` first — {PROPOSALS.name} is missing.",
+              file=sys.stderr)
+        return []
+    import csv
+    out = []
+    with PROPOSALS.open() as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            path = NORMALIZED / row["file_path"]
+            try:
+                doc = yaml.safe_load(path.read_text(errors="replace"))
+            except (yaml.YAMLError, OSError):
+                continue
+            mid = mediadive_id(doc) if isinstance(doc, dict) else None
+            if mid:
+                out.append((row["file_path"], mid))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--limit", type=int, default=0, help="Fetch only the first N (canary).")
+    ap.add_argument("--delay", type=float, default=0.34, help="Seconds between API calls.")
+    args = ap.parse_args(argv)
+
+    records = cocktail_records()
+    if args.limit:
+        records = records[:args.limit]
+    print(f"Flattened cocktails resolving to a MediaDive medium: {len(records)}")
+
+    results: dict[str, Any] = {}
+    with_volume = 0
+    for i, (path, mid) in enumerate(records, 1):
+        medium = fetch_medium(mid)
+        additions = extract_additions(medium) if medium else []
+        if additions:
+            with_volume += 1
+        results[path] = {"mediadive_id": mid, "fetched": medium is not None,
+                         "additions": additions}
+        print(f"  [{i}/{len(records)}] {path[:46]:48s} mediadive:{mid:>6s} "
+              f"-> {len(additions)} stock addition(s)"
+              + (f"  e.g. {additions[0]['solution_name']} @ "
+                 f"{additions[0]['addition_volume_ml']} ml" if additions else ""))
+        time.sleep(args.delay)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(results, indent=2) + "\n")
+    print(f"\n{with_volume}/{len(records)} records have at least one authoritative "
+          f"stock addition volume.")
+    print(f"Wrote {args.out.relative_to(REPO)} — read-only; the corpus is untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/propose_cocktail_nesting.py
+++ b/scripts/propose_cocktail_nesting.py
@@ -47,6 +47,10 @@ import audit_concentration_plausibility as acp  # noqa: E402
 
 NORMALIZED = REPO / "data" / "normalized_yaml"
 DEFAULT_OUT = REPO / "data" / "import_tracking" / "reports" / "cocktail_nesting_proposals.tsv"
+# Authoritative addition volumes fetched from MediaDive (#150), when present. These
+# beat anything scraped from the record's prose: MediaDive states the volume as a
+# structured solution reference, so it is read rather than inferred.
+MEDIADIVE_VOLUMES = REPO / "data" / "import_tracking" / "reports" / "mediadive_solution_volumes.json"
 
 # A CANDIDATE addition volume: an amount in ml sitting next to a
 # trace/vitamin/element solution word, AND in an addition context — an "add"-type
@@ -88,10 +92,21 @@ def cocktail_components(rows: list[dict[str, str]], file_path: str) -> list[dict
             and r["finding"] in ("TRACE_SALT_AS_STOCK", "INDICATOR_UNIT_SLIP")]
 
 
+def load_mediadive_volumes() -> dict[str, Any]:
+    """Authoritative addition volumes, keyed by record path, if they were fetched."""
+    if not MEDIADIVE_VOLUMES.is_file():
+        return {}
+    try:
+        return json.loads(MEDIADIVE_VOLUMES.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
 def build_proposals() -> list[dict[str, Any]]:
     rows = acp.audit(NORMALIZED)
     summary = acp.summarize_records(rows, NORMALIZED)
     cocktail_paths = [s["file_path"] for s in summary if s["flattened_cocktail"] == "yes"]
+    mediadive = load_mediadive_volumes()
     proposals = []
     for fp in sorted(cocktail_paths):
         try:
@@ -100,13 +115,25 @@ def build_proposals() -> list[dict[str, Any]]:
             doc = {}
         comps = cocktail_components(rows, fp)
         vol, evidence = recover_volume(doc)
+        # MediaDive states the volume structurally, so it supersedes a prose scrape.
+        additions = (mediadive.get(fp) or {}).get("additions") or []
+        if additions:
+            a = additions[0]
+            vol = str(a.get("addition_volume_ml") or vol)
+            evidence = (f"MediaDive {(mediadive[fp]).get('mediadive_id')}: "
+                        f"{a.get('solution_name')} added at {a.get('addition_volume_ml')} ml "
+                        f"(stock prepared in {a.get('stock_prepared_in_ml')} ml)")
         proposals.append({
             "file_path": fp,
             "record_id": str(doc.get("id") or ""),
             "n_components": len(comps),
             "components": "; ".join(f"{c['ingredient']}={c['value']}{c['unit']}" for c in comps),
             "candidate_volume_ml": vol,
-            "volume_source": "preparation_steps/notes" if vol else "MANUAL",
+            # MEDIADIVE = read from a structured solution reference (authoritative,
+            # applyable). preparation_steps/notes = scraped from prose (a candidate a
+            # curator must verify). MANUAL = nothing found.
+            "volume_source": ("MEDIADIVE" if additions
+                              else "preparation_steps/notes" if vol else "MANUAL"),
             "volume_evidence": evidence,
             # The proposed nested shape (curator applies): the flagged components move
             # under one solution added at candidate_volume_ml per litre.

--- a/tests/test_mediadive_volumes.py
+++ b/tests/test_mediadive_volumes.py
@@ -1,0 +1,115 @@
+"""Unit-test the MediaDive addition-volume extraction (#150).
+
+The cocktail repair turns on ONE number per record: the volume at which a stock
+trace/vitamin solution is added to the medium. MediaDive states it structurally, as
+a solution-to-solution reference inside a medium's recipe. These tests pin that
+extraction — offline, against the real response shape — because the two volumes in
+play are easy to confuse:
+
+    addition_volume_ml    what the medium takes      (1 ml)      <- the one we need
+    stock_prepared_in_ml  what the stock is made up to (1000 ml)
+
+Using the second as the first would understate every concentration by ~1000x, which
+is the same class of error the whole audit exists to find.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def fsv():
+    return _load("fetch_mediadive_solution_volumes")
+
+
+# The real shape of /rest/medium/1083 (ACIDULIPROFUNDUM MEDIUM), trimmed.
+MEDIUM_1083 = {
+    "medium": {"id": 1083, "name": "ACIDULIPROFUNDUM MEDIUM"},
+    "solutions": [
+        {
+            "id": 2192, "name": "Main sol. 1083", "volume": 1001,
+            "recipe": [
+                {"recipe_order": 1, "compound": "NaCl", "amount": 30, "unit": "g", "g_l": 29.97},
+                {"recipe_order": 9, "solution": "Wolfe's mineral elixir",
+                 "solution_id": 1605, "amount": 1, "unit": "ml"},
+                {"recipe_order": 16, "compound": "Distilled water", "amount": 1000, "unit": "ml"},
+            ],
+        },
+        {
+            "id": 1605, "name": "Wolfe's mineral elixir", "volume": 1000,
+            "recipe": [
+                {"compound": "MnSO4 x H2O", "amount": 5, "unit": "g", "g_l": 5},
+                {"compound": "FeSO4 x 7 H2O", "amount": 1, "unit": "g", "g_l": 1},
+                {"compound": "CoCl2 x 6 H2O", "amount": 1.8, "unit": "g", "g_l": 1.8},
+            ],
+        },
+    ],
+}
+
+
+def test_extracts_the_addition_volume_not_the_stock_volume(fsv):
+    """1 ml (what the medium takes), NOT 1000 ml (what the stock is prepared in)."""
+    additions = fsv.extract_additions(MEDIUM_1083)
+    assert len(additions) == 1
+    a = additions[0]
+    assert a["solution_name"] == "Wolfe's mineral elixir"
+    assert a["addition_volume_ml"] == 1
+    assert a["stock_prepared_in_ml"] == 1000
+
+
+def test_carries_the_stock_composition(fsv):
+    """The stock's own recipe is what gets nested under the solution."""
+    comps = fsv.extract_additions(MEDIUM_1083)[0]["stock_components"]
+    assert [c["compound"] for c in comps] == ["MnSO4 x H2O", "FeSO4 x 7 H2O", "CoCl2 x 6 H2O"]
+    assert comps[0]["g_l"] == 5
+
+
+def test_a_plain_compound_is_not_an_addition(fsv):
+    """NaCl and distilled water are components, not stock-solution references."""
+    names = [a["solution_name"] for a in fsv.extract_additions(MEDIUM_1083)]
+    assert "NaCl" not in names and "Distilled water" not in names
+
+
+def test_a_non_cocktail_solution_reference_is_ignored(fsv):
+    """Only trace/vitamin/elixir-type stocks are cocktails; a buffer reference is not."""
+    medium = {"solutions": [{
+        "id": 1, "name": "Main", "volume": 1000,
+        "recipe": [{"solution": "Phosphate buffer", "solution_id": 9, "amount": 50, "unit": "ml"}],
+    }]}
+    assert fsv.extract_additions(medium) == []
+
+
+def test_a_reference_without_ml_units_is_ignored(fsv):
+    """No ml unit means no volume can be read; silence beats a wrong number."""
+    medium = {"solutions": [{
+        "id": 1, "name": "Main", "volume": 1000,
+        "recipe": [{"solution": "Trace element solution", "solution_id": 9,
+                    "amount": 2, "unit": "g"}],
+    }]}
+    assert fsv.extract_additions(medium) == []
+
+
+def test_mediadive_id_accepts_only_mediadive_numeric_ids(fsv):
+    """A komodo.medium id is NOT a MediaDive id — they collide numerically (#239:
+    KOMODO 3136 is MediaDive 1203), so treating one as the other fetches the wrong
+    medium's composition."""
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:1083"}}}) == "1083"
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:734a"}}}) == "734a"
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "komodo.medium:3136"}}}) is None
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:J390"}}}) is None
+    assert fsv.mediadive_id({}) is None


### PR DESCRIPTION
Unblocks the hard part of #150. Still applies nothing — the corpus is untouched.

## The blocker
The repair turns on **one number per record**: the volume at which a stock
trace/vitamin solution is added. #236 could only scrape a candidate from the
record's own prose — **15 of 579**, several false positives (a volume next to
"methanol", a pH-adjust step) — because that is all the corpus holds. That left the
repair effectively curator-only.

## MediaDive states it structurally
`/rest/medium/{id}` returns `solutions[]`, and a solution's recipe references
another solution with the volume it contributes:

```json
{"solution": "Wolfe's mineral elixir", "solution_id": 1605, "amount": 1, "unit": "ml"}
```

Read, not inferred. Fetching this for the 186 cocktails that resolve to a numeric
MediaDive id gives a real volume for **180** — a **12× improvement** in actionable
coverage:

| volume_source | records |
|---|--:|
| `MEDIADIVE` (authoritative) | **180** |
| `preparation_steps/notes` (prose candidate) | 6 |
| `MANUAL` | 393 |

Volumes are genuinely varied (1, 2, 5, 10, 0.1, 0.5, 50 ml), so they could not have
been assumed.

## Verified end to end
On `aciduliprofundum_medium`: its flagged **MnSO4 5, FeSO4 1, CoCl2 1.8, ZnSO4 1.8
G_PER_L** are *exactly* Wolfe's mineral elixir's stock values in MediaDive, added at
**1 ml into 1000 ml** — so the flattening overstates them ~1000×. That is the defect
#150 describes, now with the dilution factor in hand.

## The trap, guarded
Two volumes are easy to confuse, and both are reported:
- `addition_volume_ml` (**1**) — what the medium takes ← the one the repair needs
- `stock_prepared_in_ml` (**1000**) — what the stock is made up to

Using the second as the first would understate every concentration ~1000×, the same
error class the audit exists to find. Tests pin that distinction, that a
`komodo.medium` id is never treated as a MediaDive id (#239: KOMODO 3136 is MediaDive
1203), and that a non-cocktail or non-`ml` reference yields nothing rather than a
wrong number.

- `pytest tests/test_mediadive_volumes.py tests/test_cocktail_nesting.py` → 12 passed.
- Corpus changes: **0**. Volume cache is gitignored (regenerable).

Refs #150. Applying the nesting per record remains the reviewed step, now with
authoritative volumes for ~31% of the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)