### PR TITLE
Accept JCM ids, match whole stock signatures, fix the KOMODO medium gate (#150)

### DIFF
--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -4,7 +4,7 @@ name: concentration-plausibility
 #
 # #118 asked for an audit AND a corpus repair; #135 shipped the audit only, and
 # nothing has since stopped the defect being reintroduced. The corpus backlog
-# (3,645 records, 304 flattened cocktails after the #150 nesting passes) is NOT
+# (3,621 records, 279 flattened cocktails after the #150 nesting passes) is NOT
 # fixed by this workflow — the
 # baselines hold the line while it is worked through, per the --max-allowed
 # convention already used by check-chebi-grounding.

--- a/data/import_tracking/reports/concentration_plausibility.tsv
+++ b/data/import_tracking/reports/concentration_plausibility.tsv
@@ -3615,9 +3615,6 @@ INDICATOR_UNIT_SLIP	bacterial/artficial_marine_water_medium.yaml	CultureMech:007
 INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_medium.yaml	CultureMech:008960	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_medium.yaml	CultureMech:008960	Thiamine . HCl	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_medium.yaml	CultureMech:008960	Cyanocobalamin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_vitamin_medium.yaml	CultureMech:002530	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_vitamin_medium.yaml	CultureMech:002530	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/artificial_deep_lake_vitamin_medium.yaml	CultureMech:002530	Thiamine HCl	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/artificial_pilot_plant_water_medium.yaml	CultureMech:002487	FeSO4 x 7 H2O	1.344	G_PER_L	1.344 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/artificial_sea_water_tryptone_soy_broth_medium_asw_tsb_medium.yaml	CultureMech:001173	Double distilled water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/artificial_sea_water_tryptone_soy_broth_medium_asw_tsb_medium.yaml	CultureMech:001173	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -3674,11 +3671,6 @@ TRACE_SALT_AS_STOCK	bacterial/atalassotoga_azc2201_medium.yaml	CultureMech:00235
 TRACE_SALT_AS_STOCK	bacterial/atalassotoga_azc2201_medium.yaml	CultureMech:002355	NiSO4 x 7 H2O	1.6	G_PER_L	1.6 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/athalassotoga_medium.yaml	CultureMech:001085	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/atribacterium_medium.yaml	CultureMech:002438	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/atyp_medium.yaml	CultureMech:002717	FeCl2 x 4 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/atyp_medium.yaml	CultureMech:002717	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/atyp_medium.yaml	CultureMech:002717	Thiamine HCl	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/atyp_medium.yaml	CultureMech:002717	p-Aminobenzoic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/atyp_medium.yaml	CultureMech:002717	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/azc_1502_medium.yaml	CultureMech:002295	FeSO4 x 7 H2O	1.42	G_PER_L	1.42 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/azc_1502_medium.yaml	CultureMech:002295	NiSO4 x 7 H2O	1.6	G_PER_L	1.6 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/azc_1502_medium.yaml	CultureMech:002295	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -3689,11 +3681,6 @@ TRACE_SALT_AS_STOCK	bacterial/azospira_medium.yaml	CultureMech:009571	CuSO4･7H
 TRACE_SALT_AS_STOCK	bacterial/azospira_medium.yaml	CultureMech:009571	FeCl3･6H2O	9.38	G_PER_L	9.38 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/bacillus_alkalidiazotrophicus_medium.yaml	CultureMech:000658	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/bacillus_filiformis_medium.yaml	CultureMech:002174	FeSO4 x 7 H2O	50	G_PER_L	50 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	Vitamin B12	0.10010000000000001	G_PER_L	0.1001 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	Nicotinic acid	0.20500000000000002	G_PER_L	0.205 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	Pyridoxine hydrochloride	0.31	G_PER_L	0.31 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/bacillus_medium.yaml	CultureMech:009007	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/bacillus_selenitireducens_medium.yaml	CultureMech:006925	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/bacillus_selenitireducens_medium.yaml	CultureMech:006925	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -3724,10 +3711,6 @@ TRACE_SALT_AS_STOCK	bacterial/bbm_v.yaml	CultureMech:001244	Na2MoO4 x 2 H2O	20	G
 INDICATOR_UNIT_SLIP	bacterial/bbm_v.yaml	CultureMech:001244	Thiamine	10	G_PER_L	10 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/bbm_v.yaml	CultureMech:001244	Biotine	10	G_PER_L	10 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/belh1_medium.yaml	CultureMech:003221	FeSO4 x 7 H2O	2.1	G_PER_L	2.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/betaine_bicarbonate_buffered_medium.yaml	CultureMech:003112	FeCl2 x 4 H2O	1.998	G_PER_L	1.998 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/betaine_bicarbonate_buffered_medium.yaml	CultureMech:003112	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/betaine_bicarbonate_buffered_medium.yaml	CultureMech:003112	Thiamine HCl	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/betaine_bicarbonate_buffered_medium.yaml	CultureMech:003112	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/bg11.yaml	CultureMech:000324	H3BO3	2.86	G_PER_L	2.86 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/bg11.yaml	CultureMech:000324	MnCl2 x 4 H2O	1.81	G_PER_L	1.81 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/bg11_medium.yaml	CultureMech:009170	Deionized water	2000.0	G_PER_L	2000 G_PER_L water — reads as a preparation volume, not a concentration
@@ -4016,18 +3999,6 @@ TRACE_SALT_AS_STOCK	bacterial/credm1_medium.yaml	CultureMech:001828	FeCl2 x 4 H2
 INDICATOR_UNIT_SLIP	bacterial/credm1_medium.yaml	CultureMech:001828	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/cryptoanaerobacter_medium.yaml	CultureMech:000444	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/cryptoanaerobacter_medium.yaml	CultureMech:000444	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/ctm_medium.yaml	CultureMech:002279	H3BO3	2.86	G_PER_L	2.86 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/ctm_medium.yaml	CultureMech:002279	MnCl2 x 4 H2O	1.81	G_PER_L	1.81 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Riboflavin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Thiamine HCl	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Thiamine pyrophosphate	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Folic acid	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Nicotinic acid	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	p-Aminobenzoic acid	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Pyridoxine hydrochloride	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Lipoic acid	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ctm_medium.yaml	CultureMech:002279	Vitamin B12	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/cy_h_liquid_medium_for_myxobacteria.yaml	CultureMech:001020	Vitamin B12	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/cyanobacteria_medium_1_2_swes_brackish_water_medium.yaml	CultureMech:001261	Vitamin B12	0.25	G_PER_L	0.25 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/cyanobacteria_medium_1_2_swes_brackish_water_medium.yaml	CultureMech:001261	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -4264,11 +4235,6 @@ TRACE_SALT_AS_STOCK	bacterial/desulfohalobium_utahense_medium.yaml	CultureMech:0
 TRACE_SALT_AS_STOCK	bacterial/desulfohalotomaculum_medium.yaml	CultureMech:001962	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfohalovibrio_l21_ls_medium.yaml	CultureMech:001000	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfoluna_medium.yaml	CultureMech:000530	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	Thiamine HCl	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/desulfomonile_medium.yaml	CultureMech:001654	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/desulfomusa_hansenii_medium.yaml	CultureMech:006793	FeCl2 x 4 H2O	53.5	G_PER_L	53.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/desulfomusa_hansenii_medium.yaml	CultureMech:006793	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -5411,9 +5377,6 @@ INDICATOR_UNIT_SLIP	bacterial/hydrogenobacter_medium.yaml	CultureMech:008278	Nic
 TRACE_SALT_AS_STOCK	bacterial/hydrogenobacter_thermophilus_medium.yaml	CultureMech:008001	FeSO4・7H2O	10	G_PER_L	10 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/hydroxybenzoate_medium.yaml	CultureMech:005630	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/hydroxybenzoate_medium.yaml	CultureMech:005630	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/hyl_medium.yaml	CultureMech:002968	MnSO4 x n H2O	3.26	G_PER_L	3.26 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/hyl_medium.yaml	CultureMech:002968	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/hyl_medium.yaml	CultureMech:002968	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/hylemonella_gracilis_medium.yaml	CultureMech:002458	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/hyphomicrobium_medium.yaml	CultureMech:000813	ZnSO4 x 7 H2O	4.4	G_PER_L	4.4 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/hyphomicrobium_medium.yaml	CultureMech:000813	MnCl2 x 4 H2O	1.012	G_PER_L	1.012 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -5460,10 +5423,6 @@ INDICATOR_UNIT_SLIP	bacterial/jcm_medium_242.yaml	CultureMech:009605	Vitamin B12
 INDICATOR_UNIT_SLIP	bacterial/jcm_medium_242.yaml	CultureMech:009605	Riboflavin	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/jcm_medium_242.yaml	CultureMech:009605	Nicotinic acid	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/jcm_medium_242.yaml	CultureMech:009605	Thiamine	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/jcm_medium_no_1046.yaml	CultureMech:002230	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/jcm_medium_no_1046.yaml	CultureMech:002230	CoCl2 x 6 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/jcm_medium_no_1046.yaml	CultureMech:002230	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/jcm_medium_no_1046.yaml	CultureMech:002230	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/jcm_medium_no_216.yaml	CultureMech:002578	H3BO3	1.31	G_PER_L	1.31 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/jcm_medium_no_223.yaml	CultureMech:002585	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/jcm_medium_no_272.yaml	CultureMech:002629	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -5606,9 +5565,6 @@ WATER_AS_VOLUME	bacterial/m17_medium_oxoid_supplemented_with_0_5_wt_vol_glucose.
 WATER_AS_VOLUME	bacterial/m17_medium_oxoid_supplemented_with_1_wt_vol_glucose.yaml	CultureMech:009428	Distilled water	1050.0	G_PER_L	1050 G_PER_L water — reads as a preparation volume, not a concentration
 WATER_AS_VOLUME	bacterial/m1_nocardiopsis_arabia_medium.yaml	CultureMech:000498	Sea water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 INDICATOR_UNIT_SLIP	bacterial/m1d_medium.yaml	CultureMech:008142	Phenol red	6	G_PER_L	6 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/m25y_medium.yaml	CultureMech:002246	MnSO4 x n H2O	3.26	G_PER_L	3.26 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/m25y_medium.yaml	CultureMech:002246	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/m25y_medium.yaml	CultureMech:002246	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/m2_medium.yaml	CultureMech:000805	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/m2gsc_medium.yaml	CultureMech:009240	Resazurin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/m2sgc_broth_containing_tetracycline_10_g_ml_or_rifampin_100_g_ml.yaml	CultureMech:009336	Resazurin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -5666,10 +5622,6 @@ INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium.yaml	CultureMech:001484	Ni
 INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium.yaml	CultureMech:001484	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium.yaml	CultureMech:001484	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/magnetospirillum_medium.yaml	CultureMech:001484	FeCl3 x 6 H2O	2.7	G_PER_L	2.7 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium_a.yaml	CultureMech:002906	Thiamine HCl	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium_a.yaml	CultureMech:002906	p-Aminobenzoic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium_a.yaml	CultureMech:002906	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/magnetospirillum_medium_a.yaml	CultureMech:002906	Pyridoxine hydrochloride	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/magnetospirillum_medium_b.yaml	CultureMech:003013	FeCl3 x 6 H2O	4.5	G_PER_L	4.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/magnetovibrio_medium.yaml	CultureMech:000954	FeCl2 x 4 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/magnetovibrio_medium.yaml	CultureMech:000954	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -6794,9 +6746,6 @@ TRACE_SALT_AS_STOCK	bacterial/methylotroph_medium.yaml	CultureMech:002387	FeCl3 
 INDICATOR_UNIT_SLIP	bacterial/methyloversatilis_thermotolerans_medium.yaml	CultureMech:000560	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/methylovirgula_ligni_medium.yaml	CultureMech:000677	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/mg_medium.yaml	CultureMech:005888	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/mga_agar.yaml	CultureMech:002888	FeSO4 x 7 H2O	10	G_PER_L	10 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/mga_agar.yaml	CultureMech:002888	CuSO4 x 5 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/mga_agar.yaml	CultureMech:002888	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/mgp_medium.yaml	CultureMech:002721	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/mh_ocm_medium.yaml	CultureMech:009202	Distilled Water	1289.0	G_PER_L	1289 G_PER_L water — reads as a preparation volume, not a concentration
 INDICATOR_UNIT_SLIP	bacterial/mh_ocm_medium.yaml	CultureMech:009202	Resazurin	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -6898,12 +6847,6 @@ INDICATOR_UNIT_SLIP	bacterial/modified_1161_medium.yaml	CultureMech:008694	Pyrid
 INDICATOR_UNIT_SLIP	bacterial/modified_1161_medium.yaml	CultureMech:008694	Nicotinic acid	10	G_PER_L	10 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/modified_1161_medium.yaml	CultureMech:008694	Thiamine-HCl	10	G_PER_L	10 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/modified_1161_medium.yaml	CultureMech:008694	Cyanocobalamin	5	G_PER_L	5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	Biotin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	p-Aminobenzoic acid	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	Folic acid	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	Thiamine HCl	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	Riboflavin	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	Pyridoxine hydrochloride	1.5	G_PER_L	1.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/modified_1_5_sws_casein_starch_medium.yaml	CultureMech:008383	H3BO3	4	G_PER_L	4 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/modified_1_5_sws_casein_starch_medium.yaml	CultureMech:008383	Na2MoO4·2H2O	10	G_PER_L	10 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/modified_1_5_sws_casein_starch_medium.yaml	CultureMech:008383	MnCl2·4H2O	100	G_PER_L	100 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -7695,10 +7638,6 @@ TRACE_SALT_AS_STOCK	bacterial/sbbm.yaml	CultureMech:000403	MnCl2 x 4 H2O	1.43099
 INDICATOR_UNIT_SLIP	bacterial/sbbm.yaml	CultureMech:000403	Cyanocobalamine	1.04	G_PER_L	1.04 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/sbbm.yaml	CultureMech:000403	H3BO3	2.48	G_PER_L	2.48 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/schlesneria_paludicola_medium.yaml	CultureMech:000703	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sea_salts_tyg_medium.yaml	CultureMech:003306	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sea_salts_tyg_medium.yaml	CultureMech:003306	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sea_salts_tyg_medium.yaml	CultureMech:003306	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sea_salts_tyg_medium.yaml	CultureMech:003306	ZnSO4 x 7 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/sea_salts_yeast_extract_glucose_medium.yaml	CultureMech:007654	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/sea_salts_ytg_medium.yaml	CultureMech:002466	Na2SeO3	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/sea_water_yeast_peptone_medium.yaml	CultureMech:006887	Sea water	1500.0	G_PER_L	1500 G_PER_L water — reads as a preparation volume, not a concentration
@@ -7721,11 +7660,6 @@ TRACE_SALT_AS_STOCK	bacterial/sh_seawater_medium.yaml	CultureMech:000746	Na2MoO4
 WATER_AS_VOLUME	bacterial/sh_seawater_medium.yaml	CultureMech:000746	Double distilled water	1990.0	G_PER_L	1990 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/si_medium.yaml	CultureMech:002642	FeCl3 x 6 H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/singulisphaera_medium.yaml	CultureMech:000582	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sm_medium.yaml	CultureMech:003248	ZnSO4 x 7 H2O	22	G_PER_L	22 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sm_medium.yaml	CultureMech:003248	MnCl2 x 4 H2O	5.06	G_PER_L	5.06 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sm_medium.yaml	CultureMech:003248	FeSO4 x 7 H2O	4.99	G_PER_L	4.99 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sm_medium.yaml	CultureMech:003248	CuSO4 x 5 H2O	1.57	G_PER_L	1.57 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/sm_medium.yaml	CultureMech:003248	CoCl2 x 6 H2O	1.61	G_PER_L	1.61 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/sme_medium.yaml	CultureMech:000594	Double distilled water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 WATER_AS_VOLUME	bacterial/soil_extract_medium.yaml	CultureMech:000762	Tap water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/solidesulfovibrio_marrakechensis_medium.yaml	CultureMech:000652	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -7933,10 +7867,6 @@ TRACE_SALT_AS_STOCK	bacterial/swmty_marine_medium.yaml	CultureMech:008800	MnCl2�
 TRACE_SALT_AS_STOCK	bacterial/swmty_marine_medium.yaml	CultureMech:008800	CoCl2・6H2O	40.4	G_PER_L	40.4 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/swmty_marine_medium.yaml	CultureMech:008800	CuCl2・2H2O	26.9	G_PER_L	26.9 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/swmty_marine_medium.yaml	CultureMech:008800	ZnCl2	20.8	G_PER_L	20.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syfac_medium.yaml	CultureMech:003181	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syfac_medium.yaml	CultureMech:003181	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syfac_medium.yaml	CultureMech:003181	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syfac_medium.yaml	CultureMech:003181	ZnSO4 x 7 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/sylc_medium.yaml	CultureMech:003598	MnSO4 x H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/sylc_medium.yaml	CultureMech:003598	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/sylc_medium.yaml	CultureMech:003598	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -7977,14 +7907,6 @@ INDICATOR_UNIT_SLIP	bacterial/sypg_medium.yaml	CultureMech:003816	Vitamin B12	0.
 INDICATOR_UNIT_SLIP	bacterial/sypg_medium.yaml	CultureMech:003816	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/sypg_medium.yaml	CultureMech:003816	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/sypg_medium.yaml	CultureMech:003816	Thiamine-HCl x 2 H2O	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/syphc_medium.yaml	CultureMech:003246	Vitamin B12	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/syphc_medium.yaml	CultureMech:003246	Nicotinic acid	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/syphc_medium.yaml	CultureMech:003246	Pyridoxine hydrochloride	0.3	G_PER_L	0.3 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/syphc_medium.yaml	CultureMech:003246	Thiamine HCl	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	bacterial/syphc_medium.yaml	CultureMech:003246	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syphc_medium.yaml	CultureMech:003246	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syphc_medium.yaml	CultureMech:003246	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	bacterial/syphc_medium.yaml	CultureMech:003246	ZnSO4 x 7 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/t2_medium_for_thiobacillus.yaml	CultureMech:008823	Distilled water	1001.0	G_PER_L	1001 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	bacterial/t2_medium_for_thiobacillus.yaml	CultureMech:008823	FeSO4 . 7H2O (2%, w/v, in N HCl)	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/t2_medium_for_thiobacillus.yaml	CultureMech:008823	CuSO4	1.57	G_PER_L	1.57 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -8076,9 +7998,6 @@ INDICATOR_UNIT_SLIP	bacterial/thermoacetogenium_medium.yaml	CultureMech:002040	P
 TRACE_SALT_AS_STOCK	bacterial/thermoacetogenium_phaeum_medium.yaml	CultureMech:006730	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/thermoacetogenium_phaeum_medium.yaml	CultureMech:006730	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	bacterial/thermoanaerobacter_ba_medium.yaml	CultureMech:001812	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/thermoanaerobacter_ethanolicus_medium.yaml	CultureMech:002583	p-Aminobenzoic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/thermoanaerobacter_ethanolicus_medium.yaml	CultureMech:002583	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/thermoanaerobacter_ethanolicus_medium.yaml	CultureMech:002583	Pyridoxine hydrochloride	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/thermoanaerobacter_kivui_medium.yaml	CultureMech:001198	FeSO4 x 7 H2O	1.1	G_PER_L	1.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/thermoanaerobacter_koko_medium.yaml	CultureMech:001848	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	bacterial/thermoanaerobacter_koko_medium.yaml	CultureMech:001848	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -8740,9 +8659,6 @@ INDICATOR_UNIT_SLIP	bacterial/ycfag_medium.yaml	CultureMech:009194	folic acid	5	
 TRACE_SALT_AS_STOCK	bacterial/yma_medium_modified.yaml	CultureMech:000454	FeCl3 x 6 H2O	6.66	G_PER_L	6.66 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 WATER_AS_VOLUME	bacterial/ysg_medium_ph_4_5.yaml	CultureMech:008347	Distilled water	1000.0	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 INDICATOR_UNIT_SLIP	bacterial/ytbc_medium.yaml	CultureMech:000812	Resazurin	0.5	G_PER_L	0.5 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ytps_medium.yaml	CultureMech:002188	p-Aminobenzoic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ytps_medium.yaml	CultureMech:002188	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-INDICATOR_UNIT_SLIP	bacterial/ytps_medium.yaml	CultureMech:002188	Pyridoxine hydrochloride	0.2	G_PER_L	0.2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	bacterial/z45_4_medium_for_cyanobacteria.yaml	CultureMech:001204	H3BO3	3.1	G_PER_L	3.1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/z45_4_medium_for_cyanobacteria.yaml	CultureMech:001204	MnSO4 x H2O	2.23	G_PER_L	2.23 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	bacterial/zavarzinella_formosa_medium.yaml	CultureMech:000639	ZnSO4 x 7 H2O	1.095	G_PER_L	1.095 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -9702,9 +9618,6 @@ INDICATOR_UNIT_SLIP	archaea/archaeoglobus_neptunius_medium.yaml	CultureMech:0015
 INDICATOR_UNIT_SLIP	archaea/archaeoglobus_sulfaticallidus_medium.yaml	CultureMech:000741	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/caldisphaera_medium.yaml	CultureMech:002173	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/caldivirga_medium.yaml	CultureMech:002043	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/caldococcus_medium.yaml	CultureMech:002864	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/caldococcus_medium.yaml	CultureMech:002864	CoSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/caldococcus_medium.yaml	CultureMech:002864	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	Nicotinic acid	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	Thiamine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -9744,9 +9657,6 @@ TRACE_SALT_AS_STOCK	archaea/halorhabdus_utahensis_medium.yaml	CultureMech:002099
 TRACE_SALT_AS_STOCK	archaea/halorussus_varius_medium_msc_15_2.yaml	CultureMech:001167	FeSO4 x 7 H2O	1.54	G_PER_L	1.54 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/halorutilales_haloarchaeon_medium.yaml	CultureMech:001265	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/halorutilales_haloarchaeon_medium.yaml	CultureMech:001265	Pyridoxine	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
-TRACE_SALT_AS_STOCK	archaea/halosimplex_medium.yaml	CultureMech:002655	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/halosimplex_medium.yaml	CultureMech:002655	H3BO3	3	G_PER_L	3 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/halosimplex_medium.yaml	CultureMech:002655	CoCl2 x 6 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/hydrogen_using_marine_methanogen_medium.yaml	CultureMech:008597	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/hydrogen_using_marine_methanogen_medium.yaml	CultureMech:008597	FeCl3·6H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/hydrogen_using_marine_methanogen_medium.yaml	CultureMech:008597	Biotin	2	G_PER_L	2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -9768,13 +9678,6 @@ INDICATOR_UNIT_SLIP	archaea/hydrogen_using_methanogen_medium.yaml	CultureMech:00
 INDICATOR_UNIT_SLIP	archaea/hydrogenotrophic_methanogen_medium.yaml	CultureMech:009523	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 WATER_AS_VOLUME	archaea/ignicoccus_medium_for_dsm_18386.yaml	CultureMech:009166	Distilled water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
 TRACE_SALT_AS_STOCK	archaea/ignicoccus_medium_for_dsm_18386.yaml	CultureMech:009166	H3BO3	15	G_PER_L	15 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	FeSO4 x 7 H2O	5.55	G_PER_L	5.55 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	CoCl2 x 6 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	MnSO4 x 5 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	Na2MoO4 x 2 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	Na2WO4 x 2 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	NiCl2 x 6 H2O	3	G_PER_L	3 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/marine_h2_using_methanogen_medium.yaml	CultureMech:008267	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/marine_h2_using_methanogen_medium.yaml	CultureMech:008267	FeCl3·6H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/marine_h2_using_methanogen_medium.yaml	CultureMech:008267	Biotin	2	G_PER_L	2 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -10108,10 +10011,6 @@ TRACE_SALT_AS_STOCK	archaea/modified_methanoculleus_medium.yaml	CultureMech:0086
 TRACE_SALT_AS_STOCK	archaea/modified_methanoculleus_medium.yaml	CultureMech:008672	FeCl3·6H2O	1.35	G_PER_L	1.35 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/modified_methanoculleus_medium.yaml	CultureMech:008672	Na2WO4	4	G_PER_L	4 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/modified_methanoculleus_medium.yaml	CultureMech:008672	Na2SeO3	4	G_PER_L	4 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/modified_picrophilus_medium.yaml	CultureMech:002433	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/modified_picrophilus_medium.yaml	CultureMech:002433	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/modified_picrophilus_medium.yaml	CultureMech:002433	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/modified_picrophilus_medium.yaml	CultureMech:002433	ZnSO4 x 7 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/natranaeroarchaeum_medium.yaml	CultureMech:002261	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/natranaeroarchaeum_medium_aarc1.yaml	CultureMech:000945	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	archaea/natranaeroarchaeum_medium_aarc1.yaml	CultureMech:000945	Pyridoxine	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
@@ -10141,10 +10040,6 @@ TRACE_SALT_AS_STOCK	archaea/pyrodictium_delaneyi_medium.yaml	CultureMech:000667	
 INDICATOR_UNIT_SLIP	archaea/pyrodictium_delaneyi_medium.yaml	CultureMech:000667	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	archaea/pyrodictium_occultum_medium.yaml	CultureMech:008187	Resazurin	1	G_PER_L	1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 TRACE_SALT_AS_STOCK	archaea/pyrodictium_occultum_medium.yaml	CultureMech:008187	H3BO3	15.01	G_PER_L	15.01 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/pyrolobus_medium.yaml	CultureMech:003204	MnSO4 x n H2O	5	G_PER_L	5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/pyrolobus_medium.yaml	CultureMech:003204	FeSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/pyrolobus_medium.yaml	CultureMech:003204	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	archaea/pyrolobus_medium.yaml	CultureMech:003204	ZnSO4 x 7 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	MnCl2·4H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	Na2B4O7	4.5	G_PER_L	4.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	archaea/saccharolobus_mt_4_medium.yaml	CultureMech:001258	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -10288,9 +10183,6 @@ TRACE_SALT_AS_STOCK	fungal/gyp_glucose_yeast_peptone_medium.yaml	CultureMech:010
 TRACE_SALT_AS_STOCK	fungal/gyp_glucose_yeast_peptone_medium.yaml	CultureMech:010480	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	fungal/halanaeroarchaea_medium_with_yeast_extract_and_formate.yaml	CultureMech:010500	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	fungal/halanaeroarchaea_medium_with_yeast_extract_and_glucose.yaml	CultureMech:010502	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	fungal/hepes_peptone_yeast_extract_medium.yaml	CultureMech:010548	MnSO4 x n H2O	3.26	G_PER_L	3.26 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	fungal/hepes_peptone_yeast_extract_medium.yaml	CultureMech:010548	CoCl2 x 6 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	fungal/hepes_peptone_yeast_extract_medium.yaml	CultureMech:010548	ZnSO4 x 7 H2O	1	G_PER_L	1 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	fungal/natronoanaeroarchaea_medium_with_yeast_extract_and_formate.yaml	CultureMech:010504	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	fungal/natronoanaeroarchaea_medium_with_yeast_extract_and_glucose.yaml	CultureMech:010503	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 TRACE_SALT_AS_STOCK	fungal/natronoarchaea_media_with_yeast_extract_and_lactate.yaml	CultureMech:010501	FeSO4 x 7 H2O	2	G_PER_L	2 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
@@ -10348,9 +10240,6 @@ TRACE_SALT_AS_STOCK	specialized/pygv_marine_medium_b.yaml	CultureMech:015378	ZnS
 TRACE_SALT_AS_STOCK	specialized/sporomusa_medium_marine.yaml	CultureMech:015352	FeCl2 x 4 H2O	1.5	G_PER_L	1.5 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	specialized/sporomusa_medium_marine.yaml	CultureMech:015352	Pyridoxine hydrochloride	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 WATER_AS_VOLUME	specialized/swmty_marine_medium.yaml	CultureMech:015398	Sea water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration
-TRACE_SALT_AS_STOCK	specialized/swmty_marine_medium.yaml	CultureMech:015398	H3BO3	2.85	G_PER_L	2.85 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	specialized/swmty_marine_medium.yaml	CultureMech:015398	MnCl2 x 4 H2O	1.8	G_PER_L	1.8 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
-TRACE_SALT_AS_STOCK	specialized/swmty_marine_medium.yaml	CultureMech:015398	FeSO4 x 7 H2O	1.36	G_PER_L	1.36 G_PER_L trace-element salt — stock-solution magnitude, final medium is normally mg/L or below
 INDICATOR_UNIT_SLIP	specialized/varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen.yaml	CultureMech:015780	Cyanocobalamin	0.1	G_PER_L	0.1 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 INDICATOR_UNIT_SLIP	specialized/varel_bryant_medium_lowcys_lowmet.yaml	CultureMech:015784	Cyanocobalamin	1000	G_PER_L	1000 G_PER_L indicator/vitamin — normally mg/L; likely a 1000x unit slip
 WATER_AS_VOLUME	specialized/water.yaml	CultureMech:015786	Water	1000	G_PER_L	1000 G_PER_L water — reads as a preparation volume, not a concentration

--- a/data/import_tracking/reports/concentration_plausibility_by_record.tsv
+++ b/data/import_tracking/reports/concentration_plausibility_by_record.tsv
@@ -271,7 +271,6 @@ archaea/archaeoglobus_neptunius_medium.yaml	CultureMech:001509	2	0	1	1	no	no
 archaea/archaeoglobus_sulfaticallidus_medium.yaml	CultureMech:000741	1	0	0	1	no	no
 archaea/caldisphaera_medium.yaml	CultureMech:002173	1	0	0	1	no	no
 archaea/caldivirga_medium.yaml	CultureMech:002043	1	0	0	1	no	no
-archaea/caldococcus_medium.yaml	CultureMech:002864	3	0	3	0	no	yes
 archaea/cm1a_halorubrum_medium.yaml	CultureMech:001165	3	0	1	2	no	no
 archaea/conexivisphaera_medium.yaml	CultureMech:001193	1	0	0	1	no	no
 archaea/desulfurococcus_amylolyticus_medium.yaml	CultureMech:002548	1	0	1	0	no	no
@@ -296,12 +295,10 @@ archaea/halorhabdus_medium.yaml	CultureMech:002651	1	0	1	0	no	no
 archaea/halorhabdus_utahensis_medium.yaml	CultureMech:002099	2	0	2	0	no	no
 archaea/halorussus_varius_medium_msc_15_2.yaml	CultureMech:001167	1	0	1	0	no	no
 archaea/halorutilales_haloarchaeon_medium.yaml	CultureMech:001265	2	0	1	1	no	no
-archaea/halosimplex_medium.yaml	CultureMech:002655	3	0	3	0	no	yes
 archaea/hydrogen_using_marine_methanogen_medium.yaml	CultureMech:008597	9	0	1	8	yes	no
 archaea/hydrogen_using_methanogen_medium.yaml	CultureMech:008308	9	0	1	8	yes	no
 archaea/hydrogenotrophic_methanogen_medium.yaml	CultureMech:009523	1	0	0	1	yes	no
 archaea/ignicoccus_medium_for_dsm_18386.yaml	CultureMech:009166	2	1	1	0	yes	no
-archaea/liquid_basal_medium_for_methanosarcina.yaml	CultureMech:002284	7	0	7	0	no	yes
 archaea/marine_h2_using_methanogen_medium.yaml	CultureMech:008267	9	0	1	8	yes	no
 archaea/marine_methanobacterium_medium.yaml	CultureMech:007804	1	0	0	1	yes	no
 archaea/marine_methanosaeta_medium.yaml	CultureMech:008439	9	0	1	8	yes	no
@@ -406,7 +403,6 @@ archaea/modified_9k_medium_for_ferroplasma_aeolicum.yaml	CultureMech:002941	2	0	
 archaea/modified_cellulolytic_haloarchaea_medium.yaml	CultureMech:002353	1	0	1	0	no	no
 archaea/modified_methanobacterium_medium_for_dsm_1093.yaml	CultureMech:009215	14	1	8	5	yes	no
 archaea/modified_methanoculleus_medium.yaml	CultureMech:008672	17	0	7	10	yes	no
-archaea/modified_picrophilus_medium.yaml	CultureMech:002433	4	0	4	0	no	yes
 archaea/natranaeroarchaeum_medium.yaml	CultureMech:002261	1	0	1	0	no	no
 archaea/natranaeroarchaeum_medium_aarc1.yaml	CultureMech:000945	2	0	1	1	no	no
 archaea/natronorubrum_thiooxidans_medium.yaml	CultureMech:000885	1	0	1	0	no	no
@@ -424,7 +420,6 @@ archaea/pyrococcus_medium_2.yaml	CultureMech:008136	2	0	1	1	yes	no
 archaea/pyrodictium_abyssi_medium.yaml	CultureMech:005709	5	0	0	5	no	yes
 archaea/pyrodictium_delaneyi_medium.yaml	CultureMech:000667	3	0	2	1	no	no
 archaea/pyrodictium_occultum_medium.yaml	CultureMech:008187	2	0	1	1	yes	no
-archaea/pyrolobus_medium.yaml	CultureMech:003204	4	0	4	0	no	yes
 archaea/revised_sulfolobus_medium.yaml	CultureMech:008895	2	0	2	0	no	no
 archaea/saccharolobus_mt_4_medium.yaml	CultureMech:001258	1	0	1	0	no	no
 archaea/sulfolobus_medium_anaerobic.yaml	CultureMech:008970	7	1	6	0	yes	no
@@ -1691,7 +1686,6 @@ bacterial/artficial_freshwater_medium_i.yaml	CultureMech:002297	1	0	1	0	yes	no
 bacterial/artficial_freshwater_medium_ii.yaml	CultureMech:002298	1	0	1	0	yes	no
 bacterial/artficial_marine_water_medium.yaml	CultureMech:007728	1	0	0	1	yes	no
 bacterial/artificial_deep_lake_medium.yaml	CultureMech:008960	3	0	0	3	yes	no
-bacterial/artificial_deep_lake_vitamin_medium.yaml	CultureMech:002530	3	0	0	3	no	yes
 bacterial/artificial_pilot_plant_water_medium.yaml	CultureMech:002487	1	0	1	0	no	no
 bacterial/artificial_sea_water_tryptone_soy_broth_medium_asw_tsb_medium.yaml	CultureMech:001173	2	1	1	0	no	no
 bacterial/artificial_seawater_medium_for_strain_js_srb250lac.yaml	CultureMech:008354	21	1	10	10	yes	no
@@ -1709,13 +1703,11 @@ bacterial/asw_ses.yaml	CultureMech:000318	2	1	0	1	no	no
 bacterial/atalassotoga_azc2201_medium.yaml	CultureMech:002355	3	0	3	0	yes	no
 bacterial/athalassotoga_medium.yaml	CultureMech:001085	1	0	0	1	no	no
 bacterial/atribacterium_medium.yaml	CultureMech:002438	1	0	1	0	yes	no
-bacterial/atyp_medium.yaml	CultureMech:002717	5	0	1	4	no	yes
 bacterial/azc_1502_medium.yaml	CultureMech:002295	3	0	3	0	no	yes
 bacterial/azoarcus_taiwanensis_medium.yaml	CultureMech:001123	1	0	1	0	no	no
 bacterial/azospira_medium.yaml	CultureMech:009571	4	0	4	0	yes	no
 bacterial/bacillus_alkalidiazotrophicus_medium.yaml	CultureMech:000658	1	0	1	0	no	no
 bacterial/bacillus_filiformis_medium.yaml	CultureMech:002174	1	0	1	0	no	no
-bacterial/bacillus_macyae_medium.yaml	CultureMech:003163	5	0	1	4	no	yes
 bacterial/bacillus_medium.yaml	CultureMech:009007	1	1	0	0	no	no
 bacterial/bacillus_selenitireducens_medium.yaml	CultureMech:006925	2	0	1	1	no	no
 bacterial/bacillus_tusciae_medium_add_agar.yaml	CultureMech:008976	1	1	0	0	yes	no
@@ -1728,7 +1720,6 @@ bacterial/bb.yaml	CultureMech:000320	5	0	5	0	no	yes
 bacterial/bb_merds.yaml	CultureMech:000323	6	1	5	0	no	yes
 bacterial/bbm_v.yaml	CultureMech:001244	6	0	4	2	no	yes
 bacterial/belh1_medium.yaml	CultureMech:003221	1	0	1	0	no	no
-bacterial/betaine_bicarbonate_buffered_medium.yaml	CultureMech:003112	4	0	1	3	no	yes
 bacterial/bg11.yaml	CultureMech:000324	2	0	2	0	no	no
 bacterial/bg11_medium.yaml	CultureMech:009170	3	1	2	0	no	no
 bacterial/bg11_ph9_0.yaml	CultureMech:008730	5	0	5	0	yes	no
@@ -1850,7 +1841,6 @@ bacterial/cow_manure_agar.yaml	CultureMech:001794	1	1	0	0	no	no
 bacterial/creatinine_nmh_medium.yaml	CultureMech:006007	2	0	1	1	no	no
 bacterial/credm1_medium.yaml	CultureMech:001828	2	0	1	1	no	no
 bacterial/cryptoanaerobacter_medium.yaml	CultureMech:000444	2	0	1	1	no	no
-bacterial/ctm_medium.yaml	CultureMech:002279	12	0	2	10	no	yes
 bacterial/cy_h_liquid_medium_for_myxobacteria.yaml	CultureMech:001020	1	0	0	1	no	no
 bacterial/cyanobacteria_medium_1_2_swes_brackish_water_medium.yaml	CultureMech:001261	5	0	4	1	no	yes
 bacterial/cyanobacteria_medium_ba.yaml	CultureMech:001159	4	0	3	1	no	yes
@@ -1930,7 +1920,6 @@ bacterial/desulfohalobium_utahense_medium.yaml	CultureMech:003305	1	0	1	0	no	no
 bacterial/desulfohalotomaculum_medium.yaml	CultureMech:001962	1	0	1	0	no	no
 bacterial/desulfohalovibrio_l21_ls_medium.yaml	CultureMech:001000	1	0	0	1	no	no
 bacterial/desulfoluna_medium.yaml	CultureMech:000530	1	0	1	0	no	no
-bacterial/desulfomicrobium_medium.yaml	CultureMech:002963	5	0	1	4	no	yes
 bacterial/desulfomonile_medium.yaml	CultureMech:001654	1	0	1	0	no	no
 bacterial/desulfomusa_hansenii_medium.yaml	CultureMech:006793	2	0	1	1	no	no
 bacterial/desulfonatronospira_medium.yaml	CultureMech:000534	2	0	1	1	no	no
@@ -2420,7 +2409,6 @@ bacterial/hydrogenobacter_florentissimum_medium.yaml	CultureMech:002421	1	0	1	0	
 bacterial/hydrogenobacter_medium.yaml	CultureMech:008278	8	0	1	7	yes	no
 bacterial/hydrogenobacter_thermophilus_medium.yaml	CultureMech:008001	1	0	1	0	yes	no
 bacterial/hydroxybenzoate_medium.yaml	CultureMech:005630	2	0	1	1	no	no
-bacterial/hyl_medium.yaml	CultureMech:002968	3	0	3	0	no	yes
 bacterial/hylemonella_gracilis_medium.yaml	CultureMech:002458	1	1	0	0	no	no
 bacterial/hyphomicrobium_medium.yaml	CultureMech:000813	2	0	2	0	no	no
 bacterial/hyphomicrobium_medium_saf.yaml	CultureMech:000846	3	0	1	2	no	no
@@ -2442,7 +2430,6 @@ bacterial/isosphaera_pallida_medium.yaml	CultureMech:001898	2	0	0	2	no	no
 bacterial/isp2_modified_medium_for_methylibium.yaml	CultureMech:001062	1	0	1	0	no	no
 bacterial/jcm_medium_161.yaml	CultureMech:009223	3	0	2	1	no	no
 bacterial/jcm_medium_242.yaml	CultureMech:009605	10	0	1	9	no	yes
-bacterial/jcm_medium_no_1046.yaml	CultureMech:002230	4	0	3	1	no	yes
 bacterial/jcm_medium_no_216.yaml	CultureMech:002578	1	0	1	0	no	no
 bacterial/jcm_medium_no_223.yaml	CultureMech:002585	1	0	0	1	no	no
 bacterial/jcm_medium_no_272.yaml	CultureMech:002629	1	0	1	0	no	no
@@ -2510,7 +2497,6 @@ bacterial/m17_medium_oxoid_supplemented_with_0_5_wt_vol_glucose.yaml	CultureMech
 bacterial/m17_medium_oxoid_supplemented_with_1_wt_vol_glucose.yaml	CultureMech:009428	1	1	0	0	yes	no
 bacterial/m1_nocardiopsis_arabia_medium.yaml	CultureMech:000498	1	1	0	0	no	no
 bacterial/m1d_medium.yaml	CultureMech:008142	1	0	0	1	no	no
-bacterial/m25y_medium.yaml	CultureMech:002246	3	0	3	0	no	yes
 bacterial/m2_medium.yaml	CultureMech:000805	1	0	1	0	no	no
 bacterial/m2gsc_medium.yaml	CultureMech:009240	1	0	0	1	no	no
 bacterial/m2sgc_broth_containing_tetracycline_10_g_ml_or_rifampin_100_g_ml.yaml	CultureMech:009336	1	0	0	1	no	no
@@ -2525,7 +2511,6 @@ bacterial/mac.yaml	CultureMech:008582	7	0	4	3	yes	no
 bacterial/madctw_medium.yaml	CultureMech:008986	2	0	0	2	no	no
 bacterial/maf6_se.yaml	CultureMech:000356	2	0	0	2	no	no
 bacterial/magnetospirillum_medium.yaml	CultureMech:001484	5	0	1	4	no	yes
-bacterial/magnetospirillum_medium_a.yaml	CultureMech:002906	4	0	0	4	no	yes
 bacterial/magnetospirillum_medium_b.yaml	CultureMech:003013	1	0	1	0	no	no
 bacterial/magnetovibrio_medium.yaml	CultureMech:000954	2	0	1	1	no	no
 bacterial/maleate_liquid_medium.yaml	CultureMech:002496	17	0	9	8	no	yes
@@ -2893,7 +2878,6 @@ bacterial/methylotroph_medium.yaml	CultureMech:002387	2	0	2	0	no	no
 bacterial/methyloversatilis_thermotolerans_medium.yaml	CultureMech:000560	1	0	0	1	no	no
 bacterial/methylovirgula_ligni_medium.yaml	CultureMech:000677	1	0	1	0	no	no
 bacterial/mg_medium.yaml	CultureMech:005888	1	0	0	1	no	no
-bacterial/mga_agar.yaml	CultureMech:002888	3	0	3	0	no	yes
 bacterial/mgp_medium.yaml	CultureMech:002721	1	0	1	0	no	no
 bacterial/mh_ocm_medium.yaml	CultureMech:009202	2	1	0	1	yes	no
 bacterial/mhy.yaml	CultureMech:000366	2	0	0	2	no	no
@@ -2942,7 +2926,6 @@ bacterial/mo_sedi_medium.yaml	CultureMech:003201	1	0	1	0	no	no
 bacterial/mo_xq_medium.yaml	CultureMech:002251	1	0	1	0	no	no
 bacterial/mo_ys_medium.yaml	CultureMech:002252	1	0	1	0	no	no
 bacterial/modified_1161_medium.yaml	CultureMech:008694	18	1	10	7	yes	no
-bacterial/modified_1_10_pygv_medium.yaml	CultureMech:003193	6	0	0	6	no	yes
 bacterial/modified_1_5_sws_casein_starch_medium.yaml	CultureMech:008383	6	0	6	0	yes	no
 bacterial/modified_289_medium.yaml	CultureMech:008578	10	0	4	6	yes	no
 bacterial/modified_337a_agar_medium.yaml	CultureMech:009024	5	1	3	1	yes	no
@@ -3245,7 +3228,6 @@ bacterial/saltwater_medium_with_hydrogen.yaml	CultureMech:003114	1	0	1	0	yes	no
 bacterial/saltwater_medium_with_lactate.yaml	CultureMech:002811	5	0	1	4	no	yes
 bacterial/sbbm.yaml	CultureMech:000403	4	0	2	2	no	no
 bacterial/schlesneria_paludicola_medium.yaml	CultureMech:000703	1	0	1	0	no	no
-bacterial/sea_salts_tyg_medium.yaml	CultureMech:003306	4	0	4	0	no	yes
 bacterial/sea_salts_yeast_extract_glucose_medium.yaml	CultureMech:007654	1	0	0	1	no	no
 bacterial/sea_salts_ytg_medium.yaml	CultureMech:002466	1	0	1	0	no	no
 bacterial/sea_water_yeast_peptone_medium.yaml	CultureMech:006887	1	1	0	0	no	no
@@ -3262,7 +3244,6 @@ bacterial/sf1_medium.yaml	CultureMech:005061	1	0	1	0	no	no
 bacterial/sh_seawater_medium.yaml	CultureMech:000746	3	1	2	0	no	no
 bacterial/si_medium.yaml	CultureMech:002642	1	0	1	0	no	no
 bacterial/singulisphaera_medium.yaml	CultureMech:000582	1	0	1	0	no	no
-bacterial/sm_medium.yaml	CultureMech:003248	5	0	5	0	no	yes
 bacterial/sme_medium.yaml	CultureMech:000594	1	1	0	0	no	no
 bacterial/soil_extract_medium.yaml	CultureMech:000762	1	1	0	0	no	no
 bacterial/solidesulfovibrio_marrakechensis_medium.yaml	CultureMech:000652	2	0	1	1	no	no
@@ -3345,7 +3326,6 @@ bacterial/supplemented_middlebrook.yaml	CultureMech:008987	3	1	0	2	no	no
 bacterial/supplemented_tryptophan_m9_medium.yaml	CultureMech:001561	1	0	0	1	no	no
 bacterial/svo_medium.yaml	CultureMech:009126	10	1	0	9	yes	no
 bacterial/swmty_marine_medium.yaml	CultureMech:008800	7	0	7	0	yes	no
-bacterial/syfac_medium.yaml	CultureMech:003181	4	0	4	0	no	yes
 bacterial/sylc_medium.yaml	CultureMech:003598	5	0	4	1	no	yes
 bacterial/synthetic_dextrose_sd_minimal_medium.yaml	CultureMech:008682	1	1	0	0	no	no
 bacterial/syntrophobacter_mpob_medium.yaml	CultureMech:001821	2	0	1	1	no	no
@@ -3361,7 +3341,6 @@ bacterial/syntrophus_aciditrophicus_medium.yaml	CultureMech:003308	1	0	1	0	no	no
 bacterial/syntrophus_medium.yaml	CultureMech:004741	1	0	0	1	no	no
 bacterial/sypc_medium.yaml	CultureMech:003908	4	0	4	0	no	yes
 bacterial/sypg_medium.yaml	CultureMech:003816	8	0	4	4	no	yes
-bacterial/syphc_medium.yaml	CultureMech:003246	8	0	4	4	no	yes
 bacterial/t2_medium_for_thiobacillus.yaml	CultureMech:008823	7	1	6	0	yes	no
 bacterial/t49_medium.yaml	CultureMech:004041	5	0	1	4	no	yes
 bacterial/t_asw_medium.yaml	CultureMech:006021	5	0	5	0	no	yes
@@ -3399,7 +3378,6 @@ bacterial/thermithiobacillus_medium.yaml	CultureMech:001432	4	0	3	1	no	yes
 bacterial/thermoacetogenium_medium.yaml	CultureMech:002040	2	0	1	1	no	no
 bacterial/thermoacetogenium_phaeum_medium.yaml	CultureMech:006730	2	0	1	1	no	no
 bacterial/thermoanaerobacter_ba_medium.yaml	CultureMech:001812	1	0	0	1	no	no
-bacterial/thermoanaerobacter_ethanolicus_medium.yaml	CultureMech:002583	3	0	0	3	no	yes
 bacterial/thermoanaerobacter_kivui_medium.yaml	CultureMech:001198	1	0	1	0	no	no
 bacterial/thermoanaerobacter_koko_medium.yaml	CultureMech:001848	2	0	1	1	no	no
 bacterial/thermoanaerobacter_sulfurophilus_medium.yaml	CultureMech:001976	2	0	1	1	no	no
@@ -3589,7 +3567,6 @@ bacterial/ycfag_medium.yaml	CultureMech:009194	4	0	0	4	no	yes
 bacterial/yma_medium_modified.yaml	CultureMech:000454	1	0	1	0	no	no
 bacterial/ysg_medium_ph_4_5.yaml	CultureMech:008347	1	1	0	0	yes	no
 bacterial/ytbc_medium.yaml	CultureMech:000812	1	0	0	1	no	no
-bacterial/ytps_medium.yaml	CultureMech:002188	3	0	0	3	no	yes
 bacterial/z45_4_medium_for_cyanobacteria.yaml	CultureMech:001204	2	0	2	0	no	no
 bacterial/zavarzinella_formosa_medium.yaml	CultureMech:000639	1	0	1	0	no	no
 bacterial/zf2_medium.yaml	CultureMech:006874	5	0	1	4	no	yes
@@ -3601,7 +3578,6 @@ fungal/ferrous_sulfate_yeast_extract_medium.yaml	CultureMech:010443	1	0	1	0	no	n
 fungal/gyp_glucose_yeast_peptone_medium.yaml	CultureMech:010480	2	0	2	0	no	no
 fungal/halanaeroarchaea_medium_with_yeast_extract_and_formate.yaml	CultureMech:010500	1	0	1	0	no	no
 fungal/halanaeroarchaea_medium_with_yeast_extract_and_glucose.yaml	CultureMech:010502	1	0	1	0	no	no
-fungal/hepes_peptone_yeast_extract_medium.yaml	CultureMech:010548	3	0	3	0	no	yes
 fungal/natronoanaeroarchaea_medium_with_yeast_extract_and_formate.yaml	CultureMech:010504	1	0	1	0	no	no
 fungal/natronoanaeroarchaea_medium_with_yeast_extract_and_glucose.yaml	CultureMech:010503	1	0	1	0	no	no
 fungal/natronoarchaea_media_with_yeast_extract_and_lactate.yaml	CultureMech:010501	1	0	1	0	no	no
@@ -3640,7 +3616,7 @@ specialized/propionigenium_modestum_medium_marine.yaml	CultureMech:015351	1	0	1	
 specialized/pygv_marine_medium_a.yaml	CultureMech:015399	1	0	1	0	no	no
 specialized/pygv_marine_medium_b.yaml	CultureMech:015378	1	0	1	0	no	no
 specialized/sporomusa_medium_marine.yaml	CultureMech:015352	2	0	1	1	no	no
-specialized/swmty_marine_medium.yaml	CultureMech:015398	4	1	3	0	no	yes
+specialized/swmty_marine_medium.yaml	CultureMech:015398	1	1	0	0	yes	no
 specialized/varel_bryant_medium_glucose_nomet_dtt_nas_b12_nonitrogen.yaml	CultureMech:015780	1	0	0	1	no	no
 specialized/varel_bryant_medium_lowcys_lowmet.yaml	CultureMech:015784	1	0	0	1	no	no
 specialized/water.yaml	CultureMech:015786	1	1	0	0	no	no

--- a/data/import_tracking/researched_stock_volumes.json
+++ b/data/import_tracking/researched_stock_volumes.json
@@ -21,7 +21,15 @@
     "and found to state this volume. When present, a record is nested only if its",
     "medium is on the list \u2014 a stock's volume is a property of the citing medium, not",
     "of the stock, and MediaDive shows this one used at four different volumes across",
-    "the corpus. Records citing an unverified medium are left alone."
+    "the corpus. Records citing an unverified medium are left alone.",
+    "",
+    "`match_full_signature` (optional): match the record against this stock's WHOLE",
+    "composition rather than only the audit-flagged rows. Needed for stocks whose",
+    "components mostly sit below the flagging threshold (SL-10's ZnCl2 is 0.07 g/l):",
+    "flag-only matching would move the one flagged row and strand the rest, leaving the",
+    "stock in two places at once. The evidence bar rises rather than falls \u2014 four or",
+    "more components must match at EXACTLY the stock's concentrations, and at least one",
+    "must be flagged."
   ],
   "stocks": [
     {
@@ -149,6 +157,102 @@
       "researched_by": "claude-code-web-research",
       "researched_on": "2026-08-13",
       "notes": "All 40 media citing this stock among the blocked records were fetched; 26 state the volume in their own sheet and every one of them says 1.00 ml \u2014 none contradicted it. The other 14 are lettered variants (298b-i, 503b/c, 829a) whose PDFs 404 or omit the line, so they are excluded via applies_to_media rather than assumed. MediaDive observes this stock at four different volumes corpus-wide, which is why per-medium verification gates it."
+    },
+    {
+      "solution_name": "Trace element solution SL-10",
+      "addition_volume_ml": 1,
+      "stock_prepared_in_ml": 1000,
+      "match_full_signature": true,
+      "stock_components": [
+        {
+          "compound": "HCl",
+          "amount": 10,
+          "unit": "ml",
+          "g_l": 2.5
+        },
+        {
+          "compound": "FeCl2 x 4 H2O",
+          "amount": 1.5,
+          "unit": "g",
+          "g_l": 1.5
+        },
+        {
+          "compound": "ZnCl2",
+          "amount": 70,
+          "unit": "mg",
+          "g_l": 0.07
+        },
+        {
+          "compound": "MnCl2 x 4 H2O",
+          "amount": 100,
+          "unit": "mg",
+          "g_l": 0.1
+        },
+        {
+          "compound": "H3BO3",
+          "amount": 6,
+          "unit": "mg",
+          "g_l": 0.006
+        },
+        {
+          "compound": "CoCl2 x 6 H2O",
+          "amount": 190,
+          "unit": "mg",
+          "g_l": 0.19
+        },
+        {
+          "compound": "CuCl2 x 2 H2O",
+          "amount": 2,
+          "unit": "mg",
+          "g_l": 0.002
+        },
+        {
+          "compound": "NiCl2 x 6 H2O",
+          "amount": 24,
+          "unit": "mg",
+          "g_l": 0.024
+        },
+        {
+          "compound": "Na2MoO4 x 2 H2O",
+          "amount": 36,
+          "unit": "mg",
+          "g_l": 0.036
+        }
+      ],
+      "citation": "https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium503.pdf",
+      "snippet": "Each citing medium's own DSMZ sheet states the SL-10 addition, e.g. medium 503 'Trace element solution SL-10 1.00 ml'. The composition is DSMZ's standard SL-10 (FeCl2 x 4 H2O 1.5 g/l, ZnCl2 0.07, MnCl2 x 4 H2O 0.1, H3BO3 0.006, CoCl2 x 6 H2O 0.19, CuCl2 x 2 H2O 0.002, NiCl2 x 6 H2O 0.024, Na2MoO4 x 2 H2O 0.036, HCl 2.5) made up to 1000 ml.",
+      "applies_to_media": [
+        "148",
+        "194",
+        "213",
+        "294",
+        "336",
+        "347",
+        "386",
+        "407",
+        "503",
+        "504",
+        "647",
+        "708",
+        "734",
+        "788",
+        "824",
+        "829",
+        "843",
+        "876",
+        "903",
+        "943",
+        "1010",
+        "298a",
+        "298b",
+        "386a",
+        "503a",
+        "503c",
+        "503d"
+      ],
+      "researched_by": "claude-code-web-research",
+      "researched_on": "2026-08-13",
+      "notes": "All 54 media citing SL-10 among the blocked records were fetched; 27 state the volume in their own sheet and every one says 1.00 ml \u2014 none contradicted it. The other 27 are lettered variants or JCM copies whose PDFs 404 or omit the line, so they are excluded via applies_to_media. 98 blocked records reproduce 8 or 9 of SL-10's 9 quantified components at exact stock values, which is why this entry uses match_full_signature."
     }
   ]
 }

--- a/data/normalized_yaml/archaea/caldococcus_medium.yaml
+++ b/data/normalized_yaml/archaea/caldococcus_medium.yaml
@@ -85,33 +85,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:76209
     label: Na2S x 9 H2O
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: CoSO4 x 7 H2O
-  term:
-    id: CHEBI:53470
-    label: CoSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:53470
-    label: CoSO4 x 7 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -293,3 +266,45 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:30:01.072998+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace mineral solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 25 -> 22
+solutions:
+- preferred_term: Trace mineral solution
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: CoSO4 x 7 H2O
+    term:
+      id: CHEBI:53470
+      label: CoSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:53470
+      label: CoSO4 x 7 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea/halosimplex_medium.yaml
+++ b/data/normalized_yaml/archaea/halosimplex_medium.yaml
@@ -83,16 +83,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31795
     label: MgSO4 x 7 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: MnCl2 x 4 H2O
   term:
     id: CHEBI:86368
@@ -103,26 +93,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86368
     label: MnCl2 x 4 H2O
-- preferred_term: H3BO3
-  term:
-    id: CHEBI:33118
-    label: boric acid
-  concentration:
-    value: '3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:33118
-    label: H3BO3
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -194,4 +164,49 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.220331+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace metal solution'' @ 2 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 14 -> 11
 high_metal: true
+solutions:
+- preferred_term: Trace metal solution
+  composition:
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  - preferred_term: H3BO3
+    term:
+      id: CHEBI:33118
+      label: boric acid
+    concentration:
+      value: '3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:33118
+      label: H3BO3
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  concentration:
+    value: '2'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 2 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea/liquid_basal_medium_for_methanosarcina.yaml
+++ b/data/normalized_yaml/archaea/liquid_basal_medium_for_methanosarcina.yaml
@@ -127,16 +127,6 @@ ingredients:
   concentration:
     value: '11.1'
     unit: G_PER_L
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '5.55'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
 - preferred_term: Na2SeO3 x 5 H2O
   term:
     id: CHEBI:131361
@@ -147,66 +137,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:131361
     label: Na2SeO3 x 5 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: MnSO4 x 5 H2O
-  term:
-    id: CHEBI:131524
-    label: MnSO4 x 5 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:131524
-    label: MnSO4 x 5 H2O
-- preferred_term: Na2MoO4 x 2 H2O
-  term:
-    id: CHEBI:75213
-    label: Na2MoO4 x 2 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75213
-    label: Na2MoO4 x 2 H2O
-- preferred_term: Na2WO4 x 2 H2O
-  term:
-    id: CHEBI:63939
-    label: Na2WO4 x 2 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:63939
-    label: Na2WO4 x 2 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-- preferred_term: NiCl2 x 6 H2O
-  term:
-    id: CHEBI:34887
-    label: NiCl2 x 6 H2O
-  concentration:
-    value: '3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:34887
-    label: NiCl2 x 6 H2O
 - preferred_term: H3BO3
   term:
     id: CHEBI:33118
@@ -371,3 +301,88 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.237085+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 7 stock-strength component(s) out of ingredients into 1 solution(s):
+    7 -> ''Trace elements solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 7 ingredient(s) under 1 solution(s); ingredients 32 -> 25
+solutions:
+- preferred_term: Trace elements solution
+  composition:
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '5.55'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: MnSO4 x 5 H2O
+    term:
+      id: CHEBI:131524
+      label: MnSO4 x 5 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:131524
+      label: MnSO4 x 5 H2O
+  - preferred_term: Na2MoO4 x 2 H2O
+    term:
+      id: CHEBI:75213
+      label: Na2MoO4 x 2 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75213
+      label: Na2MoO4 x 2 H2O
+  - preferred_term: Na2WO4 x 2 H2O
+    term:
+      id: CHEBI:63939
+      label: Na2WO4 x 2 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:63939
+      label: Na2WO4 x 2 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  - preferred_term: NiCl2 x 6 H2O
+    term:
+      id: CHEBI:34887
+      label: NiCl2 x 6 H2O
+    concentration:
+      value: '3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:34887
+      label: NiCl2 x 6 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea/modified_picrophilus_medium.yaml
+++ b/data/normalized_yaml/archaea/modified_picrophilus_medium.yaml
@@ -164,13 +164,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49105
     label: Thiamine HCl
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
 - preferred_term: NaCl
   term:
     id: CHEBI:26710
@@ -181,36 +174,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: NaCl
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -330,3 +293,55 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.254631+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> "Wolfe''s mineral elixir" @ 2 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 29 -> 25
+solutions:
+- preferred_term: Wolfe's mineral elixir
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '2'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 2 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea/pyrolobus_medium.yaml
+++ b/data/normalized_yaml/archaea/pyrolobus_medium.yaml
@@ -167,43 +167,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86158
     label: CaCl2 x 2 H2O
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -315,3 +278,55 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.271305+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> "Wolfe''s mineral elixir" @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 25 -> 21
+solutions:
+- preferred_term: Wolfe's mineral elixir
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/archaea_index.json
+++ b/data/normalized_yaml/archaea_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T23:45:06.738426+00:00",
+  "generated": "2026-08-13T23:34:17.196949+00:00",
   "category": "archaea",
   "count": 743,
   "recipes": {
@@ -4595,10 +4595,11 @@
     "CultureMech:002864": {
       "name": "caldococcus_medium",
       "filename": "caldococcus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 22,
       "id": "CultureMech:002864",
       "source_id": "mediadive.medium:J513",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ]
@@ -5344,10 +5345,11 @@
     "CultureMech:002655": {
       "name": "halosimplex_medium",
       "filename": "halosimplex_medium.yaml",
-      "ingredient_count": 14,
+      "ingredient_count": 11,
       "id": "CultureMech:002655",
       "source_id": "mediadive.medium:J298",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ]
@@ -5465,10 +5467,11 @@
     "CultureMech:002284": {
       "name": "liquid_basal_medium_for_methanosarcina",
       "filename": "liquid_basal_medium_for_methanosarcina.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 25,
       "id": "CultureMech:002284",
       "source_id": "mediadive.medium:J1107",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ]
@@ -7459,10 +7462,11 @@
     "CultureMech:002433": {
       "name": "modified_picrophilus_medium",
       "filename": "modified_picrophilus_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 25,
       "id": "CultureMech:002433",
       "source_id": "mediadive.medium:J1267",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -7967,10 +7971,11 @@
     "CultureMech:003204": {
       "name": "pyrolobus_medium",
       "filename": "pyrolobus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 21,
       "id": "CultureMech:003204",
       "source_id": "mediadive.medium:J859",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],

--- a/data/normalized_yaml/bacterial/artificial_deep_lake_vitamin_medium.yaml
+++ b/data/normalized_yaml/bacterial/artificial_deep_lake_vitamin_medium.yaml
@@ -77,36 +77,6 @@ ingredients:
   concentration:
     value: '1'
     unit: G_PER_L
-- preferred_term: Biotin
-  term:
-    id: CHEBI:15956
-    label: Biotin
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15956
-    label: Biotin
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -140,4 +110,49 @@ curation_history:
   notes: 'Replaced 9 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-13T23:31:54.282053+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Vitamin solution'' @ 10 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 10 -> 7
 high_metal: true
+solutions:
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: Biotin
+    term:
+      id: CHEBI:15956
+      label: Biotin
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15956
+      label: Biotin
+  - preferred_term: Vitamin B12
+    term:
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17439
+      label: Vitamin B12
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  concentration:
+    value: '10'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 10 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/atyp_medium.yaml
+++ b/data/normalized_yaml/bacterial/atyp_medium.yaml
@@ -91,16 +91,6 @@ ingredients:
   concentration:
     value: '0.299401'
     unit: G_PER_L
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: CoCl2 x 6 H2O
   term:
     id: CHEBI:35696
@@ -181,16 +171,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:131361
     label: Na2SeO3 x 5 H2O
-- preferred_term: Biotin
-  term:
-    id: CHEBI:15956
-    label: Biotin
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15956
-    label: Biotin
 - preferred_term: Niacin
   term:
     id: CHEBI:15940
@@ -201,36 +181,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15940
     label: Niacin
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -291,3 +241,76 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.294718+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Trace element solution SLA'' @ 1 ml/l; 4 -> ''Vitamin solution VA'' @ 1
+    ml/l. Each moved component matched the MediaDive stock by name AND value; bulk
+    ingredients sharing a name were left in place (#150).'
+  changes: Nested 5 ingredient(s) under 2 solution(s); ingredients 25 -> 20
+solutions:
+- preferred_term: Trace element solution SLA
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution VA
+  composition:
+  - preferred_term: Biotin
+    term:
+      id: CHEBI:15956
+      label: Biotin
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15956
+      label: Biotin
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/bacillus_macyae_medium.yaml
+++ b/data/normalized_yaml/bacterial/bacillus_macyae_medium.yaml
@@ -127,17 +127,6 @@ ingredients:
   mediaingredientmech_term:
     id: MediaIngredientMech:000170
     label: KNO3
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.10010000000000001'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.1, 0.0001]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
 - preferred_term: p-Aminobenzoic acid
   term:
     id: CHEBI:30753
@@ -160,17 +149,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: Biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.20500000000000002'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.2, 0.005]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -182,27 +160,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.31'
-    unit: G_PER_L
-  notes: ' [Merged 2 duplicates: 0.3, 0.01]'
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine-HCl x 2 H2O
-  term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:132751
-    label: Thiamine-HCl x 2 H2O
 - preferred_term: HCl
   term:
     id: CHEBI:17883
@@ -213,16 +170,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17883
     label: HCl
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: ZnCl2
   term:
     id: CHEBI:49976
@@ -381,3 +328,110 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.312806+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 3 solution(s):
+    1 -> ''Trace element solution SL-10'' @ 1 ml/l; 1 -> ''Vitamin solution'' @ 1
+    ml/l; 0 -> ''Trace vitamins'' @ 10 ml/l. 3 component(s) were SUMMED across stocks
+    by the flattening and are restored to each stock''s own value, verified by exact
+    sum: nicotinic acid, pyridoxine hydrochloride, vitamin b12. Each moved component
+    matched the MediaDive stock by name AND value; bulk ingredients sharing a name
+    were left in place (#150).'
+  changes: Nested 5 ingredient(s) under 3 solution(s); ingredients 32 -> 27
+solutions:
+- preferred_term: Trace element solution SL-10
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: Thiamine-HCl x 2 H2O
+    term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:132751
+      label: Thiamine-HCl x 2 H2O
+  - preferred_term: Nicotinic acid
+    term: &id001
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.005]'
+    mediaingredientmech_chebi_term: &id002
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term: &id003
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.01]'
+    mediaingredientmech_chebi_term: &id004
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Vitamin B12
+    term: &id005
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.0001]'
+    mediaingredientmech_chebi_term: &id006
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Trace vitamins
+  composition:
+  - preferred_term: Nicotinic acid
+    term: *id001
+    concentration:
+      value: '0.005'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.2, 0.005]'
+    mediaingredientmech_chebi_term: *id002
+  - preferred_term: Pyridoxine hydrochloride
+    term: *id003
+    concentration:
+      value: '0.01'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.3, 0.01]'
+    mediaingredientmech_chebi_term: *id004
+  - preferred_term: Vitamin B12
+    term: *id005
+    concentration:
+      value: '0.0001'
+      unit: G_PER_L
+    notes: ' [Merged 2 duplicates: 0.1, 0.0001]'
+    mediaingredientmech_chebi_term: *id006
+  concentration:
+    value: '10'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 10 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/betaine_bicarbonate_buffered_medium.yaml
+++ b/data/normalized_yaml/bacterial/betaine_bicarbonate_buffered_medium.yaml
@@ -107,16 +107,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:34683
     label: Na2HPO4
-- preferred_term: FeCl2 x 4 H2O
-  term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
-  concentration:
-    value: '1.998'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86249
-    label: FeCl2 x 4 H2O
 - preferred_term: H3BO3
   term:
     id: CHEBI:33118
@@ -287,26 +277,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:16410
     label: Pyridoxamine
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
 - preferred_term: Riboflavin
   term:
     id: CHEBI:17015
@@ -317,16 +287,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17015
     label: Riboflavin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Nicotinamide
   term:
     id: CHEBI:17154
@@ -425,6 +385,14 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.333910+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Trace metal solution'' @ 1 ml/l; 3 -> ''Vitamin solution'' @ 1 ml/l. Each
+    moved component matched the MediaDive stock by name AND value; bulk ingredients
+    sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 2 solution(s); ingredients 37 -> 33
 variant_children:
 - path: data/normalized_yaml/bacterial/lactate_bicarbonate_buffered_medium.yaml
   relationship: SOURCE_DUPLICATE
@@ -432,3 +400,58 @@ variant_children:
   name: lactate_bicarbonate_buffered_medium
   notes: Same ingredient and concentration signature; review as possible duplicate
     source record.
+solutions:
+- preferred_term: Trace metal solution
+  composition:
+  - preferred_term: FeCl2 x 4 H2O
+    term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+    concentration:
+      value: '1.998'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86249
+      label: FeCl2 x 4 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1001 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/ctm_medium.yaml
+++ b/data/normalized_yaml/bacterial/ctm_medium.yaml
@@ -63,26 +63,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: H3BO3
-  term:
-    id: CHEBI:33118
-    label: boric acid
-  concentration:
-    value: '2.86'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:33118
-    label: H3BO3
-- preferred_term: MnCl2 x 4 H2O
-  term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
-  concentration:
-    value: '1.81'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
 - preferred_term: ZnSO4 x 7 H2O
   term:
     id: CHEBI:32312
@@ -377,46 +357,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:16414
     label: L-Valine
-- preferred_term: Biotin
-  term:
-    id: CHEBI:15956
-    label: Biotin
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15956
-    label: Biotin
-- preferred_term: Riboflavin
-  term:
-    id: CHEBI:17015
-    label: Riboflavin
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17015
-    label: Riboflavin
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-- preferred_term: Thiamine pyrophosphate
-  term:
-    id: CHEBI:18290
-    label: Thiamine pyrophosphate
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:18290
-    label: Thiamine pyrophosphate
 - preferred_term: L-Ascorbic acid
   term:
     id: CHEBI:29073
@@ -437,16 +377,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Folic acid
-  term:
-    id: CHEBI:27470
-    label: Folic acid
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:27470
-    label: Folic acid
 - preferred_term: Nicotinamide
   term:
     id: CHEBI:17154
@@ -457,46 +387,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17154
     label: Nicotinamide
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Lipoic acid
-  term:
-    id: CHEBI:16494
-    label: Lipoic acid
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:16494
-    label: Lipoic acid
 - preferred_term: beta-NAD
   term:
     id: CHEBI:15846
@@ -511,16 +401,6 @@ ingredients:
   concentration:
     value: '100'
     unit: G_PER_L
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -564,4 +444,155 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.359024+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 12 stock-strength component(s) out of ingredients into 3 solution(s):
+    2 -> ''Trace metal solution'' @ 50 ml/l; 9 -> ''Vitamin solution A (1000 x stock)''
+    @ 0.25 ml/l; 1 -> ''Vitamin solution B (1000 x stock)'' @ 0.25 ml/l. Each moved
+    component matched the MediaDive stock by name AND value; bulk ingredients sharing
+    a name were left in place (#150).'
+  changes: Nested 12 ingredient(s) under 3 solution(s); ingredients 52 -> 40
 high_metal: true
+solutions:
+- preferred_term: Trace metal solution
+  composition:
+  - preferred_term: H3BO3
+    term:
+      id: CHEBI:33118
+      label: boric acid
+    concentration:
+      value: '2.86'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:33118
+      label: H3BO3
+  - preferred_term: MnCl2 x 4 H2O
+    term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+    concentration:
+      value: '1.81'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+  concentration:
+    value: '50'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 50 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution A (1000 x stock)
+  composition:
+  - preferred_term: Biotin
+    term:
+      id: CHEBI:15956
+      label: Biotin
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15956
+      label: Biotin
+  - preferred_term: Riboflavin
+    term:
+      id: CHEBI:17015
+      label: Riboflavin
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17015
+      label: Riboflavin
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  - preferred_term: Thiamine pyrophosphate
+    term:
+      id: CHEBI:18290
+      label: Thiamine pyrophosphate
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:18290
+      label: Thiamine pyrophosphate
+  - preferred_term: Folic acid
+    term:
+      id: CHEBI:27470
+      label: Folic acid
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:27470
+      label: Folic acid
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Lipoic acid
+    term:
+      id: CHEBI:16494
+      label: Lipoic acid
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:16494
+      label: Lipoic acid
+  concentration:
+    value: '0.25'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 0.25 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution B (1000 x stock)
+  composition:
+  - preferred_term: Vitamin B12
+    term:
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17439
+      label: Vitamin B12
+  concentration:
+    value: '0.25'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 0.25 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/desulfomicrobium_medium.yaml
+++ b/data/normalized_yaml/bacterial/desulfomicrobium_medium.yaml
@@ -113,16 +113,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
 - preferred_term: CoCl2 x 6 H2O
   term:
     id: CHEBI:35696
@@ -187,16 +177,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86318
     label: CuCl2 x 2 H2O
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
 - preferred_term: p-Aminobenzoic acid
   term:
     id: CHEBI:30753
@@ -217,16 +197,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: Biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: DL-Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -237,26 +207,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: DL-Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
 preparation_steps:
 - step_number: 1
   action: AUTOCLAVE
@@ -296,3 +246,76 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.379152+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 2 solution(s):
+    1 -> ''Trace element solution SL12B'' @ 1 ml/l; 4 -> ''Vitamin solution'' @ 1
+    ml/l. Each moved component matched the MediaDive stock by name AND value; bulk
+    ingredients sharing a name were left in place (#150).'
+  changes: Nested 5 ingredient(s) under 2 solution(s); ingredients 25 -> 20
+solutions:
+- preferred_term: Trace element solution SL12B
+  composition:
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: Vitamin B12
+    term:
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17439
+      label: Vitamin B12
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/hyl_medium.yaml
+++ b/data/normalized_yaml/bacterial/hyl_medium.yaml
@@ -147,33 +147,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '3.26'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: NiSO4 x 6 H2O
   term:
     id: CHEBI:53001
@@ -389,3 +362,45 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.397680+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace elements'' @ 1 ml/l. Each moved component matched the MediaDive stock
+    by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 34 -> 31
+solutions:
+- preferred_term: Trace elements
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '3.26'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/jcm_medium_no_1046.yaml
+++ b/data/normalized_yaml/bacterial/jcm_medium_no_1046.yaml
@@ -116,33 +116,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:2509
     label: Agar
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -183,16 +156,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:75213
     label: Na2MoO4 x 2 H2O
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thiamine HCl
   term:
     id: CHEBI:49105
@@ -233,3 +196,55 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.412793+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> ''Trace element solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 20 -> 16
+solutions:
+- preferred_term: Trace element solution
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/m25y_medium.yaml
+++ b/data/normalized_yaml/bacterial/m25y_medium.yaml
@@ -141,33 +141,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '3.26'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: NiSO4 x 6 H2O
   term:
     id: CHEBI:53001
@@ -281,3 +254,45 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.426874+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace elements'' @ 1 ml/l. Each moved component matched the MediaDive stock
+    by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 24 -> 21
+solutions:
+- preferred_term: Trace elements
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '3.26'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/magnetospirillum_medium_a.yaml
+++ b/data/normalized_yaml/bacterial/magnetospirillum_medium_a.yaml
@@ -173,46 +173,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Na2-EDTA
   term:
     id: CHEBI:64734
@@ -280,3 +240,58 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.441817+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> ''7 Vitamins solution'' @ 0.5 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 22 -> 18
+solutions:
+- preferred_term: 7 Vitamins solution
+  composition:
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '0.5'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 0.5 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/mga_agar.yaml
+++ b/data/normalized_yaml/bacterial/mga_agar.yaml
@@ -63,36 +63,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:2509
     label: Agar
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '10'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CuSO4 x 5 H2O
-  term:
-    id: CHEBI:31440
-    label: CuSO4 x 5 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:31440
-    label: CuSO4 x 5 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 preparation_steps:
 - step_number: 1
   action: ADJUST_PH
@@ -126,3 +96,48 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 1 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.451840+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace salts solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 8 -> 5
+solutions:
+- preferred_term: Trace salts solution
+  composition:
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '10'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CuSO4 x 5 H2O
+    term:
+      id: CHEBI:31440
+      label: CuSO4 x 5 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:31440
+      label: CuSO4 x 5 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 100 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/modified_1_10_pygv_medium.yaml
+++ b/data/normalized_yaml/bacterial/modified_1_10_pygv_medium.yaml
@@ -91,16 +91,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86158
     label: CaCl2 x 2 H2O
-- preferred_term: Biotin
-  term:
-    id: CHEBI:15956
-    label: Biotin
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15956
-    label: Biotin
 - preferred_term: Vitamine B12
   concentration:
     value: '0.1'
@@ -111,56 +101,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:176843
     label: Vitamine B12
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-- preferred_term: Folic acid
-  term:
-    id: CHEBI:27470
-    label: Folic acid
-  concentration:
-    value: '0.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:27470
-    label: Folic acid
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-- preferred_term: Riboflavin
-  term:
-    id: CHEBI:17015
-    label: Riboflavin
-  concentration:
-    value: '0.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17015
-    label: Riboflavin
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '1.5'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 preparation_steps:
 - step_number: 1
   action: ADJUST_PH
@@ -195,3 +135,78 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.461283+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 6 stock-strength component(s) out of ingredients into 1 solution(s):
+    6 -> ''100 x Vitamin mixture'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 6 ingredient(s) under 1 solution(s); ingredients 16 -> 10
+solutions:
+- preferred_term: 100 x Vitamin mixture
+  composition:
+  - preferred_term: Biotin
+    term:
+      id: CHEBI:15956
+      label: Biotin
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15956
+      label: Biotin
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Folic acid
+    term:
+      id: CHEBI:27470
+      label: Folic acid
+    concentration:
+      value: '0.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:27470
+      label: Folic acid
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  - preferred_term: Riboflavin
+    term:
+      id: CHEBI:17015
+      label: Riboflavin
+    concentration:
+      value: '0.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17015
+      label: Riboflavin
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '1.5'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/sea_salts_tyg_medium.yaml
+++ b/data/normalized_yaml/bacterial/sea_salts_tyg_medium.yaml
@@ -85,13 +85,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31795
     label: MgSO4 x 7 H2O
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
 - preferred_term: NaCl
   term:
     id: CHEBI:26710
@@ -102,26 +95,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: NaCl
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
 - preferred_term: CaCl2 x 2 H2O
   term:
     id: CHEBI:86158
@@ -132,16 +105,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86158
     label: CaCl2 x 2 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -256,3 +219,55 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.473829+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> "Wolfe''s mineral elixir" @ 2 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 22 -> 18
+solutions:
+- preferred_term: Wolfe's mineral elixir
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '2'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 2 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/sm_medium.yaml
+++ b/data/normalized_yaml/bacterial/sm_medium.yaml
@@ -73,16 +73,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64755
     label: EDTA
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '22'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CaCl2
   term:
     id: CHEBI:3312
@@ -93,26 +83,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:3312
     label: CaCl2
-- preferred_term: MnCl2 x 4 H2O
-  term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
-  concentration:
-    value: '5.06'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '4.99'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
 - preferred_term: (NH4)6Mo7O24 x 4 H2O
   concentration:
     value: '1.1'
@@ -120,26 +90,6 @@ ingredients:
   term:
     id: CHEBI:91249
     label: ammonium molybdate
-- preferred_term: CuSO4 x 5 H2O
-  term:
-    id: CHEBI:31440
-    label: CuSO4 x 5 H2O
-  concentration:
-    value: '1.57'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:31440
-    label: CuSO4 x 5 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.61'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
 preparation_steps:
 - step_number: 1
   action: ADJUST_PH
@@ -184,3 +134,68 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.485301+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 5 stock-strength component(s) out of ingredients into 1 solution(s):
+    5 -> ''Trace metal solution'' @ 5 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 5 ingredient(s) under 1 solution(s); ingredients 13 -> 8
+solutions:
+- preferred_term: Trace metal solution
+  composition:
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '22'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  - preferred_term: MnCl2 x 4 H2O
+    term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+    concentration:
+      value: '5.06'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '4.99'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CuSO4 x 5 H2O
+    term:
+      id: CHEBI:31440
+      label: CuSO4 x 5 H2O
+    concentration:
+      value: '1.57'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:31440
+      label: CuSO4 x 5 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.61'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  concentration:
+    value: '5'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 5 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/syfac_medium.yaml
+++ b/data/normalized_yaml/bacterial/syfac_medium.yaml
@@ -84,13 +84,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31795
     label: MgSO4 x 7 H2O
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
 - preferred_term: NaCl
   term:
     id: CHEBI:26710
@@ -101,26 +94,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: NaCl
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
 - preferred_term: CaCl2 x 2 H2O
   term:
     id: CHEBI:86158
@@ -131,16 +104,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86158
     label: CaCl2 x 2 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -259,3 +222,55 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 3 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.497698+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 4 stock-strength component(s) out of ingredients into 1 solution(s):
+    4 -> "Wolfe''s mineral elixir" @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 4 ingredient(s) under 1 solution(s); ingredients 22 -> 18
+solutions:
+- preferred_term: Wolfe's mineral elixir
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/syphc_medium.yaml
+++ b/data/normalized_yaml/bacterial/syphc_medium.yaml
@@ -81,16 +81,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:63036
     label: KH2PO4
-- preferred_term: Vitamin B12
-  term:
-    id: CHEBI:17439
-    label: Vitamin B12
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:17439
-    label: Vitamin B12
 - preferred_term: p-Aminobenzoic acid
   term:
     id: CHEBI:30753
@@ -111,16 +101,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: Biotin
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: DL-Calcium pantothenate
   term:
     id: CHEBI:31345
@@ -131,26 +111,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: DL-Calcium pantothenate
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.3'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-- preferred_term: Thiamine HCl
-  term:
-    id: CHEBI:49105
-    label: Thiamine HCl
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:49105
-    label: Thiamine HCl
 - preferred_term: MgSO4 x 7 H2O
   term:
     id: CHEBI:31795
@@ -161,13 +121,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31795
     label: MgSO4 x 7 H2O
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '5'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
 - preferred_term: NaCl
   term:
     id: CHEBI:26710
@@ -178,26 +131,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: NaCl
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
 - preferred_term: CaCl2 x 2 H2O
   term:
     id: CHEBI:86158
@@ -208,16 +141,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:86158
     label: CaCl2 x 2 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: CuSO4 x 5 H2O
   term:
     id: CHEBI:31440
@@ -329,3 +252,103 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 5 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.513916+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 8 stock-strength component(s) out of ingredients into 2 solution(s):
+    4 -> "Wolfe''s mineral elixir" @ 1 ml/l; 4 -> ''Vitamin solution'' @ 0.5 ml/l.
+    Each moved component matched the MediaDive stock by name AND value; bulk ingredients
+    sharing a name were left in place (#150).'
+  changes: Nested 8 ingredient(s) under 2 solution(s); ingredients 29 -> 21
+solutions:
+- preferred_term: Wolfe's mineral elixir
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '5'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: Vitamin B12
+    term:
+      id: CHEBI:17439
+      label: Vitamin B12
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:17439
+      label: Vitamin B12
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.3'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  - preferred_term: Thiamine HCl
+    term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:49105
+      label: Thiamine HCl
+  concentration:
+    value: '0.5'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 0.5 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/thermoanaerobacter_ethanolicus_medium.yaml
+++ b/data/normalized_yaml/bacterial/thermoanaerobacter_ethanolicus_medium.yaml
@@ -87,16 +87,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: Biotin
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: Folic acid
   term:
     id: CHEBI:27470
@@ -117,16 +107,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Vitamin B12
   term:
     id: CHEBI:17439
@@ -147,16 +127,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49105
     label: Thiamine HCl
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thioctic acid
   term:
     id: CHEBI:30314
@@ -384,3 +354,48 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.534785+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Vitamin solution'' @ 0.5 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 33 -> 30
+solutions:
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '0.5'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 500 ml; added at 0.5 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial/ytps_medium.yaml
+++ b/data/normalized_yaml/bacterial/ytps_medium.yaml
@@ -280,16 +280,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: Biotin
-- preferred_term: p-Aminobenzoic acid
-  term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30753
-    label: p-Aminobenzoic acid
 - preferred_term: Folic acid
   term:
     id: CHEBI:27470
@@ -310,16 +300,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31345
     label: Calcium pantothenate
-- preferred_term: Nicotinic acid
-  term:
-    id: CHEBI:15940
-    label: Nicotinic acid
-  concentration:
-    value: '0.1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:15940
-    label: Nicotinic acid
 - preferred_term: Vitamin B12
   term:
     id: CHEBI:17439
@@ -340,16 +320,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:49105
     label: Thiamine HCl
-- preferred_term: Pyridoxine hydrochloride
-  term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
-  concentration:
-    value: '0.2'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:30961
-    label: Pyridoxine hydrochloride
 - preferred_term: Thioctic acid
   term:
     id: CHEBI:30314
@@ -425,3 +395,48 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 6 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.556177+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Vitamin solution'' @ 0.5 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 37 -> 34
+solutions:
+- preferred_term: Vitamin solution
+  composition:
+  - preferred_term: p-Aminobenzoic acid
+    term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30753
+      label: p-Aminobenzoic acid
+  - preferred_term: Nicotinic acid
+    term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+    concentration:
+      value: '0.1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:15940
+      label: Nicotinic acid
+  - preferred_term: Pyridoxine hydrochloride
+    term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+    concentration:
+      value: '0.2'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:30961
+      label: Pyridoxine hydrochloride
+  concentration:
+    value: '0.5'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 500 ml; added at 0.5 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/bacterial_index.json
+++ b/data/normalized_yaml/bacterial_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T19:31:20.033710+00:00",
+  "generated": "2026-08-13T23:34:23.829259+00:00",
   "category": "bacterial",
   "count": 14304,
   "recipes": {
@@ -34962,10 +34962,11 @@
     "CultureMech:002530": {
       "name": "artificial_deep_lake_vitamin_medium",
       "filename": "artificial_deep_lake_vitamin_medium.yaml",
-      "ingredient_count": 10,
+      "ingredient_count": 7,
       "id": "CultureMech:002530",
       "source_id": "mediadive.medium:J170",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -35470,10 +35471,11 @@
     "CultureMech:002717": {
       "name": "atyp_medium",
       "filename": "atyp_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002717",
       "source_id": "mediadive.medium:J358",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -35750,10 +35752,11 @@
     "CultureMech:003163": {
       "name": "bacillus_macyae_medium",
       "filename": "bacillus_macyae_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:003163",
       "source_id": "mediadive.medium:J819",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -36466,10 +36469,11 @@
     "CultureMech:003112": {
       "name": "betaine_bicarbonate_buffered_medium",
       "filename": "betaine_bicarbonate_buffered_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 33,
       "id": "CultureMech:003112",
       "source_id": "mediadive.medium:J770",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -41240,10 +41244,11 @@
     "CultureMech:002279": {
       "name": "ctm_medium",
       "filename": "ctm_medium.yaml",
-      "ingredient_count": 52,
+      "ingredient_count": 40,
       "id": "CultureMech:002279",
       "source_id": "mediadive.medium:J1100",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ]
@@ -42790,10 +42795,11 @@
     "CultureMech:002963": {
       "name": "desulfomicrobium_medium",
       "filename": "desulfomicrobium_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002963",
       "source_id": "mediadive.medium:J616",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ]
@@ -54031,10 +54037,11 @@
     "CultureMech:002968": {
       "name": "hyl_medium",
       "filename": "hyl_medium.yaml",
-      "ingredient_count": 34,
+      "ingredient_count": 31,
       "id": "CultureMech:002968",
       "source_id": "mediadive.medium:J621",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -54769,10 +54776,11 @@
     "CultureMech:002230": {
       "name": "jcm_medium_no_1046",
       "filename": "jcm_medium_no_1046.yaml",
-      "ingredient_count": 20,
+      "ingredient_count": 16,
       "id": "CultureMech:002230",
       "source_id": "mediadive.medium:J1046",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -57636,10 +57644,11 @@
     "CultureMech:002246": {
       "name": "m25y_medium",
       "filename": "m25y_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 21,
       "id": "CultureMech:002246",
       "source_id": "mediadive.medium:J1066",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -58799,10 +58808,11 @@
     "CultureMech:002906": {
       "name": "magnetospirillum_medium_a",
       "filename": "magnetospirillum_medium_a.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:002906",
       "source_id": "mediadive.medium:J558",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -128220,10 +128230,11 @@
     "CultureMech:002888": {
       "name": "mga_agar",
       "filename": "mga_agar.yaml",
-      "ingredient_count": 8,
+      "ingredient_count": 5,
       "id": "CultureMech:002888",
       "source_id": "mediadive.medium:J53",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -130712,10 +130723,11 @@
     "CultureMech:003193": {
       "name": "modified_1_10_pygv_medium",
       "filename": "modified_1_10_pygv_medium.yaml",
-      "ingredient_count": 16,
+      "ingredient_count": 10,
       "id": "CultureMech:003193",
       "source_id": "mediadive.medium:J848",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -141587,10 +141599,11 @@
     "CultureMech:003306": {
       "name": "sea_salts_tyg_medium",
       "filename": "sea_salts_tyg_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003306",
       "source_id": "mediadive.medium:J958",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -142250,10 +142263,11 @@
     "CultureMech:003248": {
       "name": "sm_medium",
       "filename": "sm_medium.yaml",
-      "ingredient_count": 13,
+      "ingredient_count": 8,
       "id": "CultureMech:003248",
       "source_id": "mediadive.medium:J89",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -144443,10 +144457,11 @@
     "CultureMech:003181": {
       "name": "syfac_medium",
       "filename": "syfac_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003181",
       "source_id": "mediadive.medium:J837",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -144904,10 +144919,11 @@
     "CultureMech:003246": {
       "name": "syphc_medium",
       "filename": "syphc_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 21,
       "id": "CultureMech:003246",
       "source_id": "mediadive.medium:J898",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -145668,10 +145684,11 @@
     "CultureMech:002583": {
       "name": "thermoanaerobacter_ethanolicus_medium",
       "filename": "thermoanaerobacter_ethanolicus_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 30,
       "id": "CultureMech:002583",
       "source_id": "mediadive.medium:J221",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ]
@@ -155163,10 +155180,11 @@
     "CultureMech:002188": {
       "name": "ytps_medium",
       "filename": "ytps_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 34,
       "id": "CultureMech:002188",
       "source_id": "mediadive.medium:J1002",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],

--- a/data/normalized_yaml/by_source_mediadive_index.json
+++ b/data/normalized_yaml/by_source_mediadive_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T07:09:10.740975+00:00",
+  "generated": "2026-08-13T23:35:46.538437+00:00",
   "source": "MediaDive",
   "count": 3325,
   "recipes": {
@@ -627,10 +627,11 @@
     "CultureMech:002864": {
       "name": "caldococcus_medium",
       "filename": "caldococcus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 22,
       "id": "CultureMech:002864",
       "source_id": "mediadive.medium:J513",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -1359,10 +1360,11 @@
     "CultureMech:002655": {
       "name": "halosimplex_medium",
       "filename": "halosimplex_medium.yaml",
-      "ingredient_count": 14,
+      "ingredient_count": 11,
       "id": "CultureMech:002655",
       "source_id": "mediadive.medium:J298",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -1435,10 +1437,11 @@
     "CultureMech:002284": {
       "name": "liquid_basal_medium_for_methanosarcina",
       "filename": "liquid_basal_medium_for_methanosarcina.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 25,
       "id": "CultureMech:002284",
       "source_id": "mediadive.medium:J1107",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -2926,10 +2929,11 @@
     "CultureMech:002433": {
       "name": "modified_picrophilus_medium",
       "filename": "modified_picrophilus_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 25,
       "id": "CultureMech:002433",
       "source_id": "mediadive.medium:J1267",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -3375,10 +3379,11 @@
     "CultureMech:003204": {
       "name": "pyrolobus_medium",
       "filename": "pyrolobus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 21,
       "id": "CultureMech:003204",
       "source_id": "mediadive.medium:J859",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -9186,10 +9191,11 @@
     "CultureMech:002530": {
       "name": "artificial_deep_lake_vitamin_medium",
       "filename": "artificial_deep_lake_vitamin_medium.yaml",
-      "ingredient_count": 10,
+      "ingredient_count": 7,
       "id": "CultureMech:002530",
       "source_id": "mediadive.medium:J170",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -9460,10 +9466,11 @@
     "CultureMech:002717": {
       "name": "atyp_medium",
       "filename": "atyp_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002717",
       "source_id": "mediadive.medium:J358",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -9702,10 +9709,11 @@
     "CultureMech:003163": {
       "name": "bacillus_macyae_medium",
       "filename": "bacillus_macyae_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:003163",
       "source_id": "mediadive.medium:J819",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -10173,10 +10181,11 @@
     "CultureMech:003112": {
       "name": "betaine_bicarbonate_buffered_medium",
       "filename": "betaine_bicarbonate_buffered_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 33,
       "id": "CultureMech:003112",
       "source_id": "mediadive.medium:J770",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -12763,10 +12772,11 @@
     "CultureMech:002279": {
       "name": "ctm_medium",
       "filename": "ctm_medium.yaml",
-      "ingredient_count": 52,
+      "ingredient_count": 40,
       "id": "CultureMech:002279",
       "source_id": "mediadive.medium:J1100",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -13934,10 +13944,11 @@
     "CultureMech:002963": {
       "name": "desulfomicrobium_medium",
       "filename": "desulfomicrobium_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002963",
       "source_id": "mediadive.medium:J616",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -18876,10 +18887,11 @@
     "CultureMech:002968": {
       "name": "hyl_medium",
       "filename": "hyl_medium.yaml",
-      "ingredient_count": 34,
+      "ingredient_count": 31,
       "id": "CultureMech:002968",
       "source_id": "mediadive.medium:J621",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -19378,10 +19390,11 @@
     "CultureMech:002230": {
       "name": "jcm_medium_no_1046",
       "filename": "jcm_medium_no_1046.yaml",
-      "ingredient_count": 20,
+      "ingredient_count": 16,
       "id": "CultureMech:002230",
       "source_id": "mediadive.medium:J1046",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -21183,10 +21196,11 @@
     "CultureMech:002246": {
       "name": "m25y_medium",
       "filename": "m25y_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 21,
       "id": "CultureMech:002246",
       "source_id": "mediadive.medium:J1066",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -21421,10 +21435,11 @@
     "CultureMech:002906": {
       "name": "magnetospirillum_medium_a",
       "filename": "magnetospirillum_medium_a.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:002906",
       "source_id": "mediadive.medium:J558",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -23347,10 +23362,11 @@
     "CultureMech:002888": {
       "name": "mga_agar",
       "filename": "mga_agar.yaml",
-      "ingredient_count": 8,
+      "ingredient_count": 5,
       "id": "CultureMech:002888",
       "source_id": "mediadive.medium:J53",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -24808,10 +24824,11 @@
     "CultureMech:003193": {
       "name": "modified_1_10_pygv_medium",
       "filename": "modified_1_10_pygv_medium.yaml",
-      "ingredient_count": 16,
+      "ingredient_count": 10,
       "id": "CultureMech:003193",
       "source_id": "mediadive.medium:J848",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -32047,10 +32064,11 @@
     "CultureMech:003306": {
       "name": "sea_salts_tyg_medium",
       "filename": "sea_salts_tyg_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003306",
       "source_id": "mediadive.medium:J958",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -32504,10 +32522,11 @@
     "CultureMech:003248": {
       "name": "sm_medium",
       "filename": "sm_medium.yaml",
-      "ingredient_count": 13,
+      "ingredient_count": 8,
       "id": "CultureMech:003248",
       "source_id": "mediadive.medium:J89",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -33898,10 +33917,11 @@
     "CultureMech:003181": {
       "name": "syfac_medium",
       "filename": "syfac_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003181",
       "source_id": "mediadive.medium:J837",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -34162,10 +34182,11 @@
     "CultureMech:003246": {
       "name": "syphc_medium",
       "filename": "syphc_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 21,
       "id": "CultureMech:003246",
       "source_id": "mediadive.medium:J898",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -34691,10 +34712,11 @@
     "CultureMech:002583": {
       "name": "thermoanaerobacter_ethanolicus_medium",
       "filename": "thermoanaerobacter_ethanolicus_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 30,
       "id": "CultureMech:002583",
       "source_id": "mediadive.medium:J221",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -38081,10 +38103,11 @@
     "CultureMech:002188": {
       "name": "ytps_medium",
       "filename": "ytps_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 34,
       "id": "CultureMech:002188",
       "source_id": "mediadive.medium:J1002",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -38680,10 +38703,11 @@
     "CultureMech:010548": {
       "name": "hepes_peptone_yeast_extract_medium",
       "filename": "hepes_peptone_yeast_extract_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 29,
       "id": "CultureMech:010548",
       "source_id": "mediadive.medium:J764",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "fungal"
       ],
@@ -40713,10 +40737,11 @@
     "CultureMech:015398": {
       "name": "swmty_marine_medium",
       "filename": "swmty_marine_medium.yaml",
-      "ingredient_count": 15,
+      "ingredient_count": 12,
       "id": "CultureMech:015398",
       "source_id": "mediadive.medium:J227",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "specialized"
       ],

--- a/data/normalized_yaml/fungal/hepes_peptone_yeast_extract_medium.yaml
+++ b/data/normalized_yaml/fungal/hepes_peptone_yeast_extract_medium.yaml
@@ -121,33 +121,6 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:64734
     label: Na2-EDTA
-- preferred_term: MnSO4 x n H2O
-  concentration:
-    value: '3.26'
-    unit: G_PER_L
-  term:
-    id: CHEBI:86360
-    label: manganese(II) sulfate
-- preferred_term: CoCl2 x 6 H2O
-  term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:35696
-    label: CoCl2 x 6 H2O
-- preferred_term: ZnSO4 x 7 H2O
-  term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
-  concentration:
-    value: '1'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:32312
-    label: ZnSO4 x 7 H2O
 - preferred_term: NiSO4 x 6 H2O
   term:
     id: CHEBI:53001
@@ -361,3 +334,45 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.576161+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace elements'' @ 1 ml/l. Each moved component matched the MediaDive stock
+    by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 32 -> 29
+solutions:
+- preferred_term: Trace elements
+  composition:
+  - preferred_term: MnSO4 x n H2O
+    concentration:
+      value: '3.26'
+      unit: G_PER_L
+    term:
+      id: CHEBI:86360
+      label: manganese(II) sulfate
+  - preferred_term: CoCl2 x 6 H2O
+    term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:35696
+      label: CoCl2 x 6 H2O
+  - preferred_term: ZnSO4 x 7 H2O
+    term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+    concentration:
+      value: '1'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:32312
+      label: ZnSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/fungal_index.json
+++ b/data/normalized_yaml/fungal_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T07:15:56.757425+00:00",
+  "generated": "2026-08-13T23:35:42.932001+00:00",
   "category": "fungal",
   "count": 126,
   "recipes": {
@@ -529,10 +529,11 @@
     "CultureMech:010548": {
       "name": "hepes_peptone_yeast_extract_medium",
       "filename": "hepes_peptone_yeast_extract_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 29,
       "id": "CultureMech:010548",
       "source_id": "mediadive.medium:J764",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "fungal"
       ]

--- a/data/normalized_yaml/recipe_index.json
+++ b/data/normalized_yaml/recipe_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-13T19:33:07.901434+00:00",
+  "generated": "2026-08-13T23:35:46.404214+00:00",
   "description": "Master index of all CultureMech recipes",
   "total_recipes": 15877,
   "categories": {
@@ -7760,10 +7760,11 @@
     "CultureMech:002864": {
       "name": "caldococcus_medium",
       "filename": "caldococcus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 22,
       "id": "CultureMech:002864",
       "source_id": "mediadive.medium:J513",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -8576,10 +8577,11 @@
     "CultureMech:002655": {
       "name": "halosimplex_medium",
       "filename": "halosimplex_medium.yaml",
-      "ingredient_count": 14,
+      "ingredient_count": 11,
       "id": "CultureMech:002655",
       "source_id": "mediadive.medium:J298",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -8707,10 +8709,11 @@
     "CultureMech:002284": {
       "name": "liquid_basal_medium_for_methanosarcina",
       "filename": "liquid_basal_medium_for_methanosarcina.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 25,
       "id": "CultureMech:002284",
       "source_id": "mediadive.medium:J1107",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -10878,10 +10881,11 @@
     "CultureMech:002433": {
       "name": "modified_picrophilus_medium",
       "filename": "modified_picrophilus_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 25,
       "id": "CultureMech:002433",
       "source_id": "mediadive.medium:J1267",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -11430,10 +11434,11 @@
     "CultureMech:003204": {
       "name": "pyrolobus_medium",
       "filename": "pyrolobus_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 21,
       "id": "CultureMech:003204",
       "source_id": "mediadive.medium:J859",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "archaea"
       ],
@@ -50116,10 +50121,11 @@
     "CultureMech:002530": {
       "name": "artificial_deep_lake_vitamin_medium",
       "filename": "artificial_deep_lake_vitamin_medium.yaml",
-      "ingredient_count": 10,
+      "ingredient_count": 7,
       "id": "CultureMech:002530",
       "source_id": "mediadive.medium:J170",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -50669,10 +50675,11 @@
     "CultureMech:002717": {
       "name": "atyp_medium",
       "filename": "atyp_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002717",
       "source_id": "mediadive.medium:J358",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -50974,10 +50981,11 @@
     "CultureMech:003163": {
       "name": "bacillus_macyae_medium",
       "filename": "bacillus_macyae_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 27,
       "id": "CultureMech:003163",
       "source_id": "mediadive.medium:J819",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -51753,10 +51761,11 @@
     "CultureMech:003112": {
       "name": "betaine_bicarbonate_buffered_medium",
       "filename": "betaine_bicarbonate_buffered_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 33,
       "id": "CultureMech:003112",
       "source_id": "mediadive.medium:J770",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -56952,10 +56961,11 @@
     "CultureMech:002279": {
       "name": "ctm_medium",
       "filename": "ctm_medium.yaml",
-      "ingredient_count": 52,
+      "ingredient_count": 40,
       "id": "CultureMech:002279",
       "source_id": "mediadive.medium:J1100",
       "source": "MediaDive",
+      "solution_count": 3,
       "categories": [
         "bacterial"
       ],
@@ -58639,10 +58649,11 @@
     "CultureMech:002963": {
       "name": "desulfomicrobium_medium",
       "filename": "desulfomicrobium_medium.yaml",
-      "ingredient_count": 25,
+      "ingredient_count": 20,
       "id": "CultureMech:002963",
       "source_id": "mediadive.medium:J616",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -70883,10 +70894,11 @@
     "CultureMech:002968": {
       "name": "hyl_medium",
       "filename": "hyl_medium.yaml",
-      "ingredient_count": 34,
+      "ingredient_count": 31,
       "id": "CultureMech:002968",
       "source_id": "mediadive.medium:J621",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -71686,10 +71698,11 @@
     "CultureMech:002230": {
       "name": "jcm_medium_no_1046",
       "filename": "jcm_medium_no_1046.yaml",
-      "ingredient_count": 20,
+      "ingredient_count": 16,
       "id": "CultureMech:002230",
       "source_id": "mediadive.medium:J1046",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -74809,10 +74822,11 @@
     "CultureMech:002246": {
       "name": "m25y_medium",
       "filename": "m25y_medium.yaml",
-      "ingredient_count": 24,
+      "ingredient_count": 21,
       "id": "CultureMech:002246",
       "source_id": "mediadive.medium:J1066",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -76075,10 +76089,11 @@
     "CultureMech:002906": {
       "name": "magnetospirillum_medium_a",
       "filename": "magnetospirillum_medium_a.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:002906",
       "source_id": "mediadive.medium:J558",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -152204,10 +152219,11 @@
     "CultureMech:002888": {
       "name": "mga_agar",
       "filename": "mga_agar.yaml",
-      "ingredient_count": 8,
+      "ingredient_count": 5,
       "id": "CultureMech:002888",
       "source_id": "mediadive.medium:J53",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -154917,10 +154933,11 @@
     "CultureMech:003193": {
       "name": "modified_1_10_pygv_medium",
       "filename": "modified_1_10_pygv_medium.yaml",
-      "ingredient_count": 16,
+      "ingredient_count": 10,
       "id": "CultureMech:003193",
       "source_id": "mediadive.medium:J848",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -166757,10 +166774,11 @@
     "CultureMech:003306": {
       "name": "sea_salts_tyg_medium",
       "filename": "sea_salts_tyg_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003306",
       "source_id": "mediadive.medium:J958",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -167479,10 +167497,11 @@
     "CultureMech:003248": {
       "name": "sm_medium",
       "filename": "sm_medium.yaml",
-      "ingredient_count": 13,
+      "ingredient_count": 8,
       "id": "CultureMech:003248",
       "source_id": "mediadive.medium:J89",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -169866,10 +169885,11 @@
     "CultureMech:003181": {
       "name": "syfac_medium",
       "filename": "syfac_medium.yaml",
-      "ingredient_count": 22,
+      "ingredient_count": 18,
       "id": "CultureMech:003181",
       "source_id": "mediadive.medium:J837",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -170367,10 +170387,11 @@
     "CultureMech:003246": {
       "name": "syphc_medium",
       "filename": "syphc_medium.yaml",
-      "ingredient_count": 29,
+      "ingredient_count": 21,
       "id": "CultureMech:003246",
       "source_id": "mediadive.medium:J898",
       "source": "MediaDive",
+      "solution_count": 2,
       "categories": [
         "bacterial"
       ],
@@ -171198,10 +171219,11 @@
     "CultureMech:002583": {
       "name": "thermoanaerobacter_ethanolicus_medium",
       "filename": "thermoanaerobacter_ethanolicus_medium.yaml",
-      "ingredient_count": 33,
+      "ingredient_count": 30,
       "id": "CultureMech:002583",
       "source_id": "mediadive.medium:J221",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -181532,10 +181554,11 @@
     "CultureMech:002188": {
       "name": "ytps_medium",
       "filename": "ytps_medium.yaml",
-      "ingredient_count": 37,
+      "ingredient_count": 34,
       "id": "CultureMech:002188",
       "source_id": "mediadive.medium:J1002",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "bacterial"
       ],
@@ -182627,10 +182650,11 @@
     "CultureMech:010548": {
       "name": "hepes_peptone_yeast_extract_medium",
       "filename": "hepes_peptone_yeast_extract_medium.yaml",
-      "ingredient_count": 32,
+      "ingredient_count": 29,
       "id": "CultureMech:010548",
       "source_id": "mediadive.medium:J764",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "fungal"
       ],
@@ -187782,10 +187806,11 @@
     "CultureMech:015398": {
       "name": "swmty_marine_medium",
       "filename": "swmty_marine_medium.yaml",
-      "ingredient_count": 15,
+      "ingredient_count": 12,
       "id": "CultureMech:015398",
       "source_id": "mediadive.medium:J227",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "specialized"
       ],

--- a/data/normalized_yaml/specialized/swmty_marine_medium.yaml
+++ b/data/normalized_yaml/specialized/swmty_marine_medium.yaml
@@ -59,36 +59,6 @@ ingredients:
   concentration:
     value: '1000'
     unit: G_PER_L
-- preferred_term: H3BO3
-  term:
-    id: CHEBI:33118
-    label: boric acid
-  concentration:
-    value: '2.85'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:33118
-    label: H3BO3
-- preferred_term: MnCl2 x 4 H2O
-  term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
-  concentration:
-    value: '1.8'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:86368
-    label: MnCl2 x 4 H2O
-- preferred_term: FeSO4 x 7 H2O
-  term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
-  concentration:
-    value: '1.36'
-    unit: G_PER_L
-  mediaingredientmech_chebi_term:
-    id: CHEBI:75836
-    label: FeSO4 x 7 H2O
 - preferred_term: Sodium tartrate
   term:
     id: CHEBI:63017
@@ -177,3 +147,48 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 2 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-08-13T23:31:54.588839+00:00'
+  curator: apply_cocktail_nesting.py
+  action: NESTED_FLATTENED_COCKTAIL
+  notes: 'Moved 3 stock-strength component(s) out of ingredients into 1 solution(s):
+    3 -> ''Trace element solution'' @ 1 ml/l. Each moved component matched the MediaDive
+    stock by name AND value; bulk ingredients sharing a name were left in place (#150).'
+  changes: Nested 3 ingredient(s) under 1 solution(s); ingredients 15 -> 12
+solutions:
+- preferred_term: Trace element solution
+  composition:
+  - preferred_term: H3BO3
+    term:
+      id: CHEBI:33118
+      label: boric acid
+    concentration:
+      value: '2.85'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:33118
+      label: H3BO3
+  - preferred_term: MnCl2 x 4 H2O
+    term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+    concentration:
+      value: '1.8'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:86368
+      label: MnCl2 x 4 H2O
+  - preferred_term: FeSO4 x 7 H2O
+    term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+    concentration:
+      value: '1.36'
+      unit: G_PER_L
+    mediaingredientmech_chebi_term:
+      id: CHEBI:75836
+      label: FeSO4 x 7 H2O
+  concentration:
+    value: '1'
+    unit: ML_PER_L
+  preparation_notes: Stock prepared in 1000 ml; added at 1 ml per litre of medium.
+    Composition and volume from MediaDive (#150).

--- a/data/normalized_yaml/specialized_index.json
+++ b/data/normalized_yaml/specialized_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-07T07:15:57.265416+00:00",
+  "generated": "2026-08-13T23:35:43.426750+00:00",
   "category": "specialized",
   "count": 455,
   "recipes": {
@@ -3839,10 +3839,11 @@
     "CultureMech:015398": {
       "name": "swmty_marine_medium",
       "filename": "swmty_marine_medium.yaml",
-      "ingredient_count": 15,
+      "ingredient_count": 12,
       "id": "CultureMech:015398",
       "source_id": "mediadive.medium:J227",
       "source": "MediaDive",
+      "solution_count": 1,
       "categories": [
         "specialized"
       ],

--- a/project.justfile
+++ b/project.justfile
@@ -297,7 +297,7 @@ audit-selective-agent-mismatch *args="":
 [group('QC')]
 audit-concentration-plausibility *args="":
     uv run --extra dev python scripts/audit_concentration_plausibility.py \
-        --max-allowed 10355 --max-cocktails 304 {{args}}
+        --max-allowed 10244 --max-cocktails 279 {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/scripts/apply_cocktail_nesting.py
+++ b/scripts/apply_cocktail_nesting.py
@@ -114,6 +114,46 @@ def match_components(ingredients: list[dict[str, Any]],
     return indices, sorted(flagged_names - matched_names)
 
 
+def match_stock_signature(ingredients: list[dict[str, Any]],
+                          stock_components: list[dict[str, Any]],
+                          flagged_names: set[str],
+                          min_components: int = 4) -> tuple[list[int], list[str]]:
+    """Indices of ingredients that reproduce this stock's composition at stock values.
+
+    Unlike `match_components`, this does NOT require every moved row to be flagged.
+    A stock's sub-threshold components never trip the audit — SL-10 carries ZnCl2 at
+    0.07 g/l and H3BO3 at 0.006, far below the flagging cutoff — so requiring the
+    flag would move FeCl2 (1.5) alone and strand the other eight in `ingredients`.
+    That is a half-repair: the stock would exist in two places at once.
+
+    The evidence bar is raised instead of lowered. Reproducing four or more of a
+    stock's components at EXACTLY its concentrations is far stronger than three
+    flagged rows — 98 records match SL-10 on 8 or 9 of 9. At least one matched row
+    must still be flagged, so only records the audit calls broken are touched.
+
+    Returns (indices, unmatched_flagged_names) like `match_components`.
+    """
+    want: dict[str, float] = {}
+    for c in stock_components:
+        v = _num(c.get("g_l"))
+        if v is None:
+            v = _num(c.get("amount"))
+        if v is not None:
+            want[_key(c.get("compound"))] = v
+
+    indices, matched = [], set()
+    for i, ing in enumerate(ingredients):
+        name = _key(ing.get("preferred_term"))
+        got = _num((ing.get("concentration") or {}).get("value"))
+        if name in want and got is not None and abs(want[name] - got) < 1e-9:
+            indices.append(i)
+            matched.add(name)
+
+    if len(indices) < min_components or not (matched & flagged_names):
+        return [], sorted(flagged_names)
+    return indices, sorted(flagged_names - matched)
+
+
 def find_summed(ingredients: list[dict[str, Any]], additions: list[dict[str, Any]],
                 unmatched: list[str]) -> dict[str, list[tuple[str, float]]]:
     """Unmatched rows whose value is the exact SUM of that component across stocks.
@@ -164,7 +204,9 @@ def plan_record(path: Path, doc: dict[str, Any], additions: list[dict[str, Any]]
     groups: list[dict[str, Any]] = []
     claimed: set[int] = set()
     for addition in additions:
-        indices, _ = match_components(
+        matcher = (match_stock_signature if addition.get("match_full_signature")
+                   else match_components)
+        indices, _ = matcher(
             ingredients, addition.get("stock_components") or [], flagged_names)
         indices = [i for i in indices if i not in claimed]   # never move one twice
         if not indices:
@@ -286,16 +328,21 @@ def apply_plan(doc: dict[str, Any], plan: dict[str, Any]) -> None:
 
 
 def source_medium(doc: dict[str, Any]) -> str | None:
-    """The source catalogue medium number this record came from, e.g. "503" or "298a".
+    """The DSMZ medium number this record came from, or None when it cannot be trusted.
 
-    Read from the notes' "DSMZ Medium: N" stamp, else the media_term id's local part.
-    Used to gate a researched stock to the media whose own sheet was actually read.
+    `applies_to_media` gates a researched volume to media whose own DSMZ sheet was
+    read, so this number must actually address that sheet. For a KOMODO-sourced
+    record it does NOT: the notes stamp "DSMZ Medium: 294" on
+    KOMODO_294_PELOBACTER_ACIDIGALLICI_MEDIUM, but DSMZ 294 is SYNTROPHUS HQGo1 —
+    a different medium. That is the #244 collision, and trusting the stamp here would
+    cite one medium's sheet as verification for another's volume.
+
+    So only a `mediadive.medium:` id is accepted. KOMODO-sourced records are reported
+    as unverifiable and left to stocks that carry no `applies_to_media` gate.
     """
-    m = re.search(r"DSMZ Medium:\s*(\w+)", str(doc.get("notes") or ""))
-    if m:
-        return m.group(1)
     mid = str(((doc.get("media_term") or {}).get("term") or {}).get("id") or "")
-    return mid.split(":")[-1] or None
+    m = re.fullmatch(r"mediadive\.medium:(\w+)", mid)
+    return m.group(1) if m else None
 
 
 def stocks_for_record(researched: list[dict[str, Any]],

--- a/scripts/fetch_mediadive_solution_volumes.py
+++ b/scripts/fetch_mediadive_solution_volumes.py
@@ -81,13 +81,24 @@ def komodo_to_dsmz() -> dict[str, str]:
 def mediadive_id(doc: dict[str, Any], komodo_map: dict[str, str] | None = None) -> str | None:
     """The MediaDive medium id this record resolves to, if any.
 
-    `mediadive.medium:<digits>[letter]` is direct. A `komodo.medium:` id is NOT a
-    MediaDive id and must be translated through the KOMODO->DSMZ mapping first; using
-    it directly is the #239 error. The J*/C*-prefixed ids are JCM/other catalogues
-    whose composition MediaDive does not serve.
+    `mediadive.medium:<digits>[letter]` is direct, and so is the `J<digits>` form:
+    MediaDive mirrors JCM media under a J prefix and serves them through the SAME
+    endpoints, with the same nested solutions[] and solution-to-solution references
+    carrying the addition volume. `rest/medium/J58` returns "Main sol. J58" which
+    references "Trace salts solution" at 1 ml.
+
+    This function used to reject J ids, on the mistaken generalisation that MediaDive
+    does not serve JCM media. That came from sampling three ids (J390, J773, C96)
+    that simply do not exist; a random sample of 25 J ids from this corpus all
+    returned 200 with solutions[]. A nonexistent id is handled by fetch_medium
+    returning None, which is the right place for it — not by refusing the whole
+    scheme.
+
+    A `komodo.medium:` id is still NOT a MediaDive id and must be translated through
+    the KOMODO->DSMZ mapping first; using it directly is the #239 error.
     """
     mid = str(((doc.get("media_term") or {}).get("term") or {}).get("id") or "")
-    m = re.fullmatch(r"mediadive\.medium:(\d+[a-z]?)", mid)
+    m = re.fullmatch(r"mediadive\.medium:(J?\d+[a-z]?)", mid)
     if m:
         return m.group(1)
     k = re.fullmatch(r"komodo\.medium:(.+)", mid)

--- a/tests/test_apply_cocktail_nesting.py
+++ b/tests/test_apply_cocktail_nesting.py
@@ -197,11 +197,14 @@ def test_a_stock_contributing_only_summed_rows_still_gets_its_solution(acn):
 # --- researched stocks are gated to the media whose sheet was read (#150) ----
 
 
-def test_source_medium_prefers_the_dsmz_stamp(acn):
-    assert acn.source_medium({"notes": "Source: KOMODO | DSMZ Medium: 503 (mediadive.medium:503)"}) == "503"
-    assert acn.source_medium({"notes": "DSMZ Medium: 298a"}) == "298a"
-    # no stamp: fall back to the media_term id's local part
-    assert acn.source_medium({"media_term": {"term": {"id": "komodo.medium:1083"}}}) == "1083"
+def test_source_medium_trusts_only_a_mediadive_id(acn):
+    """Originally this read the notes' "DSMZ Medium: N" stamp. That was wrong: on a
+    KOMODO-sourced record N is the KOMODO id, and KOMODO 294 is not DSMZ 294 (#244).
+    Only a mediadive.medium id addresses the sheet that was actually verified."""
+    assert acn.source_medium({"media_term": {"term": {"id": "mediadive.medium:503"}}}) == "503"
+    assert acn.source_medium({"media_term": {"term": {"id": "mediadive.medium:298a"}}}) == "298a"
+    assert acn.source_medium({"notes": "DSMZ Medium: 503",
+                              "media_term": {"term": {"id": "komodo.medium:503"}}}) is None
     assert acn.source_medium({}) is None
 
 
@@ -211,9 +214,13 @@ def test_a_researched_stock_is_refused_for_an_unverified_medium(acn):
     whose medium's sheet was never read must not inherit the volume by association."""
     stock = {"solution_name": "Seven vitamins solution", "addition_volume_ml": 1,
              "applies_to_media": ["503", "194"]}
-    assert [s["solution_name"] for s in acn.stocks_for_record([stock], {"notes": "DSMZ Medium: 503"})] \
+    md = {"media_term": {"term": {"id": "mediadive.medium:503"}}}
+    assert [s["solution_name"] for s in acn.stocks_for_record([stock], md)] \
         == ["Seven vitamins solution"]
-    assert acn.stocks_for_record([stock], {"notes": "DSMZ Medium: 298b"}) == []
+    other = {"media_term": {"term": {"id": "mediadive.medium:298b"}}}
+    assert acn.stocks_for_record([stock], other) == []
+    # a KOMODO record cannot be verified at all, so a gated stock is refused
+    assert acn.stocks_for_record([stock], {"media_term": {"term": {"id": "komodo.medium:503"}}}) == []
     assert acn.stocks_for_record([stock], {}) == []
 
 
@@ -221,5 +228,57 @@ def test_a_stock_without_the_gate_stays_universal(acn):
     """`applies_to_media` is optional: a stock verified as medium-independent (or one
     whose citing media were all checked) applies wherever its composition matches."""
     stock = {"solution_name": "Trace salt solution", "addition_volume_ml": 1}
-    assert len(acn.stocks_for_record([stock], {"notes": "DSMZ Medium: anything"})) == 1
+    assert len(acn.stocks_for_record([stock], {"media_term": {"term": {"id": "komodo.medium:9"}}})) == 1
     assert len(acn.stocks_for_record([stock], {})) == 1
+
+
+# --- full-signature matching, and the id trap it must not fall into (#150) ---
+
+
+SL10 = [{"compound": "FeCl2 x 4 H2O", "g_l": 1.5}, {"compound": "ZnCl2", "g_l": 0.07},
+        {"compound": "MnCl2 x 4 H2O", "g_l": 0.1}, {"compound": "H3BO3", "g_l": 0.006},
+        {"compound": "CoCl2 x 6 H2O", "g_l": 0.19}]
+
+
+def test_signature_moves_sub_threshold_components_too(acn):
+    """The reason this matcher exists. Only FeCl2 (1.5) trips the audit; ZnCl2 0.07
+    and H3BO3 0.006 never will. Flag-only matching moves FeCl2 alone and strands the
+    rest, leaving the stock in two places at once."""
+    ings = [_ing("FeCl2 x 4 H2O", "1.5"), _ing("ZnCl2", "0.07"),
+            _ing("MnCl2 x 4 H2O", "0.1"), _ing("H3BO3", "0.006")]
+    idx, _ = acn.match_stock_signature(ings, SL10, {"fecl2 x 4 h2o"})
+    assert idx == [0, 1, 2, 3], "the whole stock must move, not just the flagged row"
+
+
+def test_signature_still_requires_a_flagged_row(acn):
+    """Only records the audit calls broken may be restructured."""
+    ings = [_ing("FeCl2 x 4 H2O", "1.5"), _ing("ZnCl2", "0.07"),
+            _ing("MnCl2 x 4 H2O", "0.1"), _ing("H3BO3", "0.006")]
+    assert acn.match_stock_signature(ings, SL10, flagged_names=set())[0] == []
+
+
+def test_signature_needs_enough_components(acn):
+    """Two coincidental value matches are not a stock. Four is the bar."""
+    ings = [_ing("FeCl2 x 4 H2O", "1.5"), _ing("ZnCl2", "0.07")]
+    assert acn.match_stock_signature(ings, SL10, {"fecl2 x 4 h2o"})[0] == []
+
+
+def test_signature_requires_exact_values(acn):
+    """A different trace stock sharing component NAMES must not match: halosimplex
+    carries H3BO3 at 3 where SL-10 has 0.006, a 500x difference."""
+    ings = [_ing("FeCl2 x 4 H2O", "1.5"), _ing("ZnCl2", "0.07"),
+            _ing("MnCl2 x 4 H2O", "0.3"), _ing("H3BO3", "3")]
+    idx, _ = acn.match_stock_signature(ings, SL10, {"fecl2 x 4 h2o"})
+    assert idx == [], "only 2 of 5 match at exact values — below the bar"
+
+
+def test_source_medium_refuses_a_komodo_number(acn):
+    """THE #244 trap, in this gate. KOMODO_294_PELOBACTER stamps "DSMZ Medium: 294"
+    in its notes, but DSMZ 294 is SYNTROPHUS HQGo1 — a different medium. Trusting the
+    stamp would cite one medium's sheet as verification for another's volume."""
+    komodo = {"notes": "Source: KOMODO ModelSEED | ID: 294 | DSMZ Medium: 294",
+              "media_term": {"term": {"id": "komodo.medium:294"}}}
+    assert acn.source_medium(komodo) is None
+
+    mediadive = {"media_term": {"term": {"id": "mediadive.medium:503"}}}
+    assert acn.source_medium(mediadive) == "503"

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -188,10 +188,10 @@ def test_stock_solution_records_are_excluded(corpus_findings):
         assert not is_solution_record(doc), f"solution record flagged: {file_path}"
 
 
-CONCENTRATION_BACKLOG_BASELINE = 10_355
+CONCENTRATION_BACKLOG_BASELINE = 10_244
 # The sharper baseline (#150): a raw row count drifts with corpus size, whereas a
 # new flattened cocktail is a specific defect shape an import has reintroduced.
-COCKTAIL_BASELINE = 304
+COCKTAIL_BASELINE = 279
 
 
 def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings):
@@ -199,7 +199,7 @@ def test_implausible_row_count_does_not_exceed_the_known_backlog(corpus_findings
 
     #135 shipped the audit; the repair is now partly done — #150 nested 135
     flattened cocktails from MediaDive data, taking the backlog from 11,540 rows
-    across 3,914 records to 10,355 across 3,645. A guard demanding zero would fail
+    across 3,914 records to 10,244 across 3,621. A guard demanding zero would fail
     immediately and be switched off — the #129 lesson about wiring a gate to a red
     suite. So this baselines at the current count, exactly as
     `check-chebi-grounding --max-allowed 101` does for grounding.
@@ -273,7 +273,7 @@ def test_the_gate_baselines_match_the_current_corpus(acp, media_records):
     """#118 asked for an audit AND a repair; #135 shipped the audit, and nothing
     stopped the defect being reintroduced for another 15 issues.
 
-    These baselines hold the line while the 3,645-record backlog is worked
+    These baselines hold the line while the 3,621-record backlog is worked
     through. They must track the corpus: a baseline above the real count is a gate
     that cannot fail.
     """

--- a/tests/test_mediadive_volumes.py
+++ b/tests/test_mediadive_volumes.py
@@ -111,8 +111,19 @@ def test_mediadive_id_accepts_only_mediadive_numeric_ids(fsv):
     assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:1083"}}}) == "1083"
     assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:734a"}}}) == "734a"
     assert fsv.mediadive_id({"media_term": {"term": {"id": "komodo.medium:3136"}}}) is None
-    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:J390"}}}) is None
     assert fsv.mediadive_id({}) is None
+
+
+def test_a_jcm_mirrored_id_is_accepted(fsv):
+    """MediaDive mirrors JCM media under a J prefix and serves them through the same
+    endpoints — rest/medium/J58 returns solutions[] with a "Trace salts solution ...
+    1 ml" reference. This assertion previously demanded J390 be REJECTED, generalising
+    from three ids that merely do not exist; 25 of 25 sampled J ids from this corpus
+    resolve. A nonexistent id is fetch_medium's problem, not the scheme's."""
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:J58"}}}) == "J58"
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "mediadive.medium:J1039"}}}) == "J1039"
+    # still not a MediaDive id
+    assert fsv.mediadive_id({"media_term": {"term": {"id": "komodo.medium:J58"}}}) is None
 
 
 # --- KOMODO id resolution and the name guard (#150 second pass) --------------


### PR DESCRIPTION
Three findings from working the curation — **two of them bugs in code I shipped in
this same issue**. Net: **24 more records repaired** from their own source recipes.

## 1. I was wrong that MediaDive doesn't serve JCM media — my own code enforced it
I concluded twice here that JCM-sourced records were unreachable. `mediadive_id()`
matched only `mediadive.medium:<digits>`, deliberately excluding the `J` form, and a
test asserted `mediadive.medium:J390` **must** return `None`. The premise came from
sampling three ids (J390, J773, C96) that simply don't exist.

Probing directly:

```
DSMZ_MediumJ58.pdf              404   <- the PDF sheets really do stop at DSMZ numbers
rest/medium/J58                 200   with solutions[]
rest/medium-composition/J58     200
jcm.riken.jp GRMD=58            200   (GRMD=390 is the empty page)
```

A random sample of **25 of our J ids: all 25 resolve with `solutions[]`**. And they
expose the *same* structure the repair already reads — `Main sol. J58` references
`Trace salts solution` at `amount: 1, unit: ml`.

**70 blocked cocktails** carried J ids the fetcher skipped outright. Coverage rose
186 → 249 resolvable, and **24 nested from each medium's OWN recipe** — the strongest
evidence class here, zero cross-medium inference.

## 2. Records carry the WHOLE stock; flag-only matching hid it
The audit flags trace salts at ≥1 g/l, so for SL-10 only FeCl2 (1.5) is flagged —
ZnCl2 0.07 and H3BO3 0.006 never are. Flag-based matching found **0** SL-10 records;
full-composition matching finds **105** (98 match 8–9 of 9 components exactly).
`match_stock_signature` moves the whole stock — moving FeCl2 alone would leave it in
**two places at once**. The bar *rises*: ≥4 exact matches, ≥1 still flagged. It
correctly refuses a different stock sharing names (`halosimplex` H3BO3 = 3 vs 0.006).

## 3. The #244 trap, inside the gate I added yesterday
`source_medium` read the notes' `"DSMZ Medium: N"` stamp — but on a KOMODO record N is
the **KOMODO** id. `KOMODO_294_PELOBACTER` stamps *"DSMZ Medium: 294"*, and **DSMZ 294
is SYNTROPHUS HQGö1**. A canary applied that record citing the wrong medium's sheet.
Now only `mediadive.medium:` ids are trusted; **two tests I wrote yesterday asserted
the unsafe behaviour** and are corrected.

| metric | before | after |
|---|--:|--:|
| implausible rows | 10,355 | **10,244** |
| flattened cocktails | 304 | **279** (300 of 579, **52%**) |

## Still your call (unchanged)
98 records are provably SL-10 (9/9 composition), and SL-10's volume is 1.00 ml across
**63 independent media** with zero variance — but none of those 98 can be verified
strictly (84 KOMODO, 14 J-ids whose sheets 404). Applying it remains a documented
cross-medium inference, recorded not applied.

- Full suite: **1135 passed**. 6 new tests + 3 corrected.

Refs #150, #244, #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)