### PR TITLE
Split summed vitamin stocks and nest 16 more cocktails (#150)

### DIFF
--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -4,7 +4,7 @@ name: concentration-plausibility
 #
 # #118 asked for an audit AND a corpus repair; #135 shipped the audit only, and
 # nothing has since stopped the defect being reintroduced. The corpus backlog
-# (3,716 records, 375 flattened cocktails after the #150 nesting passes) is NOT
+# (3,700 records, 359 flattened cocktails after the #150 nesting passes) is NOT
 # fixed by this workflow — the
 # baselines hold the line while it is worked through, per the --max-allowed
 # convention already used by check-chebi-grounding.

--- a/data/import_tracking/reports/concentration_plausibility.tsv
+++ b/data/import_tracking/reports/concentration_plausibility.tsv
@@ -272,12 +272,6 @@ INDICATOR_UNIT_SLIP	bacterial/KOMODO_1278_HYL_medium.yaml	CultureMech:004031	Pyr
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_1282_SH_SEAWATER_medium.yaml	CultureMech:004034	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_1282_SH_SEAWATER_medium.yaml	CultureMech:004034	Na2MoO4 x 2 H2O	10	G_PER_L	10 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/KOMODO_1282_SH_SEAWATER_medium.yaml	CultureMech:004034	Double distilled water	1990.0	G_PER_L	1990 G_PER_L water — reads as a preparation volume, not a concentration
-TRACE_SALT_AS_STOCK	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_1299_THERMOSIPHO_AFFECTUS_medium.yaml	CultureMech:004046	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_1299_THERMOSIPHO_AFFECTUS_medium.yaml	CultureMech:004046	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 WATER_AS_VOLUME	bacterial/KOMODO_12_SOIL_EXTRACT_medium.yaml	CultureMech:004048	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
@@ -447,11 +441,6 @@ INDICATOR_UNIT_SLIP	bacterial/KOMODO_710_KoKo_medium.yaml	CultureMech:006347	Pyr
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_711_SPOROBACTER_medium.yaml	CultureMech:006348	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_711a_EUBACTERIUM_AGGREGANS_medium.yaml	CultureMech:006349	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_712_PSEUDOBUTYRIVIBRIO_medium.yaml	CultureMech:006350	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_718_PETROTOGA_medium.yaml	CultureMech:006360	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_719_ANAEROFILUM_medium.yaml	CultureMech:006361	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_719_ANAEROFILUM_medium.yaml	CultureMech:006361	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -500,12 +489,6 @@ INDICATOR_UNIT_SLIP	bacterial/KOMODO_81-3_For_heterotrophic_growth.yaml	CultureM
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_81-3_For_heterotrophic_growth.yaml	CultureMech:006531	Pyridoxine hydrochloride	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_813_DESULFONATRONUM_medium.yaml	CultureMech:006536	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_813_DESULFONATRONUM_medium.yaml	CultureMech:006536	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_826_GEOBACTER_MEDIUM.yaml	CultureMech:006556	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/KOMODO_827_THERMOANAEROBACTER_SULFUROPHILUS_medium.yaml	CultureMech:006558	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/KOMODO_827_THERMOANAEROBACTER_SULFUROPHILUS_medium.yaml	CultureMech:006558	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -3850,11 +3833,6 @@ INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_for_dsm_22663.yaml	Culture
 INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_for_dsm_22663.yaml	CultureMech:009229	Riboflavin	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_for_dsm_22663.yaml	CultureMech:009229	Nicotinic acid	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_for_dsm_22663.yaml	CultureMech:009229	Lipoic acid	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/carboxydothermus_siderophilus_medium.yaml	CultureMech:001640	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/carcboxydibrachium_medium.yaml	CultureMech:002069	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/carcboxydibrachium_medium.yaml	CultureMech:002069	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -3960,12 +3938,6 @@ TRACE_SALT_AS_STOCK	bacterial/chromatium_medium.yaml	CultureMech:009124	CoCl2	1	
 TRACE_SALT_AS_STOCK	bacterial/chromatium_medium.yaml	CultureMech:009124	CuCl2	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/chromatium_medium.yaml	CultureMech:009124	NiCl2	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/chromatium_tepidum_medium.yaml	CultureMech:001482	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/chrysiogenes_medium.yaml	CultureMech:001965	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/clostridium_acetate_1_medium.yaml	CultureMech:003124	FeSO4 x 7 H2O	2.1	G_PER_L	2.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/clostridium_acidiurici_medium.yaml	CultureMech:006426	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/clostridium_aldrichii_medium.yaml	CultureMech:009273	Resazurin	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -4124,18 +4096,6 @@ INDICATOR_UNIT_SLIP	bacterial/deferrisoma_medium.yaml	CultureMech:000917	Pyridox
 TRACE_SALT_AS_STOCK	bacterial/deferrisoma_paleochrorii_medium.yaml	CultureMech:002236	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/defined_medium_for_sulfate_reducing_bacteria_with_butyrate.yaml	CultureMech:003054	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/defluviitoga_medium.yaml	CultureMech:000785	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	FeCl2 x 4 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	FeCl2 x 4 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/dehalococcoides_medium.yaml	CultureMech:003171	Pyridoxine hydrochloride	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/dehalococcoides_medium.yaml	CultureMech:003171	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/dehalococcoides_medium.yaml	CultureMech:003171	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -4172,11 +4132,6 @@ TRACE_SALT_AS_STOCK	bacterial/desulfitobacterium_frappieri_medium.yaml	CultureMe
 TRACE_SALT_AS_STOCK	bacterial/desulfitobacterium_hafniense_medium.yaml	CultureMech:001859	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_hafniense_medium.yaml	CultureMech:001859	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_medium.yaml	CultureMech:001801	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfitobacterium_pcp_1_medium.yaml	CultureMech:001993	FeCl2 x 4 H2O	1.502	G_PER_L	1.502 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfobacter_curvatus_medium.yaml	CultureMech:001291	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfobacter_curvatus_medium.yaml	CultureMech:001291	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -4348,20 +4303,8 @@ INDICATOR_UNIT_SLIP	bacterial/desulfonema_limicola_medium.yaml	CultureMech:00130
 TRACE_SALT_AS_STOCK	bacterial/desulfonema_magnum_medium.yaml	CultureMech:001301	AlK(SO4)2 x 12 H2O	48	G_PER_L	48 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfonema_magnum_medium.yaml	CultureMech:001301	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfonema_magnum_medium.yaml	CultureMech:001301	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfopila_msl86_medium.yaml	CultureMech:000500	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfopila_msl86_medium.yaml	CultureMech:000500	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulforhabdus_amnigenus_medium.yaml	CultureMech:006340	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigenus_medium.yaml	CultureMech:006340	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulforhabdus_amnigenus_medium.yaml	CultureMech:006340	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -4393,12 +4336,6 @@ INDICATOR_UNIT_SLIP	bacterial/desulfotalea_psychrophila_medium.yaml	CultureMech:
 TRACE_SALT_AS_STOCK	bacterial/desulfothermobacter_medium.yaml	CultureMech:001158	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfothermobacter_medium.yaml	CultureMech:001158	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfothermus_mj_medium_h2_co2.yaml	CultureMech:000430	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfotignum_medium.yaml	CultureMech:001490	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfotignum_medium.yaml	CultureMech:001490	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfotomaculum_14_5_medium.yaml	CultureMech:001774	FeSO4 x 7 H2O	50	G_PER_L	50 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -4513,12 +4450,6 @@ INDICATOR_UNIT_SLIP	bacterial/desulfurella_tr1_medium.yaml	CultureMech:002263	Vi
 INDICATOR_UNIT_SLIP	bacterial/desulfurella_tr1_medium.yaml	CultureMech:002263	Riboflavin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfuribacillus_medium_arsenate.yaml	CultureMech:000608	FeSO4 x 7 H2O	2.2	G_PER_L	2.2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfuribacillus_medium_arsenate.yaml	CultureMech:000608	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfurispirillum_medium.yaml	CultureMech:000698	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfurobacterium_crinifex_medium.yaml	CultureMech:001981	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfurobacterium_hr11_medium.yaml	CultureMech:001380	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -4533,12 +4464,6 @@ TRACE_SALT_AS_STOCK	bacterial/desulfuromonas_carbonis_medium.yaml	CultureMech:00
 INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_carbonis_medium.yaml	CultureMech:001059	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfuromonas_chloroethenica_medium.yaml	CultureMech:001992	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_chloroethenica_medium.yaml	CultureMech:001992	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	FeCl2 x 4 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_palmitatis_medium.yaml	CultureMech:001994	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfuromonas_sp_medium.yaml	CultureMech:004169	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfuromonas_sp_medium.yaml	CultureMech:004169	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -8489,12 +8414,6 @@ TRACE_SALT_AS_STOCK	bacterial/thiosphaera_pantotropha_medium.yaml	CultureMech:00
 WATER_AS_VOLUME	bacterial/tibi_medium.yaml	CultureMech:001362	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/tissierella_amo_1_medium.yaml	CultureMech:001820	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/tissierella_amo_1_medium.yaml	CultureMech:001820	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/tissierella_sp_medium_creatinine.yaml	CultureMech:001691	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/tissierella_sp_medium_creatinine.yaml	CultureMech:001691	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/tissirella_creatinophila_medium.yaml	CultureMech:006551	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -9025,12 +8944,6 @@ INDICATOR_UNIT_SLIP	archaea/KOMODO_1210_GEOGLOBUS_medium.yaml	CultureMech:003962
 TRACE_SALT_AS_STOCK	archaea/KOMODO_1257_METHANOCELLA_medium.yaml	CultureMech:004017	FeCl2 x 4 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/KOMODO_1257_METHANOCELLA_medium.yaml	CultureMech:004017	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/KOMODO_1273_METHANOSPIRILLUM_LACUNAE_MEDIUM.yaml	CultureMech:004027	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/KOMODO_1329_METHANOSAETA_PELAGICA_medium.yaml	CultureMech:004085	FeCl2 x 4 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/KOMODO_1329_METHANOSAETA_PELAGICA_medium.yaml	CultureMech:004085	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/KOMODO_150_ACIDIANUS_BRIERLEYI_MEDIUM.yaml	CultureMech:004173	FeCl3 x 6 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -10116,12 +10029,6 @@ INDICATOR_UNIT_SLIP	archaea/methanocalculus_pumilus_medium.yaml	CultureMech:0020
 INDICATOR_UNIT_SLIP	archaea/methanocaldococcus_lauensis_medium.yaml	CultureMech:000881	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/methanocaldococcus_medium.yaml	CultureMech:001378	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/methanocaldococcus_villosus_medium.yaml	CultureMech:001379	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	Vitamin B12	0.101	G_PER_L	0.101 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	p-Aminobenzoic acid	0.13	G_PER_L	0.13 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	Nicotinic acid	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	Pyridoxine hydrochloride	0.4	G_PER_L	0.4 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	archaea/methanocella_conradii_medium.yaml	CultureMech:000776	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/methanocella_medium.yaml	CultureMech:000715	FeCl2 x 4 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/methanocella_medium.yaml	CultureMech:000715	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/methanococcoides_medium.yaml	CultureMech:000883	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip

--- a/data/import_tracking/reports/concentration_plausibility_by_record.tsv
+++ b/data/import_tracking/reports/concentration_plausibility_by_record.tsv
@@ -41,7 +41,6 @@ archaea/KOMODO_120b_METHANOMICROCOCCUS_medium.yaml	CultureMech:003960	3	0	2	1	no
 archaea/KOMODO_1210_GEOGLOBUS_medium.yaml	CultureMech:003962	2	0	1	1	no	no
 archaea/KOMODO_1257_METHANOCELLA_medium.yaml	CultureMech:004017	2	0	1	1	no	no
 archaea/KOMODO_1273_METHANOSPIRILLUM_LACUNAE_MEDIUM.yaml	CultureMech:004027	1	0	0	1	no	no
-archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml	CultureMech:004073	6	0	1	5	no	yes
 archaea/KOMODO_1329_METHANOSAETA_PELAGICA_medium.yaml	CultureMech:004085	2	0	1	1	no	no
 archaea/KOMODO_150_ACIDIANUS_BRIERLEYI_MEDIUM.yaml	CultureMech:004173	1	0	1	0	no	no
 archaea/KOMODO_158_THERMOPLASMA_ACIDOPHILUM_medium.yaml	CultureMech:004181	1	0	1	0	no	no
@@ -329,7 +328,6 @@ archaea/methanocalculus_pumilus_medium.yaml	CultureMech:002055	2	0	1	1	no	no
 archaea/methanocaldococcus_lauensis_medium.yaml	CultureMech:000881	1	0	0	1	no	no
 archaea/methanocaldococcus_medium.yaml	CultureMech:001378	1	0	0	1	no	no
 archaea/methanocaldococcus_villosus_medium.yaml	CultureMech:001379	1	0	0	1	no	no
-archaea/methanocella_conradii_medium.yaml	CultureMech:000776	6	0	1	5	no	yes
 archaea/methanocella_medium.yaml	CultureMech:000715	2	0	1	1	no	no
 archaea/methanococcoides_medium.yaml	CultureMech:000883	1	0	0	1	no	no
 archaea/methanococcoides_medium_2.yaml	CultureMech:009543	1	0	0	1	yes	no
@@ -624,7 +622,6 @@ bacterial/KOMODO_1275_GEORGFUCHSIA_MEDIUM.yaml	CultureMech:004029	2	0	1	1	no	no
 bacterial/KOMODO_1277_SULFURICELLA_MEDIUM.yaml	CultureMech:004030	2	0	1	1	no	no
 bacterial/KOMODO_1278_HYL_medium.yaml	CultureMech:004031	1	0	0	1	no	no
 bacterial/KOMODO_1282_SH_SEAWATER_medium.yaml	CultureMech:004034	3	1	2	0	no	no
-bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml	CultureMech:004044	6	0	1	5	no	yes
 bacterial/KOMODO_1299_THERMOSIPHO_AFFECTUS_medium.yaml	CultureMech:004046	2	0	1	1	no	no
 bacterial/KOMODO_12_SOIL_EXTRACT_medium.yaml	CultureMech:004048	1	1	0	0	no	no
 bacterial/KOMODO_1301_TEPIDANAEROBACTER_ACETATOXYDANS_medium.yaml	CultureMech:004056	1	0	1	0	no	no
@@ -742,7 +739,6 @@ bacterial/KOMODO_710_KoKo_medium.yaml	CultureMech:006347	2	0	1	1	no	no
 bacterial/KOMODO_711_SPOROBACTER_medium.yaml	CultureMech:006348	1	0	1	0	no	no
 bacterial/KOMODO_711a_EUBACTERIUM_AGGREGANS_medium.yaml	CultureMech:006349	1	0	1	0	no	no
 bacterial/KOMODO_712_PSEUDOBUTYRIVIBRIO_medium.yaml	CultureMech:006350	1	0	0	1	no	no
-bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml	CultureMech:006354	5	0	0	5	no	yes
 bacterial/KOMODO_718_PETROTOGA_medium.yaml	CultureMech:006360	1	0	0	1	no	no
 bacterial/KOMODO_719_ANAEROFILUM_medium.yaml	CultureMech:006361	2	0	2	0	no	no
 bacterial/KOMODO_720_DESULFITOBACTERIUM_HAFNIENSE_medium.yaml	CultureMech:006363	2	0	1	1	no	no
@@ -770,7 +766,6 @@ bacterial/KOMODO_803_SPHAEROTILUS-LEPTOTHRIX_medium.yaml	CultureMech:006520	1	1	
 bacterial/KOMODO_807_HALOANAEROBIUM_ALCALIPHILUM_medium.yaml	CultureMech:006525	1	0	1	0	no	no
 bacterial/KOMODO_81-3_For_heterotrophic_growth.yaml	CultureMech:006531	4	0	0	4	no	yes
 bacterial/KOMODO_813_DESULFONATRONUM_medium.yaml	CultureMech:006536	2	0	1	1	no	no
-bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml	CultureMech:006543	6	0	1	5	no	yes
 bacterial/KOMODO_826_GEOBACTER_MEDIUM.yaml	CultureMech:006556	1	0	0	1	no	no
 bacterial/KOMODO_827_THERMOANAEROBACTER_SULFUROPHILUS_medium.yaml	CultureMech:006558	2	0	1	1	no	no
 bacterial/KOMODO_829a_DESULFUROBACTERIUM_ATLANTICUM_MEDIUM.yaml	CultureMech:006565	5	0	1	4	no	yes
@@ -1782,7 +1777,6 @@ bacterial/caloramator_viterbiensis_medium.yaml	CultureMech:002126	2	0	1	1	no	no
 bacterial/carboxydocella_manganica_medium.yaml	CultureMech:001641	1	0	0	1	no	no
 bacterial/carboxydothermus_medium.yaml	CultureMech:001639	2	0	1	1	no	no
 bacterial/carboxydothermus_medium_for_dsm_22663.yaml	CultureMech:009229	18	1	8	9	yes	no
-bacterial/carboxydothermus_medium_heterotroph.yaml	CultureMech:001642	5	0	0	5	no	yes
 bacterial/carboxydothermus_siderophilus_medium.yaml	CultureMech:001640	1	0	0	1	no	no
 bacterial/carcboxydibrachium_medium.yaml	CultureMech:002069	2	0	1	1	no	no
 bacterial/carcboxydobrachium_pacificum_medium.yaml	CultureMech:006772	2	0	1	1	no	no
@@ -1817,7 +1811,6 @@ bacterial/chopped_meat_medium_add_vitamin_k3_and_agar.yaml	CultureMech:009095	2	
 bacterial/chopped_meat_medium_for_fretibacterium_sp.yaml	CultureMech:001929	1	0	0	1	no	no
 bacterial/chromatium_medium.yaml	CultureMech:009124	12	1	6	5	yes	no
 bacterial/chromatium_tepidum_medium.yaml	CultureMech:001482	1	0	1	0	no	no
-bacterial/chrysiogenes_medium.yaml	CultureMech:001965	6	0	1	5	no	yes
 bacterial/clostridium_acetate_1_medium.yaml	CultureMech:003124	1	0	1	0	no	no
 bacterial/clostridium_acidiurici_medium.yaml	CultureMech:006426	1	0	1	0	no	no
 bacterial/clostridium_aldrichii_medium.yaml	CultureMech:009273	9	0	0	9	yes	no
@@ -1886,8 +1879,6 @@ bacterial/deferrisoma_medium.yaml	CultureMech:000917	2	0	1	1	no	no
 bacterial/deferrisoma_paleochrorii_medium.yaml	CultureMech:002236	1	0	1	0	no	no
 bacterial/defined_medium_for_sulfate_reducing_bacteria_with_butyrate.yaml	CultureMech:003054	1	0	1	0	no	no
 bacterial/defluviitoga_medium.yaml	CultureMech:000785	1	0	1	0	no	no
-bacterial/dehalobacter_restrictus_medium.yaml	CultureMech:006377	6	0	1	5	no	yes
-bacterial/dehalobacter_restrictus_medium_tce.yaml	CultureMech:001867	6	0	1	5	no	yes
 bacterial/dehalococcoides_medium.yaml	CultureMech:003171	3	0	1	2	no	no
 bacterial/dehalogenimonas_medium.yaml	CultureMech:003024	1	0	1	0	yes	no
 bacterial/dehalospirillum_medium.yaml	CultureMech:001990	7	0	2	5	no	yes
@@ -1904,7 +1895,6 @@ bacterial/desulfitobacterium_dehalogenans_medium.yaml	CultureMech:009144	3	0	3	0
 bacterial/desulfitobacterium_frappieri_medium.yaml	CultureMech:006629	1	0	1	0	no	no
 bacterial/desulfitobacterium_hafniense_medium.yaml	CultureMech:001859	2	0	1	1	no	no
 bacterial/desulfitobacterium_medium.yaml	CultureMech:001801	1	0	0	1	no	no
-bacterial/desulfitobacterium_pce_medium.yaml	CultureMech:001855	5	0	0	5	no	yes
 bacterial/desulfitobacterium_pcp_1_medium.yaml	CultureMech:001993	1	0	1	0	no	no
 bacterial/desulfobacter_curvatus_medium.yaml	CultureMech:001291	2	0	1	1	no	no
 bacterial/desulfobacter_medium.yaml	CultureMech:001285	2	0	1	1	no	no
@@ -1957,9 +1947,7 @@ bacterial/desulfonauticus_medium.yaml	CultureMech:001491	2	0	1	1	no	no
 bacterial/desulfonema_ishimotoi_medium.yaml	CultureMech:001875	3	0	2	1	no	no
 bacterial/desulfonema_limicola_medium.yaml	CultureMech:001300	2	0	1	1	no	no
 bacterial/desulfonema_magnum_medium.yaml	CultureMech:001301	3	0	2	1	no	no
-bacterial/desulfopila_corrodens_medium.yaml	CultureMech:000426	6	0	1	5	no	yes
 bacterial/desulfopila_msl86_medium.yaml	CultureMech:000500	2	0	1	1	no	no
-bacterial/desulforhabdus_amnigena_medium.yaml	CultureMech:001845	6	0	1	5	no	yes
 bacterial/desulforhabdus_amnigenus_medium.yaml	CultureMech:006340	6	0	1	5	no	yes
 bacterial/desulfosalsimonas_medium.yaml	CultureMech:000485	2	0	1	1	no	no
 bacterial/desulfosarcina_cetonica_medium.yaml	CultureMech:001741	1	0	1	0	no	no
@@ -1976,7 +1964,6 @@ bacterial/desulfosudis_medium.yaml	CultureMech:001649	3	0	1	2	no	no
 bacterial/desulfotalea_psychrophila_medium.yaml	CultureMech:002021	2	0	1	1	no	no
 bacterial/desulfothermobacter_medium.yaml	CultureMech:001158	2	0	1	1	no	no
 bacterial/desulfothermus_mj_medium_h2_co2.yaml	CultureMech:000430	1	0	0	1	no	no
-bacterial/desulfothermus_naphthae_medium.yaml	CultureMech:002034	6	0	1	5	no	yes
 bacterial/desulfotignum_medium.yaml	CultureMech:001490	2	0	1	1	no	no
 bacterial/desulfotomaculum_14_5_medium.yaml	CultureMech:001774	1	0	1	0	no	no
 bacterial/desulfotomaculum_acetoxidans_medium.yaml	CultureMech:004007	2	0	1	1	no	no
@@ -2023,7 +2010,6 @@ bacterial/desulfurella_medium_brackish_water.yaml	CultureMech:001606	2	0	1	1	no	
 bacterial/desulfurella_multipotens_medium.yaml	CultureMech:005597	2	0	1	1	no	no
 bacterial/desulfurella_tr1_medium.yaml	CultureMech:002263	7	0	0	7	no	yes
 bacterial/desulfuribacillus_medium_arsenate.yaml	CultureMech:000608	2	0	1	1	no	no
-bacterial/desulfurispirillum_indicum_medium.yaml	CultureMech:000756	6	0	1	5	no	yes
 bacterial/desulfurispirillum_medium.yaml	CultureMech:000698	1	0	1	0	no	no
 bacterial/desulfurobacterium_crinifex_medium.yaml	CultureMech:001981	1	0	0	1	no	no
 bacterial/desulfurobacterium_hr11_medium.yaml	CultureMech:001380	1	0	0	1	no	no
@@ -2032,7 +2018,6 @@ bacterial/desulfuromonas_acetexigenes_medium.yaml	CultureMech:006194	5	0	1	4	no	
 bacterial/desulfuromonas_acetoxidans_medium.yaml	CultureMech:002139	1	0	1	0	no	no
 bacterial/desulfuromonas_carbonis_medium.yaml	CultureMech:001059	2	0	1	1	no	no
 bacterial/desulfuromonas_chloroethenica_medium.yaml	CultureMech:001992	2	0	1	1	no	no
-bacterial/desulfuromonas_medium_tce.yaml	CultureMech:001868	6	0	1	5	no	yes
 bacterial/desulfuromonas_palmitatis_medium.yaml	CultureMech:001994	1	0	0	1	no	no
 bacterial/desulfuromonas_sp_medium.yaml	CultureMech:004169	5	0	1	4	no	yes
 bacterial/desulfuromusa_medium.yaml	CultureMech:001292	2	0	1	1	no	no
@@ -3545,7 +3530,6 @@ bacterial/thiosocius_medium.yaml	CultureMech:001177	2	0	1	1	no	no
 bacterial/thiosphaera_pantotropha_medium.yaml	CultureMech:001455	1	0	1	0	no	no
 bacterial/tibi_medium.yaml	CultureMech:001362	1	1	0	0	no	no
 bacterial/tissierella_amo_1_medium.yaml	CultureMech:001820	2	0	1	1	no	no
-bacterial/tissierella_creatinophila_medium.yaml	CultureMech:001972	6	0	1	5	no	yes
 bacterial/tissierella_sp_medium_creatinine.yaml	CultureMech:001691	2	0	1	1	no	no
 bacterial/tissirella_creatinophila_medium.yaml	CultureMech:006551	6	0	1	5	no	yes
 bacterial/tm_broth_medium.yaml	CultureMech:002630	2	0	2	0	no	no

--- a/data/normalized_yaml/archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml
+++ b/data/normalized_yaml/archaea/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml
@@ -125,16 +125,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -235,28 +225,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:63939
     label: Na2WO4 x 2 H2O
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.001]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.08, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: D-(+)-biotin
   term:
     id: CHEBI:15956
@@ -267,17 +235,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: D-(+)-biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.2, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -288,27 +245,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.3, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 - preferred_term: Biotin
   term:
     id: CHEBI:15956
@@ -409,6 +345,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:36:38.208071+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 36 -> 30
 parent_media:
   path: data/normalized_yaml/bacterial/methanocella_conradii_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -421,3 +368,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - KOMODO record is an exact source duplicate of DSMZ Medium 1318; local ingredient
   and concentration signatures match.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea/methanocella_conradii_medium.yaml
+++ b/data/normalized_yaml/archaea/methanocella_conradii_medium.yaml
@@ -124,16 +124,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -234,28 +224,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:63939
     label: Na2WO4 x 2 H2O
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.001]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.08, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: D-(+)-biotin
   term:
     id: CHEBI:15956
@@ -266,17 +234,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: D-(+)-biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.2, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -287,27 +244,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.3, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 - preferred_term: Biotin
   term:
     id: CHEBI:15956
@@ -423,6 +359,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.187707+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 36 -> 30
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -430,3 +377,117 @@ variant_children:
   name: methanocella_conradii_medium
   notes: KOMODO record is an exact source duplicate of DSMZ Medium 1318; local ingredient
     and concentration signatures match.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea_index.json
+++ b/data/normalized_yaml/archaea_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T20:47:30.870305+00:00",
+  "generated": "2026-08-07T23:45:06.738426+00:00",
   "category": "archaea",
   "count": 743,
   "recipes": {
@@ -595,10 +595,11 @@
     "CultureMech:004073": {
       "name": "methanocella_conradii_medium",
       "filename": "KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004073",
       "source_id": "komodo.medium:1318",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ]
@@ -6006,10 +6007,11 @@
     "CultureMech:000776": {
       "name": "methanocella_conradii_medium",
       "filename": "methanocella_conradii_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000776",
       "source_id": "mediadive.medium:1318",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ]

--- a/data/normalized_yaml/bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml
@@ -131,16 +131,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -261,17 +251,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -292,17 +271,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -310,28 +278,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -362,16 +308,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 applications:
 - Microbial cultivation
 curation_history:
@@ -415,3 +351,128 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.209859+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 36 -> 30
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml
@@ -258,17 +258,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -289,17 +278,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -307,28 +285,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -359,16 +315,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 applications:
 - Microbial cultivation
 curation_history:
@@ -416,6 +362,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.232075+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Seven vitamins solution'' @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)"
+    @ 1 ml/l. 4 component(s) were SUMMED across stocks by the flattening and are restored
+    to each stock''s own value, verified by exact sum: nicotinic acid, p-aminobenzoic
+    acid, pyridoxine hydrochloride, vitamin b12. Each moved component matched the
+    MediaDive stock by name AND value; bulk ingredients sharing a name were left in
+    place (#150).'
+  changes: Nested 5 ingredient(s) under 2 solution(s); ingredients 36 -> 31
 parent_media:
   path: data/normalized_yaml/bacterial/desulfitobacterium_pce_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -427,3 +384,100 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; KOMODO record copied from the matching
   DSMZ medium source.
+solutions:
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml
+++ b/data/normalized_yaml/bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml
@@ -133,16 +133,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA x 2 H2O
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -233,17 +223,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -264,17 +243,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -282,28 +250,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -334,16 +280,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 applications:
 - Microbial cultivation
 curation_history:
@@ -395,6 +331,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.253882+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-11'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 33 -> 27
 variant_children:
 - path: data/normalized_yaml/bacterial/for_dsm_16346.yaml
   relationship: SOURCE_DUPLICATE
@@ -413,3 +360,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; KOMODO record copied from the matching
   DSMZ medium source.
+solutions:
+- preferred_term: Trace element solution SL-11
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/carboxydothermus_medium_heterotroph.yaml
+++ b/data/normalized_yaml/bacterial/carboxydothermus_medium_heterotroph.yaml
@@ -196,28 +196,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:75213
     label: Na2MoO4 x 2 H2O
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.001]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.08, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: D-(+)-biotin
   term:
     id: CHEBI:15956
@@ -228,17 +206,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: D-(+)-biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.2, 0.05]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -249,27 +216,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.3, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 - preferred_term: Biotin
   term:
     id: CHEBI:15956
@@ -386,6 +332,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.274701+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Seven vitamins solution'' @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)"
+    @ 1 ml/l. 4 component(s) were SUMMED across stocks by the flattening and are restored
+    to each stock''s own value, verified by exact sum: nicotinic acid, p-aminobenzoic
+    acid, pyridoxine hydrochloride, vitamin b12. Each moved component matched the
+    MediaDive stock by name AND value; bulk ingredients sharing a name were left in
+    place (#150).'
+  changes: Nested 5 ingredient(s) under 2 solution(s); ingredients 32 -> 27
 parent_media:
   path: data/normalized_yaml/bacterial/pyrodictium_abyssi_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -395,3 +352,100 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.05]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.08, 0.05]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.1]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.001]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/chrysiogenes_medium.yaml
+++ b/data/normalized_yaml/bacterial/chrysiogenes_medium.yaml
@@ -132,16 +132,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA x 2 H2O
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -232,17 +222,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -263,17 +242,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -281,28 +249,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -333,16 +279,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -406,6 +342,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.295821+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-11'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 33 -> 27
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_818_CHRYSIOGENES_MEDIUM.yaml
   relationship: SOURCE_DUPLICATE
@@ -413,3 +360,117 @@ variant_children:
   name: chrysiogenes_medium
   notes: Same ingredient and concentration signature; KOMODO record copied from the
     matching DSMZ medium source.
+solutions:
+- preferred_term: Trace element solution SL-11
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/dehalobacter_restrictus_medium.yaml
+++ b/data/normalized_yaml/bacterial/dehalobacter_restrictus_medium.yaml
@@ -159,16 +159,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -269,17 +259,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -300,17 +279,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -318,28 +286,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -370,16 +316,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 applications:
 - Microbial cultivation
 curation_history:
@@ -423,6 +359,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.319352+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution'' @ 1 ml/l; 1 -> ''Seven vitamins solution'' @ 1
+    ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were SUMMED
+    across stocks by the flattening and are restored to each stock''s own value, verified
+    by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride, vitamin
+    b12. Each moved component matched the MediaDive stock by name AND value; bulk
+    ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 38 -> 32
 parent_media:
   path: data/normalized_yaml/bacterial/for_dsm_13726.yaml
   relationship: SOURCE_DUPLICATE
@@ -432,3 +379,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Trace element solution
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/dehalobacter_restrictus_medium_tce.yaml
+++ b/data/normalized_yaml/bacterial/dehalobacter_restrictus_medium_tce.yaml
@@ -128,16 +128,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -238,17 +228,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -269,17 +248,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -287,28 +255,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -339,16 +285,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -410,3 +346,128 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.342274+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution'' @ 1 ml/l; 1 -> ''Seven vitamins solution'' @ 1
+    ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were SUMMED
+    across stocks by the flattening and are restored to each stock''s own value, verified
+    by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride, vitamin
+    b12. Each moved component matched the MediaDive stock by name AND value; bulk
+    ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 35 -> 29
+solutions:
+- preferred_term: Trace element solution
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfitobacterium_pce_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfitobacterium_pce_medium.yaml
@@ -257,17 +257,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -288,17 +277,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -306,28 +284,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -358,16 +314,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -430,6 +376,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.364898+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Seven vitamins solution'' @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)"
+    @ 1 ml/l. 4 component(s) were SUMMED across stocks by the flattening and are restored
+    to each stock''s own value, verified by exact sum: nicotinic acid, p-aminobenzoic
+    acid, pyridoxine hydrochloride, vitamin b12. Each moved component matched the
+    MediaDive stock by name AND value; bulk ingredients sharing a name were left in
+    place (#150).'
+  changes: Nested 5 ingredient(s) under 2 solution(s); ingredients 36 -> 31
 variant_children:
 - path: data/normalized_yaml/bacterial/KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml
   relationship: SOURCE_DUPLICATE
@@ -437,3 +394,100 @@ variant_children:
   name: desulfitobacterium_pce_medium
   notes: Same ingredient and concentration signature; KOMODO record copied from the
     matching DSMZ medium source.
+solutions:
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfopila_corrodens_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfopila_corrodens_medium.yaml
@@ -142,16 +142,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -272,17 +262,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -303,17 +282,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -321,28 +289,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -373,16 +319,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -442,6 +378,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.387940+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 37 -> 31
 parent_media:
   path: data/normalized_yaml/bacterial/KOMODO_1010_Artificial_SEAWATER_MEDIUM.yaml
   relationship: SOURCE_DUPLICATE
@@ -451,3 +398,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulforhabdus_amnigena_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulforhabdus_amnigena_medium.yaml
@@ -132,16 +132,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -262,17 +252,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -293,17 +272,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -311,28 +279,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -363,16 +309,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -430,6 +366,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.411768+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 36 -> 30
 variant_children:
 - path: data/normalized_yaml/bacterial/desulforhabdus_amnigenus_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -437,3 +384,117 @@ variant_children:
   name: desulforhabdus_amnigenus_medium
   notes: Same ingredient and concentration signature; review as possible duplicate
     source record.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfothermus_naphthae_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfothermus_naphthae_medium.yaml
@@ -142,16 +142,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -272,17 +262,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -303,17 +282,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -321,28 +289,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -373,16 +319,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -445,6 +381,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.436362+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 37 -> 31
 parent_media:
   path: data/normalized_yaml/bacterial/KOMODO_876_TD3-MEDIUM.yaml
   relationship: SOURCE_DUPLICATE
@@ -454,3 +401,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfurispirillum_indicum_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfurispirillum_indicum_medium.yaml
@@ -132,16 +132,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -262,17 +252,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -293,17 +272,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -311,28 +279,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -363,16 +309,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -430,3 +366,128 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.459651+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 36 -> 30
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfuromonas_medium_tce.yaml
+++ b/data/normalized_yaml/bacterial/desulfuromonas_medium_tce.yaml
@@ -158,16 +158,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -268,17 +258,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -299,17 +278,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -317,28 +285,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -369,16 +315,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -439,6 +375,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.483279+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution'' @ 1 ml/l; 1 -> ''Seven vitamins solution'' @ 1
+    ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were SUMMED
+    across stocks by the flattening and are restored to each stock''s own value, verified
+    by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride, vitamin
+    b12. Each moved component matched the MediaDive stock by name AND value; bulk
+    ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 38 -> 32
 parent_media:
   path: data/normalized_yaml/bacterial/for_dsm_13726.yaml
   relationship: SOURCE_DUPLICATE
@@ -448,3 +395,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Trace element solution
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/tissierella_creatinophila_medium.yaml
+++ b/data/normalized_yaml/bacterial/tissierella_creatinophila_medium.yaml
@@ -136,16 +136,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -266,17 +256,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:27470
     label: Folic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.4'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.3]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -297,17 +276,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.25'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.2]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium D-(+)-pantothenate
   concentration:
     value: '0.05'
@@ -315,28 +283,6 @@ ingredients:
   term:
     id: CHEBI:31345
     label: ''
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.101'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.001, 0.1]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.13'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.05, 0.08]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: (DL)-alpha-Lipoic acid
   term:
     id: CHEBI:16494
@@ -367,16 +313,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -434,6 +370,17 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-07T23:42:25.508093+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Seven vitamins solution''
+    @ 1 ml/l; 0 -> "Wolin''s vitamin solution (10x)" @ 1 ml/l. 4 component(s) were
+    SUMMED across stocks by the flattening and are restored to each stock''s own value,
+    verified by exact sum: nicotinic acid, p-aminobenzoic acid, pyridoxine hydrochloride,
+    vitamin b12. Each moved component matched the MediaDive stock by name AND value;
+    bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 3 solution(s); ingredients 37 -> 31
 parent_media:
   path: data/normalized_yaml/bacterial/tissirella_creatinophila_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -443,3 +390,117 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term: &id003
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.08'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id005
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id007
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: &id008
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Wolin's vitamin solution (10x)
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.2]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: p-Aminobenzoic acid
+    term: *id003
+    concentration:
+      value: '0.05'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.05, 0.08]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id005
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.3]'
+    mediaingredientmech_chebi_term: *id006
+  - preferred_term: Vitamin B12
+    term: *id007
+    concentration:
+      value: '0.001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.001, 0.1]'
+    mediaingredientmech_chebi_term: *id008
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial_index.json
+++ b/data/normalized_yaml/bacterial_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T20:47:39.444893+00:00",
+  "generated": "2026-08-07T23:45:13.989732+00:00",
   "category": "bacterial",
   "count": 14304,
   "recipes": {
@@ -6342,10 +6342,11 @@
     "CultureMech:004044": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004044",
       "source_id": "komodo.medium:1294",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -11139,10 +11140,11 @@
     "CultureMech:006354": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:006354",
       "source_id": "komodo.medium:717",
       "source": "KOMODO",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -11959,10 +11961,11 @@
     "CultureMech:006543": {
       "name": "chrysiogenes_medium",
       "filename": "KOMODO_818_CHRYSIOGENES_MEDIUM.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:006543",
       "source_id": "komodo.medium:818",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -38493,10 +38496,11 @@
     "CultureMech:001642": {
       "name": "carboxydothermus_medium_heterotroph",
       "filename": "carboxydothermus_medium_heterotroph.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:001642",
       "source_id": "mediadive.medium:508",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -39707,10 +39711,11 @@
     "CultureMech:001965": {
       "name": "chrysiogenes_medium",
       "filename": "chrysiogenes_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:001965",
       "source_id": "mediadive.medium:818",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -41956,10 +41961,11 @@
     "CultureMech:006377": {
       "name": "dehalobacter_restrictus_medium",
       "filename": "dehalobacter_restrictus_medium.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:006377",
       "source_id": "komodo.medium:732",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -41967,10 +41973,11 @@
     "CultureMech:001867": {
       "name": "dehalobacter_restrictus_medium_tce",
       "filename": "dehalobacter_restrictus_medium_tce.yaml",
-      "ingredient_count": 35,
+      "ingredient_count": 29,
       "id": "CultureMech:001867",
       "source_id": "mediadive.medium:732",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -42239,10 +42246,11 @@
     "CultureMech:001855": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "desulfitobacterium_pce_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:001855",
       "source_id": "mediadive.medium:717",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -42981,10 +42989,11 @@
     "CultureMech:000426": {
       "name": "desulfopila_corrodens_medium",
       "filename": "desulfopila_corrodens_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:000426",
       "source_id": "mediadive.medium:1010",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -43003,10 +43012,11 @@
     "CultureMech:001845": {
       "name": "desulforhabdus_amnigena_medium",
       "filename": "desulforhabdus_amnigena_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:001845",
       "source_id": "mediadive.medium:708",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -43191,10 +43201,11 @@
     "CultureMech:002034": {
       "name": "desulfothermus_naphthae_medium",
       "filename": "desulfothermus_naphthae_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:002034",
       "source_id": "mediadive.medium:876",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -43945,10 +43956,11 @@
     "CultureMech:000756": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "desulfurispirillum_indicum_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000756",
       "source_id": "mediadive.medium:1294",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -44069,10 +44081,11 @@
     "CultureMech:001868": {
       "name": "desulfuromonas_medium_tce",
       "filename": "desulfuromonas_medium_tce.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:001868",
       "source_id": "mediadive.medium:732a",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -147478,10 +147491,11 @@
     "CultureMech:001972": {
       "name": "tissierella_creatinophila_medium",
       "filename": "tissierella_creatinophila_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:001972",
       "source_id": "mediadive.medium:824",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]

--- a/data/normalized_yaml/by_source_komodo_index.json
+++ b/data/normalized_yaml/by_source_komodo_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T20:49:10.743345+00:00",
+  "generated": "2026-08-07T23:46:50.458709+00:00",
   "source": "KOMODO",
   "count": 3637,
   "recipes": {
@@ -226,10 +226,11 @@
     "CultureMech:004073": {
       "name": "methanocella_conradii_medium",
       "filename": "KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004073",
       "source_id": "komodo.medium:1318",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ],
@@ -4275,10 +4276,11 @@
     "CultureMech:004044": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004044",
       "source_id": "komodo.medium:1294",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -9501,10 +9503,11 @@
     "CultureMech:006354": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:006354",
       "source_id": "komodo.medium:717",
       "source": "KOMODO",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -10394,10 +10397,11 @@
     "CultureMech:006543": {
       "name": "chrysiogenes_medium",
       "filename": "KOMODO_818_CHRYSIOGENES_MEDIUM.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:006543",
       "source_id": "komodo.medium:818",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -13569,10 +13573,11 @@
     "CultureMech:006377": {
       "name": "dehalobacter_restrictus_medium",
       "filename": "dehalobacter_restrictus_medium.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:006377",
       "source_id": "komodo.medium:732",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],

--- a/data/normalized_yaml/by_source_mediadive_index.json
+++ b/data/normalized_yaml/by_source_mediadive_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T07:16:00.484862+00:00",
+  "generated": "2026-08-07T23:46:50.483552+00:00",
   "source": "MediaDive",
   "count": 3325,
   "recipes": {
@@ -1871,10 +1871,11 @@
     "CultureMech:000776": {
       "name": "methanocella_conradii_medium",
       "filename": "methanocella_conradii_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000776",
       "source_id": "mediadive.medium:1318",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ],
@@ -11370,10 +11371,11 @@
     "CultureMech:001642": {
       "name": "carboxydothermus_medium_heterotroph",
       "filename": "carboxydothermus_medium_heterotroph.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:001642",
       "source_id": "mediadive.medium:508",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -11921,10 +11923,11 @@
     "CultureMech:001965": {
       "name": "chrysiogenes_medium",
       "filename": "chrysiogenes_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:001965",
       "source_id": "mediadive.medium:818",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -13264,10 +13267,11 @@
     "CultureMech:001867": {
       "name": "dehalobacter_restrictus_medium_tce",
       "filename": "dehalobacter_restrictus_medium_tce.yaml",
-      "ingredient_count": 35,
+      "ingredient_count": 29,
       "id": "CultureMech:001867",
       "source_id": "mediadive.medium:732",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -13487,10 +13491,11 @@
     "CultureMech:001855": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "desulfitobacterium_pce_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:001855",
       "source_id": "mediadive.medium:717",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -14122,10 +14127,11 @@
     "CultureMech:000426": {
       "name": "desulfopila_corrodens_medium",
       "filename": "desulfopila_corrodens_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:000426",
       "source_id": "mediadive.medium:1010",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -14146,10 +14152,11 @@
     "CultureMech:001845": {
       "name": "desulforhabdus_amnigena_medium",
       "filename": "desulforhabdus_amnigena_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:001845",
       "source_id": "mediadive.medium:708",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -14327,10 +14334,11 @@
     "CultureMech:002034": {
       "name": "desulfothermus_naphthae_medium",
       "filename": "desulfothermus_naphthae_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:002034",
       "source_id": "mediadive.medium:876",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -14764,10 +14772,11 @@
     "CultureMech:000756": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "desulfurispirillum_indicum_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000756",
       "source_id": "mediadive.medium:1294",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -14887,10 +14896,11 @@
     "CultureMech:001868": {
       "name": "desulfuromonas_medium_tce",
       "filename": "desulfuromonas_medium_tce.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:001868",
       "source_id": "mediadive.medium:732a",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -36088,10 +36098,11 @@
     "CultureMech:001972": {
       "name": "tissierella_creatinophila_medium",
       "filename": "tissierella_creatinophila_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:001972",
       "source_id": "mediadive.medium:824",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],

--- a/data/normalized_yaml/recipe_index.json
+++ b/data/normalized_yaml/recipe_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T20:49:10.633960+00:00",
+  "generated": "2026-08-07T23:46:50.348162+00:00",
   "description": "Master index of all CultureMech recipes",
   "total_recipes": 15877,
   "categories": {
@@ -3423,10 +3423,11 @@
     "CultureMech:004073": {
       "name": "methanocella_conradii_medium",
       "filename": "KOMODO_1318_METHANOCELLA_CONRADII_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004073",
       "source_id": "komodo.medium:1318",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ],
@@ -9296,10 +9297,11 @@
     "CultureMech:000776": {
       "name": "methanocella_conradii_medium",
       "filename": "methanocella_conradii_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000776",
       "source_id": "mediadive.medium:1318",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "archaea"
       ],
@@ -19012,10 +19014,11 @@
     "CultureMech:004044": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "KOMODO_1294_DESULFURISPIRILLUM_INDICUM_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:004044",
       "source_id": "komodo.medium:1294",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -24238,10 +24241,11 @@
     "CultureMech:006354": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "KOMODO_717_DESULFITOBACTERIUM_PCE_MEDIUM.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:006354",
       "source_id": "komodo.medium:717",
       "source": "KOMODO",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -25131,10 +25135,11 @@
     "CultureMech:006543": {
       "name": "chrysiogenes_medium",
       "filename": "KOMODO_818_CHRYSIOGENES_MEDIUM.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:006543",
       "source_id": "komodo.medium:818",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -53959,10 +53964,11 @@
     "CultureMech:001642": {
       "name": "carboxydothermus_medium_heterotroph",
       "filename": "carboxydothermus_medium_heterotroph.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:001642",
       "source_id": "mediadive.medium:508",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -55280,10 +55286,11 @@
     "CultureMech:001965": {
       "name": "chrysiogenes_medium",
       "filename": "chrysiogenes_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 27,
       "id": "CultureMech:001965",
       "source_id": "mediadive.medium:818",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -57730,10 +57737,11 @@
     "CultureMech:006377": {
       "name": "dehalobacter_restrictus_medium",
       "filename": "dehalobacter_restrictus_medium.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:006377",
       "source_id": "komodo.medium:732",
       "source": "KOMODO",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -57742,10 +57750,11 @@
     "CultureMech:001867": {
       "name": "dehalobacter_restrictus_medium_tce",
       "filename": "dehalobacter_restrictus_medium_tce.yaml",
-      "ingredient_count": 35,
+      "ingredient_count": 29,
       "id": "CultureMech:001867",
       "source_id": "mediadive.medium:732",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -58038,10 +58047,11 @@
     "CultureMech:001855": {
       "name": "desulfitobacterium_pce_medium",
       "filename": "desulfitobacterium_pce_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 31,
       "id": "CultureMech:001855",
       "source_id": "mediadive.medium:717",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -58846,10 +58856,11 @@
     "CultureMech:000426": {
       "name": "desulfopila_corrodens_medium",
       "filename": "desulfopila_corrodens_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:000426",
       "source_id": "mediadive.medium:1010",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -58870,10 +58881,11 @@
     "CultureMech:001845": {
       "name": "desulforhabdus_amnigena_medium",
       "filename": "desulforhabdus_amnigena_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:001845",
       "source_id": "mediadive.medium:708",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -59075,10 +59087,11 @@
     "CultureMech:002034": {
       "name": "desulfothermus_naphthae_medium",
       "filename": "desulfothermus_naphthae_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:002034",
       "source_id": "mediadive.medium:876",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -59897,10 +59910,11 @@
     "CultureMech:000756": {
       "name": "desulfurispirillum_indicum_medium",
       "filename": "desulfurispirillum_indicum_medium.yaml",
-      "ingredient_count": 36,
+      "ingredient_count": 30,
       "id": "CultureMech:000756",
       "source_id": "mediadive.medium:1294",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -60032,10 +60046,11 @@
     "CultureMech:001868": {
       "name": "desulfuromonas_medium_tce",
       "filename": "desulfuromonas_medium_tce.yaml",
-      "ingredient_count": 38,
+      "ingredient_count": 32,
       "id": "CultureMech:001868",
       "source_id": "mediadive.medium:732a",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -173171,10 +173186,11 @@
     "CultureMech:001972": {
       "name": "tissierella_creatinophila_medium",
       "filename": "tissierella_creatinophila_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 31,
       "id": "CultureMech:001972",
       "source_id": "mediadive.medium:824",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],

--- a/project.justfile
+++ b/project.justfile
@@ -274,7 +274,7 @@ audit-selective-agent-mismatch *args="":
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py \
-        --max-allowed 10614 --max-cocktails 375 {{args}}
+        --max-allowed 10521 --max-cocktails 359 {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/scripts/apply_cocktail_nesting.py
+++ b/scripts/apply_cocktail_nesting.py
@@ -107,8 +107,42 @@ def match_components(ingredients: list[dict[str, Any]],
     return indices, sorted(flagged_names - matched_names)
 
 
+def find_summed(ingredients: list[dict[str, Any]], additions: list[dict[str, Any]],
+                unmatched: list[str]) -> dict[str, list[tuple[str, float]]]:
+    """Unmatched rows whose value is the exact SUM of that component across stocks.
+
+    When a medium references two stocks that share a component, the flattening added
+    them together into one ingredient: `chrysiogenes_medium` carries pyridoxine 0.4,
+    which is Wolin's 0.1 + Seven vitamins 0.3. Neither stock matches 0.4, so the
+    plain name+value pass correctly refuses it — but the decomposition is recoverable,
+    because it is arithmetic over the specific stocks THIS medium references, checked
+    to exact equality.
+
+    Returns {ingredient_name: [(solution_name, stock_value), ...]} for the rows where
+    the sum reconciles, and nothing for any row where it does not.
+    """
+    by_name = {_key(i.get("preferred_term")): _num((i.get("concentration") or {}).get("value"))
+               for i in ingredients}
+    contributions: dict[str, list[tuple[str, float]]] = {}
+    for add in additions:
+        for c in add.get("stock_components") or []:
+            v = _num(c.get("g_l"))
+            if v is None:
+                continue
+            contributions.setdefault(_key(c.get("compound")), []).append(
+                (str(add.get("solution_name")), v))
+
+    out = {}
+    for name in unmatched:
+        parts = contributions.get(name, [])
+        got = by_name.get(name)
+        if len(parts) >= 2 and got is not None and abs(sum(v for _, v in parts) - got) < 1e-9:
+            out[name] = parts
+    return out
+
+
 def plan_record(path: Path, doc: dict[str, Any], additions: list[dict[str, Any]],
-                flagged_names: set[str]) -> dict[str, Any] | None:
+                flagged_names: set[str], split_summed: bool = False) -> dict[str, Any] | None:
     """What nesting this record would do, or None when it is not safely nestable.
 
     Handles EVERY stock the medium references, not just the first. A medium commonly
@@ -136,15 +170,53 @@ def plan_record(path: Path, doc: dict[str, Any], additions: list[dict[str, Any]]
             "stock_prepared_in_ml": addition.get("stock_prepared_in_ml"),
             "moved": [ingredients[i].get("preferred_term") for i in indices],
         })
-    if not groups:
-        return None
-
+    # NOTE: the "nothing to do" check happens AFTER the split pass below, not here.
+    # A record can have no direct name+value match at all and still be repairable —
+    # when every flagged row was summed across two stocks, which is exactly the case
+    # the split exists for. Returning early here refused those records outright.
     matched_names = {_key(ingredients[i].get("preferred_term")) for i in claimed}
+    unmatched = sorted(flagged_names - matched_names)
+
+    # Rows the flattening SUMMED across two stocks are recoverable by arithmetic.
+    splits: dict[str, list[tuple[str, float]]] = {}
+    if split_summed and unmatched:
+        splits = find_summed(ingredients, additions, unmatched)
+        if splits:
+            idx_by_name = {_key(i.get("preferred_term")): n for n, i in enumerate(ingredients)}
+            for name in splits:
+                claimed.add(idx_by_name[name])
+            unmatched = [u for u in unmatched if u not in splits]
+
+            # A stock may contribute ONLY summed rows — every one of its components
+            # was merged into another stock's entry, so the name+value pass created
+            # no group for it. Without a group its share of the split is dropped and
+            # the record silently loses that stock entirely, which is worse than not
+            # splitting at all. Give each contributing stock a group.
+            have = {g["solution_name"] for g in groups}
+            by_solution = {a.get("solution_name"): a for a in additions}
+            for parts in splits.values():
+                for solution_name, _value in parts:
+                    if solution_name in have:
+                        continue
+                    add = by_solution.get(solution_name) or {}
+                    groups.append({
+                        "indices": [],
+                        "solution_name": solution_name,
+                        "addition_volume_ml": add.get("addition_volume_ml"),
+                        "stock_prepared_in_ml": add.get("stock_prepared_in_ml"),
+                        "moved": [],
+                    })
+                    have.add(solution_name)
+
+    if not groups:
+        return None                        # nothing matched, and nothing reconciled
+
     return {
         "path": path,
         "groups": groups,
-        "unmatched": sorted(flagged_names - matched_names),
-        "moved_total": sum(len(g["moved"]) for g in groups),
+        "splits": splits,
+        "unmatched": unmatched,
+        "moved_total": sum(len(g["moved"]) for g in groups) + len(splits),
     }
 
 
@@ -152,13 +224,30 @@ def apply_plan(doc: dict[str, Any], plan: dict[str, Any]) -> None:
     """Move each stock's matched ingredients under its own solutions[] entry."""
     ingredients = [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]
     all_moved = {i for g in plan["groups"] for i in g["indices"]}
+
+    splits = plan.get("splits") or {}
+    by_name_idx = {_key(i.get("preferred_term")): n for n, i in enumerate(ingredients)}
+    all_moved |= {by_name_idx[n] for n in splits}
     kept = [ing for i, ing in enumerate(ingredients) if i not in all_moved]
+
+    def split_parts(solution_name: str) -> list[dict[str, Any]]:
+        """Copies of summed ingredients belonging to this solution, each restored to
+        its own stock value rather than the summed one."""
+        out = []
+        for name, parts in splits.items():
+            for sol, value in parts:
+                if sol != solution_name:
+                    continue
+                src = dict(ingredients[by_name_idx[name]])
+                src["concentration"] = {"value": str(value), "unit": "G_PER_L"}
+                out.append(src)
+        return out
 
     solutions = []
     for g in plan["groups"]:
         solutions.append({
             "preferred_term": g["solution_name"],
-            "composition": [ingredients[i] for i in g["indices"]],
+            "composition": [ingredients[i] for i in g["indices"]] + split_parts(g["solution_name"]),
             "concentration": {"value": str(g["addition_volume_ml"]), "unit": "ML_PER_L"},
             "preparation_notes": (
                 f"Stock prepared in {g['stock_prepared_in_ml']} ml; added at "
@@ -173,14 +262,18 @@ def apply_plan(doc: dict[str, Any], plan: dict[str, Any]) -> None:
     record_curation_event(
         doc, curator="apply_cocktail_nesting.py", action="NESTED_FLATTENED_COCKTAIL",
         notes=(f"Moved {plan['moved_total']} stock-strength component(s) out of "
-               f"ingredients into {len(solutions)} solution(s): {detail}. Each moved "
-               f"component matched the MediaDive stock by name AND value; bulk "
-               f"ingredients sharing a name were left in place (#150)."),
+               f"ingredients into {len(solutions)} solution(s): {detail}."
+               + (f" {len(splits)} component(s) were SUMMED across stocks by the "
+                  f"flattening and are restored to each stock's own value, verified by "
+                  f"exact sum: {', '.join(sorted(splits))}." if splits else "")
+               + " Each moved "
+               "component matched the MediaDive stock by name AND value; bulk "
+               "ingredients sharing a name were left in place (#150)."),
         changes=(f"Nested {plan['moved_total']} ingredient(s) under {len(solutions)} "
                  f"solution(s); ingredients {len(ingredients)} -> {len(kept)}"))
 
 
-def build_plans() -> tuple[list[dict[str, Any]], list[tuple[str, list[str]]]]:
+def build_plans(split_summed: bool = False) -> tuple[list[dict[str, Any]], list[tuple[str, list[str]]]]:
     if not VOLUMES.is_file():
         print(f"Run `just fetch-mediadive-volumes` first — {VOLUMES.name} is missing.",
               file=sys.stderr)
@@ -207,7 +300,7 @@ def build_plans() -> tuple[list[dict[str, Any]], list[tuple[str, list[str]]]]:
         flagged = flagged_by_file.get(rel, set())
         if not flagged:
             continue
-        plan = plan_record(path, doc, additions, flagged)
+        plan = plan_record(path, doc, additions, flagged, split_summed)
         if plan is None:
             continue
         if plan["unmatched"]:
@@ -222,9 +315,14 @@ def main(argv: list[str] | None = None) -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--apply", action="store_true", help="Write. Default is report-only.")
     ap.add_argument("--limit", type=int, default=0, help="Only the first N records.")
+    ap.add_argument("--split-summed", action="store_true",
+                    help="Also repair rows the flattening SUMMED across two stocks, "
+                         "restoring each stock's own value. Opt-in: it reconstructs a "
+                         "decomposition rather than moving a value verbatim, and is "
+                         "accepted only on an exact sum match.")
     args = ap.parse_args(argv)
 
-    plans, skipped = build_plans()
+    plans, skipped = build_plans(args.split_summed)
     if args.limit:
         plans = plans[:args.limit]
 

--- a/tests/test_apply_cocktail_nesting.py
+++ b/tests/test_apply_cocktail_nesting.py
@@ -131,3 +131,64 @@ def test_an_ingredient_is_never_claimed_by_two_stocks(acn):
           "stock_prepared_in_ml": 1000}],
         {"mnso4 x h2o"})
     assert len(plan["groups"]) == 1 and plan["moved_total"] == 1
+
+
+# --- splitting values the flattening SUMMED across two stocks (#150) ---------
+
+
+VIT_A = [{"compound": "Pyridoxine hydrochloride", "g_l": 0.1},
+         {"compound": "Nicotinic acid", "g_l": 0.05}]
+VIT_B = [{"compound": "Pyridoxine hydrochloride", "g_l": 0.3},
+         {"compound": "Nicotinic acid", "g_l": 0.2}]
+
+
+def _two_vitamin_stocks():
+    return [{"stock_components": VIT_A, "solution_name": "Wolin's", "addition_volume_ml": 1,
+             "stock_prepared_in_ml": 1000},
+            {"stock_components": VIT_B, "solution_name": "Seven vitamins",
+             "addition_volume_ml": 1, "stock_prepared_in_ml": 1000}]
+
+
+def test_find_summed_recognises_an_exact_two_stock_sum(acn):
+    """pyridoxine 0.4 = Wolin's 0.1 + Seven vitamins 0.3."""
+    ings = [_ing("Pyridoxine hydrochloride", "0.4")]
+    got = acn.find_summed(ings, _two_vitamin_stocks(), ["pyridoxine hydrochloride"])
+    assert got == {"pyridoxine hydrochloride": [("Wolin's", 0.1), ("Seven vitamins", 0.3)]}
+
+
+def test_find_summed_refuses_a_value_that_does_not_reconcile(acn):
+    """Silence beats a guessed decomposition: 0.35 is not 0.1 + 0.3."""
+    ings = [_ing("Pyridoxine hydrochloride", "0.35")]
+    assert acn.find_summed(ings, _two_vitamin_stocks(), ["pyridoxine hydrochloride"]) == {}
+
+
+def test_split_is_opt_in(acn):
+    """Without --split-summed the record is refused, not silently reconstructed."""
+    doc = {"ingredients": [_ing("Pyridoxine hydrochloride", "0.4")]}
+    plan = acn.plan_record(Path("x.yaml"), doc, _two_vitamin_stocks(),
+                           {"pyridoxine hydrochloride"}, split_summed=False)
+    assert plan is None or plan["unmatched"] == ["pyridoxine hydrochloride"]
+
+
+def test_a_stock_contributing_only_summed_rows_still_gets_its_solution(acn):
+    """The bug the canary caught. Both stocks' components were merged into one
+    ingredient, so neither had a direct name+value match. Creating a group only for
+    directly-matched stocks dropped one stock's share entirely — the record would
+    silently lose Wolin's contribution."""
+    doc = {"ingredients": [_ing("Pyridoxine hydrochloride", "0.4"),
+                           _ing("Nicotinic acid", "0.25")]}
+    plan = acn.plan_record(Path("x.yaml"), doc, _two_vitamin_stocks(),
+                           {"pyridoxine hydrochloride", "nicotinic acid"}, split_summed=True)
+    acn.apply_plan(doc, plan)
+    names = [s["preferred_term"] for s in doc["solutions"]]
+    assert set(names) == {"Wolin's", "Seven vitamins"}, names
+
+    # mass conservation: each component's parts must re-sum to the flattened value
+    totals: dict[str, float] = {}
+    for s in doc["solutions"]:
+        for c in s["composition"]:
+            totals[c["preferred_term"]] = totals.get(c["preferred_term"], 0.0) + float(
+                c["concentration"]["value"])
+    assert abs(totals["Pyridoxine hydrochloride"] - 0.4) < 1e-9
+    assert abs(totals["Nicotinic acid"] - 0.25) < 1e-9
+    assert doc["ingredients"] == []

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -188,10 +188,10 @@ def test_stock_solution_records_are_excluded(corpus_findings):
         assert not is_solution_record(doc), f"solution record flagged: {file_path}"
 
 
-CONCENTRATION_BACKLOG_BASELINE = 10_614
+CONCENTRATION_BACKLOG_BASELINE = 10_521
 # The sharper baseline (#150): a raw row count drifts with corpus size, whereas a
 # new flattened cocktail is a specific defect shape an import has reintroduced.
-COCKTAIL_BASELINE = 375
+COCKTAIL_BASELINE = 359
 
 
 def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings):
@@ -199,7 +199,7 @@ def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings
 
     #135 shipped the audit; the repair is now partly done — #150 nested 135
     flattened cocktails from MediaDive data, taking the backlog from 11,540 rows
-    across 3,914 records to 10,614 across 3,716. A guard demanding zero would fail
+    across 3,914 records to 10,521 across 3,700. A guard demanding zero would fail
     immediately and be switched off — the #129 lesson about wiring a gate to a red
     suite. So this baselines at the current count, exactly as
     `check-chebi-grounding --max-allowed 101` does for grounding.
@@ -273,7 +273,7 @@ def test_the_gate_baselines_match_the_current_corpus(acp, media_records):
     """#118 asked for an audit AND a repair; #135 shipped the audit, and nothing
     stopped the defect being reintroduced for another 15 issues.
 
-    These baselines hold the line while the 3,716-record backlog is worked
+    These baselines hold the line while the 3,700-record backlog is worked
     through. They must track the corpus: a baseline above the real count is a gate
     that cannot fail.
     """


### PR DESCRIPTION
Recovers 16 of the 57 records the previous passes refused.

## The diagnosis
Those records were refused because some flagged rows matched no stock by name+value.
The cause: when a medium references **two stocks that share a component**, the
flattening **added them together** into one ingredient.

`chrysiogenes_medium` carries pyridoxine **0.4** — which is Wolin's `0.1` + Seven
vitamins `0.3`. Likewise nicotinic `0.25` = `0.05 + 0.2`, vitamin B12 `0.101` =
`0.001 + 0.1`, p-aminobenzoic `0.13` = `0.05 + 0.08`.

That decomposition is *recoverable*: it's arithmetic over the specific stocks **this
medium references**, accepted only on exact equality. `--split-summed` restores each
stock's own value into its own solution. **Opt-in**, because it reconstructs a
decomposition rather than moving a value verbatim.

| metric | before | after |
|---|--:|--:|
| implausible rows | 10,614 | **10,521** |
| flattened cocktails | 375 | **359** |

Cumulative on #150: **579 → 359** (220 repaired, 38%).

## Two silent-data-loss bugs, caught by the canary and a test
1. **A stock can contribute only summed rows**, so the name+value pass creates no
   group for it. The first canary put every split component into "Seven vitamins"
   and **dropped Wolin's share entirely** — the record would have lost a whole stock.
   Each contributing stock now gets a group.
2. **With no direct match anywhere**, `plan_record` returned `None` before the split
   ran, so records where *every* flagged row was summed were refused outright. The
   nothing-to-do check now runs after the split pass.

## Mass conservation is the proof
After nesting, each component's parts re-sum to the original flattened value — on the
canary: 0.25, 0.13, 0.4, 0.101, exactly the pre-split numbers. A test asserts that
**invariant** rather than the individual values, so it holds for any stock pair.

```yaml
'Seven vitamins solution' @ 1 ml/l     "Wolin's vitamin solution (10x)" @ 1 ml/l
    Nicotinic acid      0.2                Nicotinic acid      0.05
    Pyridoxine HCl      0.3                Pyridoxine HCl      0.1
    Vitamin B12         0.1                Vitamin B12         0.001
```

## Testing
- Full local suite: **1121 passed**, 2 skipped.
- 4 new tests: exact-sum recognition, refusal when it doesn't reconcile, opt-in
  behaviour, and the dropped-stock bug with its mass-conservation check.
- Baselines tightened to 10,521 / 359; indexes regenerated.

Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)