### PR TITLE
Report the sidecars this Edison run wrote, not the ones lying around (#288)

### DIFF
--- a/scripts/_edison_capture.py
+++ b/scripts/_edison_capture.py
@@ -392,14 +392,19 @@ def capture_full_response(
     answer_reasoning = _get_attr(response, "answer_reasoning")
     body = formatted_answer or answer or "(no answer field on this job's response type)"
     md_path.write_text(body)
+    # Track what THIS invocation wrote, so the meta reports its own provenance
+    # rather than whatever a previous run of the same stem left on disk.
+    written: set[str] = {"answer_md"}
 
     # Full raw response dump (every SDK field, future-proof)
     response_dump = _safe_model_dump(response)
     response_json_path.write_text(json.dumps(response_dump, indent=2, default=str))
+    written.add("response_json")
 
     # Citations sidecar
     citations = parse_citations(formatted_answer or answer)
     citations_md_path.write_text(render_citations_md(citations, query=query))
+    written.add("citations_md")
 
     # Verbose + files via secondary fetches (no extra billing)
     task_id = str(_get_attr(response, "task_id") or "")
@@ -415,12 +420,14 @@ def capture_full_response(
                 "environment_frame": environment_frame,
                 "metadata": verbose_metadata,
             }, indent=2, default=str))
+            written.add("agent_state_json")
 
     files_listing = _try_list_files(client, task_id) if task_id else None
     artifacts_manifest: list[dict[str, Any]] = []
     if files_listing is not None:
         files_path.write_text(json.dumps(_safe_model_dump(files_listing),
                                          indent=2, default=str))
+        written.add("files_json")
         # Pull the actual content of named curation artifacts (small,
         # not internal PaperQA pickles) into a sibling artifacts/ dir.
         artifacts_manifest = fetch_named_artifacts(
@@ -453,7 +460,7 @@ def capture_full_response(
         "answer_reasoning_chars": len(answer_reasoning or ""),
         "citations_parsed": len(citations),
         "query_sha256": query_sha256(query),
-        "sidecar_files": _existing_sidecars(out_dir, stem),
+        "sidecar_files": _existing_sidecars(out_dir, stem, written),
         "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
         "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
     })
@@ -483,15 +490,34 @@ def capture_dry_run(
     return meta
 
 
-def _existing_sidecars(out_dir: Path, stem: str) -> dict[str, bool]:
-    """Snapshot which sidecar files exist for this stem — for the meta."""
-    return {
+def _existing_sidecars(
+    out_dir: Path, stem: str, written: set[str] | None = None
+) -> dict[str, bool]:
+    """Which sidecars this invocation produced for this stem.
+
+    The stem is deterministic (``{slug}-edison-{job}``), so a re-run of the same
+    record and job finds the previous run's files already on disk. Reporting a
+    plain ``.exists()`` snapshot therefore attributed a prior task's trace to the
+    new ``task_id`` whenever the new run failed to fetch it — for a feature whose
+    whole point is provenance, an auditor following the meta would read the wrong
+    trajectory.
+
+    Pass ``written`` (the keys this run actually wrote) to report truthfully. It
+    is optional so the call sites that genuinely want a disk snapshot keep
+    working — ``enrich_edison_response`` backfills sidecars for the *same*
+    ``task_id`` already recorded in the meta, so for it "what is on disk now" is
+    the honest answer.
+    """
+    on_disk = {
         "answer_md": (out_dir / f"{stem}.md").exists(),
         "response_json": (out_dir / f"{stem}-response.json").exists(),
         "citations_md": (out_dir / f"{stem}-citations.md").exists(),
         "agent_state_json": (out_dir / f"{stem}-agent-state.json").exists(),
         "files_json": (out_dir / f"{stem}-files.json").exists(),
     }
+    if written is None:
+        return on_disk
+    return {key: (key in written and value) for key, value in on_disk.items()}
 
 
 def _to_iso(dt: Any) -> str | None:

--- a/tests/test_edison_capture_sidecar_provenance.py
+++ b/tests/test_edison_capture_sidecar_provenance.py
@@ -1,0 +1,211 @@
+"""Tests that ``sidecar_files`` describes THIS Edison run, not the directory.
+
+Edison output stems are deterministic — ``{slug}-edison-{job}`` — so re-running
+the same medium and job writes into a directory that already holds the previous
+run's sidecars. ``capture_full_response`` used to report ``sidecar_files`` from a
+plain ``.exists()`` sweep of that directory, which meant a fresh run that failed
+to fetch the agent-state trace still reported ``agent_state_json: true`` next to
+its own new ``task_id``. An auditor following the meta would open the previous
+task's trajectory believing it belonged to the new one (#288).
+
+The fix records which keys the invocation actually wrote. These tests pin that
+behaviour, and pin the deliberate escape hatch: ``_existing_sidecars`` without a
+written-set still returns a disk snapshot, because ``enrich_edison_response``
+backfills sidecars for the *same* ``task_id`` already in the meta.
+
+No Edison client is constructed and no credits are spent — the response is a
+stub object and ``client=None`` exercises the "verbose fetch skipped" path.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_module():
+    path = REPO_ROOT / "scripts" / "_edison_capture.py"
+    spec = importlib.util.spec_from_file_location("_edison_capture", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_edison_capture"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def ec():
+    return _load_module()
+
+
+class _StubResponse:
+    """Minimal stand-in for the SDK response object.
+
+    Only the attributes ``capture_full_response`` reads are defined; anything
+    else falls through ``getattr(..., default)`` as it would for a job type that
+    does not carry the field.
+    """
+
+    def __init__(self, task_id: str, answer: str = "new answer"):
+        self.task_id = task_id
+        self.answer = answer
+        self.formatted_answer = f"{answer}\n\nReferences\n\n1. doe2020paper pages 1-2\n"
+        self.status = "success"
+        self.has_successful_answer = True
+
+
+STEM = "archaeoglobus_medium_dsm_399-edison-literature"
+
+# The sidecars a *previous*, fully successful run of the same stem left behind.
+PRIOR_RUN_FILES = {
+    f"{STEM}.md": "old answer",
+    f"{STEM}-response.json": '{"task_id": "task-OLD"}',
+    f"{STEM}-citations.md": "# Citations\n",
+    f"{STEM}-agent-state.json": '{"task_id": "task-OLD", "agent_state": []}',
+    f"{STEM}-files.json": "[]",
+}
+
+
+@pytest.fixture
+def prior_run_dir(tmp_path: Path) -> Path:
+    for name, body in PRIOR_RUN_FILES.items():
+        (tmp_path / name).write_text(body)
+    return tmp_path
+
+
+def test_stale_sidecars_are_not_attributed_to_the_new_task(ec, prior_run_dir):
+    """The regression: a rerun that fetches neither trace reports neither.
+
+    ``client=None`` is how a run behaves when the verbose fetch and
+    ``list_files`` are skipped, so nothing rewrites the agent-state or files
+    sidecars — yet both are sitting on disk from ``task-OLD``.
+    """
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-NEW"),
+        client=None,
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="q",
+        base_meta={"slug": "archaeoglobus_medium_dsm_399"},
+    )
+
+    assert meta["task_id"] == "task-NEW"
+    assert meta["sidecar_files"] == {
+        # written by this invocation, unconditionally
+        "answer_md": True,
+        "response_json": True,
+        "citations_md": True,
+        # left over from task-OLD — must not be claimed by task-NEW
+        "agent_state_json": False,
+        "files_json": False,
+    }
+
+    # The stale files themselves are left alone; only the claim about them
+    # changes. Deleting them would destroy the earlier run's evidence.
+    assert (prior_run_dir / f"{STEM}-agent-state.json").exists()
+    assert json.loads(
+        (prior_run_dir / f"{STEM}-agent-state.json").read_text()
+    )["task_id"] == "task-OLD"
+
+
+def test_sidecars_this_run_did_write_are_reported_true(ec, prior_run_dir):
+    """The fix must not simply report False for everything it did not fetch.
+
+    A client that answers both secondary fetches makes this run the author of
+    all five sidecars, and the meta should say so even though five files of the
+    same names were already present.
+    """
+
+    class _Client:
+        def get_task(self, task_id, verbose=False):  # noqa: ARG002
+            return type("V", (), {"agent_state": [{"tool": "search"}],
+                                  "environment_frame": None,
+                                  "metadata": None})()
+
+        def list_files(self, trajectory_id):  # noqa: ARG002
+            return []
+
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-NEW"),
+        client=_Client(),
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="q",
+        base_meta={},
+    )
+
+    assert meta["sidecar_files"] == dict.fromkeys(
+        ["answer_md", "response_json", "citations_md",
+         "agent_state_json", "files_json"],
+        True,
+    )
+    # ...and the rewritten trace really is the new task's.
+    assert json.loads(
+        (prior_run_dir / f"{STEM}-agent-state.json").read_text()
+    )["task_id"] == "task-NEW"
+
+
+def test_empty_output_dir_reports_only_what_was_written(ec, tmp_path):
+    """First run of a stem: no prior files, so the two unfetched keys are False
+    for the ordinary reason rather than the stale-file reason."""
+    meta = ec.capture_full_response(
+        response=_StubResponse("task-FIRST"),
+        client=None,
+        out_dir=tmp_path / "nested",
+        stem=STEM,
+        query="q",
+        base_meta={},
+    )
+    assert meta["sidecar_files"]["answer_md"] is True
+    assert meta["sidecar_files"]["agent_state_json"] is False
+
+
+def test_written_set_cannot_claim_a_file_that_is_absent(ec, tmp_path):
+    """Belt-and-braces: the report is an AND of "we wrote it" and "it is there".
+
+    A key in the written set whose file never materialised (a failed write, a
+    later unlink) must still report False, so the meta never points at a path
+    that does not exist.
+    """
+    assert ec._existing_sidecars(tmp_path, STEM, {"answer_md", "files_json"}) == {
+        "answer_md": False,
+        "response_json": False,
+        "citations_md": False,
+        "agent_state_json": False,
+        "files_json": False,
+    }
+
+
+def test_omitting_the_written_set_still_snapshots_the_disk(ec, prior_run_dir):
+    """The ``enrich_edison_response`` contract.
+
+    Backfill runs against the ``task_id`` already stored in the meta, so "what
+    is on disk for this stem" is the truthful answer there and must not regress
+    to the written-set semantics.
+    """
+    assert ec._existing_sidecars(prior_run_dir, STEM) == dict.fromkeys(
+        ["answer_md", "response_json", "citations_md",
+         "agent_state_json", "files_json"],
+        True,
+    )
+
+
+def test_dry_run_reports_no_sidecars_at_all(ec, prior_run_dir):
+    """A dry run spends nothing and authors nothing, so it must not inherit the
+    previous run's sidecar claims — ``capture_dry_run`` omits the key entirely
+    rather than reporting a directory snapshot."""
+    meta = ec.capture_dry_run(
+        out_dir=prior_run_dir,
+        stem=STEM,
+        query="rendered prompt",
+        base_meta={"slug": "archaeoglobus_medium_dsm_399"},
+    )
+    assert meta["status"] == "dry-run"
+    assert "sidecar_files" not in meta
+    assert "task_id" not in meta
+    # and it must not have overwritten the earlier run's answer
+    assert (prior_run_dir / f"{STEM}.md").read_text() == "old answer"


### PR DESCRIPTION
Closes #288 for CultureMech.

## The defect

Edison output stems are deterministic — `{slug}-edison-{job}` — so re-running
the same medium and job writes into a directory that already holds the previous
run's sidecars. `capture_full_response` built its `sidecar_files` provenance
block from a plain `.exists()` sweep of that directory:

```python
"sidecar_files": _existing_sidecars(out_dir, stem),
```

A rerun whose verbose fetch or `list_files` call failed therefore wrote
`agent_state_json: true` into a meta stamped with a **new** `task_id`, pointing
at a trace belonging to the old one. For a field whose entire purpose is
provenance, an auditor following the meta reads the wrong trajectory.

## The fix

Track the keys the invocation actually writes, and report the AND of "we wrote
it" and "it is on disk". This is TraitMech's fix, ported.

The stale files stay where they are — only the claim about them changes.
Deleting them would destroy the earlier run's evidence.

`_existing_sidecars` keeps its disk-snapshot behaviour when the written-set is
omitted, which is what `enrich_edison_response` needs: backfill runs against the
`task_id` already stored in the meta, so there "what is on disk for this stem"
*is* the truthful answer. That call site is unchanged, and a test now pins why
it is allowed to differ.

## Tests

TraitMech shipped this fix with no test, so all six cases are new:

| test | pins |
|---|---|
| `test_stale_sidecars_are_not_attributed_to_the_new_task` | the regression itself — prior sidecars from `task-OLD`, new response, neither refetched |
| `test_sidecars_this_run_did_write_are_reported_true` | the fix does not just report `False` for everything |
| `test_empty_output_dir_reports_only_what_was_written` | first run of a stem |
| `test_written_set_cannot_claim_a_file_that_is_absent` | a failed write never yields a path that is not there |
| `test_omitting_the_written_set_still_snapshots_the_disk` | the `enrich_edison_response` contract |
| `test_dry_run_reports_no_sidecars_at_all` | a dry run inherits nothing and overwrites nothing |

Verified the regression tests bite — reverting only the source change:

```
FAILED test_stale_sidecars_are_not_attributed_to_the_new_task
FAILED test_written_set_cannot_claim_a_file_that_is_absent
2 failed, 4 passed
```

**No credits spent.** No Edison client is constructed: the response is a stub
object and `client=None` exercises the skipped-fetch path. 127 edison/research
tests pass.

## Scope note

Issue #288 also asks to propagate the fix to MediaIngredientMech and
CommunityMech and put `_edison_capture.py` under shared drift enforcement. Those
are spoke-side changes in other repositories and are deliberately not in this PR;
the new docstring says "record" rather than "medium" so this copy stays adoptable
verbatim. Follow-up issues will be filed in those repos with CultureMech as the
canonical source.

The two ruff findings in `_edison_capture.py` (`I001`, `B009`) predate this
change — confirmed identical on `origin/main` — and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
