### PR TITLE
Identify the stock behind 190 blocked cocktails; do not guess their volume (#150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ data/import_tracking/reports/mediadive_id_audit.tsv
 
 # Cocktail research target list: regenerable from the corpus + volume cache (#150).
 data/import_tracking/reports/cocktail_research_targets.json
+
+# Cocktail stock identification report: regenerable diagnostic (#150).
+data/import_tracking/reports/cocktail_stock_identification.tsv

--- a/project.justfile
+++ b/project.justfile
@@ -270,6 +270,14 @@ fetch-mediadive-volumes *args="":
 # List flattened cocktails that MediaDive cannot supply a stock+volume for, with the
 # reason each is blocked (#150). Feeds Edison via
 # templates/media_stock_solution_research.md. Read-only.
+# Name the stock a blocked flattened cocktail came from, by exact name+value match
+# against every stock MediaDive has returned (#150). Reports the stock's observed
+# volume distribution as EVIDENCE and deliberately does not fill the volume in —
+# see the script docstring for why the invariant-volume shortcut does not hold.
+[group('QC')]
+identify-cocktail-stocks *args="":
+    uv run --extra dev python scripts/identify_cocktail_stocks.py {{args}}
+
 [group('QC')]
 list-cocktail-research-targets *args="":
     uv run --extra dev python scripts/list_cocktail_research_targets.py {{args}}

--- a/scripts/identify_cocktail_stocks.py
+++ b/scripts/identify_cocktail_stocks.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Name the stock a flattened cocktail came from, without guessing its volume (#150).
+
+The nesting repair needs two facts per record: WHICH stock solution the
+stock-strength ingredients belong to, and the VOLUME it is added at. For records
+MediaDive serves, both come from that medium's own recipe. For the 315 it does not
+serve, neither does — and the Edison literature lane recovers the volume for only
+~12% of them.
+
+This recovers the FIRST fact for most of them, cheaply and without inference.
+
+## How the identification is safe
+
+Every stock MediaDive has ever returned is collected into a library of
+`name -> composition`. A blocked record is matched against that library the same
+way `apply_cocktail_nesting` matches: an ingredient counts only if it agrees with a
+stock component on NAME **and** VALUE, and only if the plausibility audit already
+flagged it. Three or more such agreements identify the stock — a coincidence would
+require three independent compounds to carry the same stock-strength values.
+
+## Why it does NOT fill in the volume
+
+The obvious next step is to reuse the stock's usual addition volume. The data does
+not support it, and the reason is worth recording so it is not re-proposed:
+
+    Trace element solution SL-10   n=36  1 distinct volume  <- invariant, but matches
+                                                               0 blocked records
+    Seven vitamins solution        n=48  4 distinct volumes <- matches 97 records
+    Trace salt solution            n=3   1 distinct volume  <- "invariant" at n=3
+
+The well-sampled stocks vary; the ones that look invariant are under-sampled. SL-10
+is the one stock whose volume is genuinely constant across a large sample, and it
+matches no blocked record at all — because SL-10 is a DSMZ stock, DSMZ media are
+exactly what MediaDive serves, so every SL-10 user was already repaired. The blocked
+population is blocked *because* it is non-DSMZ, and it uses other stocks.
+
+So this reports the observed volume distribution as EVIDENCE and stops there. A
+curator confirming "Seven vitamins solution, 44 of 48 observed at 1 ml/L" against the
+record's own source is doing something this script cannot: checking.
+
+Read-only.
+
+Usage::
+
+    just identify-cocktail-stocks
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+import apply_cocktail_nesting as acn  # noqa: E402
+import audit_concentration_plausibility as acp  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+REPORTS = REPO / "data" / "import_tracking" / "reports"
+PROPOSALS = REPORTS / "cocktail_nesting_proposals.tsv"
+VOLUMES = REPORTS / "mediadive_solution_volumes.json"
+DEFAULT_OUT = REPORTS / "cocktail_stock_identification.tsv"
+
+MIN_COMPONENTS = 3   # a cocktail is >=3 flagged rows by the audit's own definition
+
+
+def build_library(volumes: dict[str, Any]) -> tuple[dict[str, list], dict[str, Counter]]:
+    """stock name -> (largest observed composition, distribution of addition volumes)."""
+    comps: dict[str, list] = {}
+    vols: dict[str, Counter] = defaultdict(Counter)
+    for info in volumes.values():
+        for add in info.get("additions") or []:
+            name = str(add.get("solution_name"))
+            components = add.get("stock_components") or []
+            vols[name][str(add.get("addition_volume_ml"))] += 1
+            if name not in comps or len(components) > len(comps[name]):
+                comps[name] = components
+    return comps, vols
+
+
+def blocked_records(volumes: dict[str, Any]) -> list[tuple[str, list]]:
+    """Flattened cocktails still unrepaired that MediaDive gave no stock for."""
+    out = []
+    with PROPOSALS.open() as fh:
+        for row in csv.DictReader(fh, delimiter="\t"):
+            rel = row["file_path"]
+            try:
+                doc = yaml.safe_load((NORMALIZED / rel).read_text(errors="replace"))
+            except (yaml.YAMLError, OSError):
+                continue
+            if not isinstance(doc, dict) or doc.get("solutions"):
+                continue
+            if (volumes.get(rel) or {}).get("additions"):
+                continue
+            out.append((rel, [i for i in doc.get("ingredients") or [] if isinstance(i, dict)]))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = ap.parse_args(argv)
+
+    if not (PROPOSALS.is_file() and VOLUMES.is_file()):
+        print("Run `just propose-cocktail-nesting` and `just fetch-mediadive-volumes` first.",
+              file=sys.stderr)
+        return 1
+    volumes = json.loads(VOLUMES.read_text())
+    comps, vols = build_library(volumes)
+
+    flagged: dict[str, set[str]] = {}
+    for r in acp.audit(NORMALIZED):
+        if r["finding"] in ("TRACE_SALT_AS_STOCK", "INDICATOR_UNIT_SLIP"):
+            flagged.setdefault(r["file_path"], set()).add(acn._key(r["ingredient"]))
+
+    rows = []
+    for rel, ingredients in blocked_records(volumes):
+        marks = flagged.get(rel, set())
+        best: tuple[int, str] = (0, "")
+        for name, components in comps.items():
+            idx, _ = acn.match_components(ingredients, components, marks)
+            if len(idx) > best[0]:
+                best = (len(idx), name)
+        matched, name = best
+        if matched < MIN_COMPONENTS:
+            continue
+        dist = vols[name]
+        total = sum(dist.values())
+        top_vol, top_n = dist.most_common(1)[0]
+        rows.append({
+            "file_path": rel,
+            "identified_stock": name,
+            "matched_components": str(matched),
+            "flagged_components": str(len(marks)),
+            # Evidence, deliberately not a decision: how often this stock was seen,
+            # and how consistent its volume was when it was.
+            "observed_n": str(total),
+            "volume_distribution": "; ".join(f"{v}ml x{c}" for v, c in dist.most_common()),
+            "modal_volume_ml": top_vol,
+            "modal_share": f"{top_n / total * 100:.0f}%",
+            "volume_is_invariant": "yes" if len(dist) == 1 else "no",
+        })
+
+    rows.sort(key=lambda r: (-int(r["matched_components"]), r["file_path"]))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, delimiter="\t", fieldnames=list(rows[0]) if rows else
+                           ["file_path", "identified_stock"])
+        w.writeheader()
+        w.writerows(rows)
+
+    blocked = blocked_records(volumes)
+    print(f"Blocked flattened cocktails: {len(blocked)}")
+    print(f"Stock identified by exact name+value match (>={MIN_COMPONENTS} components): "
+          f"{len(rows)}\n")
+    by_stock = Counter(r["identified_stock"] for r in rows)
+    print(f"  {'stock':42s} {'records':>7s} {'obs n':>6s} {'modal':>8s} {'invariant':>10s}")
+    for name, n in by_stock.most_common(10):
+        ex = next(r for r in rows if r["identified_stock"] == name)
+        print(f"  {name[:40]:42s} {n:7d} {ex['observed_n']:>6s} "
+              f"{ex['modal_volume_ml'] + 'ml ' + ex['modal_share']:>8s} "
+              f"{ex['volume_is_invariant']:>10s}")
+
+    print("\nThe volume is NOT filled in. The one stock with a genuinely invariant")
+    print("volume across a large sample (SL-10, n=36) matches none of these records —")
+    print("see this script's docstring for why. Confirm the volume against each")
+    print("record's own source before nesting.")
+    print(f"\nWrote {args.out.relative_to(REPO)} — read-only.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_identify_cocktail_stocks.py
+++ b/tests/test_identify_cocktail_stocks.py
@@ -1,0 +1,90 @@
+"""Pin the stock-identification report and its refusal to guess volumes (#150).
+
+Identifying WHICH stock a flattened cocktail came from is safe — it is an exact
+name+value agreement on three or more compounds. Filling in the stock's usual
+addition VOLUME is not, and these tests exist to keep the second from creeping in
+after the first.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ics():
+    return _load("identify_cocktail_stocks")
+
+
+def test_library_keeps_the_largest_observed_composition(ics):
+    """A stock is reported differently by different media (optional components,
+    truncated lists). Matching against the fullest one seen maximises the chance of
+    clearing the 3-component bar without loosening the per-component test."""
+    volumes = {
+        "a.yaml": {"additions": [{"solution_name": "SL-10", "addition_volume_ml": 1,
+                                  "stock_components": [{"compound": "FeCl2", "g_l": 1.5}]}]},
+        "b.yaml": {"additions": [{"solution_name": "SL-10", "addition_volume_ml": 1,
+                                  "stock_components": [{"compound": "FeCl2", "g_l": 1.5},
+                                                       {"compound": "ZnCl2", "g_l": 0.07}]}]},
+    }
+    comps, vols = ics.build_library(volumes)
+    assert [c["compound"] for c in comps["SL-10"]] == ["FeCl2", "ZnCl2"]
+    assert vols["SL-10"] == Counter({"1": 2})
+
+
+def test_library_records_volume_spread_not_just_the_mode(ics):
+    """The report's whole value is showing HOW consistent a stock's volume is, so
+    the distribution must survive, not collapse to a single number."""
+    volumes = {
+        f"{i}.yaml": {"additions": [{"solution_name": "Seven vitamins solution",
+                                     "addition_volume_ml": v, "stock_components": []}]}
+        for i, v in enumerate([1, 1, 1, 5])
+    }
+    _, vols = ics.build_library(volumes)
+    assert vols["Seven vitamins solution"] == Counter({"1": 3, "5": 1})
+    assert len(vols["Seven vitamins solution"]) > 1, "spread must be visible"
+
+
+def test_three_components_is_the_identification_bar(ics):
+    """The audit defines a cocktail as >=3 flagged rows, so three independent
+    name+value agreements is the same bar — one or two could coincide."""
+    assert ics.MIN_COMPONENTS == 3
+
+
+def test_the_report_never_emits_an_applied_volume(ics):
+    """The load-bearing guarantee. The report may carry a modal volume as EVIDENCE,
+    but must not present it as the record's volume — no column may imply an
+    applied or chosen value."""
+    import inspect
+
+    src = inspect.getsource(ics)
+    fields = src.split('rows.append({')[1].split('})')[0]
+    assert "modal_volume_ml" in fields and "volume_distribution" in fields, (
+        "the evidence columns disappeared; the report is no longer showing its working")
+    for banned in ("addition_volume_ml", "applied_volume", "chosen_volume"):
+        assert f'"{banned}"' not in fields, (
+            f"{banned} implies a decision the data does not support — see the "
+            "docstring: the one stock with an invariant volume matches no blocked record")
+
+
+def test_the_negative_finding_is_recorded_in_the_docstring(ics):
+    """The invariant-volume shortcut is the obvious next idea and it does NOT hold.
+    Losing that explanation would invite someone to re-propose it."""
+    doc = ics.__doc__ or ""
+    assert "SL-10" in doc and "0 blocked records" in doc
+    assert "under-sampled" in doc or "under-sampled" in doc.lower()


### PR DESCRIPTION
I proposed reusing a stock's usual addition volume for the records MediaDive cannot
serve ("SL-10 is 1 ml/L in 36/36 media"). **I tested it and it does not hold.** This
PR records that negative result and ships what the data *does* support.

## Why the invariant shortcut fails

```
Trace element solution SL-10   n=36  1 distinct volume   invariant — but matches 0 blocked records
Seven vitamins solution        n=48  4 distinct volumes  matches 87 blocked records
Trace salt solution            n=3   1 distinct volume   "invariant" at n=3
```

**The well-sampled stocks vary; the ones that look invariant are under-sampled.**
There is no stock where the argument is both strong and applicable.

The reason is a selection effect I missed when I recommended it: SL-10 is a **DSMZ**
stock, DSMZ media are exactly what MediaDive serves, so every SL-10 user was already
repaired in #243/#245. The blocked population is blocked *because* it is non-DSMZ
(CCAP/JCM/TOGO and unresolvable KOMODO), and it uses different stocks entirely —
their SL-10 name matches carry wildly different values (MnCl2 5.1 vs SL-10's 0.1).

## What the data does support

`just identify-cocktail-stocks` matches each blocked record against every stock
MediaDive has returned, using the **same name+value agreement** the applier requires
(≥3 components — the audit's own definition of a cocktail, so a coincidence would
need three independent compounds to share stock-strength values).

**190 of 315 blocked records now have their stock named:**

| stock | records | observed n | modal volume | invariant |
|---|--:|--:|---|---|
| Seven vitamins solution | 87 | 48 | 1 ml (92%) | no |
| Trace salt solution | 54 | 3 | 1 ml (100%) | yes* |
| Wolfe's mineral elixir | 15 | 12 | 1 ml (83%) | no |
| Trace element solution (Vishniac & Santer) | 9 | 5 | 0.2 ml (40%) | no |

\* at n=3, "invariant" is not evidence.

The volume distribution is reported as **evidence**, not filled in. A test asserts no
column can imply an applied or chosen volume, and another asserts the negative
finding stays in the docstring so the shortcut isn't re-proposed.

## What this is and isn't
It repairs nothing by itself. It converts *"unknown stock, unknown volume"* into
*"known stock, volume to confirm"* — the state a curator can finish from, for 190
records at once, versus the Edison lane's ~12% hit rate one record at a time.

- 5 tests; corpus untouched (0 changes); report gitignored (regenerable).

Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)