### PR TITLE
Validate provider_adjustments and stage capabilities keys

### DIFF
--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -228,6 +228,9 @@ PROVIDERS: dict[str, Provider] = {
 }
 
 ALIASES = {"edison": "falcon", "futurehouse": "falcon", "claude-code": "claude_code"}
+_ALL_CAPABILITIES = frozenset(
+    cap for provider in PROVIDERS.values() for cap in provider.capabilities
+)
 COST_VALUE = {"low": 1, "medium": 2, "high": 3, "very_high": 4}
 TIME_VALUE = {"fast": 1, "medium": 2, "slow": 3, "very_slow": 4}
 SYNTHESIS_VALUE = {"none": 0, "summary": 1, "deep": 2, "agentic": 3}
@@ -345,6 +348,36 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities must be a mapping"
                 )
+            unknown_caps = set(capabilities) - _ALL_CAPABILITIES
+            if unknown_caps:
+                raise ValueError(
+                    f"Stage {focus_name}.{stage_name}.capabilities names unknown "
+                    f"capability/ies {sorted(unknown_caps)}; no provider declares "
+                    f"them, so they would silently score 0"
+                )
+        adjustments = focus.get("provider_adjustments")
+        if adjustments is not None:
+            if not isinstance(adjustments, dict):
+                raise ValueError(
+                    f"Focus {focus_name!r}.provider_adjustments must be a mapping"
+                )
+            canonical: dict[str, Any] = {}
+            for raw_name, value in adjustments.items():
+                name = canonical_provider(str(raw_name))
+                if name not in PROVIDERS:
+                    raise ValueError(
+                        f"Focus {focus_name!r}.provider_adjustments names unknown "
+                        f"provider {raw_name!r} (resolved to {name!r}); "
+                        f"known providers: {', '.join(sorted(PROVIDERS))}"
+                    )
+                if name in canonical:
+                    raise ValueError(
+                        f"Focus {focus_name!r}.provider_adjustments has multiple "
+                        f"keys resolving to provider {name!r} (e.g. {raw_name!r}); "
+                        f"use a single canonical key per provider"
+                    )
+                canonical[name] = value
+            focus["provider_adjustments"] = canonical
     return data
 
 
@@ -376,7 +409,18 @@ def rank_stage(
         name: _score(provider, stage, adjustments)
         for name, provider in PROVIDERS.items()
     }
-    high = max(raw.values()) or 1.0
+    # `or 1.0` only replaces an exact-zero max (e.g. every raw score landing
+    # at precisely 0 through cancelling adjustments) — a real, if rare, case
+    # this guards. It does NOT fix the harder case where every score is
+    # negative: fit is 0/high either way there (0.0 divided by any nonzero
+    # number is 0.0), so the ranking still collapses to alphabetical order
+    # once every candidate is "actively bad" rather than merely "not the
+    # best." That needs a different normalization (e.g. min-max instead of
+    # max-only) and is a real design decision, not a one-line fix — see
+    # CultureMech#315.
+    high = max(raw.values())
+    if high <= 0:
+        high = 1.0
     rows = []
     for name, provider in PROVIDERS.items():
         status, reason = provider_status(name)

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -548,8 +548,7 @@ def print_report(report: Mapping[str, Any], provider_name: str | None = None) ->
             if fallback:
                 message += f"; cross-check/fallback: {fallback['provider']}"
             print(message)
-        elif any(row["status"] == "available" and row["provider"] != "mock"
-                 for row in stage["ranking"]):
+        elif recommendable(stage["ranking"]):
             print(
                 "Route now: no provider passes the current --allow/--no-paid "
                 "filters, though at least one is otherwise available."

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -548,6 +548,12 @@ def print_report(report: Mapping[str, Any], provider_name: str | None = None) ->
             if fallback:
                 message += f"; cross-check/fallback: {fallback['provider']}"
             print(message)
+        elif any(row["status"] == "available" and row["provider"] != "mock"
+                 for row in stage["ranking"]):
+            print(
+                "Route now: no provider passes the current --allow/--no-paid "
+                "filters, though at least one is otherwise available."
+            )
         else:
             print(
                 "Route now: no real provider is currently available; configure a listed credential or CLI."
@@ -601,8 +607,12 @@ def main(argv: list[str] | None = None) -> int:
             f"Unknown provider {args.provider!r}; choose one of: {', '.join(PROVIDERS)}"
         )
     allow = (frozenset(canonical_provider(p) for p in args.allow.split(",") if p.strip())
-             if args.allow else None)
+             if args.allow is not None else None)
     if allow is not None:
+        if not allow:
+            raise ValueError(
+                f"--allow {args.allow!r} did not contain any provider names"
+            )
         unknown = allow - set(PROVIDERS)
         if unknown:
             raise ValueError(

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -348,7 +348,7 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities must be a mapping"
                 )
-            unknown_caps = set(capabilities) - _ALL_CAPABILITIES
+            unknown_caps = {str(cap) for cap in capabilities} - _ALL_CAPABILITIES
             if unknown_caps:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities names unknown "

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -356,6 +356,24 @@ def load_config(path: Path) -> dict[str, Any]:
                     f"them, so they would silently score 0. Choose one of: "
                     f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
+            # Same null-vs-absent gap as provider_adjustments below, for the
+            # values _score() calls float() on: an explicit
+            # `capabilities: {academic_search: null}` or `synthesis_weight:
+            # null` loaded successfully and crashed later in _score with an
+            # uncaught TypeError instead of a clean ValueError here.
+            for cap_name, cap_weight in capabilities.items():
+                if not isinstance(cap_weight, (int, float)) or isinstance(cap_weight, bool):
+                    raise ValueError(
+                        f"Stage {focus_name}.{stage_name}.capabilities[{cap_name!r}] "
+                        f"must be a number, got {cap_weight!r}"
+                    )
+            for weight_key in ("synthesis_weight", "speed_weight", "cost_weight"):
+                weight = stage.get(weight_key, 0)
+                if not isinstance(weight, (int, float)) or isinstance(weight, bool):
+                    raise ValueError(
+                        f"Stage {focus_name}.{stage_name}.{weight_key} must be a "
+                        f"number, got {weight!r}"
+                    )
         # .get(key, {}) only supplies the default when the key is ABSENT — an
         # explicit YAML `provider_adjustments: null` still returns None here,
         # so the isinstance check below (unconditional, like the sibling
@@ -623,6 +641,11 @@ def main(argv: list[str] | None = None) -> int:
         if unknown:
             raise ValueError(
                 f"Unknown provider(s) in --allow: {', '.join(sorted(unknown))}"
+            )
+        if "mock" in allow:
+            raise ValueError(
+                "--allow may not include 'mock': recommendable() always excludes "
+                "it, so it can never be recommended regardless of --allow"
             )
     report = build_report(config, focus_name, allow=allow, no_paid=args.no_paid)
     if args.json:

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -353,7 +353,8 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities names unknown "
                     f"capability/ies {sorted(unknown_caps)}; no provider declares "
-                    f"them, so they would silently score 0"
+                    f"them, so they would silently score 0. Known capabilities: "
+                    f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
         adjustments = focus.get("provider_adjustments")
         if adjustments is not None:

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -402,6 +402,11 @@ def load_config(path: Path) -> dict[str, Any]:
                         f"keys resolving to provider {name!r} (e.g. {raw_name!r}); "
                         f"use a single canonical key per provider"
                     )
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    raise ValueError(
+                        f"Focus {focus_name!r}.provider_adjustments[{raw_name!r}] "
+                        f"must be a number, got {value!r}"
+                    )
                 canonical[name] = value
             focus["provider_adjustments"] = canonical
     return data

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -353,7 +353,7 @@ def load_config(path: Path) -> dict[str, Any]:
                 raise ValueError(
                     f"Stage {focus_name}.{stage_name}.capabilities names unknown "
                     f"capability/ies {sorted(unknown_caps)}; no provider declares "
-                    f"them, so they would silently score 0. Known capabilities: "
+                    f"them, so they would silently score 0. Choose one of: "
                     f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
         adjustments = focus.get("provider_adjustments")
@@ -369,7 +369,7 @@ def load_config(path: Path) -> dict[str, Any]:
                     raise ValueError(
                         f"Focus {focus_name!r}.provider_adjustments names unknown "
                         f"provider {raw_name!r} (resolved to {name!r}); "
-                        f"known providers: {', '.join(sorted(PROVIDERS))}"
+                        f"choose one of: {', '.join(sorted(PROVIDERS))}"
                     )
                 if name in canonical:
                     raise ValueError(

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -356,12 +356,19 @@ def load_config(path: Path) -> dict[str, Any]:
                     f"them, so they would silently score 0. Choose one of: "
                     f"{', '.join(sorted(_ALL_CAPABILITIES))}"
                 )
-        adjustments = focus.get("provider_adjustments")
-        if adjustments is not None:
-            if not isinstance(adjustments, dict):
-                raise ValueError(
-                    f"Focus {focus_name!r}.provider_adjustments must be a mapping"
-                )
+        # .get(key, {}) only supplies the default when the key is ABSENT — an
+        # explicit YAML `provider_adjustments: null` still returns None here,
+        # so the isinstance check below (unconditional, like the sibling
+        # `capabilities` check above) must run either way. It used to be
+        # guarded behind `if adjustments is not None:`, silently skipping
+        # validation for a null block and crashing later in
+        # rank_stage/_score with AttributeError instead of this ValueError.
+        adjustments = focus.get("provider_adjustments", {})
+        if not isinstance(adjustments, dict):
+            raise ValueError(
+                f"Focus {focus_name!r}.provider_adjustments must be a mapping"
+            )
+        if adjustments:
             canonical: dict[str, Any] = {}
             for raw_name, value in adjustments.items():
                 name = canonical_provider(str(raw_name))

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -269,6 +269,38 @@ def test_exact_zero_max_score_does_not_divide_by_zero(monkeypatch):
     assert all(row["fit"] == 0 for row in rows)
 
 
+def test_negative_nonzero_max_score_does_not_divide_by_zero_either(monkeypatch):
+    """Distinct code path from the exact-zero test above (max(raw.values())
+    is a genuinely negative number here, not exactly 0, so this exercises
+    the `high <= 0` half of the guard's condition rather than only the
+    `high == 0` half). The *outcome* is unavoidably identical either way —
+    `fit = round(100 * max(0.0, raw[name]) / high)` clamps any negative raw
+    score to 0.0 in the numerator before the division even happens, so no
+    test can make the divisor's value (old `or 1.0`'s actual-negative-number
+    vs. this guard's 1.0 fallback) produce a different result. That's
+    exactly the CultureMech#315 problem: for negative scores, `high`'s value
+    is provably irrelevant. This test only pins down "doesn't crash and
+    yields 0" for a non-uniform negative distribution, which the exact-zero
+    test's uniform-zero input doesn't exercise."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+    # Every provider negative, but not uniformly so — max(raw.values()) is a
+    # genuinely negative number rather than exactly 0.
+    config["focuses"][focus_name]["provider_adjustments"] = {
+        name: (-2 if name == "asta" else -1) for name in drp.PROVIDERS
+    }
+
+    rows = drp.rank_stage(config, focus_name, stage_name)  # must not raise ZeroDivisionError
+    assert all(row["fit"] == 0 for row in rows)
+
+
 # --- policy and machine-readable consistency (#290) ------------------------
 
 

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -164,6 +164,26 @@ def test_stage_capabilities_unknown_key_is_rejected(tmp_path):
         drp.load_config(profile)
 
 
+def test_stage_capabilities_yaml_bool_key_still_raises_value_error(tmp_path):
+    """PyYAML's safe_load (YAML 1.1) parses an unquoted `no:` key as the
+    Python bool False. Mixed into a dict with a genuine unknown string
+    capability, `sorted(unknown_caps)` used to raise TypeError comparing
+    str to bool instead of the intended ValueError."""
+    profile = tmp_path / "boolkey.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        capabilities:\n"
+        "          no: 5\n"
+        "          acadmic_search: 3\n"
+    )
+    with pytest.raises(ValueError, match="unknown capability"):
+        drp.load_config(profile)
+
+
 def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
     """Config-loading validation alone doesn't prove the bonus reaches the
     ranking — this proves it does."""

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -28,6 +28,17 @@ def _run_json(extra):
     return json.loads(buf.getvalue())
 
 
+def _run_text(extra):
+    """Run main() without --json and return the printed text."""
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        drp.main(["--config", str(CONFIG_PATH), *extra])
+    return buf.getvalue()
+
+
 def test_profile_has_domain_specific_default_and_three_stage_triage():
     config = drp.load_config(CONFIG_PATH)
     focus = config["focuses"][config["default_focus"]]
@@ -263,3 +274,41 @@ def test_an_allowlist_confines_the_recommendation(monkeypatch):
 def test_an_unknown_provider_in_the_allowlist_is_rejected():
     with pytest.raises(ValueError, match="Unknown provider"):
         drp.main(["--config", str(CONFIG_PATH), "--allow", "not_a_provider"])
+
+
+def test_recommendable_no_paid_actually_excludes_a_high_cost_row():
+    """test_no_paid_keeps_the_medium_cost_provider above can pass even with
+    no_paid filtering fully removed, if the ambient environment never makes a
+    genuinely paid provider available. This exercises recommendable()
+    directly against a hand-built row set that guarantees a high-cost
+    candidate is in contention, so the filter has something real to
+    exclude."""
+    rows = [
+        {"provider": "cheap", "status": "available", "cost": "low"},
+        {"provider": "pricey", "status": "available", "cost": "very_high"},
+    ]
+    with_paid = drp.recommendable(rows, no_paid=False)
+    without_paid = drp.recommendable(rows, no_paid=True)
+    assert {r["provider"] for r in with_paid} == {"cheap", "pricey"}
+    assert {r["provider"] for r in without_paid} == {"cheap"}
+
+
+def test_an_empty_allowlist_string_is_rejected():
+    """--allow "" (an explicitly empty string, distinct from omitting the flag
+    entirely) used to be indistinguishable from "not passed" because Python
+    treats "" as falsy — `if args.allow` silently fell through to allow=None,
+    bypassing the "did not contain any provider names" check below it and
+    recommending with no filtering at all."""
+    with pytest.raises(ValueError, match="did not contain any provider names"):
+        drp.main(["--config", str(CONFIG_PATH), "--allow", ""])
+
+
+def test_policy_filtered_empty_recommendation_names_the_actual_cause(monkeypatch):
+    """The fallback "no real provider is currently available; configure a
+    listed credential or CLI" message predates --allow/--no-paid and is wrong
+    when one of those, not missing credentials, emptied the recommendation:
+    real, working providers exist but were excluded by policy, not absence."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    out = _run_text(["--allow", "openai"])
+    assert "no provider passes the current --allow/--no-paid filters" in out
+    assert "configure a listed credential or CLI" not in out

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -85,6 +85,119 @@ def test_unknown_default_focus_is_rejected(tmp_path):
         drp.load_config(profile)
 
 
+# --- provider_adjustments / capabilities validation -------------------------
+
+
+def test_provider_adjustments_alias_key_is_canonicalized(tmp_path):
+    profile = tmp_path / "aliased.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      edison: 3\n"
+        "      Claude Code: 2\n"
+    )
+    config = drp.load_config(profile)
+    adjustments = config["focuses"]["f"]["provider_adjustments"]
+    assert adjustments == {"falcon": 3, "claude_code": 2}
+
+
+def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
+    profile = tmp_path / "typo.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      flacon: 3\n"  # typo of "falcon"
+    )
+    with pytest.raises(ValueError, match="unknown provider"):
+        drp.load_config(profile)
+
+
+def test_provider_adjustments_colliding_aliases_are_rejected(tmp_path):
+    """Two raw keys that canonicalize to the same provider (edison/falcon)
+    must not silently let the second overwrite the first."""
+    profile = tmp_path / "collision.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      edison: 3\n"
+        "      falcon: 5\n"
+    )
+    with pytest.raises(ValueError, match="multiple"):
+        drp.load_config(profile)
+
+
+def test_stage_capabilities_unknown_key_is_rejected(tmp_path):
+    profile = tmp_path / "badcap.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        capabilities:\n"
+        "          acadmic_search: 5\n"  # typo of "academic_search"
+    )
+    with pytest.raises(ValueError, match="unknown capability"):
+        drp.load_config(profile)
+
+
+def test_provider_adjustment_actually_changes_rank_order(monkeypatch):
+    """Config-loading validation alone doesn't prove the bonus reaches the
+    ranking — this proves it does."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+
+    baseline = drp.rank_stage(config, focus_name, stage_name)
+    target = min(baseline, key=lambda row: row["fit"])["provider"]
+    baseline_fit = {row["provider"]: row["fit"] for row in baseline}
+
+    config["focuses"][focus_name]["provider_adjustments"] = {target: 1000}
+    boosted = drp.rank_stage(config, focus_name, stage_name)
+    boosted_fit = {row["provider"]: row["fit"] for row in boosted}
+
+    assert boosted_fit[target] > baseline_fit[target]
+    assert boosted[0]["provider"] == target
+
+
+def test_exact_zero_max_score_does_not_divide_by_zero(monkeypatch):
+    """`high = max(raw.values()); if high <= 0: high = 1.0` exists to guard
+    an exact-zero max (every raw score landing at 0, e.g. through cancelling
+    adjustments) from a ZeroDivisionError. It does NOT make the ranking
+    meaningful when every score is negative — that's CultureMech#315, a
+    separate, harder problem (0.0 divided by any nonzero number, positive or
+    negative, is still 0.0, so this guard is a no-op for the negative case).
+    This test covers only what the guard actually does."""
+    monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    # Zero out every capability weight and adjustment so every raw score is
+    # exactly 0.0 — the precise edge case `or 1.0` was written for.
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+    config["focuses"][focus_name]["provider_adjustments"] = {}
+
+    rows = drp.rank_stage(config, focus_name, stage_name)  # must not raise ZeroDivisionError
+    assert all(row["fit"] == 0 for row in rows)
+
+
 # --- policy and machine-readable consistency (#290) ------------------------
 
 

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -116,6 +116,26 @@ def test_provider_adjustments_alias_key_is_canonicalized(tmp_path):
     assert adjustments == {"falcon": 3, "claude_code": 2}
 
 
+def test_provider_adjustments_explicit_null_is_rejected(tmp_path):
+    """focus.get("provider_adjustments", {}) only supplies the {} default
+    when the key is absent — an explicit YAML `provider_adjustments: null`
+    still returns None, which used to skip validation entirely (guarded
+    behind `if adjustments is not None:`) and crash later in
+    rank_stage/_score with AttributeError instead of this clean
+    ValueError."""
+    profile = tmp_path / "nulladj.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments: null\n"
+    )
+    with pytest.raises(ValueError, match="provider_adjustments must be a mapping"):
+        drp.load_config(profile)
+
+
 def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
     profile = tmp_path / "typo.yaml"
     profile.write_text(

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -272,7 +272,7 @@ def test_exact_zero_max_score_does_not_divide_by_zero(monkeypatch):
 # --- policy and machine-readable consistency (#290) ------------------------
 
 
-def test_a_measured_dead_provider_is_not_recommended():
+def test_a_measured_dead_provider_is_not_recommended(monkeypatch):
     """The tool used to contradict the justfile beside it.
 
     #284 measured falcon returning HTTP 402 and cyberian HTTP 500, and recorded
@@ -284,11 +284,23 @@ def test_a_measured_dead_provider_is_not_recommended():
     assert "402" in reason
     assert "secret" not in reason
 
+    # Exercise the override end-to-end through rank_stage/build_report, not
+    # just the direct provider_status() call above. With no credentials set
+    # at all every provider is "unavailable" and recommended_available is
+    # None for an unrelated reason, making an assertion against
+    # build_report() vacuous unless falcon is actually made
+    # "available"-but-blocked here.
+    monkeypatch.setenv("EDISON_API_KEY", "test-only")
     config = drp.load_config(CONFIG_PATH)
     report = drp.build_report(config, config["default_focus"])
     for stage in report["stages"]:
-        recommended = stage["recommended_available"]
-        assert recommended is None or recommended["provider"] not in drp.KNOWN_BLOCKED
+        falcon_row = next(row for row in stage["ranking"] if row["provider"] == "falcon")
+        assert falcon_row["status"] == "blocked"
+        # Checking recommended_available's None-or-not-blocked would still
+        # pass vacuously if nothing else happens to be available either —
+        # assert against recommendable() directly instead, which has no
+        # None-branch escape hatch.
+        assert "falcon" not in {row["provider"] for row in drp.recommendable(stage["ranking"])}
 
 
 def test_provider_filtered_json_never_recommends_a_provider_it_did_not_rank(monkeypatch):

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -316,6 +316,50 @@ def test_an_unknown_provider_in_the_allowlist_is_rejected():
         drp.main(["--config", str(CONFIG_PATH), "--allow", "not_a_provider"])
 
 
+def test_allow_mock_is_rejected_rather_than_silently_unrecommendable():
+    """mock passes the "is it a known provider" check in --allow (it's a real
+    PROVIDERS key), but recommendable() unconditionally excludes it — so
+    --allow mock used to run without error and silently never recommend
+    anything, with no diagnostic explaining why."""
+    with pytest.raises(ValueError, match="mock"):
+        drp.main(["--config", str(CONFIG_PATH), "--allow", "mock"])
+
+
+def test_stage_capability_null_weight_is_rejected(tmp_path):
+    """Same null-vs-absent gap as provider_adjustments, for the values
+    _score() calls float() on: an explicit `capabilities: {x: null}` used to
+    load successfully and crash later in _score with an uncaught TypeError
+    instead of this clean ValueError."""
+    profile = tmp_path / "nullcap.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        capabilities:\n"
+        "          academic_search: null\n"
+    )
+    with pytest.raises(ValueError, match="must be a number"):
+        drp.load_config(profile)
+
+
+def test_stage_weight_scalar_null_is_rejected(tmp_path):
+    """Same gap as above, for the stage-level synthesis_weight/speed_weight/
+    cost_weight scalars."""
+    profile = tmp_path / "nullweight.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        synthesis_weight: null\n"
+    )
+    with pytest.raises(ValueError, match="synthesis_weight must be a number"):
+        drp.load_config(profile)
+
+
 def test_recommendable_no_paid_actually_excludes_a_high_cost_row():
     """test_no_paid_keeps_the_medium_cost_provider above can pass even with
     no_paid filtering fully removed, if the ambient environment never makes a

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -329,6 +329,11 @@ def test_policy_filtered_empty_recommendation_names_the_actual_cause(monkeypatch
     when one of those, not missing credentials, emptied the recommendation:
     real, working providers exist but were excluded by policy, not absence."""
     monkeypatch.setenv("ASTA_API_KEY", "test-only")
+    # An ambient OPENAI_API_KEY would make the --allow'd openai itself
+    # "available", taking the pre-existing recommended-provider branch instead
+    # of the one this test exercises — this test asserts an exact message, so
+    # unlike its permissive siblings it cannot tolerate that.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     out = _run_text(["--allow", "openai"])
     assert "no provider passes the current --allow/--no-paid filters" in out
     assert "configure a listed credential or CLI" not in out

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -136,6 +136,26 @@ def test_provider_adjustments_explicit_null_is_rejected(tmp_path):
         drp.load_config(profile)
 
 
+def test_provider_adjustments_null_value_is_rejected(tmp_path):
+    """The key-shape validation above (unknown/duplicate keys) never checked
+    that the VALUE is numeric — a profile with provider_adjustments:
+    {asta: null} loaded cleanly and crashed later in _score's
+    float(adjustments.get(...)) with an uncaught TypeError instead of this
+    ValueError."""
+    profile = tmp_path / "nulladjvalue.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      asta: null\n"
+    )
+    with pytest.raises(ValueError, match="must be a number"):
+        drp.load_config(profile)
+
+
 def test_provider_adjustments_unknown_key_is_rejected(tmp_path):
     profile = tmp_path / "typo.yaml"
     profile.write_text(
@@ -357,6 +377,58 @@ def test_stage_weight_scalar_null_is_rejected(tmp_path):
         "        synthesis_weight: null\n"
     )
     with pytest.raises(ValueError, match="synthesis_weight must be a number"):
+        drp.load_config(profile)
+
+
+def test_stage_capability_bool_weight_is_rejected(tmp_path):
+    """bool is a subclass of int, so isinstance(cap_weight, (int, float))
+    alone would silently accept a YAML boolean (e.g. an unquoted `yes`) as a
+    1.0/0.0 weight. The explicit `or isinstance(cap_weight, bool)` exclusion
+    guards against that; this pins it down so the exclusion clause can't be
+    silently dropped or inverted without a test failing."""
+    profile = tmp_path / "boolcap.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        capabilities:\n"
+        "          academic_search: true\n"
+    )
+    with pytest.raises(ValueError, match="must be a number"):
+        drp.load_config(profile)
+
+
+def test_stage_weight_scalar_bool_is_rejected(tmp_path):
+    """Same bool-vs-int gap as the capability weight above, for the
+    stage-level weight scalars."""
+    profile = tmp_path / "boolweight.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery:\n"
+        "        speed_weight: true\n"
+    )
+    with pytest.raises(ValueError, match="speed_weight must be a number"):
+        drp.load_config(profile)
+
+
+def test_provider_adjustments_bool_value_is_rejected(tmp_path):
+    """Same bool-vs-int gap, for provider_adjustments values."""
+    profile = tmp_path / "booladj.yaml"
+    profile.write_text(
+        "default_focus: f\n"
+        "focuses:\n"
+        "  f:\n"
+        "    stages:\n"
+        "      discovery: {}\n"
+        "    provider_adjustments:\n"
+        "      asta: true\n"
+    )
+    with pytest.raises(ValueError, match="must be a number"):
         drp.load_config(profile)
 
 

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -302,15 +302,18 @@ def test_recommendable_no_paid_actually_excludes_a_high_cost_row():
     genuinely paid provider available. This exercises recommendable()
     directly against a hand-built row set that guarantees a high-cost
     candidate is in contention, so the filter has something real to
-    exclude."""
+    exclude. Also guards PAID_COSTS itself: mutation-verified that without a
+    medium-cost row in contention, nothing catches PAID_COSTS silently
+    growing to include "medium"."""
     rows = [
         {"provider": "cheap", "status": "available", "cost": "low"},
+        {"provider": "midpriced", "status": "available", "cost": "medium"},
         {"provider": "pricey", "status": "available", "cost": "very_high"},
     ]
     with_paid = drp.recommendable(rows, no_paid=False)
     without_paid = drp.recommendable(rows, no_paid=True)
-    assert {r["provider"] for r in with_paid} == {"cheap", "pricey"}
-    assert {r["provider"] for r in without_paid} == {"cheap"}
+    assert {r["provider"] for r in with_paid} == {"cheap", "midpriced", "pricey"}
+    assert {r["provider"] for r in without_paid} == {"cheap", "midpriced"}
 
 
 def test_an_empty_allowlist_string_is_rejected():


### PR DESCRIPTION
## Summary
Adds `provider_adjustments`/`capabilities`-key validation to this canonical copy of `scripts/deep_research_provider.py`:

- `provider_adjustments` keys are canonicalized and validated against known providers at config-load time — a typo'd or aliased key no longer silently no-ops. Also rejects two raw keys (e.g. `edison`/`falcon`) that canonicalize to the same provider, which would otherwise let the second silently overwrite the first. Also rejects an explicit `provider_adjustments: null` block, which used to skip validation entirely (guarded behind `if adjustments is not None:`) and crash later in `rank_stage`/`_score` with `AttributeError` instead of a clean `ValueError` — and, separately, rejects a non-numeric `provider_adjustments` *value* (including an explicit `null`), which crashed the same way in `_score`'s `float(adjustments.get(...))`.
- Stage `capabilities` keys are validated against the union of capabilities any `PROVIDERS` entry actually declares, mirroring the `provider_adjustments` check — a typo'd capability key previously contributed 0 to every provider's score with no error. Capability dict keys are coerced to `str` before diffing, closing a `TypeError` when YAML 1.1 parses an unquoted key like `no:` as bool `False`. Capability weight *values* and the stage-level `synthesis_weight`/`speed_weight`/`cost_weight` scalars are validated numeric too (including rejecting a YAML boolean, since `bool` subclasses `int`), for the same crash-vs-clean-error reason.

**Provenance correction** (an earlier revision of this description got this backwards): this PR is the *originating* fix, not a port. ProteinTraitsMech#487, MediaIngredientMech#412, and CommunityMech#657 (the spoke PRs originally cited as the source) do **not** contain any of this validation — none of them, verified directly. The three spoke ports that actually carry this logic (ProteinTraitsMech#514, MediaIngredientMech#418, CommunityMech#662) are downstream of *this* PR, still open pending it, and each states so in its own description. CultureMech#328 tracks that dependency. Flagged by dynamic-review.

**Beyond the validation work above**, review while backporting proteintraitsmech#514's fixes into this same branch surfaced several more real, independent gaps that are now also fixed here:
- `--allow ""` (an explicit empty string) used to be indistinguishable from omitting the flag, silently disabling all `--allow` filtering — a real policy-bypass bug, not a doc nit. Now rejected with the same "did not contain any provider names" error as other empty-after-strip `--allow` values.
- `--allow mock` passed validation (mock is a real `PROVIDERS` key) but `recommendable()` unconditionally excludes it — structurally impossible to recommend regardless of `--allow`. Now rejected explicitly.
- `print_report`'s fallback message was wrong when `--allow`/`--no-paid` policy, not missing credentials, emptied a stage's recommendation; it now names the actual cause and routes through the single `recommendable()` helper rather than re-implementing its filter as a second, independently-maintained condition.
- `test_a_measured_dead_provider_is_not_recommended`'s end-to-end assertion was vacuous under real CI conditions (no credential set at all, and even after fixing that, a `None`-branch escape hatch let it pass regardless of whether the block was actually enforced) — reproduced live, fixed to assert against `recommendable()` directly.

Also documents (does **not** fully fix) a real, separate gap found while porting: `high = max(raw.values()) or 1.0` only guards an exact-zero max. When every provider's adjusted score is negative, `fit` is `0/high` either way (0.0 divided by any nonzero number, positive or negative, is still 0.0), so the ranking still collapses to alphabetical order. Fixing that needs a real normalization design decision (min-max vs. the current absolute-zero-floor semantics), not a one-line change — filed as #315. I initially wrote a "fix" that didn't actually address this (confirmed via test failure, not just review) and corrected course rather than merge something that only looked fixed. Note: `test_exact_zero_max_score_does_not_divide_by_zero` covers only the pre-existing exact-zero case, not the new `if high <= 0` branch's negative-`high` path specifically (both clamp to the same result for that test's all-zero input) — a genuine but low-priority test-precision gap, not a functional one.

## Test plan
- [x] Full `uv run --extra dev pytest tests/` — 1117 passed, 17 skipped, 0 failed (re-verified against current head; an earlier revision of this description cited a stale count from an earlier commit)
- [x] `ruff check` on changed files — clean
- [x] Mutation-tested every new fix (capabilities-key validation, `--allow ""`/`mock` rejection, str-coercion, PAID_COSTS medium-cost blind spot, `provider_adjustments`/capability/weight null and bool values, vacuous-assertion fix) — each reverts to a red test
- [x] Confirmed the real config (`conf/deep_research_provider.yaml`) still loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)