### PR TITLE
Let client flags reach deep-research-client again (#297, #289)

### DIFF
--- a/docs/RESEARCH_ARTIFACT_CONTRACT.md
+++ b/docs/RESEARCH_ARTIFACT_CONTRACT.md
@@ -33,6 +33,22 @@ non-default focus, or use `research-entity`.
 
 `just research-focuses` prints the table below from the code.
 
+### Passing options to deep-research-client
+
+Client flags go after a `--` separator:
+
+```
+just research-entity claude_code ko2_no3 formulation --dry-run -- --max-cost 1
+just research-media  claude_code ko2_no3 --dry-run -- --max-cost 1
+```
+
+Without the separator, argparse claims the flag as one of the runner's own and
+rejects it (`unrecognized arguments: --max-cost`). That is #297, and until it was
+fixed no client flag was reachable through the runner at all — the unit tests
+missed it because they call `build_command` directly, where passthrough always
+worked. The separator itself is stripped before the command is built, so the
+child never sees a bare `--`.
+
 ### Focuses
 
 | focus | template | question it asks |

--- a/project.justfile
+++ b/project.justfile
@@ -47,6 +47,10 @@ fetch-raw-data:
 # here, which is what let `--focus formulation` rank providers for formulation
 # work and then research growth evidence anyway.
 #
+# Options for deep-research-client go after a `--` separator:
+#     just research-entity claude_code ko2_no3 formulation --dry-run -- --max-cost 1
+# Without it argparse claims the flag as the runner's own and rejects it (#297).
+#
 # `focus` is POSITIONAL, so flags must come after it:
 #     just research-entity claude_code ko2_no3 formulation --dry-run
 #     just research-entity claude_code ko2_no3 growth_evidence --dry-run

--- a/scripts/research_media.py
+++ b/scripts/research_media.py
@@ -532,8 +532,34 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Print the deep-research-client command without running it.",
     )
-    parser.add_argument("passthrough_args", nargs=argparse.REMAINDER)
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "passthrough_args",
+        nargs=argparse.REMAINDER,
+        help="Arguments for deep-research-client, after a `--` separator: "
+             "`... --target ko2_no3 -- --max-cost 1`",
+    )
+    args = parser.parse_args(argv)
+    args.passthrough_args = strip_separator(args.passthrough_args)
+    return args
+
+
+def strip_separator(passthrough: list[str]) -> list[str]:
+    """Drop the `--` that hands the rest of the line to deep-research-client.
+
+    `argparse.REMAINDER` on a positional does not capture a leading-`--` token
+    that appears before any positional — argparse claims it as an unknown option
+    first — so the documented `--max-cost 1` was simply rejected (#297):
+
+        research_media.py: error: unrecognized arguments: --max-cost
+
+    A `--` separator fixes that, but REMAINDER then captures the separator TOO,
+    and forwarding a bare `--` to the client makes it an argument of the child.
+    Stripping it here is what makes the conventional shape actually work.
+
+    Only a LEADING separator is removed. A later `--` belongs to the child (some
+    CLIs use it to mark their own positionals) and passing it on is correct.
+    """
+    return passthrough[1:] if passthrough and passthrough[0] == "--" else passthrough
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_research_media.py
+++ b/tests/test_research_media.py
@@ -188,6 +188,45 @@ def test_the_research_media_alias_takes_no_positional_focus():
     assert 'research-entity provider target focus="growth_evidence" *args=""' in recipes
 
 
+def test_client_flags_reach_the_client_after_a_separator():
+    """#297: every deep-research-client flag was unreachable through the runner.
+
+    `argparse.REMAINDER` on a positional does not capture a leading-`--` token
+    appearing before any positional — argparse claims it as an unknown option
+    first — so the documented form was simply rejected:
+
+        research_media.py: error: unrecognized arguments: --max-cost
+
+    The unit tests missed it because they call `build_command` directly, where
+    passthrough always worked. The break was purely in CLI argument routing.
+    """
+    args = parse_args(["--provider", "claude_code", "--target", "ko2_no3",
+                       "--dry-run", "--", "--max-cost", "1"])
+    assert args.passthrough_args == ["--max-cost", "1"]
+    assert args.dry_run is True
+
+    command = build_command(
+        provider="claude_code",
+        template=Path("templates/media_growth_research.md"),
+        output_file=Path("out.md"),
+        variables={},
+        passthrough_args=args.passthrough_args,
+    )
+    assert command[-2:] == ["--max-cost", "1"]
+    assert "--" not in command, "the separator must not be forwarded to the client"
+
+
+def test_only_the_leading_separator_is_stripped():
+    """A later `--` belongs to the child — some CLIs use it to mark their own
+    positionals — so passing it on is correct."""
+    from research_media import strip_separator
+
+    assert strip_separator(["--", "--max-cost", "1"]) == ["--max-cost", "1"]
+    assert strip_separator(["--", "-a", "--", "-b"]) == ["-a", "--", "-b"]
+    assert strip_separator(["--max-cost", "1"]) == ["--max-cost", "1"]
+    assert strip_separator([]) == []
+
+
 def test_the_recipes_quote_the_values_that_can_contain_spaces():
     """Record `name:` values contain spaces, and a target may be one.
 


### PR DESCRIPTION
Closes #297. Part of #289's "one consistent operational contract".

## The defect

`argparse.REMAINDER` on a positional does not capture a leading-`--` token that appears before any positional — argparse claims it as an unknown option first. So the documented way to pass client options simply failed:

```
$ ... --target ko2_no3 --max-cost 1 --dry-run
research_media.py: error: unrecognized arguments: --max-cost
```

**Every `deep-research-client` flag was unreachable through the runner**, and callers were silently limited to the defaults. Every recipe in the Research group ends with `{{args}}` and the skills advertise passing client options that way, so this had been quietly broken.

The existing tests missed it because they call `build_command` directly with `passthrough_args=["--max-cost", "1"]`, where passthrough always worked. The break was purely in CLI argument routing — so the new test is at that layer.

## The fix

A `--` separator fixes the routing, but `REMAINDER` then captures the separator **too**, and forwarding a bare `--` makes it an argument of the child. Stripping the leading one is what makes the conventional shape work:

```
$ just research-media claude_code ko2_no3 --dry-run -- --max-cost 1
... --provider claude_code --output research/media/bacterial/ko2_no3-...md --max-cost 1
```

Only the **leading** separator is removed. A later `--` belongs to the child — some CLIs use it to mark their own positionals — so it is passed on.

## Why not `parse_known_args`

It would forward this script's own typos to the client instead of rejecting them. `--focsu formulation` should be an error, not a mystery flag arriving at the child.

## Notes

- Documented in the recipe comment and in `docs/RESEARCH_ARTIFACT_CONTRACT.md`.
- Verified through both entry points — direct and via `just`.
- No provider called, no credits: `--dry-run` throughout.
- 26 tests in the runner suite, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
