### PR TITLE
Raise the CHEBI accession ceiling to 1000000, matching MIM (#247)

### DIFF
--- a/conf/id_label_targets.yaml
+++ b/conf/id_label_targets.yaml
@@ -89,8 +89,20 @@ plausibility_severity: warn
 # above the ceiling is a foreign identifier wearing an OBO prefix (PubChem CIDs
 # reach 8 digits; CHEBI:10716816 was asserted for "Nicotinate") rather than a
 # retired accession — a different repair, so it gets its own verdict.
+#
+# The ceiling tracks the DIGIT COUNT of the foreign namespace it separates out,
+# not how far the ontology has minted. It moves when PubChem changes width, not
+# when ChEBI mints higher — so it must sit above ChEBI's real accession space.
+# CHEBI was 300000, an order of magnitude below every sibling here and below
+# ChEBI's own range (the local semsql build reaches 747618, and this corpus
+# already cites CHEBI:747199 = strontium sulfate). Any ChEBI term newer than the
+# local build would then fail to resolve AND clear the ceiling, and be reported
+# ID_OUT_OF_RANGE — "a foreign identifier wearing an OBO prefix" — which in MIM
+# demoted 17 real ChEBI terms to UNMAPPED (MIM #193/#197/#205). Raised to
+# 1000000 to match what MIM shipped and mediaingredientmech's curie.py
+# MAX_ACCESSION (#247).
 max_accession:
-  CHEBI: 300000
+  CHEBI: 1000000
   FOODON: 4000000
   UBERON: 9000000
   ENVO: 9000000


### PR DESCRIPTION
Closes #247.

## Not already fixed here — the config is per-repo
`scripts/validate_id_label_correspondence.py` is byte-identical across the Mech
repos, but `conf/id_label_targets.yaml` is **not shared** (different md5s), by
design. So MIM's fix did not propagate:

```
CultureMech  CHEBI: 300000   <- wrong
MIM          CHEBI: 1000000  <- fixed
```

## Why 300000 was wrong
The ceiling separates *foreign identifiers wearing an OBO prefix* (PubChem CIDs, 8
digits) from *retired accessions*. It therefore tracks the **digit count of that
foreign namespace**, not how far ChEBI has minted — it should move when PubChem
changes width, not when ChEBI mints higher. At 300000 it was an order of magnitude
below every sibling prefix here, and below ChEBI's own range.

## Exposure, which #247 left unmeasured
Four corpus CHEBI accessions sit above the old ceiling:

```
CHEBI:326268  CHEBI:495055  CHEBI:506227  CHEBI:747199
```

**All four resolve** against the local build, and the ceiling is consulted *only* for
ids that already failed to resolve — so nothing is misdiagnosed today. This is
**preventive**, as it was in MIM.

It isn't hypothetical, though: the local build reaches **747618** and the corpus
already cites **CHEBI:747199** (strontium sulfate), so a term newer than the build
would fail to resolve, clear the old ceiling, and be reported `ID_OUT_OF_RANGE` —
*"a foreign identifier wearing an OBO prefix"*. That verdict demoted **17 real ChEBI
terms to UNMAPPED** in MIM (#193/#197/#205).

## Nothing that fails today starts passing
`ID_OUT_OF_RANGE` and `ID_NOT_FOUND` are both in `_ERROR_VERDICTS` (verified), so
this only changes **which of two fatal diagnoses** a curator is shown.

- `just validate-products` → "All id↔label pairs correspond", same pre-existing
  hydrate warnings (9,811 HYDRATE_ON_ANHYDROUS_TERM etc.).
- id↔label test suites → 22 passed.

Related: MediaIngredientMech #210, #197, #205, #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)