### PR TITLE
Add an Edison stock-solution recovery prompt and target list (#150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ data/import_tracking/reports/mediadive_solution_volumes.json
 
 # MediaDive id audit report: a regenerable diagnostic (#244), needs the live API.
 data/import_tracking/reports/mediadive_id_audit.tsv
+
+# Cocktail research target list: regenerable from the corpus + volume cache (#150).
+data/import_tracking/reports/cocktail_research_targets.json

--- a/project.justfile
+++ b/project.justfile
@@ -267,6 +267,13 @@ fetch-mediadive-volumes *args="":
 # Established that the corpus's own mediadive.medium ids are sound (3,325/3,325) and
 # that the KOMODO->DSMZ mapping is what misleads (~72% land on another medium), so a
 # komodo id must never be used as a MediaDive id without a name check. Read-only.
+# List flattened cocktails that MediaDive cannot supply a stock+volume for, with the
+# reason each is blocked (#150). Feeds Edison via
+# templates/media_stock_solution_research.md. Read-only.
+[group('QC')]
+list-cocktail-research-targets *args="":
+    uv run --extra dev python scripts/list_cocktail_research_targets.py {{args}}
+
 [group('QC')]
 audit-mediadive-ids *args="":
     uv run --extra dev python scripts/audit_mediadive_ids.py {{args}}

--- a/scripts/list_cocktail_research_targets.py
+++ b/scripts/list_cocktail_research_targets.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""List the flattened cocktails that need literature research, and why (#150).
+
+The cocktail repair nests a stock solution back under `solutions:` with the volume
+it is added at. Both facts come from MediaDive for the records that resolve there.
+This lists the ones that do NOT, so they can be sent to Edison
+(`templates/media_stock_solution_research.md`) instead — and, just as usefully,
+records the reason each is blocked so the population is not treated as homogeneous.
+
+## Reasons
+
+id resolves to a DIFFERENT medium
+    The record's id translates to a MediaDive medium whose NAME disagrees. Almost
+    always a KOMODO id: DSMZ medium numbers are MediaDive ids, but the KOMODO->DSMZ
+    mapping is 43.5% bare identity and MediaDive has renumbered since (#244). The
+    record's own id is fine; there is simply no trustworthy MediaDive counterpart.
+
+no MediaDive-resolvable id
+    A JCM/TOGO/CCAP-sourced record. MediaDive does not serve these.
+
+resolved but no cocktail stock in MediaDive
+    The medium was found and matched by name, but its recipe references no
+    trace/vitamin stock — so the flattening came from somewhere else.
+
+Read-only. Output feeds `research_media_edison.py --batch`.
+
+Usage::
+
+    just list-cocktail-research-targets
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+NORMALIZED = REPO / "data" / "normalized_yaml"
+REPORTS = REPO / "data" / "import_tracking" / "reports"
+PROPOSALS = REPORTS / "cocktail_nesting_proposals.tsv"
+VOLUMES = REPORTS / "mediadive_solution_volumes.json"
+DEFAULT_OUT = REPORTS / "cocktail_research_targets.json"
+
+
+def build() -> list[dict[str, str]]:
+    if not PROPOSALS.is_file():
+        print(f"Run `just propose-cocktail-nesting` first — {PROPOSALS.name} missing.",
+              file=sys.stderr)
+        return []
+    volumes = json.loads(VOLUMES.read_text()) if VOLUMES.is_file() else {}
+
+    out = []
+    with PROPOSALS.open() as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            rel = row["file_path"]
+            try:
+                doc = yaml.safe_load((NORMALIZED / rel).read_text(errors="replace"))
+            except (yaml.YAMLError, OSError):
+                continue
+            if not isinstance(doc, dict) or doc.get("solutions"):
+                continue                      # already repaired
+            info = volumes.get(rel)
+            if info and info.get("name_mismatch"):
+                reason = "id resolves to a DIFFERENT medium"
+            elif info and info.get("additions"):
+                continue                      # MediaDive has the data; not blocked
+            elif info:
+                reason = "resolved but no cocktail stock in MediaDive"
+            else:
+                reason = "no MediaDive-resolvable id"
+            out.append({
+                "file_path": rel,
+                "record_id": row["record_id"],
+                "name": str(doc.get("original_name") or doc.get("name") or ""),
+                "n_components": row["n_components"],
+                "reason": reason,
+            })
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--reason", help="Only targets with this blocking reason.")
+    args = ap.parse_args(argv)
+
+    targets = build()
+    if args.reason:
+        targets = [t for t in targets if t["reason"] == args.reason]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(targets, indent=2) + "\n")
+
+    print(f"Flattened cocktails still needing a stock + volume: {len(targets)}")
+    for reason, n in Counter(t["reason"] for t in targets).most_common():
+        print(f"  {n:5d}  {reason}")
+
+    # Many are near-duplicate variants of one base medium ("MEDIUM 252 MODIFIED FOR
+    # DSM ..."), so researching the base answers all of them. Worth knowing before
+    # spending research time per record.
+    import re
+
+    def base(name: str) -> str:
+        n = re.sub(r"\s*(modified\s+)?for dsm.*", "", name.lower())
+        return re.sub(r"[^a-z0-9]+", " ", n).strip()
+
+    clusters = Counter(base(t["name"]) for t in targets)
+    multi = {k: v for k, v in clusters.items() if v > 1 and k}
+    print(f"\n  distinct base media: {len(clusters)} "
+          f"({sum(multi.values())} records fall into {len(multi)} multi-record clusters)")
+    for k, v in Counter(multi).most_common(5):
+        print(f"    {v:4d}x  {k[:56]}")
+    print(f"\nWrote {args.out.relative_to(REPO)} — feed to "
+          f"`research_media_edison.py --batch`.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/media_stock_solution_research.md
+++ b/templates/media_stock_solution_research.md
@@ -1,0 +1,110 @@
+# CultureMech Stock-Solution Recovery Template
+
+A **structural** deep-research prompt for the flattened-cocktail repair (#150).
+It does not look for organisms (`media_growth_research.md`) and does not audit the
+whole formulation (`media_recipe_validation.md`). It asks for exactly two facts that
+the corpus cannot supply and MediaDive does not serve for this record.
+
+## The defect being repaired
+
+This medium's `ingredients` list contains trace-element and/or vitamin entries at
+**stock-solution strength** — concentrations that are implausible as final
+per-litre values (e.g. ZnSO4 at 22 g/L, where a real medium uses ~0.02 g/L). They
+were flattened out of a stock solution during import: the stock's components were
+written straight into the ingredient list, and the *volume at which the stock is
+added* was lost.
+
+Repairing it needs the stock nested back under a `solutions:` entry with its
+addition volume, so the true final concentration is recoverable as:
+
+    final_concentration = stock_concentration x addition_volume / stock_prepared_volume
+
+For most media this comes from MediaDive's API. **For this record it cannot**: its
+source id has no trustworthy MediaDive counterpart, so the two numbers must come
+from the literature or the culture-collection catalogue instead.
+
+## Target Medium
+
+- **Record path:** {record_path}
+- **CultureMech ID:** {media_id}
+- **Name:** {media_name}
+- **Original/source name:** {original_name}
+- **Category:** {category}
+- **Physical state:** {physical_state}
+- **Media term (source catalogue reference):** {media_term}
+- **Synonyms:** {synonyms}
+- **Conditions:** {conditions}
+- **Target organisms:** {target_organisms}
+- **Notes / provenance:** {notes}
+
+### Full ingredient list as currently recorded (SUSPECT — see above)
+
+{ingredients}
+
+### Solutions currently recorded
+
+{solutions}
+
+## What to determine
+
+### 1. Which named stock solution(s) do the stock-strength entries belong to?
+
+Many are standard, reused formulations with published names — "Trace element
+solution SL-10", "Wolfe's mineral elixir", "Wolin's vitamin solution", "Seven
+vitamins solution", "Pfennig's trace elements", "Hutner's basal salts", "f/2 trace
+metals", "Bold's Basal Medium trace elements". Identify the specific one **this
+medium** uses, by name, as published for this medium.
+
+For each stock solution, report its **full composition** as published: every
+component with its amount and unit, and the total volume the stock is prepared in
+(commonly 1 L).
+
+### 2. At what volume is each stock added to the final medium?
+
+The single most important number. Report it as **volume per litre of final medium**
+(e.g. "1 ml/L", "10 ml/L"). State it exactly as the source gives it, and give the
+source's own wording in the snippet.
+
+**Do not confuse** the addition volume with the volume the stock is *prepared* in.
+"Dissolve in 1000 ml, then add 1 ml per litre of medium" contains both: the addition
+volume is 1 ml/L, the preparation volume is 1000 ml.
+
+## Evidence requirements
+
+- Prefer the **original publication describing this medium**, or the culture
+  collection's own medium sheet (DSMZ, JCM, ATCC, CCAP, NBRC).
+- Every number must carry a citation (DOI, PMID, or catalogue URL) and a short
+  verbatim snippet showing where it came from.
+- Give the concentration **as printed in the source**; do not convert units.
+- If the source states the stock composition but NOT the addition volume, say so
+  explicitly rather than inferring a typical value. A plausible-looking invented
+  volume is worse than an acknowledged gap — it would be applied to a real recipe.
+- If this medium's identity is ambiguous (several published media share the name),
+  report the ambiguity and what distinguishes them instead of choosing one.
+
+## Output format
+
+Return a YAML block, then prose discussion.
+
+```yaml
+medium: {media_name}
+culturemech_id: {media_id}
+identity_confidence: high | medium | low   # is this the same medium as the record?
+identity_notes: <what confirmed or complicated the identification>
+stock_solutions:
+  - name: <published stock solution name>
+    addition_volume: <e.g. "1 ml/L">        # omit entirely if not found
+    addition_volume_found: true | false
+    prepared_in: <e.g. "1000 ml">
+    composition:
+      - compound: <name as printed>
+        amount: <number>
+        unit: <g | mg | ml | ...>
+    citation: <DOI / PMID / URL>
+    snippet: <verbatim sentence carrying the volume and/or composition>
+unresolved:
+  - <anything the sources did not settle>
+```
+
+Report `addition_volume_found: false` and omit `addition_volume` whenever the
+sources do not state it. That case is a useful result, not a failure.


### PR DESCRIPTION
Opens the literature lane for the 315 flattened cocktails MediaDive cannot supply —
including the 165 blocked by the #244 KOMODO→DSMZ wall.

## What they're blocked on
Two facts the corpus doesn't hold: **which named stock solution** the stock-strength
entries belong to, and **the volume it's added at per litre**.

`templates/media_stock_solution_research.md` asks for exactly those — distinct from
the organism-discovery and recipe-validation templates, which ask neither. Its
load-bearing instruction is the **refusal clause**: report
`addition_volume_found: false` rather than infer a typical dose, because a plausible
invented volume gets applied to a real recipe (#166). It also warns against the one
confusion that would silently corrupt the repair — the **addition** volume (1 ml/L)
versus the volume the stock is **prepared in** (1000 ml).

`just list-cocktail-research-targets` emits the blocked set *with the reason each is
blocked*, so the population isn't treated as homogeneous:

```
165  id resolves to a DIFFERENT medium   (the #244 KOMODO->DSMZ wall)
132  no MediaDive-resolvable id          (JCM/TOGO/CCAP sources)
 18  resolved but no cocktail stock in MediaDive
```

It also reports **cluster structure**: 104 records are near-duplicate variants of 28
base media ("MEDIUM 252 MODIFIED FOR DSM …" ×30), so researching a base answers many
at once — 110 runs instead of 165 for that group.

## Canary + sample (live, cost 0.0000)
| record | stocks named | addition volume |
|---|--:|---|
| `KOMODO_503c_PROPIONISPORA` | 3 | **found — 1 mL/L each** |
| `KOMODO_194_DESULFOBULBUS` | 3 | not found |
| `KOMODO_294_PELOBACTER` | 3 | not found |
| `pyrodictium_abyssi` | 0 | — |

**3 of 4 identified the stocks by name with composition; 1 of 4 yielded the volume.**
The canary returned a well-reasoned negative — *"A generic seven-vitamin dose such as
1 ml/L must not be inferred"* — so the refusal clause works. It also independently
confirmed #244 (*"no authoritative DSMZ Medium 508 sheet was retrievable"*) and
spotted a defect I hadn't: several vitamins appear twice under variant names, i.e.
two overlapping flattened blocks.

## A cross-check worth recording
Every stock Edison named is a standard DSMZ one, and the MediaDive data already
fetched shows how invariant their volumes are:

```
Trace element solution SL-10   36/36 at 1 ml/L  (100%)
Trace elements solution         6/6  at 10 ml/L (100%)
Seven vitamins solution        44/48 at 1 ml/L  (92%)
Vitamin solution                3/8  at 1 ml/L  (38%)   <- genuinely varies
```

So for a record where Edison names SL-10, 1 ml/L is strongly evidenced — but it is
still a population statistic applied to an individual record, which is what the
template forbids the model from doing. **Left as curator evidence, not auto-applied.**

Research outputs stay under gitignored `research/`; the target list is regenerable and
gitignored. A 106-record deduplicated batch is running in the background (resumable —
the runner skips completed records).

Refs #150, #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)