### PR TITLE
Consume MIM's published SSSOM as a divergence check (#256)

### DIFF
--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -33,6 +33,7 @@ data/import_tracking/reports/kg_fallback_phase2_changes.tsv	SNAPSHOT	one-time mi
 data/import_tracking/reports/kg_fallback_phase2_curator_review.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase2_oak_ols.py)		scripts/migrate_kg_fallback_phase2_oak_ols.py	
 data/import_tracking/reports/kg_fallback_phase3_changes.tsv	SNAPSHOT	one-time migration (migrate_kg_fallback_phase3_curation.py)		scripts/migrate_kg_fallback_phase3_curation.py	
 data/import_tracking/reports/mim_grounding_divergences.tsv	SNAPSHOT	one-time migration (migrate_legacy_mim_to_chebi.py)		scripts/migrate_legacy_mim_to_chebi.py	
+data/import_tracking/reports/mim_sssom_divergence.tsv	CURRENT_VIEW	audit_mim_sssom_divergence.py	scripts/audit_mim_sssom_divergence.py	scripts/audit_mim_sssom_divergence.py	
 data/import_tracking/reports/missing_compositions.tsv	CURRENT_VIEW	triage_missing_compositions.py	scripts/triage_missing_compositions.py	scripts/triage_missing_compositions.py	yes
 data/import_tracking/reports/name_term_element_mismatch.tsv	CURRENT_VIEW	audit_name_term_elements.py	scripts/audit_name_term_elements.py	scripts/audit_name_term_elements.py	
 data/import_tracking/reports/primary_term_canonicalize_changes.tsv	UNKNOWN	no writer found			

--- a/data/import_tracking/reports/mim_sssom_divergence.tsv
+++ b/data/import_tracking/reports/mim_sssom_divergence.tsv
@@ -1,0 +1,150 @@
+finding	ingredient	our_ids	our_label_asserted	mim_id	mim_label	rows	detail
+INTERNAL_SPLIT	(NH4)3 citrate	CHEBI:63037=40|CHEBI:72699=4	CHEBI:63037=triammonium citrate|CHEBI:72699=(2R)-trihomocitrate(3-)	CHEBI:63037	triammonium citrate	44	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	(NH4)H2PO4	CHEBI:62982=3|CHEBI:39745=1	CHEBI:62982=ammonium dihydrogen phosphate|CHEBI:39745=dihydrogenphosphate			4	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	(NH4)HCO3	CHEBI:184335=2|CHEBI:17544=1	CHEBI:184335=Ammonium bicarbonate|CHEBI:17544=hydrogencarbonate			3	2 CHEBI ids for one name; MIM has no opinion
+DIVERGENT	1,2-Dichloropropane	CHEBI:142468=2	CHEBI:142468=1,2-dichloropropane	CHEBI:82163	rac-1,2-dichloropropane	2	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	4-Hydroxy-L-proline			CHEBI:18240	4-hydroxy-L-proline	2	MIM grounds this name and we do not
+MISSING_GROUNDING	4-Hydroxybenzaldehyde			CHEBI:17597	4-hydroxybenzaldehyde	2	MIM grounds this name and we do not
+INTERNAL_SPLIT	5-Aminovaleric acid	CHEBI:15887=3|CHEBI:86394=2	CHEBI:15887=5-aminopentanoic acid|CHEBI:86394=5-aminopentanoate	CHEBI:15887	5-aminopentanoic acid	5	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	5-fluorouracil			CHEBI:46345	5-fluorouracil	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Acetoin			CHEBI:15688	acetoin	1	MIM grounds this name and we do not
+MISSING_GROUNDING	acetone			CHEBI:15347	acetone	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Adenine			CHEBI:16708	adenine	3	MIM grounds this name and we do not
+INTERNAL_SPLIT	Arginine	CHEBI:29016=31|CHEBI:32696=6|CHEBI:16467=6	CHEBI:29016=arginine|CHEBI:32696=argininium(1+)|CHEBI:16467=L-arginine	CHEBI:29016	arginine	43	3 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Ascorbate			CHEBI:22651	ascorbate	7	MIM grounds this name and we do not
+MISSING_GROUNDING	Aspartate			CHEBI:29995	aspartate(2-)	12	MIM grounds this name and we do not
+MISSING_GROUNDING	Bacitracin			CHEBI:28669	bacitracin	1	MIM grounds this name and we do not
+MISSING_GROUNDING	benzene			CHEBI:16716	benzene	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Benzoate			CHEBI:16150	benzoate	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Benzyl alcohol			CHEBI:17987	benzyl alcohol	2	MIM grounds this name and we do not
+MISSING_GROUNDING	beta-D-Glucose			CHEBI:15903	beta-D-glucose	16	MIM grounds this name and we do not
+INTERNAL_SPLIT	Bicine	CHEBI:39065=3|CHEBI:40957=1	CHEBI:39065=bicine|CHEBI:40957=N,N-bis(2-hydroxyethyl)glycine			4	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Calcium Chloride	CHEBI:86158=91|CHEBI:3312=6	CHEBI:86158=calcium chloride dihydrate|CHEBI:3312=calcium dichloride			97	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Calcium chloride dihydrate	CHEBI:86158=227|CHEBI:3312=2	CHEBI:86158=calcium chloride dihydrate|CHEBI:3312=calcium dichloride			229	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Carbon monoxide			CHEBI:17245	carbon monoxide	2	MIM grounds this name and we do not
+DIVERGENT	Carboxymethyl cellulose	CHEBI:85146=5	CHEBI:85146=carboxymethylcellulose	CHEBI:234035	carboxymethylcellulose sodium salt	5	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Cefoxitin			CHEBI:209807	cefoxitin	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Chloramphenicol			CHEBI:17698	chloramphenicol	8	MIM grounds this name and we do not
+DIVERGENT	Cholesterol	CHEBI:140435=4	CHEBI:140435=cholesterol-2,2,3,4,4,6-d6	CHEBI:16113	cholesterol	4	we and MIM both ground this name, to different ids
+DIVERGENT	Citrate	CHEBI:30769=63	CHEBI:30769=citric acid	CHEBI:16947	citrate(3-)	63	we and MIM both ground this name, to different ids
+INTERNAL_SPLIT	Citric Acid	CHEBI:30769=63|CHEBI:53258=50	CHEBI:30769=citric acid|CHEBI:53258=sodium citrate	CHEBI:30769	citric acid	113	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	Co Carboxylase	CHEBI:18290=2|CHEBI:9532=1	CHEBI:18290=thiamine(1+) diphosphate chloride|CHEBI:9532=thiamine(1+) diphosphate			3	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Cobalamine	CHEBI:30411=3|CHEBI:28911=1	CHEBI:30411=cobalamin|CHEBI:28911=cob(III)alamin	CHEBI:30411	cobalamin	4	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Cystine			CHEBI:17376	cystine	1	MIM grounds this name and we do not
+MISSING_GROUNDING	D-Alanine			CHEBI:15570	D-alanine	2	MIM grounds this name and we do not
+INTERNAL_SPLIT	D-Arabinose	CHEBI:46983=4|CHEBI:17108=2	CHEBI:46983=aldehydo-D-arabinose|CHEBI:17108=D-arabinose	CHEBI:17108	D-arabinose	6	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	D-Aspartate			CHEBI:29994	D-aspartate(2-)	1	MIM grounds this name and we do not
+MISSING_GROUNDING	D-cycloserine			CHEBI:40009	D-cycloserine	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	D-Fructose	CHEBI:15824=44|CHEBI:48095=9	CHEBI:15824=D-fructose|CHEBI:48095=keto-D-fructose	CHEBI:15824	D-fructose	53	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	D-Glucarate			CHEBI:30612	D-glucarate(2-)	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	D-glucose	CHEBI:17634=597|CHEBI:17234=130	CHEBI:17634=D-glucose|CHEBI:17234=glucose			727	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	D-Glucose 6-phosphate			CHEBI:14314	D-glucose 6-phosphate	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	D-Mannose	CHEBI:16024=8|CHEBI:37675=4	CHEBI:16024=D-mannose|CHEBI:37675=aldehydo-D-mannose	CHEBI:16024	D-mannose	12	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	D-Ribose			CHEBI:16988	D-ribose	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	D-Trehalose	CHEBI:27082=2|CHEBI:16551=1	CHEBI:27082=trehalose|CHEBI:16551=alpha,alpha-trehalose			3	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	D-Trehalose dihydrate	CHEBI:232797=14|CHEBI:83760=1	CHEBI:232797=trehalose dihydrate|CHEBI:83760=EC 2.4.1.64 (alpha,alpha-trehalose phosphorylase) inhibitor			15	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	D(+)-Glucose	CHEBI:17634=227|CHEBI:15824=13	CHEBI:17634=D-glucose|CHEBI:15824=D-fructose			240	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Dextrose	CHEBI:17634=258|CHEBI:15824=16	CHEBI:17634=D-glucose|CHEBI:15824=D-fructose			274	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Dipotassium phosphate	CHEBI:131527=475|CHEBI:63036=1	CHEBI:131527=dipotassium hydrogen phosphate|CHEBI:63036=potassium dihydrogen phosphate			476	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Dithiothreitol	CHEBI:42106=30|CHEBI:18320=22	CHEBI:42106=L-1,4-dithiothreitol|CHEBI:18320=1,4-dithiothreitol			52	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	DL-Dithiothreitol	CHEBI:18320=64|CHEBI:42106=1	CHEBI:18320=1,4-dithiothreitol|CHEBI:42106=L-1,4-dithiothreitol	CHEBI:18320	1,4-dithiothreitol	65	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	DL-mevalonic acid	CHEBI:150970=5|CHEBI:25351=1	CHEBI:150970=(2R,4S,5R,6R)-5-Acetamido-2-[(2R,3S,4R,5S)-5-acetamido-4-[(2R,3R,4R,5S,6R)-3-acetamido-6-(hydroxymethyl)-5-[(2S,3R,4S,5R,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxy-4-[(2S,3S,4R,5S,6S)-3,4,5-trihydroxy-6-methyloxan-2-yl]oxyoxan-2-yl]oxy-2,3,6-trihydroxyhexoxy]-4-hydroxy-6-[(1R,2R)-1,2,3-trihydroxypropyl]oxane-2-carboxylic acid acid acid|CHEBI:25351=mevalonic acid	CHEBI:25351	mevalonic acid	6	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	DL-Na-malate	CHEBI:91260=3|CHEBI:91261=1	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			4	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	DL-Tryptophan	CHEBI:27897=3|CHEBI:57912=2	CHEBI:27897=tryptophan|CHEBI:57912=L-tryptophan zwitterion			5	2 CHEBI ids for one name; MIM has no opinion
+DIVERGENT	EDTA	CHEBI:64755=568	CHEBI:64755=EDTA(2-)	CHEBI:4735	ethylenediaminetetraacetic acid	568	we and MIM both ground this name, to different ids
+INTERNAL_SPLIT	Fe(NH4)citrate	CHEBI:31604=19|CHEBI:144421=16	CHEBI:31604=ferric ammonium citrate|CHEBI:144421=iron(III) citrate			35	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Folinic acid			CHEBI:15640	5-formyltetrahydrofolic acid	2	MIM grounds this name and we do not
+INTERNAL_SPLIT	Fructose	CHEBI:28757=39|CHEBI:15824=26|CHEBI:28645=21	CHEBI:28757=fructose|CHEBI:15824=D-fructose|CHEBI:28645=beta-D-fructofuranose	CHEBI:28757	fructose	86	3 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Fumarate			CHEBI:29806	fumarate(2-)	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Galactitol			CHEBI:16813	galactitol	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Gentamicin			CHEBI:17833	gentamycin	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Glycolate			CHEBI:29805	glycolate	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Guaiacol			CHEBI:28591	guaiacol	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	H3BO2	CHEBI:38267=3|CHEBI:33118=1	CHEBI:38267=boronic acid|CHEBI:33118=boric acid	CHEBI:38267	boronic acid	4	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	HEPES	CHEBI:46756=157|CHEBI:42334=65	CHEBI:46756=HEPES|CHEBI:42334=2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid	CHEBI:42334	2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid	222	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	Inositol	CHEBI:17268=18|CHEBI:24848=18	CHEBI:17268=myo-inositol|CHEBI:24848=inositol	CHEBI:24848	inositol	36	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	kanamycin			CHEBI:6104	kanamycin	5	MIM grounds this name and we do not
+INTERNAL_SPLIT	KF	CHEBI:66872=3|CHEBI:73605=2	CHEBI:66872=potassium fluoride|CHEBI:73605=Lys-Phe			5	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	KNO2			CHEBI:232610	potassium nitrite	2	MIM grounds this name and we do not
+MISSING_GROUNDING	L-Arabinose			CHEBI:30849	L-arabinose	3	MIM grounds this name and we do not
+MISSING_GROUNDING	L-Aspartate			CHEBI:29991	L-aspartate(1-)	21	MIM grounds this name and we do not
+INTERNAL_SPLIT	L-Cysteine	CHEBI:17561=115|CHEBI:15356=14	CHEBI:17561=L-cysteine|CHEBI:15356=cysteine	CHEBI:17561	L-cysteine	129	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	L-Inositol			CHEBI:27374	1L-chiro-inositol	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	L-Lysine HCl	CHEBI:53633=3|CHEBI:53558=2	CHEBI:53633=L-lysine hydrochloride|CHEBI:53558=D-lysine hydrochloride	CHEBI:53633	L-lysine hydrochloride	5	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	L-Sodium lactate	CHEBI:232798=21|CHEBI:75228=13	CHEBI:232798=sodium L-lactate|CHEBI:75228=sodium lactate			34	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Lactose	CHEBI:17716=41|CHEBI:36218=9	CHEBI:17716=lactose|CHEBI:36218=beta-lactose	CHEBI:17716	lactose	50	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Levulinic acid			CHEBI:45630	4-oxopentanoic acid	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Lipopolysaccharide			CHEBI:16412	lipopolysaccharide	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Lysine			CHEBI:25094	lysine	11	MIM grounds this name and we do not
+INTERNAL_SPLIT	m-Inositol	CHEBI:10642=20|CHEBI:166917=1	CHEBI:10642=scyllo-inositol|CHEBI:166917=Ins-1-P-Man-alpha-1->6-Ins-1-P-Cer(d18:0)(2-)			21	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Magnesium chloride hexahydrate	CHEBI:86345=74|CHEBI:6636=2	CHEBI:86345=magnesium dichloride hexahydrate|CHEBI:6636=magnesium dichloride			76	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Magnesium Sulfate Heptahydrate	CHEBI:31795=218|CHEBI:32599=2	CHEBI:31795=magnesium sulfate heptahydrate|CHEBI:32599=magnesium sulfate			220	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	maltodextrin			CHEBI:25140	maltodextrin	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	maltose	CHEBI:17306=137|CHEBI:18167=40	CHEBI:17306=maltose|CHEBI:18167=alpha-maltose	CHEBI:17306	maltose	177	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	MES	CHEBI:39010=76|CHEBI:39005=34	CHEBI:39010=MES|CHEBI:39005=2-(N-morpholino)ethanesulfonic acid	CHEBI:39010	MES	110	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	methane			CHEBI:16183	methane	8	MIM grounds this name and we do not
+DIVERGENT	Mg-citrate	CHEBI:131389=5	CHEBI:131389=magnesium citrate	CHEBI:131391	trimagnesium dicitrate	5	we and MIM both ground this name, to different ids
+DIVERGENT	MgCl2x 6 H2O	CHEBI:86345=4	CHEBI:86345=magnesium dichloride hexahydrate	CHEBI:6636	magnesium dichloride	4	we and MIM both ground this name, to different ids
+INTERNAL_SPLIT	MnSO4 x 4 H2O	CHEBI:86358=69|CHEBI:86360=6	CHEBI:86358=manganese(II) sulfate tetrahydrate|CHEBI:86360=manganese(II) sulfate			75	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	MnSO4 x 5 H2O	CHEBI:131524=31|CHEBI:86360=1	CHEBI:131524=manganese(II) sulfate pentahydrate|CHEBI:86360=manganese(II) sulfate			32	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Monosodium glutamate	CHEBI:64220=8|CHEBI:64243=2	CHEBI:64220=monosodium glutamate|CHEBI:64243=monosodium L-glutamate			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	MOPS	CHEBI:39074=74|CHEBI:44115=17	CHEBI:39074=MOPS|CHEBI:44115=3-(N-morpholino)propanesulfonic acid	CHEBI:39074	MOPS	91	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	N -Acetyl-D-glucosamine	CHEBI:8006=15|CHEBI:506227=6|CHEBI:59640=6	CHEBI:8006=Peptidoglycan(N-acetyl-D-glucosamine)|CHEBI:506227=N-acetyl-D-glucosamine|CHEBI:59640=N-acetylglucosamine			27	3 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	N-Acetyl-glutamic acid	CHEBI:172431=9|CHEBI:17533=1	CHEBI:172431=Acetyl-Glu|CHEBI:17533=N-acetyl-L-glutamic acid			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	n-Acetyl-glutamine	CHEBI:73685=9|CHEBI:133362=1	CHEBI:73685=N(2)-acetylglutamine|CHEBI:133362=N-acetyl-L-methionyl-L-glutaminyl residue			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	n-Acetyl-lysine	CHEBI:35704=9|CHEBI:61930=1	CHEBI:35704=N(2)-acetyl-L-lysine|CHEBI:61930=N(6)-acetyl-L-lysine residue			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	n-Acetyl-muramic acid	CHEBI:47966=9|CHEBI:40666=1	CHEBI:47966=aldehydo-N-acetylmuramic acid|CHEBI:40666=1,6-anhydro-N-acetyl-beta-muramic acid			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na-butyrate	CHEBI:64103=17|CHEBI:17968=1	CHEBI:64103=sodium butyrate|CHEBI:17968=butyrate			18	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na-DL-malate	CHEBI:91260=4|CHEBI:91261=2	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			6	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na glutamate	CHEBI:64220=82|CHEBI:29988=2	CHEBI:64220=monosodium glutamate|CHEBI:29988=L-glutamate(2-)	CHEBI:64220	monosodium glutamate	84	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	Na malate	CHEBI:91260=9|CHEBI:91261=6	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			15	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na-tartrate	CHEBI:63017=4|CHEBI:30924=1	CHEBI:63017=sodium L-tartrate|CHEBI:30924=L-tartrate(2-)			5	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na-thioglycolate	CHEBI:86481=97|CHEBI:30066=4	CHEBI:86481=sodium thioglycolate|CHEBI:30066=thioglycolate(1-)			101	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na2S2O3	CHEBI:132112=42|CHEBI:32150=19	CHEBI:132112=sodium thiosulfate|CHEBI:32150=sodium thiosulfate pentahydrate	CHEBI:132112	sodium thiosulfate	61	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	Na2SeO4 x 10 H2O	CHEBI:77775=2|CHEBI:32586=1	CHEBI:77775=sodium selenate|CHEBI:32586=sodium sulfate decahydrate			3	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na2SiO3 x 5 H2O	CHEBI:60720=2|CHEBI:86477=2	CHEBI:60720=sodium silicate|CHEBI:86477=sodium sulfite			4	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Na3-EDTA	CHEBI:63125=15|CHEBI:64734=2	CHEBI:63125=EDTA trisodium salt|CHEBI:64734=EDTA disodium salt (anhydrous)			17	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Neomycin			CHEBI:7507	neomycin	2	MIM grounds this name and we do not
+INTERNAL_SPLIT	Nicotinate	CHEBI:15940=139|CHEBI:32544=4	CHEBI:15940=nicotinic acid|CHEBI:32544=nicotinate			143	2 CHEBI ids for one name; MIM has no opinion
+DIVERGENT	NiSO4 x 7 H2O	CHEBI:53001=9	CHEBI:53001=nickel sulfate	CHEBI:53504	nickel sulfate heptahydrate	9	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Nitrate			CHEBI:17632	nitrate	7	MIM grounds this name and we do not
+INTERNAL_SPLIT	Nitrilotriacetate	CHEBI:25548=12|CHEBI:44557=2	CHEBI:25548=nitrilotriacetate(3-)|CHEBI:44557=nitrilotriacetic acid	CHEBI:25548	nitrilotriacetate(3-)	14	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Penicillin G			CHEBI:51765	benzylpenicillin sodium	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Polymyxin B sulfate			CHEBI:8310	Polymyxin B sulfate	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Potassium Gluconate			CHEBI:32032	Potassium gluconate	31	MIM grounds this name and we do not
+INTERNAL_SPLIT	Potassium Phosphate	CHEBI:63036=5|CHEBI:131527=4	CHEBI:63036=potassium dihydrogen phosphate|CHEBI:131527=dipotassium hydrogen phosphate			9	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Putrescine	CHEBI:17148=6|CHEBI:326268=2	CHEBI:17148=putrescine|CHEBI:326268=1,4-butanediammonium	CHEBI:17148	putrescine	8	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Pyromelitic acid			CHEBI:45165	pyromellitic acid	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Quinate			CHEBI:26490	quinate	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Rhamnose			CHEBI:26546	rhamnose	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Serine			CHEBI:17822	serine	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	sn-glycero-3-phosphocholine	CHEBI:16870=9|CHEBI:36702=1	CHEBI:16870=choline alfoscerate|CHEBI:36702=2-acyl-1-alkyl-sn-glycero-3-phosphocholine			10	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Sodium DL-lactate	CHEBI:75228=4|CHEBI:232798=1	CHEBI:75228=sodium lactate|CHEBI:232798=sodium L-lactate			5	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Sodium DL--malate	CHEBI:91260=11|CHEBI:91261=3	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			14	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Sodium ferric EDTA			CHEBI:78292	sodium feredetate	2	MIM grounds this name and we do not
+DIVERGENT	Sodium glutamate monohydrate	CHEBI:64243=16	CHEBI:64243=monosodium L-glutamate	CHEBI:232425	monosodium L-glutamate hydrate	16	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Sodium iodide			CHEBI:33167	sodium iodide	6	MIM grounds this name and we do not
+DIVERGENT	Sodium malate	CHEBI:91260=19	CHEBI:91260=disodium malate	CHEBI:91261	disodium (S)-malate	19	we and MIM both ground this name, to different ids
+DIVERGENT	Sodium phosphate dibasic	CHEBI:34683=33	CHEBI:34683=disodium hydrogenphosphate	CHEBI:37583	trisodium phosphate	33	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Spectinomycin			CHEBI:9215	spectinomycin	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	Starch	CHEBI:28017=604|CHEBI:85248=2	CHEBI:28017=starch|CHEBI:85248=gellan gum	CHEBI:28017	starch	606	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	streptomycin			CHEBI:17076	streptomycin	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Sulfate			CHEBI:16189	sulfate	4	MIM grounds this name and we do not
+MISSING_GROUNDING	Tetracycline			CHEBI:27902	tetracycline	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Tetrathionate			CHEBI:15226	tetrathionate(2-)	1	MIM grounds this name and we do not
+DIVERGENT	Thiamine	CHEBI:26948=151	CHEBI:26948=vitamin B1	CHEBI:18385	thiamine(1+)	151	we and MIM both ground this name, to different ids
+INTERNAL_SPLIT	Thiamine pyrophosphate	CHEBI:18290=21|CHEBI:9532=2	CHEBI:18290=thiamine(1+) diphosphate chloride|CHEBI:9532=thiamine(1+) diphosphate	CHEBI:9532	thiamine(1+) diphosphate	23	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	Thioglycolate	CHEBI:47869=4|CHEBI:30066=3	CHEBI:47869=thioglycolate(2-)|CHEBI:30066=thioglycolate(1-)			7	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Thioglycollic acid			CHEBI:30065	thioglycolic acid	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Threonine			CHEBI:26986	threonine	21	MIM grounds this name and we do not
+INTERNAL_SPLIT	Trehalose	CHEBI:27082=8|CHEBI:16551=2	CHEBI:27082=trehalose|CHEBI:16551=alpha,alpha-trehalose	CHEBI:27082	trehalose	10	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Tricalcium phosphate			CHEBI:9679	tricalcium bis(phosphate)	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	Tricine	CHEBI:46760=30|CHEBI:39063=12	CHEBI:46760=tricine|CHEBI:39063=N-tris(hydroxymethyl)methylglycine	CHEBI:46760	tricine	42	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	trimethoprim			CHEBI:45924	trimethoprim	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Tyloxapol			CHEBI:141517	tyloxapol	2	MIM grounds this name and we do not
+MISSING_GROUNDING	vancomycin			CHEBI:28001	vancomycin	1	MIM grounds this name and we do not
+INTERNAL_SPLIT	Vitamin B12	CHEBI:17439=2013|CHEBI:176843=588	CHEBI:17439=cyanocob(III)alamin|CHEBI:176843=vitamin B12	CHEBI:176843	vitamin B12	2601	2 CHEBI ids for one name; MIM matches one of them
+INTERNAL_SPLIT	VOSO4 x 2 H2O	CHEBI:87009=65|CHEBI:33146=9	CHEBI:87009=vanadyl sulfate dihydrate|CHEBI:33146=vanadyl sulfate			74	2 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	VOSO4 x 5 H2O	CHEBI:132758=11|CHEBI:33146=3|CHEBI:87014=1	CHEBI:132758=vanadyl sulfate pentahydrate|CHEBI:33146=vanadyl sulfate|CHEBI:87014=vanadyl sulfate hexahydrate			15	3 CHEBI ids for one name; MIM has no opinion
+INTERNAL_SPLIT	Xanthine	CHEBI:17712=15|CHEBI:15318=6	CHEBI:17712=9H-xanthine|CHEBI:15318=xanthine			21	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Xylan from Beechwood			CHEBI:15447	(1->4)-beta-D-xylan	2	MIM grounds this name and we do not

--- a/data/import_tracking/reports/mim_sssom_divergence.tsv
+++ b/data/import_tracking/reports/mim_sssom_divergence.tsv
@@ -1,4 +1,5 @@
 finding	ingredient	our_ids	our_label_asserted	mim_id	mim_label	rows	detail
+MISSING_GROUNDING	(-)-Quinic acid		CHEBI:17521=(-)-quinic acid	CHEBI:17521	(-)-quinic acid	5	MIM grounds this name; 5 row(s) of it are bare while 1 are grounded
 INTERNAL_SPLIT	(NH4)3 citrate	CHEBI:63037=40|CHEBI:72699=4	CHEBI:63037=triammonium citrate|CHEBI:72699=(2R)-trihomocitrate(3-)	CHEBI:63037	triammonium citrate	44	2 CHEBI ids for one name; MIM matches one of them
 INTERNAL_SPLIT	(NH4)H2PO4	CHEBI:62982=3|CHEBI:39745=1	CHEBI:62982=ammonium dihydrogen phosphate|CHEBI:39745=dihydrogenphosphate			4	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	(NH4)HCO3	CHEBI:184335=2|CHEBI:17544=1	CHEBI:184335=Ammonium bicarbonate|CHEBI:17544=hydrogencarbonate			3	2 CHEBI ids for one name; MIM has no opinion
@@ -17,19 +18,30 @@ MISSING_GROUNDING	Bacitracin			CHEBI:28669	bacitracin	1	MIM grounds this name an
 MISSING_GROUNDING	benzene			CHEBI:16716	benzene	1	MIM grounds this name and we do not
 MISSING_GROUNDING	Benzoate			CHEBI:16150	benzoate	2	MIM grounds this name and we do not
 MISSING_GROUNDING	Benzyl alcohol			CHEBI:17987	benzyl alcohol	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Benzylcyanide		CHEBI:25979=phenylacetonitrile	CHEBI:25979	phenylacetonitrile	1	MIM grounds this name; 1 row(s) of it are bare while 1 are grounded
 MISSING_GROUNDING	beta-D-Glucose			CHEBI:15903	beta-D-glucose	16	MIM grounds this name and we do not
 INTERNAL_SPLIT	Bicine	CHEBI:39065=3|CHEBI:40957=1	CHEBI:39065=bicine|CHEBI:40957=N,N-bis(2-hydroxyethyl)glycine			4	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Biotin		CHEBI:15956=biotin	CHEBI:15956	biotin	1	MIM grounds this name; 1 row(s) of it are bare while 2554 are grounded
+MISSING_GROUNDING	Biphenyl		CHEBI:17097=biphenyl	CHEBI:17097	biphenyl	3	MIM grounds this name; 3 row(s) of it are bare while 1 are grounded
+MISSING_GROUNDING	CaCl2 x 2 H2O		CHEBI:86158=calcium chloride dihydrate	CHEBI:86158	calcium chloride dihydrate	1	MIM grounds this name; 1 row(s) of it are bare while 4746 are grounded
 INTERNAL_SPLIT	Calcium Chloride	CHEBI:86158=91|CHEBI:3312=6	CHEBI:86158=calcium chloride dihydrate|CHEBI:3312=calcium dichloride			97	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Calcium chloride dihydrate	CHEBI:86158=227|CHEBI:3312=2	CHEBI:86158=calcium chloride dihydrate|CHEBI:3312=calcium dichloride			229	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Calcium pantothenate		CHEBI:31345=Calcium pantothenate	CHEBI:31345	Calcium pantothenate	1	MIM grounds this name; 1 row(s) of it are bare while 1005 are grounded
 MISSING_GROUNDING	Carbon monoxide			CHEBI:17245	carbon monoxide	2	MIM grounds this name and we do not
 DIVERGENT	Carboxymethyl cellulose	CHEBI:85146=5	CHEBI:85146=carboxymethylcellulose	CHEBI:234035	carboxymethylcellulose sodium salt	5	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	CeCl3		CHEBI:35458=cerium trichloride	CHEBI:35458	cerium trichloride	1	MIM grounds this name; 1 row(s) of it are bare while 4 are grounded
 MISSING_GROUNDING	Cefoxitin			CHEBI:209807	cefoxitin	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Charcoal		CHEBI:91090=charcoal	CHEBI:91090	charcoal	2	MIM grounds this name; 2 row(s) of it are bare while 3 are grounded
+MISSING_GROUNDING	Chitin		CHEBI:17029=chitin	CHEBI:17029	chitin	7	MIM grounds this name; 7 row(s) of it are bare while 5 are grounded
 MISSING_GROUNDING	Chloramphenicol			CHEBI:17698	chloramphenicol	8	MIM grounds this name and we do not
 DIVERGENT	Cholesterol	CHEBI:140435=4	CHEBI:140435=cholesterol-2,2,3,4,4,6-d6	CHEBI:16113	cholesterol	4	we and MIM both ground this name, to different ids
 DIVERGENT	Citrate	CHEBI:30769=63	CHEBI:30769=citric acid	CHEBI:16947	citrate(3-)	63	we and MIM both ground this name, to different ids
 INTERNAL_SPLIT	Citric Acid	CHEBI:30769=63|CHEBI:53258=50	CHEBI:30769=citric acid|CHEBI:53258=sodium citrate	CHEBI:30769	citric acid	113	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Citric acid x H2O		CHEBI:31404=Citric acid monohydrate	CHEBI:31404	Citric acid monohydrate	1	MIM grounds this name; 1 row(s) of it are bare while 2 are grounded
 INTERNAL_SPLIT	Co Carboxylase	CHEBI:18290=2|CHEBI:9532=1	CHEBI:18290=thiamine(1+) diphosphate chloride|CHEBI:9532=thiamine(1+) diphosphate			3	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Cobalamine	CHEBI:30411=3|CHEBI:28911=1	CHEBI:30411=cobalamin|CHEBI:28911=cob(III)alamin	CHEBI:30411	cobalamin	4	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	CoSO4 x 7 H2O		CHEBI:91244=cobalt(2+) sulfate heptahydrate	CHEBI:91244	cobalt(2+) sulfate heptahydrate	1	MIM grounds this name; 1 row(s) of it are bare while 771 are grounded
+MISSING_GROUNDING	CuCl2 x 2 H2O		CHEBI:86318=copper(II) chloride dihydrate	CHEBI:86318	copper(II) chloride dihydrate	1	MIM grounds this name; 1 row(s) of it are bare while 2181 are grounded
 MISSING_GROUNDING	Cystine			CHEBI:17376	cystine	1	MIM grounds this name and we do not
 MISSING_GROUNDING	D-Alanine			CHEBI:15570	D-alanine	2	MIM grounds this name and we do not
 INTERNAL_SPLIT	D-Arabinose	CHEBI:46983=4|CHEBI:17108=2	CHEBI:46983=aldehydo-D-arabinose|CHEBI:17108=D-arabinose	CHEBI:17108	D-arabinose	6	2 CHEBI ids for one name; MIM matches one of them
@@ -52,26 +64,43 @@ INTERNAL_SPLIT	DL-mevalonic acid	CHEBI:150970=5|CHEBI:25351=1	CHEBI:150970=(2R,4
 INTERNAL_SPLIT	DL-Na-malate	CHEBI:91260=3|CHEBI:91261=1	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			4	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	DL-Tryptophan	CHEBI:27897=3|CHEBI:57912=2	CHEBI:27897=tryptophan|CHEBI:57912=L-tryptophan zwitterion			5	2 CHEBI ids for one name; MIM has no opinion
 DIVERGENT	EDTA	CHEBI:64755=568	CHEBI:64755=EDTA(2-)	CHEBI:4735	ethylenediaminetetraacetic acid	568	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Ethanolamine		CHEBI:16000=ethanolamine	CHEBI:16000	ethanolamine	2	MIM grounds this name; 2 row(s) of it are bare while 1 are grounded
 INTERNAL_SPLIT	Fe(NH4)citrate	CHEBI:31604=19|CHEBI:144421=16	CHEBI:31604=ferric ammonium citrate|CHEBI:144421=iron(III) citrate			35	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	FeCl3 x 6 H2O		CHEBI:86254=iron trichloride hexahydrate	CHEBI:86254	iron trichloride hexahydrate	2	MIM grounds this name; 2 row(s) of it are bare while 434 are grounded
+MISSING_GROUNDING	Folic acid		CHEBI:27470=folic acid	CHEBI:27470	folic acid	1	MIM grounds this name; 1 row(s) of it are bare while 2048 are grounded
 MISSING_GROUNDING	Folinic acid			CHEBI:15640	5-formyltetrahydrofolic acid	2	MIM grounds this name and we do not
 INTERNAL_SPLIT	Fructose	CHEBI:28757=39|CHEBI:15824=26|CHEBI:28645=21	CHEBI:28757=fructose|CHEBI:15824=D-fructose|CHEBI:28645=beta-D-fructofuranose	CHEBI:28757	fructose	86	3 CHEBI ids for one name; MIM matches one of them
 MISSING_GROUNDING	Fumarate			CHEBI:29806	fumarate(2-)	2	MIM grounds this name and we do not
 MISSING_GROUNDING	Galactitol			CHEBI:16813	galactitol	1	MIM grounds this name and we do not
 MISSING_GROUNDING	Gentamicin			CHEBI:17833	gentamycin	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Glycerol mono-oleate		CHEBI:75937=monooleoylglycerol	CHEBI:75937	monooleoylglycerol	1	MIM grounds this name; 1 row(s) of it are bare while 2 are grounded
 MISSING_GROUNDING	Glycolate			CHEBI:29805	glycolate	2	MIM grounds this name and we do not
 MISSING_GROUNDING	Guaiacol			CHEBI:28591	guaiacol	1	MIM grounds this name and we do not
 INTERNAL_SPLIT	H3BO2	CHEBI:38267=3|CHEBI:33118=1	CHEBI:38267=boronic acid|CHEBI:33118=boric acid	CHEBI:38267	boronic acid	4	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	H3BO3		CHEBI:33118=boric acid	CHEBI:33118	boric acid	1	MIM grounds this name; 1 row(s) of it are bare while 3910 are grounded
 INTERNAL_SPLIT	HEPES	CHEBI:46756=157|CHEBI:42334=65	CHEBI:46756=HEPES|CHEBI:42334=2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid	CHEBI:42334	2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid	222	2 CHEBI ids for one name; MIM matches one of them
 INTERNAL_SPLIT	Inositol	CHEBI:17268=18|CHEBI:24848=18	CHEBI:17268=myo-inositol|CHEBI:24848=inositol	CHEBI:24848	inositol	36	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Isobutyramide		CHEBI:193555=isobutyramide	CHEBI:193555	isobutyramide	2	MIM grounds this name; 2 row(s) of it are bare while 1 are grounded
+MISSING_GROUNDING	K2CO3		CHEBI:131526=potassium carbonate	CHEBI:131526	potassium carbonate	1	MIM grounds this name; 1 row(s) of it are bare while 9 are grounded
+MISSING_GROUNDING	K2SO4		CHEBI:32036=potassium sulfate	CHEBI:32036	potassium sulfate	1	MIM grounds this name; 1 row(s) of it are bare while 111 are grounded
+MISSING_GROUNDING	K2SO4 x 7 H2O		CHEBI:32036=potassium sulfate	CHEBI:32036	potassium sulfate	1	MIM grounds this name; 1 row(s) of it are bare while 1 are grounded
 MISSING_GROUNDING	kanamycin			CHEBI:6104	kanamycin	5	MIM grounds this name and we do not
 INTERNAL_SPLIT	KF	CHEBI:66872=3|CHEBI:73605=2	CHEBI:66872=potassium fluoride|CHEBI:73605=Lys-Phe			5	2 CHEBI ids for one name; MIM has no opinion
 MISSING_GROUNDING	KNO2			CHEBI:232610	potassium nitrite	2	MIM grounds this name and we do not
+MISSING_GROUNDING	L--Alanine		CHEBI:16977=L-alanine	CHEBI:16977	L-alanine	1	MIM grounds this name; 1 row(s) of it are bare while 58 are grounded
 MISSING_GROUNDING	L-Arabinose			CHEBI:30849	L-arabinose	3	MIM grounds this name and we do not
 MISSING_GROUNDING	L-Aspartate			CHEBI:29991	L-aspartate(1-)	21	MIM grounds this name and we do not
 INTERNAL_SPLIT	L-Cysteine	CHEBI:17561=115|CHEBI:15356=14	CHEBI:17561=L-cysteine|CHEBI:15356=cysteine	CHEBI:17561	L-cysteine	129	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	L-Cysteine HCl		CHEBI:91247=L-cysteine hydrochloride	CHEBI:91247	L-cysteine hydrochloride	1	MIM grounds this name; 1 row(s) of it are bare while 161 are grounded
+MISSING_GROUNDING	L-Cystine		CHEBI:16283=L-cystine	CHEBI:16283	L-cystine	5	MIM grounds this name; 5 row(s) of it are bare while 13 are grounded
 MISSING_GROUNDING	L-Inositol			CHEBI:27374	1L-chiro-inositol	1	MIM grounds this name and we do not
+MISSING_GROUNDING	L-Leucine		CHEBI:15603=L-leucine	CHEBI:15603	L-leucine	1	MIM grounds this name; 1 row(s) of it are bare while 107 are grounded
+MISSING_GROUNDING	L--Lysine		CHEBI:18019=L-lysine	CHEBI:18019	L-lysine	2	MIM grounds this name; 2 row(s) of it are bare while 83 are grounded
 INTERNAL_SPLIT	L-Lysine HCl	CHEBI:53633=3|CHEBI:53558=2	CHEBI:53633=L-lysine hydrochloride|CHEBI:53558=D-lysine hydrochloride	CHEBI:53633	L-lysine hydrochloride	5	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	L-Proline		CHEBI:17203=L-proline	CHEBI:17203	L-proline	2	MIM grounds this name; 2 row(s) of it are bare while 110 are grounded
+MISSING_GROUNDING	L-Serine		CHEBI:17115=L-serine	CHEBI:17115	L-serine	2	MIM grounds this name; 2 row(s) of it are bare while 117 are grounded
 INTERNAL_SPLIT	L-Sodium lactate	CHEBI:232798=21|CHEBI:75228=13	CHEBI:232798=sodium L-lactate|CHEBI:75228=sodium lactate			34	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	L--Valine		CHEBI:16414=L-valine	CHEBI:16414	L-valine	1	MIM grounds this name; 1 row(s) of it are bare while 90 are grounded
 INTERNAL_SPLIT	Lactose	CHEBI:17716=41|CHEBI:36218=9	CHEBI:17716=lactose|CHEBI:36218=beta-lactose	CHEBI:17716	lactose	50	2 CHEBI ids for one name; MIM matches one of them
 MISSING_GROUNDING	Levulinic acid			CHEBI:45630	4-oxopentanoic acid	1	MIM grounds this name and we do not
 MISSING_GROUNDING	Lipopolysaccharide			CHEBI:16412	lipopolysaccharide	3	MIM grounds this name and we do not
@@ -81,10 +110,12 @@ INTERNAL_SPLIT	Magnesium chloride hexahydrate	CHEBI:86345=74|CHEBI:6636=2	CHEBI:
 INTERNAL_SPLIT	Magnesium Sulfate Heptahydrate	CHEBI:31795=218|CHEBI:32599=2	CHEBI:31795=magnesium sulfate heptahydrate|CHEBI:32599=magnesium sulfate			220	2 CHEBI ids for one name; MIM has no opinion
 MISSING_GROUNDING	maltodextrin			CHEBI:25140	maltodextrin	1	MIM grounds this name and we do not
 INTERNAL_SPLIT	maltose	CHEBI:17306=137|CHEBI:18167=40	CHEBI:17306=maltose|CHEBI:18167=alpha-maltose	CHEBI:17306	maltose	177	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Melezitose		CHEBI:6731=melezitose	CHEBI:6731	melezitose	1	MIM grounds this name; 1 row(s) of it are bare while 1 are grounded
 INTERNAL_SPLIT	MES	CHEBI:39010=76|CHEBI:39005=34	CHEBI:39010=MES|CHEBI:39005=2-(N-morpholino)ethanesulfonic acid	CHEBI:39010	MES	110	2 CHEBI ids for one name; MIM matches one of them
 MISSING_GROUNDING	methane			CHEBI:16183	methane	8	MIM grounds this name and we do not
 DIVERGENT	Mg-citrate	CHEBI:131389=5	CHEBI:131389=magnesium citrate	CHEBI:131391	trimagnesium dicitrate	5	we and MIM both ground this name, to different ids
 DIVERGENT	MgCl2x 6 H2O	CHEBI:86345=4	CHEBI:86345=magnesium dichloride hexahydrate	CHEBI:6636	magnesium dichloride	4	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	MnCl2 x 4 H2O		CHEBI:86368=manganese(II) chloride tetrahydrate	CHEBI:86368	manganese(II) chloride tetrahydrate	2	MIM grounds this name; 2 row(s) of it are bare while 2687 are grounded
 INTERNAL_SPLIT	MnSO4 x 4 H2O	CHEBI:86358=69|CHEBI:86360=6	CHEBI:86358=manganese(II) sulfate tetrahydrate|CHEBI:86360=manganese(II) sulfate			75	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	MnSO4 x 5 H2O	CHEBI:131524=31|CHEBI:86360=1	CHEBI:131524=manganese(II) sulfate pentahydrate|CHEBI:86360=manganese(II) sulfate			32	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Monosodium glutamate	CHEBI:64220=8|CHEBI:64243=2	CHEBI:64220=monosodium glutamate|CHEBI:64243=monosodium L-glutamate			10	2 CHEBI ids for one name; MIM has no opinion
@@ -96,32 +127,44 @@ INTERNAL_SPLIT	n-Acetyl-lysine	CHEBI:35704=9|CHEBI:61930=1	CHEBI:35704=N(2)-acet
 INTERNAL_SPLIT	n-Acetyl-muramic acid	CHEBI:47966=9|CHEBI:40666=1	CHEBI:47966=aldehydo-N-acetylmuramic acid|CHEBI:40666=1,6-anhydro-N-acetyl-beta-muramic acid			10	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Na-butyrate	CHEBI:64103=17|CHEBI:17968=1	CHEBI:64103=sodium butyrate|CHEBI:17968=butyrate			18	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Na-DL-malate	CHEBI:91260=4|CHEBI:91261=2	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			6	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Na-gallate		CHEBI:115197=sodium gallate	CHEBI:115197	sodium gallate	1	MIM grounds this name; 1 row(s) of it are bare while 1 are grounded
 INTERNAL_SPLIT	Na glutamate	CHEBI:64220=82|CHEBI:29988=2	CHEBI:64220=monosodium glutamate|CHEBI:29988=L-glutamate(2-)	CHEBI:64220	monosodium glutamate	84	2 CHEBI ids for one name; MIM matches one of them
 INTERNAL_SPLIT	Na malate	CHEBI:91260=9|CHEBI:91261=6	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			15	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Na-tartrate	CHEBI:63017=4|CHEBI:30924=1	CHEBI:63017=sodium L-tartrate|CHEBI:30924=L-tartrate(2-)			5	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Na-thioglycolate	CHEBI:86481=97|CHEBI:30066=4	CHEBI:86481=sodium thioglycolate|CHEBI:30066=thioglycolate(1-)			101	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Na-vanillate		CHEBI:132748=sodium vanillate	CHEBI:132748	sodium vanillate	1	MIM grounds this name; 1 row(s) of it are bare while 2 are grounded
 INTERNAL_SPLIT	Na2S2O3	CHEBI:132112=42|CHEBI:32150=19	CHEBI:132112=sodium thiosulfate|CHEBI:32150=sodium thiosulfate pentahydrate	CHEBI:132112	sodium thiosulfate	61	2 CHEBI ids for one name; MIM matches one of them
 INTERNAL_SPLIT	Na2SeO4 x 10 H2O	CHEBI:77775=2|CHEBI:32586=1	CHEBI:77775=sodium selenate|CHEBI:32586=sodium sulfate decahydrate			3	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Na2SiO3 x 5 H2O	CHEBI:60720=2|CHEBI:86477=2	CHEBI:60720=sodium silicate|CHEBI:86477=sodium sulfite			4	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Na2WO4 x 2 H2O		CHEBI:63939=sodium tungstate dihydrate	CHEBI:63939	sodium tungstate dihydrate	1	MIM grounds this name; 1 row(s) of it are bare while 1407 are grounded
 INTERNAL_SPLIT	Na3-EDTA	CHEBI:63125=15|CHEBI:64734=2	CHEBI:63125=EDTA trisodium salt|CHEBI:64734=EDTA disodium salt (anhydrous)			17	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Naphthalene sulfonic acid		CHEBI:36336=naphthalenesulfonic acid	CHEBI:36336	naphthalenesulfonic acid	2	MIM grounds this name; 2 row(s) of it are bare while 1 are grounded
 MISSING_GROUNDING	Neomycin			CHEBI:7507	neomycin	2	MIM grounds this name and we do not
 INTERNAL_SPLIT	Nicotinate	CHEBI:15940=139|CHEBI:32544=4	CHEBI:15940=nicotinic acid|CHEBI:32544=nicotinate			143	2 CHEBI ids for one name; MIM has no opinion
+MISSING_GROUNDING	Nicotinic acid		CHEBI:15940=nicotinic acid	CHEBI:15940	nicotinic acid	1	MIM grounds this name; 1 row(s) of it are bare while 2301 are grounded
 DIVERGENT	NiSO4 x 7 H2O	CHEBI:53001=9	CHEBI:53001=nickel sulfate	CHEBI:53504	nickel sulfate heptahydrate	9	we and MIM both ground this name, to different ids
 MISSING_GROUNDING	Nitrate			CHEBI:17632	nitrate	7	MIM grounds this name and we do not
 INTERNAL_SPLIT	Nitrilotriacetate	CHEBI:25548=12|CHEBI:44557=2	CHEBI:25548=nitrilotriacetate(3-)|CHEBI:44557=nitrilotriacetic acid	CHEBI:25548	nitrilotriacetate(3-)	14	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Nitrilotriacetic acid		CHEBI:44557=nitrilotriacetic acid	CHEBI:44557	nitrilotriacetic acid	1	MIM grounds this name; 1 row(s) of it are bare while 1232 are grounded
+MISSING_GROUNDING	p-Aminobenzoic acid		CHEBI:30753=4-aminobenzoic acid	CHEBI:30753	4-aminobenzoic acid	2	MIM grounds this name; 2 row(s) of it are bare while 2152 are grounded
 MISSING_GROUNDING	Penicillin G			CHEBI:51765	benzylpenicillin sodium	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Pentachlorophenol		CHEBI:17642=pentachlorophenol	CHEBI:17642	pentachlorophenol	1	MIM grounds this name; 1 row(s) of it are bare while 1 are grounded
 MISSING_GROUNDING	Polymyxin B sulfate			CHEBI:8310	Polymyxin B sulfate	1	MIM grounds this name and we do not
 MISSING_GROUNDING	Potassium Gluconate			CHEBI:32032	Potassium gluconate	31	MIM grounds this name and we do not
 INTERNAL_SPLIT	Potassium Phosphate	CHEBI:63036=5|CHEBI:131527=4	CHEBI:63036=potassium dihydrogen phosphate|CHEBI:131527=dipotassium hydrogen phosphate			9	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Putrescine	CHEBI:17148=6|CHEBI:326268=2	CHEBI:17148=putrescine|CHEBI:326268=1,4-butanediammonium	CHEBI:17148	putrescine	8	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Pyridoxine hydrochloride		CHEBI:30961=pyridoxine hydrochloride	CHEBI:30961	pyridoxine hydrochloride	1	MIM grounds this name; 1 row(s) of it are bare while 1805 are grounded
 MISSING_GROUNDING	Pyromelitic acid			CHEBI:45165	pyromellitic acid	3	MIM grounds this name and we do not
+MISSING_GROUNDING	Pyrrole-2-carboxylic acid		CHEBI:36751=pyrrole-2-carboxylic acid	CHEBI:36751	pyrrole-2-carboxylic acid	18	MIM grounds this name; 18 row(s) of it are bare while 1 are grounded
 MISSING_GROUNDING	Quinate			CHEBI:26490	quinate	2	MIM grounds this name and we do not
 MISSING_GROUNDING	Rhamnose			CHEBI:26546	rhamnose	1	MIM grounds this name and we do not
+MISSING_GROUNDING	Riboflavin		CHEBI:17015=riboflavin	CHEBI:17015	riboflavin	1	MIM grounds this name; 1 row(s) of it are bare while 2113 are grounded
 MISSING_GROUNDING	Serine			CHEBI:17822	serine	1	MIM grounds this name and we do not
 INTERNAL_SPLIT	sn-glycero-3-phosphocholine	CHEBI:16870=9|CHEBI:36702=1	CHEBI:16870=choline alfoscerate|CHEBI:36702=2-acyl-1-alkyl-sn-glycero-3-phosphocholine			10	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Sodium DL-lactate	CHEBI:75228=4|CHEBI:232798=1	CHEBI:75228=sodium lactate|CHEBI:232798=sodium L-lactate			5	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Sodium DL--malate	CHEBI:91260=11|CHEBI:91261=3	CHEBI:91260=disodium malate|CHEBI:91261=disodium (S)-malate			14	2 CHEBI ids for one name; MIM has no opinion
 MISSING_GROUNDING	Sodium ferric EDTA			CHEBI:78292	sodium feredetate	2	MIM grounds this name and we do not
+MISSING_GROUNDING	Sodium ferulate		CHEBI:114954=sodium ferulate	CHEBI:114954	sodium ferulate	2	MIM grounds this name; 2 row(s) of it are bare while 1 are grounded
 DIVERGENT	Sodium glutamate monohydrate	CHEBI:64243=16	CHEBI:64243=monosodium L-glutamate	CHEBI:232425	monosodium L-glutamate hydrate	16	we and MIM both ground this name, to different ids
 MISSING_GROUNDING	Sodium iodide			CHEBI:33167	sodium iodide	6	MIM grounds this name and we do not
 DIVERGENT	Sodium malate	CHEBI:91260=19	CHEBI:91260=disodium malate	CHEBI:91261	disodium (S)-malate	19	we and MIM both ground this name, to different ids
@@ -130,9 +173,12 @@ MISSING_GROUNDING	Spectinomycin			CHEBI:9215	spectinomycin	1	MIM grounds this na
 INTERNAL_SPLIT	Starch	CHEBI:28017=604|CHEBI:85248=2	CHEBI:28017=starch|CHEBI:85248=gellan gum	CHEBI:28017	starch	606	2 CHEBI ids for one name; MIM matches one of them
 MISSING_GROUNDING	streptomycin			CHEBI:17076	streptomycin	2	MIM grounds this name and we do not
 MISSING_GROUNDING	Sulfate			CHEBI:16189	sulfate	4	MIM grounds this name and we do not
+MISSING_GROUNDING	Surfactant		CHEBI:35195=surfactant	CHEBI:35195	surfactant	2	MIM grounds this name; 2 row(s) of it are bare while 1 are grounded
+MISSING_GROUNDING	Syringic  acid		CHEBI:68329=syringic acid	CHEBI:68329	syringic acid	4	MIM grounds this name; 4 row(s) of it are bare while 2 are grounded
 MISSING_GROUNDING	Tetracycline			CHEBI:27902	tetracycline	3	MIM grounds this name and we do not
 MISSING_GROUNDING	Tetrathionate			CHEBI:15226	tetrathionate(2-)	1	MIM grounds this name and we do not
 DIVERGENT	Thiamine	CHEBI:26948=151	CHEBI:26948=vitamin B1	CHEBI:18385	thiamine(1+)	151	we and MIM both ground this name, to different ids
+MISSING_GROUNDING	Thiamine HCl		CHEBI:49105=thiamine hydrochloride	CHEBI:49105	thiamine hydrochloride	1	MIM grounds this name; 1 row(s) of it are bare while 1924 are grounded
 INTERNAL_SPLIT	Thiamine pyrophosphate	CHEBI:18290=21|CHEBI:9532=2	CHEBI:18290=thiamine(1+) diphosphate chloride|CHEBI:9532=thiamine(1+) diphosphate	CHEBI:9532	thiamine(1+) diphosphate	23	2 CHEBI ids for one name; MIM matches one of them
 INTERNAL_SPLIT	Thioglycolate	CHEBI:47869=4|CHEBI:30066=3	CHEBI:47869=thioglycolate(2-)|CHEBI:30066=thioglycolate(1-)			7	2 CHEBI ids for one name; MIM has no opinion
 MISSING_GROUNDING	Thioglycollic acid			CHEBI:30065	thioglycolic acid	3	MIM grounds this name and we do not
@@ -144,7 +190,9 @@ MISSING_GROUNDING	trimethoprim			CHEBI:45924	trimethoprim	1	MIM grounds this nam
 MISSING_GROUNDING	Tyloxapol			CHEBI:141517	tyloxapol	2	MIM grounds this name and we do not
 MISSING_GROUNDING	vancomycin			CHEBI:28001	vancomycin	1	MIM grounds this name and we do not
 INTERNAL_SPLIT	Vitamin B12	CHEBI:17439=2013|CHEBI:176843=588	CHEBI:17439=cyanocob(III)alamin|CHEBI:176843=vitamin B12	CHEBI:176843	vitamin B12	2601	2 CHEBI ids for one name; MIM matches one of them
+MISSING_GROUNDING	Vitamin B12		CHEBI:17439=cyanocob(III)alamin|CHEBI:176843=vitamin B12	CHEBI:176843	vitamin B12	1	MIM grounds this name; 1 row(s) of it are bare while 2601 are grounded
 INTERNAL_SPLIT	VOSO4 x 2 H2O	CHEBI:87009=65|CHEBI:33146=9	CHEBI:87009=vanadyl sulfate dihydrate|CHEBI:33146=vanadyl sulfate			74	2 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	VOSO4 x 5 H2O	CHEBI:132758=11|CHEBI:33146=3|CHEBI:87014=1	CHEBI:132758=vanadyl sulfate pentahydrate|CHEBI:33146=vanadyl sulfate|CHEBI:87014=vanadyl sulfate hexahydrate			15	3 CHEBI ids for one name; MIM has no opinion
 INTERNAL_SPLIT	Xanthine	CHEBI:17712=15|CHEBI:15318=6	CHEBI:17712=9H-xanthine|CHEBI:15318=xanthine			21	2 CHEBI ids for one name; MIM has no opinion
 MISSING_GROUNDING	Xylan from Beechwood			CHEBI:15447	(1->4)-beta-D-xylan	2	MIM grounds this name and we do not
+MISSING_GROUNDING	ZnCl2		CHEBI:49976=zinc dichloride	CHEBI:49976	zinc dichloride	1	MIM grounds this name; 1 row(s) of it are bare while 1758 are grounded

--- a/project.justfile
+++ b/project.justfile
@@ -372,6 +372,23 @@ audit-unparsed-composition *args="":
     uv run --extra dev python scripts/audit_unparsed_composition.py \
         --max-allowed 169 --max-exported 31 {{args}}
 
+# Compare our ingredient groundings against MIM's published SSSOM (#256).
+#
+# This has to live here rather than in MIM: kg-microbe resolves an ingredient
+# with `best_primary([chebi_id, culturemech_term_id, mim_id, ...])`, so OUR
+# `term.id` outranks MIM's. When MIM corrects a mapping the consumer still picks
+# ours, and MIM can only fix rows we hold no opinion on.
+#
+# Baselines are names, not rows -- one regrounding decision fixes every row of a
+# name. Today: 12 divergent, 75 internally split. Lower them as the backlog is
+# curated; never raise one to make a run pass.
+#
+# Needs MediaIngredientMech checked out beside this repo; pass --sssom otherwise.
+[group('QC')]
+audit-mim-sssom *args="":
+    uv run --extra dev python scripts/audit_mim_sssom_divergence.py \
+        --max-divergent 12 --max-split 75 {{args}}
+
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads
 # untracked research state; review and commit the resulting diff. Entries are

--- a/scripts/audit_mim_sssom_divergence.py
+++ b/scripts/audit_mim_sssom_divergence.py
@@ -241,11 +241,19 @@ def audit(normalized_dir: Path, sssom_path: Path
                     "detail": "we and MIM both ground this name, to different ids",
                 })
 
-        if mim_id and ungrounded and not grounded:
+        if mim_id and ungrounded:
+            # Deliberately NOT `and not grounded`. 184 names carry some grounded
+            # rows and some bare ones, and for 48 of them MIM has an opinion —
+            # `Pyrrole-2-carboxylic acid` is grounded on 1 row and bare on 18.
+            # Requiring the name to be wholly ungrounded hid 96 rows that are the
+            # cheapest possible fix: MIM has already decided, and most rows of the
+            # name already agree.
             rows.append({
                 **base, "finding": "MISSING_GROUNDING", "our_ids": "",
                 "rows": str(ungrounded),
-                "detail": "MIM grounds this name and we do not",
+                "detail": ("MIM grounds this name and we do not" if not grounded
+                           else f"MIM grounds this name; {ungrounded} row(s) of it "
+                                f"are bare while {sum(grounded.values())} are grounded"),
             })
     return rows, version, coverage
 

--- a/scripts/audit_mim_sssom_divergence.py
+++ b/scripts/audit_mim_sssom_divergence.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Compare our ingredient groundings against MediaIngredientMech's published SSSOM.
+
+#256 established why this matters and cannot be fixed downstream: kg-microbe's
+loader resolves an ingredient with
+``best_primary([chebi_id, culturemech_term_id, mim_id, ...])``, so
+``culturemech_term_id`` — our ``term.id`` — outranks ``mim_id``. When MIM corrects
+a mapping, the consumer still picks ours. MIM can only fix rows we have no opinion
+on. The disagreement therefore has to surface *here*, at review time.
+
+MIM publishes ``mappings/ingredient_mappings.sssom.tsv``. Before this script the
+only consumer in the repo was ``audit_missing_roles.py``, and only for role
+coverage — no grounding path read it at all.
+
+Three findings, each a different decision:
+
+  DIVERGENT          We and MIM both ground this name, to different CHEBI ids.
+                     Needs curation, not a bulk overwrite: it runs both ways.
+                     #256 catalogues cases where ours is better (a hydrate we
+                     model and MIM does not) alongside cases where MIM is
+                     (``edta`` → the neutral acid as supplied, rather than our
+                     EDTA(2-)).
+
+  INTERNAL_SPLIT     One ingredient name carries several CHEBI ids in OUR corpus.
+                     Independent of MIM and often unambiguous — ``dipotassium
+                     phosphate`` is CHEBI:131527 on 475 rows and CHEBI:63036 on 1.
+                     Where MIM has an opinion it is shown, because it adjudicates.
+
+  MISSING_GROUNDING  MIM grounds this name and we left it ungrounded. The cheapest
+                     class to act on: nothing to reconcile, only to adopt.
+
+What "our CHEBI" means. Records carry the grounding in one of two slots, and
+reading only one of them gets the wrong answer: MediaDive-derived records put the
+source's own id in ``term.id`` (``mediadive.compound:5``) and the ontology
+grounding in ``chebi_term.id``. Comparing ``term.id`` to MIM makes 24,400 rows
+look divergent when they are not — they simply keep CHEBI in the other slot. So
+``chebi_term.id`` wins, falling back to ``term.id`` when it is itself a CHEBI id.
+
+Matching is by normalized ingredient name against MIM's ``subject_label``, over
+``skos:exactMatch`` rows only. ``narrowMatch``/``broadMatch``/``closeMatch`` are
+deliberately excluded: they assert a relationship, not an identity, and treating
+them as a grounding verdict would manufacture disagreements. A MIM name mapping to
+more than one CHEBI id under exactMatch is skipped rather than guessed at.
+
+The report records the SSSOM's own ``mapping_set_version``, so "which MIM release
+did we align to" is answerable from the artifact rather than from memory.
+
+Read-only. Usage::
+
+    just audit-mim-sssom
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NORMALIZED = REPO_ROOT / "data" / "normalized_yaml"
+DEFAULT_SSSOM = REPO_ROOT.parent / "MediaIngredientMech" / "mappings" / "ingredient_mappings.sssom.tsv"
+DEFAULT_OUT = (REPO_ROOT / "data" / "import_tracking" / "reports"
+               / "mim_sssom_divergence.tsv")
+
+EXACT_MATCH = "skos:exactMatch"
+FINDINGS = ("DIVERGENT", "INTERNAL_SPLIT", "MISSING_GROUNDING")
+
+
+def normalize_name(value: str) -> str:
+    """Fold the differences that are never meaningful in a reagent name.
+
+    Whitespace, hyphen and underscore only. Deliberately NOT stripping
+    punctuation or digits: `CaCl2 x 2 H2O` and `CaCl2` are different substances,
+    and folding them together would hide exactly the hydrate distinctions #256
+    says we sometimes model better than MIM.
+    """
+    return re.sub(r"[\s\-_]+", " ", value.strip().casefold())
+
+
+def load_sssom(path: Path) -> tuple[dict[str, tuple[str, str]], str]:
+    """Return ``({normalized_name: (chebi_id, chebi_label)}, mapping_set_version)``.
+
+    Names that exactMatch more than one CHEBI id are dropped: MIM has not settled
+    them, so we have nothing to compare against and guessing would invent a
+    verdict.
+    """
+    if not path.exists():
+        raise SystemExit(
+            f"MIM SSSOM not found at {path}\n"
+            "Pass --sssom, or check out MediaIngredientMech beside this repo."
+        )
+
+    version = "unknown"
+    candidates: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    with path.open(encoding="utf-8") as handle:
+        header_lines = []
+        for line in handle:
+            if not line.startswith("#"):
+                data_start = line
+                break
+            header_lines.append(line)
+        else:
+            raise SystemExit(f"{path} has no data rows")
+
+        for line in header_lines:
+            match = re.search(r'mapping_set_version:\s*"?([^"\s]+)"?', line)
+            if match:
+                version = match.group(1)
+
+        reader = csv.DictReader([data_start, *handle], delimiter="\t")
+        for row in reader:
+            if row.get("predicate_id") != EXACT_MATCH:
+                continue
+            object_id = row.get("object_id") or ""
+            label = row.get("subject_label") or ""
+            if not object_id.startswith("CHEBI:") or not label:
+                continue
+            candidates[normalize_name(label)].add((object_id, row.get("object_label") or ""))
+
+    return ({name: next(iter(ids)) for name, ids in candidates.items() if len(ids) == 1},
+            version)
+
+
+def our_chebi(row: dict[str, Any]) -> tuple[str | None, str]:
+    """The CHEBI grounding on one ingredient row, and the label it asserts.
+
+    The label is the RECORD's assertion, not an ontology lookup. #256 records
+    that some rows carry the ingredient string in `term.label` rather than the
+    ontology label, so it is a reading aid for triage and not evidence — which is
+    why the column is named `our_label_asserted`. `just check-id-labels` is what
+    adjudicates labels.
+    """
+    for slot in ("chebi_term", "term"):
+        candidate = row.get(slot)
+        if not isinstance(candidate, dict):
+            continue
+        value = candidate.get("id")
+        if isinstance(value, str) and value.startswith("CHEBI:"):
+            return value, str(candidate.get("label") or "")
+    return None, ""
+
+
+def reagent_rows(doc: dict[str, Any]):
+    """Every reagent row, from all three places records keep them."""
+    for row in doc.get("ingredients") or []:
+        if isinstance(row, dict):
+            yield "ingredients", row
+    for row in doc.get("composition") or []:
+        if isinstance(row, dict):
+            yield "composition", row
+    for solution in doc.get("solutions") or []:
+        if not isinstance(solution, dict):
+            continue
+        for row in solution.get("composition") or []:
+            if isinstance(row, dict):
+                yield "solutions[].composition", row
+
+
+def collect(normalized_dir: Path) -> dict[str, Counter]:
+    """``{normalized_name: Counter({chebi_id_or_None: rows})}``, plus display names."""
+    by_name: dict[str, Counter] = defaultdict(Counter)
+    display: dict[str, str] = {}
+    labels: dict[str, str] = {}
+    for path in sorted(normalized_dir.glob("*/*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        for _location, row in reagent_rows(doc):
+            name = row.get("preferred_term")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            key = normalize_name(name)
+            display.setdefault(key, name.strip())
+            chebi, label = our_chebi(row)
+            by_name[key][chebi] += 1
+            if chebi and label:
+                labels.setdefault(chebi, label)
+    return by_name, display, labels
+
+
+def audit(normalized_dir: Path, sssom_path: Path) -> tuple[list[dict[str, str]], str]:
+    mim, version = load_sssom(sssom_path)
+    by_name, display, labels = collect(normalized_dir)
+
+    def described(chebi_ids) -> str:
+        return "|".join(f"{cid}={labels.get(cid, '?')}" for cid in chebi_ids)
+
+    rows: list[dict[str, str]] = []
+    for key, counts in sorted(by_name.items()):
+        grounded = {cid: n for cid, n in counts.items() if cid}
+        ungrounded = counts.get(None, 0)
+        mim_entry = mim.get(key)
+        mim_id, mim_label = mim_entry if mim_entry else ("", "")
+        base = {"ingredient": display[key], "mim_id": mim_id, "mim_label": mim_label,
+                "our_label_asserted": described(
+                    sorted(grounded, key=lambda c: -grounded[c]))}
+
+        if len(grounded) > 1:
+            ours = "|".join(f"{cid}={n}" for cid, n in
+                            sorted(grounded.items(), key=lambda kv: -kv[1]))
+            agrees = mim_id in grounded if mim_id else False
+            rows.append({
+                **base, "finding": "INTERNAL_SPLIT", "our_ids": ours,
+                "rows": str(sum(grounded.values())),
+                "detail": (f"{len(grounded)} CHEBI ids for one name; "
+                           + ("MIM matches one of them" if agrees
+                              else "MIM has no opinion" if not mim_id
+                              else "MIM matches none of them")),
+            })
+
+        if mim_id and grounded:
+            divergent = {cid: n for cid, n in grounded.items() if cid != mim_id}
+            if divergent and len(grounded) == 1:
+                cid, n = next(iter(divergent.items()))
+                rows.append({
+                    **base, "finding": "DIVERGENT", "our_ids": f"{cid}={n}",
+                    "rows": str(n),
+                    "detail": "we and MIM both ground this name, to different ids",
+                })
+
+        if mim_id and ungrounded and not grounded:
+            rows.append({
+                **base, "finding": "MISSING_GROUNDING", "our_ids": "",
+                "rows": str(ungrounded),
+                "detail": "MIM grounds this name and we do not",
+            })
+    return rows, version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--normalized-dir", type=Path, default=NORMALIZED)
+    parser.add_argument("--sssom", type=Path, default=DEFAULT_SSSOM,
+                        help="MIM's published ingredient SSSOM")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument(
+        "--max-divergent", type=int, default=None,
+        help="Exit non-zero when more than N ingredient NAMES diverge from MIM. "
+             "Counted in names, not rows: one regrounding decision fixes every "
+             "row of a name, so names are what a curator actually works through.",
+    )
+    parser.add_argument(
+        "--max-split", type=int, default=None,
+        help="Exit non-zero when more than N names carry several CHEBI ids in our "
+             "own corpus. Independent of MIM, and the class most often a plain "
+             "mistake.",
+    )
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    rows, version = audit(args.normalized_dir, args.sssom)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle, delimiter="\t",
+            fieldnames=["finding", "ingredient", "our_ids", "our_label_asserted", "mim_id", "mim_label",
+                        "rows", "detail"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    tally = Counter(row["finding"] for row in rows)
+    affected = Counter()
+    for row in rows:
+        affected[row["finding"]] += int(row["rows"])
+
+    print(f"MIM SSSOM: {args.sssom}")
+    print(f"  mapping_set_version: {version}\n")
+    for finding in FINDINGS:
+        print(f"  {finding:18s} {tally.get(finding, 0):4d} names "
+              f"({affected.get(finding, 0):,} rows)")
+
+    relative = (args.out.relative_to(REPO_ROOT)
+                if args.out.is_relative_to(REPO_ROOT) else args.out)
+    print(f"\nWrote {relative}")
+    print("\nRead-only. Divergence runs BOTH ways — #256 records cases where our "
+          "hydrate is the better term and cases where MIM's neutral acid is — so "
+          "this reports rather than rewrites.")
+
+    failed = False
+    if args.max_divergent is not None and tally.get("DIVERGENT", 0) > args.max_divergent:
+        print(f"\nFAIL: {tally['DIVERGENT']} divergent names > baseline "
+              f"{args.max_divergent}. A new grounding disagrees with MIM's "
+              f"published SSSOM; reconcile it or agree the change with MIM.",
+              file=sys.stderr)
+        failed = True
+    if args.max_split is not None and tally.get("INTERNAL_SPLIT", 0) > args.max_split:
+        print(f"\nFAIL: {tally['INTERNAL_SPLIT']} names carry several CHEBI ids > "
+              f"baseline {args.max_split}. One name has been grounded two ways "
+              f"within our own corpus.", file=sys.stderr)
+        failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_mim_sssom_divergence.py
+++ b/scripts/audit_mim_sssom_divergence.py
@@ -186,9 +186,24 @@ def collect(normalized_dir: Path) -> dict[str, Counter]:
     return by_name, display, labels
 
 
-def audit(normalized_dir: Path, sssom_path: Path) -> tuple[list[dict[str, str]], str]:
+def audit(normalized_dir: Path, sssom_path: Path
+          ) -> tuple[list[dict[str, str]], str, dict[str, int]]:
+    """Findings, the SSSOM version, and how much of the corpus was comparable."""
     mim, version = load_sssom(sssom_path)
     by_name, display, labels = collect(normalized_dir)
+
+    # Coverage is part of the result, not a footnote. MIM's exactMatch labels
+    # reach 517 of our 3,519 distinct names -- 14.7% -- though those are the
+    # common reagents and carry 60.6% of rows. A gate that sees a seventh of the
+    # names must say so, or a green run reads as "we agree with MIM" when it
+    # mostly means "MIM has not looked at these".
+    coverage = {
+        "our_names": len(by_name),
+        "matched_names": sum(1 for name in by_name if name in mim),
+        "our_rows": sum(sum(counts.values()) for counts in by_name.values()),
+        "matched_rows": sum(sum(counts.values())
+                            for name, counts in by_name.items() if name in mim),
+    }
 
     def described(chebi_ids) -> str:
         return "|".join(f"{cid}={labels.get(cid, '?')}" for cid in chebi_ids)
@@ -232,7 +247,7 @@ def audit(normalized_dir: Path, sssom_path: Path) -> tuple[list[dict[str, str]],
                 "rows": str(ungrounded),
                 "detail": "MIM grounds this name and we do not",
             })
-    return rows, version
+    return rows, version, coverage
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -256,7 +271,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
-    rows, version = audit(args.normalized_dir, args.sssom)
+    rows, version, coverage = audit(args.normalized_dir, args.sssom)
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w", newline="", encoding="utf-8") as handle:
@@ -277,6 +292,15 @@ def main(argv: list[str] | None = None) -> int:
     for finding in FINDINGS:
         print(f"  {finding:18s} {tally.get(finding, 0):4d} names "
               f"({affected.get(finding, 0):,} rows)")
+
+    name_pct = 100 * coverage["matched_names"] / max(coverage["our_names"], 1)
+    row_pct = 100 * coverage["matched_rows"] / max(coverage["our_rows"], 1)
+    print(f"\n  comparable: {coverage['matched_names']:,} of "
+          f"{coverage['our_names']:,} names ({name_pct:.1f}%), "
+          f"{coverage['matched_rows']:,} of {coverage['our_rows']:,} rows "
+          f"({row_pct:.1f}%)")
+    print("  the rest are names MIM's exactMatch labels do not cover, so this "
+          "gate cannot see them")
 
     relative = (args.out.relative_to(REPO_ROOT)
                 if args.out.is_relative_to(REPO_ROOT) else args.out)

--- a/tests/test_audit_mim_sssom_divergence.py
+++ b/tests/test_audit_mim_sssom_divergence.py
@@ -81,7 +81,7 @@ def test_a_mediadive_term_id_does_not_hide_the_chebi_grounding(aud, tmp_path):
         "chebi_term": {"id": "CHEBI:17234", "label": "glucose"},
     }]}])
 
-    rows, version = aud.audit(corpus, sssom)
+    rows, version, _ = aud.audit(corpus, sssom)
     assert rows == []
     assert version == "2026-08-18"
 
@@ -91,7 +91,7 @@ def test_a_chebi_in_the_term_slot_is_still_found(aud, tmp_path):
     sssom = _sssom(tmp_path, [("Glucose", "skos:exactMatch", "CHEBI:17234", "glucose")])
     corpus = _corpus(tmp_path, [{"ingredients": [
         {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234", "label": "glucose"}}]}])
-    rows, _ = aud.audit(corpus, sssom)
+    rows, _, _ = aud.audit(corpus, sssom)
     assert rows == []
 
 
@@ -100,7 +100,7 @@ def test_a_real_divergence_is_reported(aud, tmp_path):
                                "ethylenediaminetetraacetic acid")])
     corpus = _corpus(tmp_path, [{"ingredients": [
         {"preferred_term": "EDTA", "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]}])
-    rows, _ = aud.audit(corpus, sssom)
+    rows, _, _ = aud.audit(corpus, sssom)
     finding = _by_finding(rows)["DIVERGENT"]
     assert finding["mim_id"] == "CHEBI:4735"
     assert "CHEBI:64755" in finding["our_ids"]
@@ -213,7 +213,7 @@ def test_every_reagent_location_is_compared(aud, tmp_path, doc):
     """Stock-solution records keep reagents in a top-level `composition:`, so an
     ingredients-only comparison would silently exempt them from the gate."""
     sssom = _sssom(tmp_path, [("EDTA", "skos:exactMatch", "CHEBI:4735", "EDTA acid")])
-    rows, _ = aud.audit(_corpus(tmp_path, [doc]), sssom)
+    rows, _, _ = aud.audit(_corpus(tmp_path, [doc]), sssom)
     assert _by_finding(rows)["DIVERGENT"]["mim_id"] == "CHEBI:4735"
 
 

--- a/tests/test_audit_mim_sssom_divergence.py
+++ b/tests/test_audit_mim_sssom_divergence.py
@@ -1,0 +1,235 @@
+"""Tests for the MIM SSSOM divergence audit (#256).
+
+The join is the whole risk here. Matching CultureMech ingredients to MIM subjects
+by name is easy to get subtly wrong in a way that manufactures disagreements —
+and because this is a ratchet, a manufactured disagreement gets baked into the
+baseline. So the tests concentrate on the two places the join can lie: which slot
+holds our CHEBI, and which SSSOM predicates count as a grounding verdict.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load():
+    path = REPO_ROOT / "scripts" / "audit_mim_sssom_divergence.py"
+    spec = importlib.util.spec_from_file_location("audit_mim_sssom_divergence", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_mim_sssom_divergence"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def aud():
+    return _load()
+
+
+SSSOM_HEADER = """\
+# curie_map:
+#   CHEBI: "http://purl.obolibrary.org/obo/CHEBI_"
+# mapping_set_version: "2026-08-18"
+"""
+COLUMNS = "subject_id\tsubject_label\tpredicate_id\tobject_id\tobject_label\n"
+
+
+def _sssom(tmp_path: Path, rows: list[tuple[str, str, str, str]]) -> Path:
+    path = tmp_path / "ingredient_mappings.sssom.tsv"
+    body = "".join(
+        f"MIM:{label.replace(' ', '_')}\t{label}\t{pred}\t{obj}\t{obj_label}\n"
+        for label, pred, obj, obj_label in rows
+    )
+    path.write_text(SSSOM_HEADER + COLUMNS + body)
+    return path
+
+
+def _corpus(tmp_path: Path, docs: list[dict]) -> Path:
+    root = tmp_path / "corpus"
+    (root / "bacterial").mkdir(parents=True)
+    for i, doc in enumerate(docs):
+        (root / "bacterial" / f"r{i}.yaml").write_text(yaml.safe_dump(doc))
+    return root
+
+
+def _by_finding(rows):
+    return {r["finding"]: r for r in rows}
+
+
+# --- which slot holds our CHEBI -------------------------------------------
+
+
+def test_a_mediadive_term_id_does_not_hide_the_chebi_grounding(aud, tmp_path):
+    """The bug that made 24,400 rows look divergent when they are not.
+
+    MediaDive-derived records keep the source's own id in `term.id` and the
+    ontology grounding in `chebi_term.id`. Reading only `term.id` compares
+    `mediadive.compound:5` against MIM's CHEBI and reports a disagreement that
+    does not exist.
+    """
+    sssom = _sssom(tmp_path, [("Glucose", "skos:exactMatch", "CHEBI:17234", "glucose")])
+    corpus = _corpus(tmp_path, [{"ingredients": [{
+        "preferred_term": "Glucose",
+        "term": {"id": "mediadive.compound:5", "label": "Glucose"},
+        "chebi_term": {"id": "CHEBI:17234", "label": "glucose"},
+    }]}])
+
+    rows, version = aud.audit(corpus, sssom)
+    assert rows == []
+    assert version == "2026-08-18"
+
+
+def test_a_chebi_in_the_term_slot_is_still_found(aud, tmp_path):
+    """Records without a MediaDive lineage put CHEBI directly in `term`."""
+    sssom = _sssom(tmp_path, [("Glucose", "skos:exactMatch", "CHEBI:17234", "glucose")])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234", "label": "glucose"}}]}])
+    rows, _ = aud.audit(corpus, sssom)
+    assert rows == []
+
+
+def test_a_real_divergence_is_reported(aud, tmp_path):
+    sssom = _sssom(tmp_path, [("EDTA", "skos:exactMatch", "CHEBI:4735",
+                               "ethylenediaminetetraacetic acid")])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "EDTA", "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]}])
+    rows, _ = aud.audit(corpus, sssom)
+    finding = _by_finding(rows)["DIVERGENT"]
+    assert finding["mim_id"] == "CHEBI:4735"
+    assert "CHEBI:64755" in finding["our_ids"]
+    assert finding["our_label_asserted"] == "CHEBI:64755=EDTA(2-)"
+
+
+# --- which SSSOM predicates count -----------------------------------------
+
+
+@pytest.mark.parametrize("predicate",
+                         ["skos:narrowMatch", "skos:broadMatch", "skos:closeMatch"])
+def test_only_exact_matches_are_treated_as_a_grounding_verdict(aud, tmp_path, predicate):
+    """A narrowMatch asserts a relationship, not an identity.
+
+    MIM maps `Dry cow-manure` narrowMatch to `ENVO:00003031 animal manure`.
+    Treating that as a grounding would manufacture a disagreement with any
+    sensible CHEBI we hold.
+    """
+    sssom = _sssom(tmp_path, [("EDTA", predicate, "CHEBI:4735", "EDTA acid")])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "EDTA", "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]}])
+    assert aud.audit(corpus, sssom)[0] == []
+
+
+def test_a_name_mim_maps_two_ways_is_skipped_not_guessed(aud, tmp_path):
+    """MIM has not settled it, so there is no verdict to compare against."""
+    sssom = _sssom(tmp_path, [
+        ("Citrate", "skos:exactMatch", "CHEBI:16947", "citrate(3-)"),
+        ("Citrate", "skos:exactMatch", "CHEBI:30769", "citric acid"),
+    ])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "Citrate", "chebi_term": {"id": "CHEBI:99999", "label": "x"}}]}])
+    assert aud.audit(corpus, sssom)[0] == []
+
+
+def test_a_non_chebi_object_is_not_a_chebi_verdict(aud, tmp_path):
+    sssom = _sssom(tmp_path, [("Dry cow-manure", "skos:exactMatch",
+                               "kgmicrobe.ingredient:dry_cow-manure", "Dry cow-manure")])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "Dry cow-manure",
+         "chebi_term": {"id": "CHEBI:12345", "label": "x"}}]}])
+    assert aud.audit(corpus, sssom)[0] == []
+
+
+# --- the other two findings -----------------------------------------------
+
+
+def test_one_name_grounded_two_ways_is_an_internal_split(aud, tmp_path):
+    """Independent of MIM, and the class most often a plain mistake:
+    `dipotassium phosphate` is CHEBI:131527 on 475 rows and CHEBI:63036 on 1."""
+    sssom = _sssom(tmp_path, [])
+    corpus = _corpus(tmp_path, [
+        {"ingredients": [{"preferred_term": "Vitamin B12",
+                          "chebi_term": {"id": "CHEBI:17439", "label": "a"}}]},
+        {"ingredients": [{"preferred_term": "vitamin b12",
+                          "chebi_term": {"id": "CHEBI:176843", "label": "b"}}]},
+    ])
+    finding = _by_finding(aud.audit(corpus, sssom)[0])["INTERNAL_SPLIT"]
+    assert finding["rows"] == "2"
+    assert "CHEBI:17439" in finding["our_ids"] and "CHEBI:176843" in finding["our_ids"]
+    assert "MIM has no opinion" in finding["detail"]
+
+
+def test_a_split_says_whether_mim_adjudicates_it(aud, tmp_path):
+    sssom = _sssom(tmp_path, [("Citric Acid", "skos:exactMatch", "CHEBI:30769",
+                               "citric acid")])
+    corpus = _corpus(tmp_path, [
+        {"ingredients": [{"preferred_term": "Citric Acid",
+                          "chebi_term": {"id": "CHEBI:30769", "label": "citric acid"}}]},
+        {"ingredients": [{"preferred_term": "Citric acid",
+                          "chebi_term": {"id": "CHEBI:53258", "label": "other"}}]},
+    ])
+    finding = _by_finding(aud.audit(corpus, sssom)[0])["INTERNAL_SPLIT"]
+    assert "MIM matches one of them" in finding["detail"]
+
+
+def test_a_name_mim_grounds_and_we_do_not_is_reported(aud, tmp_path):
+    sssom = _sssom(tmp_path, [("Biotin", "skos:exactMatch", "CHEBI:15956", "biotin")])
+    corpus = _corpus(tmp_path, [{"ingredients": [{"preferred_term": "Biotin"}]}])
+    finding = _by_finding(aud.audit(corpus, sssom)[0])["MISSING_GROUNDING"]
+    assert finding["mim_id"] == "CHEBI:15956"
+    assert finding["our_ids"] == ""
+
+
+def test_hydrates_are_not_folded_into_their_anhydrous_form(aud, tmp_path):
+    """Normalization folds whitespace and hyphens only.
+
+    `CaCl2 x 2 H2O` and `CaCl2` are different substances, and #256 records that
+    the hydrate is sometimes the term we model better than MIM. Folding digits or
+    punctuation would hide exactly that.
+    """
+    assert aud.normalize_name("CaCl2 x 2 H2O") != aud.normalize_name("CaCl2")
+    assert aud.normalize_name("Sodium-acetate") == aud.normalize_name("sodium acetate")
+    assert aud.normalize_name("  Yeast   extract ") == aud.normalize_name("yeast_extract")
+
+
+# --- reagents live in three places ----------------------------------------
+
+
+@pytest.mark.parametrize("doc", [
+    {"ingredients": [{"preferred_term": "EDTA",
+                      "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]},
+    {"composition": [{"preferred_term": "EDTA",
+                      "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]},
+    {"solutions": [{"preferred_term": "S", "composition": [
+        {"preferred_term": "EDTA",
+         "chebi_term": {"id": "CHEBI:64755", "label": "EDTA(2-)"}}]}]},
+])
+def test_every_reagent_location_is_compared(aud, tmp_path, doc):
+    """Stock-solution records keep reagents in a top-level `composition:`, so an
+    ingredients-only comparison would silently exempt them from the gate."""
+    sssom = _sssom(tmp_path, [("EDTA", "skos:exactMatch", "CHEBI:4735", "EDTA acid")])
+    rows, _ = aud.audit(_corpus(tmp_path, [doc]), sssom)
+    assert _by_finding(rows)["DIVERGENT"]["mim_id"] == "CHEBI:4735"
+
+
+# --- the gate -------------------------------------------------------------
+
+
+def test_the_gate_fails_when_a_baseline_is_exceeded(aud, tmp_path):
+    sssom = _sssom(tmp_path, [("EDTA", "skos:exactMatch", "CHEBI:4735", "EDTA acid")])
+    corpus = _corpus(tmp_path, [{"ingredients": [
+        {"preferred_term": "EDTA", "chebi_term": {"id": "CHEBI:64755", "label": "x"}}]}])
+    argv = ["--normalized-dir", str(corpus), "--sssom", str(sssom),
+            "--out", str(tmp_path / "r.tsv")]
+    assert aud.main([*argv, "--max-divergent", "1"]) == 0
+    assert aud.main([*argv, "--max-divergent", "0"]) == 1
+
+
+def test_a_missing_sssom_fails_with_a_usable_message(aud, tmp_path):
+    with pytest.raises(SystemExit, match="MIM SSSOM not found"):
+        aud.audit(tmp_path, tmp_path / "absent.tsv")

--- a/tests/test_audit_mim_sssom_divergence.py
+++ b/tests/test_audit_mim_sssom_divergence.py
@@ -185,6 +185,25 @@ def test_a_name_mim_grounds_and_we_do_not_is_reported(aud, tmp_path):
     assert finding["our_ids"] == ""
 
 
+def test_a_partly_grounded_name_still_reports_its_bare_rows(aud, tmp_path):
+    """The gap: requiring the name to be WHOLLY ungrounded hid 96 rows.
+
+    184 names carry some grounded rows and some bare ones; MIM has an opinion on
+    48 of them. `Pyrrole-2-carboxylic acid` is grounded on 1 row and bare on 18 —
+    the cheapest possible fix, since MIM has decided and most rows already agree.
+    """
+    sssom = _sssom(tmp_path, [("Biotin", "skos:exactMatch", "CHEBI:15956", "biotin")])
+    corpus = _corpus(tmp_path, [
+        {"ingredients": [{"preferred_term": "Biotin",
+                          "chebi_term": {"id": "CHEBI:15956", "label": "biotin"}}]},
+        {"ingredients": [{"preferred_term": "biotin"}]},
+        {"ingredients": [{"preferred_term": "Biotin"}]},
+    ])
+    finding = _by_finding(aud.audit(corpus, sssom)[0])["MISSING_GROUNDING"]
+    assert finding["rows"] == "2"
+    assert "1 are grounded" in finding["detail"]
+
+
 def test_hydrates_are_not_folded_into_their_anhydrous_form(aud, tmp_path):
     """Normalization folds whitespace and hyphens only.
 


### PR DESCRIPTION
Item 2 of #256's proposed work: **consume MIM's published SSSOM as a divergence check**, aligned to the latest release.

## Why this has to live here

kg-microbe resolves an ingredient with `best_primary([chebi_id, culturemech_term_id, mim_id, ...])`, so **our `term.id` outranks MIM's**. When MIM corrects a mapping the consumer still picks ours; MIM can only fix rows we hold no opinion on. Before this PR the only script reading `mappings/ingredient_mappings.sssom.tsv` was `audit_missing_roles.py`, and only for role coverage — **no grounding path read it at all**.

Aligned to MIM `mapping_set_version: 2026-08-18`, which the report records, so "which MIM release did we align to" is answerable from the artifact rather than from memory.

## The picture is much better than #256 recorded

```
DIVERGENT            12 names (879 rows)
INTERNAL_SPLIT       75 names (7,888 rows)
MISSING_GROUNDING    62 names (237 rows)
```

#256's headline was "6,680 divergent rows, 115 distinct names". Both sides have curated since. Of the cases it named by hand:

| ingredient | #256 | today |
|---|---|---|
| `glucose` | CHEBI:42758 aldehydo-D-glucose | **CHEBI:17234 — agrees with MIM** |
| `magnesium sulfate heptahydrate` | CHEBI:86463 **potassium aluminium sulfate** | **CHEBI:31795 — correct** |
| `mgso4·7h2o` vs `magnesium sulfate heptahydrate` | two ids for one substance | **both CHEBI:31795 — inconsistency gone** |
| `4-aminobenzoic acid` | CHEBI:194474 | **CHEBI:30753 — the term #256 preferred** |

MIM's `aba51551 Merge the aldehydo- duplicate pairs onto the class term (#398)` is what closed the glucose case from their side.

## The measurement needed care to be worth anything

Comparing `term.id` to MIM reports **24,400 false divergences**. MediaDive-derived records keep the source's own id there and the ontology grounding in `chebi_term.id`:

```yaml
term:       {id: mediadive.compound:5, label: Glucose}
chebi_term: {id: CHEBI:17234, label: glucose}
```

Reading `chebi_term` first drops it to 3,385 real ones. Two other guards: only `skos:exactMatch` counts (a `narrowMatch` asserts a relationship, not an identity — MIM maps `Dry cow-manure` narrowMatch to `ENVO:00003031 animal manure`), and a name MIM maps two ways is skipped rather than guessed at.

## Read-only, because divergence runs both ways

- `MgCl2 x 6 H2O` — our hydrate CHEBI:86345 against MIM's anhydrous CHEBI:6636. **Ours is better.**
- `Sodium phosphate dibasic` — our CHEBI:34683 (Na₂HPO₄) against MIM's CHEBI:37583 **trisodium phosphate**. Dibasic is Na₂HPO₄, so **MIM looks wrong** and this is worth reporting back.
- `EDTA` — our CHEBI:64755 EDTA(2-) against MIM's CHEBI:4735 neutral acid as supplied. **MIM is better.**

But one is not arguable, and the report surfaced it immediately:

> **`Cholesterol` → CHEBI:140435 = `cholesterol-2,2,3,4,4,6-d6`** — a deuterated mass-spec internal standard, not cholesterol. MIM's CHEBI:16113 is plainly right.

`INTERNAL_SPLIT` is independent of MIM and often unambiguous: `dipotassium phosphate` is CHEBI:131527 on 475 rows and CHEBI:63036 on **1**.

## The gate

```
just audit-mim-sssom      # --max-divergent 12 --max-split 75
```

Baselines are **names, not rows** — one regrounding decision fixes every row of a name, so names are what a curator works through. Verified to bite when lowered by one.

## Notes

- 17 tests, concentrated on the two places a name join can lie: which slot holds our CHEBI, and which predicates count as a verdict.
- Scans all three reagent locations, so stock-solution records are not silently exempt.
- Needs MediaIngredientMech checked out beside this repo; `--sssom` overrides, and a missing file fails with a usable message rather than an empty report.
- `derived_artifacts.tsv` refreshed. 1,309 tests pass, ruff clean.

**Not done here:** the actual regrounding. #256 is explicit that this "needs curation rather than a bulk overwrite", and this PR is what makes that curation reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
