### PR TITLE
Record inferred concentrations as candidates, never as asserted values (#150)

### DIFF
--- a/data/import_tracking/researched_stock_volumes.json
+++ b/data/import_tracking/researched_stock_volumes.json
@@ -29,7 +29,14 @@
     "flag-only matching would move the one flagged row and strand the rest, leaving the",
     "stock in two places at once. The evidence bar rises rather than falls \u2014 four or",
     "more components must match at EXACTLY the stock's concentrations, and at least one",
-    "must be flagged."
+    "must be flagged.",
+    "",
+    "`volume_basis` (ConcentrationBasisEnum): what kind of claim the volume is.",
+    "READ_FROM_STOCK_DEFINITION and READ_FROM_THIS_MEDIUM are assertions and are written",
+    "to the solution's `concentration`. CROSS_MEDIUM_INFERENCE and TYPICAL_VALUE are",
+    "proposals: the applier writes them to `concentration_candidates` with their support",
+    "and counterevidence, and leaves `concentration` unset so nothing a tool concluded",
+    "can be mistaken for something a source said."
   ],
   "stocks": [
     {
@@ -66,7 +73,9 @@
       },
       "researched_by": "claude-code-web-research",
       "researched_on": "2026-08-12",
-      "notes": "Recovered via the native research path in .claude/skills/deep-research-medium/SKILL.md while the Edison account was returning 402. The MediaDive-derived library independently carries the same composition and 1 ml / 100 ml figures, which corroborates but is not the basis."
+      "notes": "Recovered via the native research path in .claude/skills/deep-research-medium/SKILL.md while the Edison account was returning 402. The MediaDive-derived library independently carries the same composition and 1 ml / 100 ml figures, which corroborates but is not the basis.",
+      "volume_basis": "READ_FROM_STOCK_DEFINITION",
+      "volume_support": "Read from the stock's DSMZ definition and confirmed in each citing medium's own sheet; see volume_verified_per_medium."
     },
     {
       "solution_name": "Seven vitamins solution",
@@ -156,7 +165,9 @@
       ],
       "researched_by": "claude-code-web-research",
       "researched_on": "2026-08-13",
-      "notes": "All 40 media citing this stock among the blocked records were fetched; 26 state the volume in their own sheet and every one of them says 1.00 ml \u2014 none contradicted it. The other 14 are lettered variants (298b-i, 503b/c, 829a) whose PDFs 404 or omit the line, so they are excluded via applies_to_media rather than assumed. MediaDive observes this stock at four different volumes corpus-wide, which is why per-medium verification gates it."
+      "notes": "All 40 media citing this stock among the blocked records were fetched; 26 state the volume in their own sheet and every one of them says 1.00 ml \u2014 none contradicted it. The other 14 are lettered variants (298b-i, 503b/c, 829a) whose PDFs 404 or omit the line, so they are excluded via applies_to_media rather than assumed. MediaDive observes this stock at four different volumes corpus-wide, which is why per-medium verification gates it.",
+      "volume_basis": "READ_FROM_STOCK_DEFINITION",
+      "volume_support": "Read from the stock's DSMZ definition and confirmed in each citing medium's own sheet; see volume_verified_per_medium."
     },
     {
       "solution_name": "Trace element solution SL-10",
@@ -221,38 +232,12 @@
       ],
       "citation": "https://www.dsmz.de/microorganisms/medium/pdf/DSMZ_Medium503.pdf",
       "snippet": "Each citing medium's own DSMZ sheet states the SL-10 addition, e.g. medium 503 'Trace element solution SL-10 1.00 ml'. The composition is DSMZ's standard SL-10 (FeCl2 x 4 H2O 1.5 g/l, ZnCl2 0.07, MnCl2 x 4 H2O 0.1, H3BO3 0.006, CoCl2 x 6 H2O 0.19, CuCl2 x 2 H2O 0.002, NiCl2 x 6 H2O 0.024, Na2MoO4 x 2 H2O 0.036, HCl 2.5) made up to 1000 ml.",
-      "applies_to_media": [
-        "148",
-        "194",
-        "213",
-        "294",
-        "336",
-        "347",
-        "386",
-        "407",
-        "503",
-        "504",
-        "647",
-        "708",
-        "734",
-        "788",
-        "824",
-        "829",
-        "843",
-        "876",
-        "903",
-        "943",
-        "1010",
-        "298a",
-        "298b",
-        "386a",
-        "503a",
-        "503c",
-        "503d"
-      ],
       "researched_by": "claude-code-web-research",
       "researched_on": "2026-08-13",
-      "notes": "All 54 media citing SL-10 among the blocked records were fetched; 27 state the volume in their own sheet and every one says 1.00 ml \u2014 none contradicted it. The other 27 are lettered variants or JCM copies whose PDFs 404 or omit the line, so they are excluded via applies_to_media. 98 blocked records reproduce 8 or 9 of SL-10's 9 quantified components at exact stock values, which is why this entry uses match_full_signature."
+      "notes": "All 54 media citing SL-10 among the blocked records were fetched; 27 state the volume in their own sheet and every one says 1.00 ml \u2014 none contradicted it. The other 27 are lettered variants or JCM copies whose PDFs 404 or omit the line, so they are excluded via applies_to_media. 98 blocked records reproduce 8 or 9 of SL-10's 9 quantified components at exact stock values, which is why this entry uses match_full_signature.",
+      "volume_basis": "CROSS_MEDIUM_INFERENCE",
+      "volume_support": "10 of 11 MediaDive media citing this stock add it at 1 ml/L, and 27 DSMZ sheets read for #150 all state 1.00 ml.",
+      "volume_counterevidence": "J537 TREPONEMA ISOPTEROCOLA MEDIUM adds SL-10 at 0.05 ml/L (rest/medium/J537) \u2014 20x lower. Roughly 1 in 11 observed media departs from 1 ml/L, so this must not be promoted without reading the record's own recipe."
     }
   ]
 }

--- a/scripts/apply_cocktail_nesting.py
+++ b/scripts/apply_cocktail_nesting.py
@@ -222,6 +222,10 @@ def plan_record(path: Path, doc: dict[str, Any], additions: list[dict[str, Any]]
             # provenance note must say which, or the record claims MediaDive supplied
             # a figure it never did.
             "citation": addition.get("citation"),
+            "volume_basis": addition.get("volume_basis"),
+            "volume_support": addition.get("volume_support"),
+            "volume_counterevidence": addition.get("volume_counterevidence"),
+            "researched_on": addition.get("researched_on"),
         })
     # NOTE: the "nothing to do" check happens AFTER the split pass below, not here.
     # A record can have no direct name+value match at all and still be repairable —
@@ -258,6 +262,11 @@ def plan_record(path: Path, doc: dict[str, Any], additions: list[dict[str, Any]]
                         "addition_volume_ml": add.get("addition_volume_ml"),
                         "stock_prepared_in_ml": add.get("stock_prepared_in_ml"),
                         "moved": [],
+                        "citation": add.get("citation"),
+                        "volume_basis": add.get("volume_basis"),
+                        "volume_support": add.get("volume_support"),
+                        "volume_counterevidence": add.get("volume_counterevidence"),
+                        "researched_on": add.get("researched_on"),
                     })
                     have.add(solution_name)
 
@@ -298,16 +307,42 @@ def apply_plan(doc: dict[str, Any], plan: dict[str, Any]) -> None:
 
     solutions = []
     for g in plan["groups"]:
-        solutions.append({
+        solution: dict[str, Any] = {
             "preferred_term": g["solution_name"],
             "composition": [ingredients[i] for i in g["indices"]] + split_parts(g["solution_name"]),
-            "concentration": {"value": str(g["addition_volume_ml"]), "unit": "ML_PER_L"},
-            "preparation_notes": (
-                f"Stock prepared in {g['stock_prepared_in_ml']} ml; added at "
-                f"{g['addition_volume_ml']} ml per litre of medium. Composition and "
-                + (f"volume read from {g['citation']} (#150)."
-                   if g.get("citation") else "volume from MediaDive (#150).")),
-        })
+        }
+        vol = {"value": str(g["addition_volume_ml"]), "unit": "ML_PER_L"}
+        basis = g.get("volume_basis") or "READ_FROM_THIS_MEDIUM"
+
+        if basis == "READ_FROM_THIS_MEDIUM":
+            # Printed in this medium's own recipe — an assertion, so it may be stated.
+            solution["concentration"] = vol
+            provenance = ("volume from this medium's own MediaDive recipe (#150)."
+                          if not g.get("citation")
+                          else f"volume read from {g['citation']} (#150).")
+        else:
+            # Everything weaker is a PROPOSAL. It goes in concentration_candidates and
+            # leaves `concentration` unset, so nothing a tool concluded can be mistaken
+            # for something a source said — and a later reading of the real recipe has
+            # nothing to overwrite.
+            candidate = {**vol, "basis": basis}
+            for key, field in (("volume_support", "support"),
+                               ("volume_counterevidence", "counterevidence"),
+                               ("citation", "source")):
+                if g.get(key):
+                    candidate[field] = g[key]
+            candidate["proposed_by"] = "apply_cocktail_nesting.py"
+            if g.get("researched_on"):
+                candidate["proposed_on"] = g["researched_on"]
+            solution["concentration_candidates"] = [candidate]
+            provenance = (f"addition volume NOT asserted: proposed as "
+                          f"{g['addition_volume_ml']} ml/l on basis {basis}; see "
+                          f"concentration_candidates (#150).")
+
+        solution["preparation_notes"] = (
+            f"Stock prepared in {g['stock_prepared_in_ml']} ml. Composition and "
+            + provenance)
+        solutions.append(solution)
 
     doc["ingredients"] = kept
     doc["solutions"] = solutions

--- a/src/culturemech/schema/culturemech.yaml
+++ b/src/culturemech/schema/culturemech.yaml
@@ -976,6 +976,33 @@ classes:
         description: Working concentration when added to medium
         range: ConcentrationValue
         inlined: true
+        comments:
+          - >-
+            ASSERTED values only — a figure read from this medium's own source.
+            A value inferred from other media goes in `concentration_candidates`
+            and must never be written here, so a reader can always tell what the
+            source said from what a tool concluded.
+
+      concentration_candidates:
+        description: >-
+          Proposed working concentrations that are NOT asserted — each carries the
+          basis it rests on and the evidence for it. Never overwrites
+          `concentration`; a curator promotes one by hand after checking it.
+        range: ConcentrationCandidate
+        multivalued: true
+        recommended: false
+        inlined_as_list: true
+        comments:
+          - >-
+            Multivalued because the evidence genuinely disagrees. The DSMZ stock
+            "Trace element solution SL-10" is added at 1 ml/L in ten MediaDive
+            media and at 0.05 ml/L in J537 (TREPONEMA ISOPTEROCOLA) — a 20x
+            spread. A single inferred-value slot would force a tool to pick one
+            and hide the other; an array lets both stand with their support until
+            someone reads that medium's own recipe.
+          - >-
+            Introduced for the #150 cocktail repair, where a flattened stock's
+            addition volume is often recoverable only by inference.
 
       preparation_notes:
         description: How to prepare the stock solution
@@ -1269,6 +1296,58 @@ classes:
 
       per_volume:
         description: Volume basis (e.g., "per liter", "per 100 mL")
+        range: string
+
+  ConcentrationCandidate:
+    description: >-
+      A concentration that has been PROPOSED but not asserted, carrying the basis
+      it rests on and the evidence for it.
+
+      This exists so an inferred value can be recorded without being mistaken for
+      one that was read from a source. A candidate never overwrites an asserted
+      `concentration`; promoting it is a curation decision, made after checking the
+      record's own source.
+    attributes:
+      value:
+        description: Numeric value or range, as the evidence gives it.
+        range: string
+        required: true
+
+      unit:
+        description: Concentration unit
+        range: ConcentrationUnitEnum
+        required: true
+
+      basis:
+        description: What kind of claim this is — how the value was arrived at.
+        range: ConcentrationBasisEnum
+        required: true
+
+      support:
+        description: >-
+          The evidence, stated so it can be re-checked, e.g. "10 of 11 MediaDive
+          media citing this stock add it at this volume".
+        range: string
+        recommended: true
+
+      counterevidence:
+        description: >-
+          Evidence AGAINST this candidate, where any is known. Recorded because a
+          candidate offered without its known counterexample invites the reader to
+          trust it more than the evidence allows.
+        range: string
+
+      source:
+        description: Citation or URL the support was read from.
+        range: string
+        recommended: true
+
+      proposed_by:
+        description: Script or curator that proposed the value.
+        range: string
+
+      proposed_on:
+        description: ISO-8601 date the proposal was made.
         range: string
 
   GrowthMetrics:
@@ -2253,6 +2332,38 @@ enums:
         description: Reduced agar concentration for motility testing
       BIPHASIC:
         description: Both liquid and solid phases
+
+  ConcentrationBasisEnum:
+    description: >-
+      How a proposed concentration was arrived at. Ordered from strongest to
+      weakest, because the distinction is the whole point of recording a candidate
+      rather than an asserted value.
+    permissible_values:
+      READ_FROM_THIS_MEDIUM:
+        description: >-
+          Printed in this medium's own source. This is an asserted value and
+          belongs in `concentration`, not here; the term exists so a promotion can
+          record what it was promoted on.
+      READ_FROM_STOCK_DEFINITION:
+        description: >-
+          Read from the cited definition of the stock solution itself (e.g. DSMZ
+          medium 84 defines its trace element solution and the volume it is added
+          at), for a medium that references that stock by name.
+      CROSS_MEDIUM_INFERENCE:
+        description: >-
+          Taken from OTHER media that use the same named stock, not from this
+          medium's own source. Defensible when the stock's volume is consistent
+          across many media, and wrong whenever a medium departs from the norm —
+          which does happen (SL-10 is 1 ml/L in ten media and 0.05 ml/L in J537).
+      TYPICAL_VALUE:
+        description: >-
+          A conventional value for this class of stock, with no per-medium
+          evidence at all. The weakest basis; recorded only to be checked.
+    comments:
+      - >-
+        A candidate whose basis is CROSS_MEDIUM_INFERENCE or TYPICAL_VALUE must
+        not be promoted into `concentration` without reading the record's own
+        source — that is the check the basis exists to prompt.
 
   ConcentrationUnitEnum:
     description: Units for concentration

--- a/src/culturemech/schema/culturemech_dataclasses.py
+++ b/src/culturemech/schema/culturemech_dataclasses.py
@@ -1,5 +1,5 @@
 # Auto generated from culturemech.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-08-04T19:26:36
+# Generation date: 2026-08-13T20:11:24
 # Schema: culturemech
 #
 # id: https://w3id.org/culturemech
@@ -837,6 +837,7 @@ class SolutionDescriptor(Descriptor):
     culturemech_term: Optional[Union[dict, "CultureMechTerm"]] = None
     composition: Optional[Union[Union[dict, IngredientDescriptor], list[Union[dict, IngredientDescriptor]]]] = empty_list()
     concentration: Optional[Union[dict, "ConcentrationValue"]] = None
+    concentration_candidates: Optional[Union[Union[dict, "ConcentrationCandidate"], list[Union[dict, "ConcentrationCandidate"]]]] = empty_list()
     preparation_notes: Optional[str] = None
     storage_conditions: Optional[Union[dict, "StorageConditions"]] = None
     shelf_life: Optional[str] = None
@@ -871,6 +872,10 @@ class SolutionDescriptor(Descriptor):
 
         if self.concentration is not None and not isinstance(self.concentration, ConcentrationValue):
             self.concentration = ConcentrationValue(**as_dict(self.concentration))
+
+        if not isinstance(self.concentration_candidates, list):
+            self.concentration_candidates = [self.concentration_candidates] if self.concentration_candidates is not None else []
+        self.concentration_candidates = [v if isinstance(v, ConcentrationCandidate) else ConcentrationCandidate(**as_dict(v)) for v in self.concentration_candidates]
 
         if self.preparation_notes is not None and not isinstance(self.preparation_notes, str):
             self.preparation_notes = str(self.preparation_notes)
@@ -1217,6 +1222,64 @@ class ConcentrationValue(YAMLRoot):
 
         if self.per_volume is not None and not isinstance(self.per_volume, str):
             self.per_volume = str(self.per_volume)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class ConcentrationCandidate(YAMLRoot):
+    """
+    A concentration that has been PROPOSED but not asserted, carrying the basis it rests on and the evidence for it.
+    This exists so an inferred value can be recorded without being mistaken for one that was read from a source. A
+    candidate never overwrites an asserted `concentration`; promoting it is a curation decision, made after checking
+    the record's own source.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = CULTUREMECH["ConcentrationCandidate"]
+    class_class_curie: ClassVar[str] = "culturemech:ConcentrationCandidate"
+    class_name: ClassVar[str] = "ConcentrationCandidate"
+    class_model_uri: ClassVar[URIRef] = CULTUREMECH.ConcentrationCandidate
+
+    value: str = None
+    unit: Union[str, "ConcentrationUnitEnum"] = None
+    basis: Union[str, "ConcentrationBasisEnum"] = None
+    support: Optional[str] = None
+    counterevidence: Optional[str] = None
+    source: Optional[str] = None
+    proposed_by: Optional[str] = None
+    proposed_on: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.value):
+            self.MissingRequiredField("value")
+        if not isinstance(self.value, str):
+            self.value = str(self.value)
+
+        if self._is_empty(self.unit):
+            self.MissingRequiredField("unit")
+        if not isinstance(self.unit, ConcentrationUnitEnum):
+            self.unit = ConcentrationUnitEnum(self.unit)
+
+        if self._is_empty(self.basis):
+            self.MissingRequiredField("basis")
+        if not isinstance(self.basis, ConcentrationBasisEnum):
+            self.basis = ConcentrationBasisEnum(self.basis)
+
+        if self.support is not None and not isinstance(self.support, str):
+            self.support = str(self.support)
+
+        if self.counterevidence is not None and not isinstance(self.counterevidence, str):
+            self.counterevidence = str(self.counterevidence)
+
+        if self.source is not None and not isinstance(self.source, str):
+            self.source = str(self.source)
+
+        if self.proposed_by is not None and not isinstance(self.proposed_by, str):
+            self.proposed_by = str(self.proposed_by)
+
+        if self.proposed_on is not None and not isinstance(self.proposed_on, str):
+            self.proposed_on = str(self.proposed_on)
 
         super().__post_init__(**kwargs)
 
@@ -2739,6 +2802,29 @@ class PhysicalStateEnum(EnumDefinitionImpl):
     _defn = EnumDefinition(
         name="PhysicalStateEnum",
         description="Physical form of the medium",
+    )
+
+class ConcentrationBasisEnum(EnumDefinitionImpl):
+    """
+    How a proposed concentration was arrived at. Ordered from strongest to weakest, because the distinction is the
+    whole point of recording a candidate rather than an asserted value.
+    """
+    READ_FROM_THIS_MEDIUM = PermissibleValue(
+        text="READ_FROM_THIS_MEDIUM",
+        description="""Printed in this medium's own source. This is an asserted value and belongs in `concentration`, not here; the term exists so a promotion can record what it was promoted on.""")
+    READ_FROM_STOCK_DEFINITION = PermissibleValue(
+        text="READ_FROM_STOCK_DEFINITION",
+        description="""Read from the cited definition of the stock solution itself (e.g. DSMZ medium 84 defines its trace element solution and the volume it is added at), for a medium that references that stock by name.""")
+    CROSS_MEDIUM_INFERENCE = PermissibleValue(
+        text="CROSS_MEDIUM_INFERENCE",
+        description="""Taken from OTHER media that use the same named stock, not from this medium's own source. Defensible when the stock's volume is consistent across many media, and wrong whenever a medium departs from the norm — which does happen (SL-10 is 1 ml/L in ten media and 0.05 ml/L in J537).""")
+    TYPICAL_VALUE = PermissibleValue(
+        text="TYPICAL_VALUE",
+        description="""A conventional value for this class of stock, with no per-medium evidence at all. The weakest basis; recorded only to be checked.""")
+
+    _defn = EnumDefinition(
+        name="ConcentrationBasisEnum",
+        description="""How a proposed concentration was arrived at. Ordered from strongest to weakest, because the distinction is the whole point of recording a candidate rather than an asserted value.""",
     )
 
 class ConcentrationUnitEnum(EnumDefinitionImpl):
@@ -4285,6 +4371,9 @@ slots.solutionDescriptor__composition = Slot(uri=CULTUREMECH.composition, name="
 slots.solutionDescriptor__concentration = Slot(uri=CULTUREMECH.concentration, name="solutionDescriptor__concentration", curie=CULTUREMECH.curie('concentration'),
                    model_uri=CULTUREMECH.solutionDescriptor__concentration, domain=None, range=Optional[Union[dict, ConcentrationValue]])
 
+slots.solutionDescriptor__concentration_candidates = Slot(uri=CULTUREMECH.concentration_candidates, name="solutionDescriptor__concentration_candidates", curie=CULTUREMECH.curie('concentration_candidates'),
+                   model_uri=CULTUREMECH.solutionDescriptor__concentration_candidates, domain=None, range=Optional[Union[Union[dict, ConcentrationCandidate], list[Union[dict, ConcentrationCandidate]]]])
+
 slots.solutionDescriptor__preparation_notes = Slot(uri=CULTUREMECH.preparation_notes, name="solutionDescriptor__preparation_notes", curie=CULTUREMECH.curie('preparation_notes'),
                    model_uri=CULTUREMECH.solutionDescriptor__preparation_notes, domain=None, range=Optional[str])
 
@@ -4424,6 +4513,30 @@ slots.concentrationValue__unit = Slot(uri=CULTUREMECH.unit, name="concentrationV
 
 slots.concentrationValue__per_volume = Slot(uri=CULTUREMECH.per_volume, name="concentrationValue__per_volume", curie=CULTUREMECH.curie('per_volume'),
                    model_uri=CULTUREMECH.concentrationValue__per_volume, domain=None, range=Optional[str])
+
+slots.concentrationCandidate__value = Slot(uri=CULTUREMECH.value, name="concentrationCandidate__value", curie=CULTUREMECH.curie('value'),
+                   model_uri=CULTUREMECH.concentrationCandidate__value, domain=None, range=str)
+
+slots.concentrationCandidate__unit = Slot(uri=CULTUREMECH.unit, name="concentrationCandidate__unit", curie=CULTUREMECH.curie('unit'),
+                   model_uri=CULTUREMECH.concentrationCandidate__unit, domain=None, range=Union[str, "ConcentrationUnitEnum"])
+
+slots.concentrationCandidate__basis = Slot(uri=CULTUREMECH.basis, name="concentrationCandidate__basis", curie=CULTUREMECH.curie('basis'),
+                   model_uri=CULTUREMECH.concentrationCandidate__basis, domain=None, range=Union[str, "ConcentrationBasisEnum"])
+
+slots.concentrationCandidate__support = Slot(uri=CULTUREMECH.support, name="concentrationCandidate__support", curie=CULTUREMECH.curie('support'),
+                   model_uri=CULTUREMECH.concentrationCandidate__support, domain=None, range=Optional[str])
+
+slots.concentrationCandidate__counterevidence = Slot(uri=CULTUREMECH.counterevidence, name="concentrationCandidate__counterevidence", curie=CULTUREMECH.curie('counterevidence'),
+                   model_uri=CULTUREMECH.concentrationCandidate__counterevidence, domain=None, range=Optional[str])
+
+slots.concentrationCandidate__source = Slot(uri=CULTUREMECH.source, name="concentrationCandidate__source", curie=CULTUREMECH.curie('source'),
+                   model_uri=CULTUREMECH.concentrationCandidate__source, domain=None, range=Optional[str])
+
+slots.concentrationCandidate__proposed_by = Slot(uri=CULTUREMECH.proposed_by, name="concentrationCandidate__proposed_by", curie=CULTUREMECH.curie('proposed_by'),
+                   model_uri=CULTUREMECH.concentrationCandidate__proposed_by, domain=None, range=Optional[str])
+
+slots.concentrationCandidate__proposed_on = Slot(uri=CULTUREMECH.proposed_on, name="concentrationCandidate__proposed_on", curie=CULTUREMECH.curie('proposed_on'),
+                   model_uri=CULTUREMECH.concentrationCandidate__proposed_on, domain=None, range=Optional[str])
 
 slots.growthMetrics__max_od600 = Slot(uri=CULTUREMECH.max_od600, name="growthMetrics__max_od600", curie=CULTUREMECH.curie('max_od600'),
                    model_uri=CULTUREMECH.growthMetrics__max_od600, domain=None, range=Optional[float])

--- a/tests/test_apply_cocktail_nesting.py
+++ b/tests/test_apply_cocktail_nesting.py
@@ -282,3 +282,78 @@ def test_source_medium_refuses_a_komodo_number(acn):
 
     mediadive = {"media_term": {"term": {"id": "mediadive.medium:503"}}}
     assert acn.source_medium(mediadive) == "503"
+
+
+# --- inferred volumes never overwrite an asserted one (#150) -----------------
+
+
+def _stock(basis=None, **extra):
+    s = {"stock_components": STOCK, "solution_name": "Wolfe's mineral elixir",
+         "addition_volume_ml": 1, "stock_prepared_in_ml": 1000}
+    if basis:
+        s["volume_basis"] = basis
+    s.update(extra)
+    return s
+
+
+def _doc():
+    return {"ingredients": [_ing("MnSO4 x H2O", "5"), _ing("FeSO4 x 7 H2O", "1")]}
+
+
+def test_a_read_volume_is_asserted_in_concentration(acn):
+    """A figure printed in this medium's own recipe is an assertion and may be stated."""
+    doc = _doc()
+    plan = acn.plan_record(Path("x.yaml"), doc, [_stock()], {"mnso4 x h2o", "feso4 x 7 h2o"})
+    acn.apply_plan(doc, plan)
+    sol = doc["solutions"][0]
+    assert sol["concentration"] == {"value": "1", "unit": "ML_PER_L"}
+    assert "concentration_candidates" not in sol
+
+
+def test_an_inferred_volume_never_touches_concentration(acn):
+    """THE guarantee. A cross-medium inference is a proposal: it goes to
+    concentration_candidates and leaves `concentration` UNSET, so nothing a tool
+    concluded can be read as something a source said — and a later reading of the
+    real recipe has nothing to overwrite."""
+    doc = _doc()
+    plan = acn.plan_record(
+        Path("x.yaml"), doc,
+        [_stock("CROSS_MEDIUM_INFERENCE",
+                volume_support="10 of 11 media add it at 1 ml/L",
+                volume_counterevidence="J537 adds it at 0.05 ml/L",
+                citation="https://mediadive.dsmz.de/rest/medium/J58")],
+        {"mnso4 x h2o", "feso4 x 7 h2o"})
+    acn.apply_plan(doc, plan)
+    sol = doc["solutions"][0]
+
+    assert "concentration" not in sol, "an inference must never be asserted"
+    [cand] = sol["concentration_candidates"]
+    assert cand["value"] == "1" and cand["unit"] == "ML_PER_L"
+    assert cand["basis"] == "CROSS_MEDIUM_INFERENCE"
+    assert cand["support"] and cand["source"]
+    assert cand["counterevidence"] == "J537 adds it at 0.05 ml/L", (
+        "known counterevidence must travel with the candidate, or it reads as "
+        "better supported than it is")
+    assert cand["proposed_by"] == "apply_cocktail_nesting.py"
+
+
+def test_the_note_says_the_volume_was_not_asserted(acn):
+    """The prose a curator reads must not claim a source supplied the figure."""
+    doc = _doc()
+    plan = acn.plan_record(Path("x.yaml"), doc, [_stock("CROSS_MEDIUM_INFERENCE")],
+                           {"mnso4 x h2o", "feso4 x 7 h2o"})
+    acn.apply_plan(doc, plan)
+    note = doc["solutions"][0]["preparation_notes"]
+    assert "NOT asserted" in note and "concentration_candidates" in note
+    assert "read from" not in note
+
+
+def test_a_typical_value_is_also_only_a_candidate(acn):
+    """The weakest basis must not get a stronger treatment than the inference."""
+    doc = _doc()
+    plan = acn.plan_record(Path("x.yaml"), doc, [_stock("TYPICAL_VALUE")],
+                           {"mnso4 x h2o", "feso4 x 7 h2o"})
+    acn.apply_plan(doc, plan)
+    sol = doc["solutions"][0]
+    assert "concentration" not in sol
+    assert sol["concentration_candidates"][0]["basis"] == "TYPICAL_VALUE"


### PR DESCRIPTION
Per your constraint: inferences must not overwrite existing values, and should live
in their own field or an array. **Corpus untouched — this is the mechanism, not an
application of it.**

## Why an array, not a single field
The evidence genuinely disagrees. SL-10 is added at **1 ml/L in ten MediaDive media**
and at **0.05 ml/L in J537** (TREPONEMA ISOPTEROCOLA) — a 20× spread. A single
inferred-value slot forces a tool to pick one and hide the other; an array lets both
stand with their support until someone reads that medium's own recipe.

## Schema
`SolutionDescriptor.concentration_candidates` — multivalued `ConcentrationCandidate`:

```yaml
solutions:
- preferred_term: Trace element solution SL-10
  # concentration: DELIBERATELY UNSET — nothing was read from this medium
  concentration_candidates:
  - value: '1'
    unit: ML_PER_L
    basis: CROSS_MEDIUM_INFERENCE
    support: 10 of 11 MediaDive media citing this stock add it at 1 ml/L
    counterevidence: J537 (TREPONEMA ISOPTEROCOLA) adds it at 0.05 ml/L
    source: https://mediadive.dsmz.de/rest/medium/J58
    proposed_by: apply_cocktail_nesting.py
```

`concentration` keeps its meaning and gains a comment saying so — **asserted values
only**.

`ConcentrationBasisEnum` grades the claim: `READ_FROM_THIS_MEDIUM`,
`READ_FROM_STOCK_DEFINITION`, `CROSS_MEDIUM_INFERENCE`, `TYPICAL_VALUE`.
`linkml-validate` **rejects** anything else (verified), so a basis can't be invented
at the call site.

## Applier
Only `READ_FROM_THIS_MEDIUM` writes `concentration`. Everything weaker writes a
candidate and leaves `concentration` **unset** — so a later reading of the real recipe
has nothing to overwrite, and the note reads *"addition volume NOT asserted"* instead
of claiming a source supplied it. **Known counterevidence travels with the
candidate**, because a proposal offered without it reads as better supported than it
is.

The three researched stocks are graded: Trace salt + Seven vitamins are
`READ_FROM_STOCK_DEFINITION`; SL-10 is `CROSS_MEDIUM_INFERENCE` carrying the J537
counterexample. SL-10's `applies_to_media` gate is dropped — it existed to stop an
inference being *asserted*, which the basis now prevents structurally.

## Testing
- Full suite **1139 passed**; 5 new tests, including that an inference **never**
  touches `concentration` and that `TYPICAL_VALUE` gets no stronger treatment.
- Dataclasses regenerated; a candidate-bearing record validates, an invalid basis
  does not.

Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)