### PR TITLE
Research "Seven vitamins solution" and gate researched stocks per medium (#150)

### DIFF
--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -4,7 +4,7 @@ name: concentration-plausibility
 #
 # #118 asked for an audit AND a corpus repair; #135 shipped the audit only, and
 # nothing has since stopped the defect being reintroduced. The corpus backlog
-# (3,646 records, 305 flattened cocktails after the #150 nesting passes) is NOT
+# (3,645 records, 304 flattened cocktails after the #150 nesting passes) is NOT
 # fixed by this workflow — the
 # baselines hold the line while it is worked through, per the --max-allowed
 # convention already used by check-chebi-grounding.

--- a/data/import_tracking/reports/concentration_plausibility.tsv
+++ b/data/import_tracking/reports/concentration_plausibility.tsv
@@ -4366,10 +4366,6 @@ INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gabonensis_medium.yaml	CultureMech:0
 INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gabonensis_medium.yaml	CultureMech:006365	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gabonensis_medium.yaml	CultureMech:006365	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gabonensis_medium.yaml	CultureMech:006365	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gigas_medium.yaml	CultureMech:004170	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gigas_medium.yaml	CultureMech:004170	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gigas_medium.yaml	CultureMech:004170	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_gigas_medium.yaml	CultureMech:004170	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfovibrio_halophilus_medium.yaml	CultureMech:005626	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfovibrio_halophilus_medium.yaml	CultureMech:005626	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfovibrio_heb233_medium.yaml	CultureMech:002914	FeSO4 x 7 H2O	2.1	G_PER_L	2.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below

--- a/data/import_tracking/reports/concentration_plausibility_by_record.tsv
+++ b/data/import_tracking/reports/concentration_plausibility_by_record.tsv
@@ -1982,7 +1982,6 @@ bacterial/desulfovibrio_b0109p2_medium.yaml	CultureMech:003174	1	0	1	0	no	no
 bacterial/desulfovibrio_dechloracetivorans_medium.yaml	CultureMech:002338	3	0	1	2	no	no
 bacterial/desulfovibrio_fss_1_medium.yaml	CultureMech:002374	1	0	0	1	no	no
 bacterial/desulfovibrio_gabonensis_medium.yaml	CultureMech:006365	5	0	1	4	no	yes
-bacterial/desulfovibrio_gigas_medium.yaml	CultureMech:004170	4	0	0	4	no	yes
 bacterial/desulfovibrio_halophilus_medium.yaml	CultureMech:005626	2	0	1	1	no	no
 bacterial/desulfovibrio_heb233_medium.yaml	CultureMech:002914	1	0	1	0	no	no
 bacterial/desulfovibrio_magneticus_medium.yaml	CultureMech:002755	1	0	1	0	no	no

--- a/data/import_tracking/researched_stock_volumes.json
+++ b/data/import_tracking/researched_stock_volumes.json
@@ -13,9 +13,15 @@
     "citing medium, not generalised from a population.",
     "",
     "An entry is usable by apply_cocktail_nesting only if a record's flagged ingredients",
-    "match its `stock_components` on NAME and VALUE — the same test used for",
+    "match its `stock_components` on NAME and VALUE \u2014 the same test used for",
     "MediaDive-sourced stocks, so a wrong stock cannot be applied on the strength of this",
-    "file alone."
+    "file alone.",
+    "",
+    "`applies_to_media` (optional): the source medium numbers whose OWN sheet was read",
+    "and found to state this volume. When present, a record is nested only if its",
+    "medium is on the list \u2014 a stock's volume is a property of the citing medium, not",
+    "of the stock, and MediaDive shows this one used at four different volumes across",
+    "the corpus. Records citing an unverified medium are left alone."
   ],
   "stocks": [
     {
@@ -23,9 +29,24 @@
       "addition_volume_ml": 1,
       "stock_prepared_in_ml": 100,
       "stock_components": [
-        {"compound": "FeSO4 x 7 H2O", "amount": 0.1, "unit": "g", "g_l": 1},
-        {"compound": "MnCl2 x 4 H2O", "amount": 0.1, "unit": "g", "g_l": 1},
-        {"compound": "ZnSO4 x 7 H2O", "amount": 0.1, "unit": "g", "g_l": 1}
+        {
+          "compound": "FeSO4 x 7 H2O",
+          "amount": 0.1,
+          "unit": "g",
+          "g_l": 1
+        },
+        {
+          "compound": "MnCl2 x 4 H2O",
+          "amount": 0.1,
+          "unit": "g",
+          "g_l": 1
+        },
+        {
+          "compound": "ZnSO4 x 7 H2O",
+          "amount": 0.1,
+          "unit": "g",
+          "g_l": 1
+        }
       ],
       "citation": "https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium84.pdf",
       "snippet": "Trace element solution: FeSO4 x 7 H2O 0.1 g / MnCl2 x 4 H2O 0.1 g / ZnSO4 x 7 H2O 0.1 g / Distilled water 100.0 ml; used in the medium as 'Trace element solution (see below) 1.0 ml' per 1000.0 ml distilled water.",
@@ -38,6 +59,96 @@
       "researched_by": "claude-code-web-research",
       "researched_on": "2026-08-12",
       "notes": "Recovered via the native research path in .claude/skills/deep-research-medium/SKILL.md while the Edison account was returning 402. The MediaDive-derived library independently carries the same composition and 1 ml / 100 ml figures, which corroborates but is not the basis."
+    },
+    {
+      "solution_name": "Seven vitamins solution",
+      "addition_volume_ml": 1,
+      "stock_prepared_in_ml": 1000,
+      "stock_components": [
+        {
+          "compound": "Vitamin B12",
+          "amount": 100,
+          "unit": "mg",
+          "g_l": 0.1
+        },
+        {
+          "compound": "p-Aminobenzoic acid",
+          "amount": 80,
+          "unit": "mg",
+          "g_l": 0.08
+        },
+        {
+          "compound": "D-(+)-biotin",
+          "amount": 20,
+          "unit": "mg",
+          "g_l": 0.02
+        },
+        {
+          "compound": "Nicotinic acid",
+          "amount": 200,
+          "unit": "mg",
+          "g_l": 0.2
+        },
+        {
+          "compound": "Calcium pantothenate",
+          "amount": 100,
+          "unit": "mg",
+          "g_l": 0.1
+        },
+        {
+          "compound": "Pyridoxine hydrochloride",
+          "amount": 300,
+          "unit": "mg",
+          "g_l": 0.3
+        },
+        {
+          "compound": "Thiamine-HCl x 2 H2O",
+          "amount": 200,
+          "unit": "mg",
+          "g_l": 0.2
+        }
+      ],
+      "citation": "https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium503.pdf",
+      "snippet": "Medium 503 (ANAEROBIC FRESHWATER (FWM) MEDIUM) lists 'Seven vitamins solution 1.00 ml'; medium 194 states 'Supplement medium with 1.00 ml/l seven vitamins solution (see medium 503)'; medium 504 reproduces the stock as 'Seven vitamins solution (from medium 503) Vitamin B12 100.00 mg ...' in 1000 ml.",
+      "volume_verified_per_medium": {
+        "503": "Seven vitamins solution 1.00 ml",
+        "194": "Supplement medium with 1.00 ml/l seven vitamins solution (see medium 503)",
+        "504": "Seven vitamins solution 1.00 ml",
+        "1058": "Seven vitamins solution 1.00 ml",
+        "829": "Seven vitamins solution 1.00 ml",
+        "843": "Seven vitamins solution 1.00 ml"
+      },
+      "applies_to_media": [
+        "148",
+        "149",
+        "194",
+        "213",
+        "294",
+        "336",
+        "347",
+        "386",
+        "407",
+        "503",
+        "504",
+        "647",
+        "722",
+        "734",
+        "788",
+        "829",
+        "843",
+        "845",
+        "903",
+        "943",
+        "1058",
+        "1291",
+        "298a",
+        "386a",
+        "503a",
+        "503d"
+      ],
+      "researched_by": "claude-code-web-research",
+      "researched_on": "2026-08-13",
+      "notes": "All 40 media citing this stock among the blocked records were fetched; 26 state the volume in their own sheet and every one of them says 1.00 ml \u2014 none contradicted it. The other 14 are lettered variants (298b-i, 503b/c, 829a) whose PDFs 404 or omit the line, so they are excluded via applies_to_media rather than assumed. MediaDive observes this stock at four different volumes corpus-wide, which is why per-medium verification gates it."
     }
   ]
 }

--- a/data/normalized_yaml/bacterial/desulfovibrio_gigas_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfovibrio_gigas_medium.yaml
@@ -181,16 +181,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:75213
     label: Na2MoO4 x 2 H2O
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
 - preferred_term: p-Aminobenzoic acid
   term:
     id: CHEBI:30753
@@ -211,16 +201,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: D-(+)-biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -231,26 +211,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 applications:
 - Microbial cultivation
 curation_history:
@@ -285,6 +245,13 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T19:27:41.833128+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> ''Seven vitamins solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 24 -> 20
 parent_media:
   path: data/normalized_yaml/bacterial/megadesulfovibrio_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -294,3 +261,52 @@ variant_relationship: SOURCE_DUPLICATE
 variant_modifications:
 - Same ingredient and concentration signature; review as possible duplicate source
   record.
+solutions:
+- preferred_term: Seven vitamins solution
+  composition:
+  - preferred_term: Vitamin B12
+    term:
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17439
+      label: Vitamin B12
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume read from https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium503.pdf
+    (#150).

--- a/data/normalized_yaml/bacterial_index.json
+++ b/data/normalized_yaml/bacterial_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T07:07:08.443630+00:00",
+  "generated": "2026-08-13T19:31:20.033710+00:00",
   "category": "bacterial",
   "count": 14304,
   "recipes": {
@@ -43546,10 +43546,11 @@
     "CultureMech:004170": {
       "name": "desulfovibrio_gigas_medium",
       "filename": "desulfovibrio_gigas_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 20,
       "id": "CultureMech:004170",
       "source_id": "komodo.medium:149",
       "source": "KOMODO",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]

--- a/data/normalized_yaml/by_source_komodo_index.json
+++ b/data/normalized_yaml/by_source_komodo_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T07:09:10.711187+00:00",
+  "generated": "2026-08-13T19:33:08.014481+00:00",
   "source": "KOMODO",
   "count": 3637,
   "recipes": {
@@ -13934,10 +13934,11 @@
     "CultureMech:004170": {
       "name": "desulfovibrio_gigas_medium",
       "filename": "desulfovibrio_gigas_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 20,
       "id": "CultureMech:004170",
       "source_id": "komodo.medium:149",
       "source": "KOMODO",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],

--- a/data/normalized_yaml/recipe_index.json
+++ b/data/normalized_yaml/recipe_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T07:09:10.593801+00:00",
+  "generated": "2026-08-13T19:33:07.901434+00:00",
   "description": "Master index of all CultureMech recipes",
   "total_recipes": 15877,
   "categories": {
@@ -59463,10 +59463,11 @@
     "CultureMech:004170": {
       "name": "desulfovibrio_gigas_medium",
       "filename": "desulfovibrio_gigas_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 20,
       "id": "CultureMech:004170",
       "source_id": "komodo.medium:149",
       "source": "KOMODO",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],

--- a/project.justfile
+++ b/project.justfile
@@ -297,7 +297,7 @@ audit-selective-agent-mismatch *args="":
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py \
-        --max-allowed 10359 --max-cocktails 305 {{args}}
+        --max-allowed 10355 --max-cocktails 304 {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/scripts/apply_cocktail_nesting.py
+++ b/scripts/apply_cocktail_nesting.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -284,6 +285,38 @@ def apply_plan(doc: dict[str, Any], plan: dict[str, Any]) -> None:
                  f"solution(s); ingredients {len(ingredients)} -> {len(kept)}"))
 
 
+def source_medium(doc: dict[str, Any]) -> str | None:
+    """The source catalogue medium number this record came from, e.g. "503" or "298a".
+
+    Read from the notes' "DSMZ Medium: N" stamp, else the media_term id's local part.
+    Used to gate a researched stock to the media whose own sheet was actually read.
+    """
+    m = re.search(r"DSMZ Medium:\s*(\w+)", str(doc.get("notes") or ""))
+    if m:
+        return m.group(1)
+    mid = str(((doc.get("media_term") or {}).get("term") or {}).get("id") or "")
+    return mid.split(":")[-1] or None
+
+
+def stocks_for_record(researched: list[dict[str, Any]],
+                      doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Researched stocks usable for THIS record.
+
+    A stock carrying `applies_to_media` is restricted to those media: the addition
+    volume is a property of the citing medium, not of the stock — MediaDive observes
+    "Seven vitamins solution" at four different volumes — so a record whose medium
+    was not read is left alone rather than given a volume by association.
+    """
+    med = source_medium(doc)
+    usable = []
+    for stock in researched:
+        allowed = stock.get("applies_to_media")
+        if allowed and med not in set(allowed):
+            continue
+        usable.append(stock)
+    return usable
+
+
 def load_researched_stocks() -> list[dict[str, Any]]:
     """Researched stocks, shaped like a MediaDive `addition` so the same code path
     and the same name+value safety test apply to both."""
@@ -322,16 +355,19 @@ def build_plans(split_summed: bool = False, use_researched: bool = False) -> tup
 
     for rel, mediadive_additions in sorted(candidates.items()):
         # A researched stock is only consulted when MediaDive gave nothing for this
-        # record — never to override the medium's own recipe.
-        additions = mediadive_additions or researched
-        if not additions:
-            continue
+        # record — never to override the medium's own recipe — and only if it is
+        # cleared for that record's source medium.
+        additions = mediadive_additions
         path = NORMALIZED / rel
         try:
             doc = yaml.safe_load(path.read_text(errors="replace"))
         except (yaml.YAMLError, OSError):
             continue
         if not isinstance(doc, dict):
+            continue
+        if not additions and researched:
+            additions = stocks_for_record(researched, doc)
+        if not additions:
             continue
         flagged = flagged_by_file.get(rel, set())
         if not flagged:

--- a/tests/test_apply_cocktail_nesting.py
+++ b/tests/test_apply_cocktail_nesting.py
@@ -192,3 +192,34 @@ def test_a_stock_contributing_only_summed_rows_still_gets_its_solution(acn):
     assert abs(totals["Pyridoxine hydrochloride"] - 0.4) < 1e-9
     assert abs(totals["Nicotinic acid"] - 0.25) < 1e-9
     assert doc["ingredients"] == []
+
+
+# --- researched stocks are gated to the media whose sheet was read (#150) ----
+
+
+def test_source_medium_prefers_the_dsmz_stamp(acn):
+    assert acn.source_medium({"notes": "Source: KOMODO | DSMZ Medium: 503 (mediadive.medium:503)"}) == "503"
+    assert acn.source_medium({"notes": "DSMZ Medium: 298a"}) == "298a"
+    # no stamp: fall back to the media_term id's local part
+    assert acn.source_medium({"media_term": {"term": {"id": "komodo.medium:1083"}}}) == "1083"
+    assert acn.source_medium({}) is None
+
+
+def test_a_researched_stock_is_refused_for_an_unverified_medium(acn):
+    """THE gate. An addition volume belongs to the CITING MEDIUM, not to the stock —
+    MediaDive observes "Seven vitamins solution" at four different volumes. A record
+    whose medium's sheet was never read must not inherit the volume by association."""
+    stock = {"solution_name": "Seven vitamins solution", "addition_volume_ml": 1,
+             "applies_to_media": ["503", "194"]}
+    assert [s["solution_name"] for s in acn.stocks_for_record([stock], {"notes": "DSMZ Medium: 503"})] \
+        == ["Seven vitamins solution"]
+    assert acn.stocks_for_record([stock], {"notes": "DSMZ Medium: 298b"}) == []
+    assert acn.stocks_for_record([stock], {}) == []
+
+
+def test_a_stock_without_the_gate_stays_universal(acn):
+    """`applies_to_media` is optional: a stock verified as medium-independent (or one
+    whose citing media were all checked) applies wherever its composition matches."""
+    stock = {"solution_name": "Trace salt solution", "addition_volume_ml": 1}
+    assert len(acn.stocks_for_record([stock], {"notes": "DSMZ Medium: anything"})) == 1
+    assert len(acn.stocks_for_record([stock], {})) == 1

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -188,10 +188,10 @@ def test_stock_solution_records_are_excluded(corpus_findings):
         assert not is_solution_record(doc), f"solution record flagged: {file_path}"
 
 
-CONCENTRATION_BACKLOG_BASELINE = 10_359
+CONCENTRATION_BACKLOG_BASELINE = 10_355
 # The sharper baseline (#150): a raw row count drifts with corpus size, whereas a
 # new flattened cocktail is a specific defect shape an import has reintroduced.
-COCKTAIL_BASELINE = 305
+COCKTAIL_BASELINE = 304
 
 
 def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings):
@@ -199,7 +199,7 @@ def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings
 
     #135 shipped the audit; the repair is now partly done — #150 nested 135
     flattened cocktails from MediaDive data, taking the backlog from 11,540 rows
-    across 3,914 records to 10,359 across 3,646. A guard demanding zero would fail
+    across 3,914 records to 10,355 across 3,645. A guard demanding zero would fail
     immediately and be switched off — the #129 lesson about wiring a gate to a red
     suite. So this baselines at the current count, exactly as
     `check-chebi-grounding --max-allowed 101` does for grounding.
@@ -273,7 +273,7 @@ def test_the_gate_baselines_match_the_current_corpus(acp, media_records):
     """#118 asked for an audit AND a repair; #135 shipped the audit, and nothing
     stopped the defect being reintroduced for another 15 issues.
 
-    These baselines hold the line while the 3,646-record backlog is worked
+    These baselines hold the line while the 3,645-record backlog is worked
     through. They must track the corpus: a baseline above the real count is a gate
     that cannot fail.
     """


### PR DESCRIPTION
Researched the next-largest stock the same way as #252 (Edison still returns 402).
**The research is sound; my yield projection was wrong, and that correction is the
more useful result.**

## The research
DSMZ medium **503**: *"Seven vitamins solution 1.00 ml"*. Medium **504** reproduces
the stock in full (*"from medium 503"*, Vitamin B12 100.00 mg … in 1000 ml). The 87
identified records carry all seven vitamins at exactly those stock values.

**Every one of the 40 citing media was fetched.** 26 state the volume in their own
sheet and **all 26 say 1.00 ml — none contradicted it**. The other 14 are lettered
variants (298b–i, 503b/c, 829a) whose PDFs 404 or omit the line.

## The gate this forced
MediaDive observes this stock at **four different volumes** corpus-wide, so a volume
is a property of the *citing medium*, not of the stock. Researched entries now carry
`applies_to_media`, and a record whose medium was never read is **left alone** rather
than inheriting a volume by association.

Verified: a medium-503 record is offered the stock; a medium-298b record is not.

## Why this unlocks 1 record, not 87
I projected *"one more research question unblocks 87"*. **That was wrong.** Those 87
have their *vitamin* stock identified, but 94 records are blocked by their **other**
stock. The dominant unmatched row is `FeCl2 x 4 H2O` at 1.5 (63 records) — I assumed
SL-10, and it is not: `halosimplex_medium` carries H3BO3 at **3** where SL-10 has
**0.006**, a 500× difference. Those media use other, unresearched trace stocks, and
the refuse-partial guard correctly declines to half-repair them.

So the remainder is a **long tail of per-stock research**, not one more question. The
Seven-vitamins entry is still a permanent asset — those records unlock the moment
their trace stock is researched.

| metric | before | after |
|---|--:|--:|
| implausible rows | 10,359 | **10,355** |
| flattened cocktails | 305 | **304** (275 of 579, 47%) |

## Testing
- Full suite: **1129 passed**, 2 skipped. 3 new tests pin the medium gate.
- Derived-artifacts manifest refreshed **in this commit** — CI caught that omission
  on #252 because the manifest is built from `git ls-files`.

Refs #150, #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)