### PR TITLE
Close provider-ranking and Edison provenance review gaps

### DIFF
--- a/scripts/_edison_capture.py
+++ b/scripts/_edison_capture.py
@@ -17,8 +17,10 @@ Files written per task (under ``out_dir``):
                                Every SDK-exposed field, future-proof
                                against new ones.
     {stem}-citations.md        Parsed reference list from
-                               ``formatted_answer`` (PaperQA convention,
-                               matches the falcon citations.md sidecar).
+                               ``formatted_answer`` (PaperQA convention).
+                               Unrelated to falcon's removed
+                               --separate-citations sidecar; Edison's own
+                               extractor here is not affected.
     {stem}-agent-state.json    ``agent_state`` (tool-call trace) +
                                ``environment_frame`` + verbose
                                ``metadata``. Only written when verbose
@@ -37,6 +39,7 @@ returns the meta dict the caller should also yaml-dump as
 ``{stem}-meta.yaml``. Idempotent: re-invoking overwrites; existing
 sibling files are not read.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -46,14 +49,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 # -- citation extraction --------------------------------------------------
 
 _NUMBERED_REF_RE = re.compile(r"^\s*(\d+)\.\s+(.+?)\s*$", re.MULTILINE)
 _URL_RE = re.compile(r"https?://[^\s<>)\]]+", re.IGNORECASE)
 _PMID_RE = re.compile(r"\bPMID[:\s]+(\d+)", re.IGNORECASE)
-_DOI_RE = re.compile(r"\b(?:doi[:\s]+|https?://(?:dx\.)?doi\.org/)(10\.[^\s<>)\]]+)",
-                     re.IGNORECASE)
+_DOI_RE = re.compile(r"\b(?:doi[:\s]+|https?://(?:dx\.)?doi\.org/)(10\.[^\s<>)\]]+)", re.IGNORECASE)
 
 
 def parse_citations(formatted_answer: str | None) -> list[dict[str, Any]]:
@@ -80,7 +81,7 @@ def parse_citations(formatted_answer: str | None) -> list[dict[str, Any]]:
     # it as the reference block; fall back to scanning the full text.
     text = formatted_answer
     m = re.search(r"\n\s*references\s*\n", text, re.IGNORECASE)
-    block = text[m.end():] if m else text
+    block = text[m.end() :] if m else text
 
     out: list[dict[str, Any]] = []
     seen_keys: set[str] = set()
@@ -117,8 +118,7 @@ def parse_citations(formatted_answer: str | None) -> list[dict[str, Any]]:
     return out
 
 
-def render_citations_md(citations: list[dict[str, Any]],
-                        query: str | None = None) -> str:
+def render_citations_md(citations: list[dict[str, Any]], query: str | None = None) -> str:
     """Render the parsed citations as a human-readable markdown sidecar."""
     lines: list[str] = ["# Citations", ""]
     if query:
@@ -147,6 +147,7 @@ def render_citations_md(citations: list[dict[str, Any]],
 
 # -- helpers --------------------------------------------------------------
 
+
 def query_sha256(query: str) -> str:
     """Stable hash of the rendered query — useful for dedup / cache keys."""
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
@@ -169,8 +170,7 @@ def _safe_model_dump(obj: Any) -> Any:
             except Exception:
                 pass
     if hasattr(obj, "__dict__"):
-        return {k: _safe_model_dump(v) for k, v in obj.__dict__.items()
-                if not k.startswith("_")}
+        return {k: _safe_model_dump(v) for k, v in obj.__dict__.items() if not k.startswith("_")}
     if isinstance(obj, (list, tuple)):
         return [_safe_model_dump(v) for v in obj]
     if isinstance(obj, dict):
@@ -222,8 +222,7 @@ _DEFAULT_ARTIFACT_MAX_BYTES = 2_000_000
 
 def _safe_artifact_name(raw_name: str) -> str:
     """Sanitize an Edison data-storage name for use as a filename."""
-    safe = "".join(c if c.isalnum() or c in "._- " else "_"
-                   for c in raw_name).strip().rstrip(".")
+    safe = "".join(c if c.isalnum() or c in "._- " else "_" for c in raw_name).strip().rstrip(".")
     safe = "_".join(safe.split())  # collapse whitespace
     return safe[:120] or "artifact"
 
@@ -244,7 +243,7 @@ def _fetch_artifact_content(client: Any, data_storage_id: str) -> tuple[str, str
         return None
     # RawFetchResponse-ish: has .content
     if hasattr(result, "content"):
-        content = getattr(result, "content")
+        content = result.content
         if isinstance(content, bytes):
             try:
                 return ("txt", content.decode("utf-8"))
@@ -266,8 +265,9 @@ def _fetch_artifact_content(client: Any, data_storage_id: str) -> tuple[str, str
         for i, p in enumerate(result):
             if hasattr(p, "read_text"):
                 try:
-                    parts.append(f"# file {i}: {p.name if hasattr(p, 'name') else p}\n"
-                                 + p.read_text())
+                    parts.append(
+                        f"# file {i}: {p.name if hasattr(p, 'name') else p}\n" + p.read_text()
+                    )
                 except Exception:  # pylint: disable=broad-except
                     parts.append(f"# file {i}: <binary, not inlined>")
         return ("txt", "\n\n".join(parts))
@@ -326,8 +326,9 @@ def fetch_named_artifacts(
             continue
         size = (ds.get("metadata") or {}).get("size")
         if isinstance(size, int) and size > max_bytes:
-            manifest.append({"name": name, "id": str(ds_id),
-                             "status": "skipped-too-large", "size": size})
+            manifest.append(
+                {"name": name, "id": str(ds_id), "status": "skipped-too-large", "size": size}
+            )
             continue
         fetched = _fetch_artifact_content(client, str(ds_id))
         if fetched is None:
@@ -343,13 +344,20 @@ def fetch_named_artifacts(
             out_path.write_bytes(content)
         else:
             out_path.write_text(content)
-        manifest.append({"name": name, "id": str(ds_id), "status": "fetched",
-                         "path": str(out_path.relative_to(out_dir)),
-                         "chars": len(content) if isinstance(content, str) else None})
+        manifest.append(
+            {
+                "name": name,
+                "id": str(ds_id),
+                "status": "fetched",
+                "path": str(out_path.relative_to(out_dir)),
+                "chars": len(content) if isinstance(content, str) else None,
+            }
+        )
     return manifest
 
 
 # -- main entry point -----------------------------------------------------
+
 
 def capture_full_response(
     *,
@@ -414,19 +422,24 @@ def capture_full_response(
         environment_frame = _safe_model_dump(_get_attr(verbose, "environment_frame"))
         verbose_metadata = _safe_model_dump(_get_attr(verbose, "metadata"))
         if any(x is not None for x in (agent_state, environment_frame, verbose_metadata)):
-            agent_state_path.write_text(json.dumps({
-                "task_id": task_id,
-                "agent_state": agent_state,
-                "environment_frame": environment_frame,
-                "metadata": verbose_metadata,
-            }, indent=2, default=str))
+            agent_state_path.write_text(
+                json.dumps(
+                    {
+                        "task_id": task_id,
+                        "agent_state": agent_state,
+                        "environment_frame": environment_frame,
+                        "metadata": verbose_metadata,
+                    },
+                    indent=2,
+                    default=str,
+                )
+            )
             written.add("agent_state_json")
 
     files_listing = _try_list_files(client, task_id) if task_id else None
     artifacts_manifest: list[dict[str, Any]] = []
     if files_listing is not None:
-        files_path.write_text(json.dumps(_safe_model_dump(files_listing),
-                                         indent=2, default=str))
+        files_path.write_text(json.dumps(_safe_model_dump(files_listing), indent=2, default=str))
         written.add("files_json")
         # Pull the actual content of named curation artifacts (small,
         # not internal PaperQA pickles) into a sibling artifacts/ dir.
@@ -439,31 +452,33 @@ def capture_full_response(
 
     # Build the meta dict the caller will yaml-dump
     meta: dict[str, Any] = dict(base_meta)
-    meta.update({
-        "task_id": task_id,
-        "status": _get_attr(response, "status"),
-        "job_name": _get_attr(response, "job_name"),
-        "user": _get_attr(response, "user"),
-        "agent_name": _get_attr(response, "agent_name"),
-        "build_owner": _get_attr(response, "build_owner"),
-        "environment_name": _get_attr(response, "environment_name"),
-        "project_id": str(_get_attr(response, "project_id") or "") or None,
-        "share_status": _get_attr(response, "share_status"),
-        "created_at": _to_iso(_get_attr(response, "created_at")),
-        "answer_received_at": datetime.now(timezone.utc).isoformat(),
-        "total_cost": _get_attr(response, "total_cost"),
-        "total_queries": _get_attr(response, "total_queries"),
-        "has_successful_answer": _get_attr(response, "has_successful_answer"),
-        "has_answer_reasoning": bool(answer_reasoning),
-        "answer_chars": len(answer or ""),
-        "formatted_answer_chars": len(formatted_answer or ""),
-        "answer_reasoning_chars": len(answer_reasoning or ""),
-        "citations_parsed": len(citations),
-        "query_sha256": query_sha256(query),
-        "sidecar_files": _existing_sidecars(out_dir, stem, written),
-        "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
-        "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
-    })
+    meta.update(
+        {
+            "task_id": task_id,
+            "status": _get_attr(response, "status"),
+            "job_name": _get_attr(response, "job_name"),
+            "user": _get_attr(response, "user"),
+            "agent_name": _get_attr(response, "agent_name"),
+            "build_owner": _get_attr(response, "build_owner"),
+            "environment_name": _get_attr(response, "environment_name"),
+            "project_id": str(_get_attr(response, "project_id") or "") or None,
+            "share_status": _get_attr(response, "share_status"),
+            "created_at": _to_iso(_get_attr(response, "created_at")),
+            "answer_received_at": datetime.now(timezone.utc).isoformat(),
+            "total_cost": _get_attr(response, "total_cost"),
+            "total_queries": _get_attr(response, "total_queries"),
+            "has_successful_answer": _get_attr(response, "has_successful_answer"),
+            "has_answer_reasoning": bool(answer_reasoning),
+            "answer_chars": len(answer or ""),
+            "formatted_answer_chars": len(formatted_answer or ""),
+            "answer_reasoning_chars": len(answer_reasoning or ""),
+            "citations_parsed": len(citations),
+            "query_sha256": query_sha256(query),
+            "sidecar_files": _existing_sidecars(out_dir, stem, written),
+            "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
+            "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
+        }
+    )
     return meta
 
 
@@ -481,12 +496,14 @@ def capture_dry_run(
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     meta: dict[str, Any] = dict(base_meta)
-    meta.update({
-        "status": "dry-run",
-        "query_chars": len(query),
-        "query": query,
-        "query_sha256": query_sha256(query),
-    })
+    meta.update(
+        {
+            "status": "dry-run",
+            "query_chars": len(query),
+            "query": query,
+            "query_sha256": query_sha256(query),
+        }
+    )
     return meta
 
 
@@ -502,11 +519,9 @@ def _existing_sidecars(
     whole point is provenance, an auditor following the meta would read the wrong
     trajectory.
 
-    Pass ``written`` (the keys this run actually wrote) to report truthfully. It
-    is optional so the call sites that genuinely want a disk snapshot keep
-    working — ``enrich_edison_response`` backfills sidecars for the *same*
-    ``task_id`` already recorded in the meta, so for it "what is on disk now" is
-    the honest answer.
+    Pass ``written`` (the keys this run actually wrote) to report truthfully.
+    With ``written=None``, this returns a disk snapshot only; callers must
+    separately validate that task-specific artifacts belong to their task id.
     """
     on_disk = {
         "answer_md": (out_dir / f"{stem}.md").exists(),

--- a/scripts/check_vendored_sync.sh
+++ b/scripts/check_vendored_sync.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Drift check for vendored byte-identical files (hub-and-spoke model).
+#
+# THE FIX for the self-referential-pin blind spot: instead of hashing a file
+# against a hash generated FROM THE SAME REPO, this fetches the authoritative
+# copy from the canonical hub at a pinned commit and diffs. A repo that edits
+# its vendored copy now fails CI, because the reference lives elsewhere.
+#
+# The hub is the PUBLIC CultureBotAI/CultureMech (culturebotai-claw is private,
+# so public Mech CI cannot fetch raw content from it). Dependency-free: bash +
+# curl + diff only (no uv/OAK), so it runs as a fast blocking CI job before any
+# heavy setup. The pinned canonical commit lives in scripts/.vendored_canon_ref;
+# the file list is embedded (this script is itself vendored byte-identical across
+# the spokes). Bump .vendored_canon_ref in the same PR that syncs a changed file
+# from the hub — that bump is the deliberate propagation act.
+set -euo pipefail
+
+CANON_REPO="CultureBotAI/CultureMech"
+REF_FILE="scripts/.vendored_canon_ref"
+
+# Same-path vendored files: identical relative path in the hub and here.
+FILES=(
+  scripts/check_vendored_sync.sh
+  tests/test_provider_triage_contract.py
+  scripts/validate_id_label_correspondence.py
+  scripts/chem_formula.py
+  tests/test_id_label_empty_adapter.py
+  tests/test_id_label_unknown_prefix.py
+  tests/test_id_label_plausibility.py
+)
+
+# Package-namespaced shared files: same bytes, but the local path is namespaced
+# by this repo's package while the hub's is culturemech. Format "local_glob|hub".
+MAPPED=(
+  "src/*/schema/mech_shared.yaml|src/culturemech/schema/mech_shared.yaml"
+  "src/*/schema/history.yaml|src/culturemech/schema/history.yaml"
+)
+
+# Edison capture is shared only by the Mechs that have an Edison runner.
+# Select it by repository identity rather than file existence: existence-based
+# selection would let deleting the local copy silently remove it from the gate.
+REPO_ID="${GITHUB_REPOSITORY:-$(git config --get remote.origin.url || true)}"
+case "$REPO_ID" in
+  *CultureMech*|*TraitMech*|*MediaIngredientMech*|*CommunityMech*)
+    FILES+=(scripts/_edison_capture.py)
+    ;;
+  *proteintraitsmech*)
+    ;;
+  *)
+    echo "ERROR: cannot identify Mech repository from: $REPO_ID" >&2
+    exit 2
+    ;;
+esac
+
+[ -f "$REF_FILE" ] || { echo "ERROR: $REF_FILE missing (pinned canonical commit)"; exit 2; }
+REF="$(tr -d '[:space:]' < "$REF_FILE")"
+[ -n "$REF" ] || { echo "ERROR: $REF_FILE is empty"; exit 2; }
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+fail=0
+checked=0
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || { echo "MISSING: $f not present locally"; fail=1; continue; }
+  url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${f}"
+  # --max-time bounds each fetch (curl has no default timeout and would hang
+  # indefinitely on a stalled connection). Deliberately NOT using curl's own
+  # --retry/--retry-max-time here: --retry-max-time only gates starting a new
+  # attempt, not an in-flight one, so combined with the calling workflow's own
+  # outer retry loop the worst case could exceed the job's timeout. Retries
+  # live in the outer loop only.
+  if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
+    echo "ERROR: could not fetch $f from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
+  fi
+  # byte-exact comparison (temp file preserves the trailing newline that $() would strip)
+  if ! cmp -s "$tmp" "$f"; then
+    echo "DRIFT: $f differs from ${CANON_REPO}@${REF:0:8}"; fail=1
+  fi
+  checked=$((checked + 1))
+done
+
+# Path-mapped files: resolve the single local match via glob, diff the hub copy.
+for entry in "${MAPPED[@]}"; do
+  glob="${entry%%|*}"; hubf="${entry#*|}"
+  local=""
+  for cand in $glob; do [ -f "$cand" ] && local="$cand" && break; done
+  if [ -z "$local" ]; then echo "MISSING: no local file matching $glob"; fail=1; continue; fi
+  url="https://raw.githubusercontent.com/${CANON_REPO}/${REF}/${hubf}"
+  # --max-time bounds each fetch (curl has no default timeout and would hang
+  # indefinitely on a stalled connection). Deliberately NOT using curl's own
+  # --retry/--retry-max-time here: --retry-max-time only gates starting a new
+  # attempt, not an in-flight one, so combined with the calling workflow's own
+  # outer retry loop the worst case could exceed the job's timeout. Retries
+  # live in the outer loop only.
+  if ! curl -fsSL --max-time 10 "$url" -o "$tmp"; then
+    echo "ERROR: could not fetch $hubf from ${CANON_REPO}@${REF:0:8} ($url)"; fail=1; continue
+  fi
+  if ! cmp -s "$tmp" "$local"; then
+    echo "DRIFT: $local differs from ${CANON_REPO}@${REF:0:8}:$hubf"; fail=1
+  fi
+  checked=$((checked + 1))
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: all ${checked} vendored files match ${CANON_REPO}@${REF:0:8}"
+else
+  echo ""
+  echo "To resolve: copy the canonical files from ${CANON_REPO}@${REF:0:8}, and if the"
+  echo "hub intentionally changed them, bump ${REF_FILE} to the new hub commit."
+  exit 1
+fi

--- a/scripts/deep_research_provider.py
+++ b/scripts/deep_research_provider.py
@@ -470,7 +470,13 @@ def rank_stage(
                 "limitation": provider.limitation,
             }
         )
-    return sorted(rows, key=lambda row: (-row["fit"], row["provider"]))
+    # Preserve relative order when the absolute-zero fit floor collapses
+    # several (or all) negative raw scores to fit=0.  The public fit meaning
+    # stays unchanged; raw score is only a deterministic tie-breaker.
+    return sorted(
+        rows,
+        key=lambda row: (-row["fit"], -raw[row["provider"]], row["provider"]),
+    )
 
 
 def recommendable(rows: list[dict[str, Any]], *, allow: frozenset[str] | None = None,

--- a/scripts/enrich_edison_response.py
+++ b/scripts/enrich_edison_response.py
@@ -38,6 +38,7 @@ Usage::
     # See what would happen without making any API calls
     python scripts/enrich_edison_response.py --dry-run
 """
+
 from __future__ import annotations
 
 import argparse
@@ -65,14 +66,41 @@ def _strip_meta_suffix(name: str) -> str:
     return name
 
 
-def needs_enrichment(out_dir: Path, stem: str, *, force: bool) -> dict[str, bool]:
-    """Return a dict of which sidecars are missing for this stem."""
+def _agent_state_matches_task(out_dir: Path, stem: str, task_id: str) -> bool:
+    """Whether the saved trace is readable and belongs to the task."""
+    path = out_dir / f"{stem}-agent-state.json"
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(payload, dict) and str(payload.get("task_id") or "") == task_id
+
+
+def _attributable_sidecars(out_dir: Path, stem: str, task_id: str) -> dict[str, bool]:
+    """Return on-disk sidecars this task's metadata may truthfully claim."""
+    sidecars = ec._existing_sidecars(out_dir, stem)  # pylint: disable=protected-access
+    if sidecars["agent_state_json"]:
+        sidecars["agent_state_json"] = _agent_state_matches_task(out_dir, stem, task_id)
+    return sidecars
+
+
+def needs_enrichment(
+    out_dir: Path, stem: str, *, force: bool, task_id: str | None = None
+) -> dict[str, bool]:
+    """Return which sidecars are absent or cannot be attributed to this task."""
+    task_set_unverified = bool(task_id) and not _agent_state_matches_task(out_dir, stem, task_id)
     return {
-        "response_json": force or not (out_dir / f"{stem}-response.json").exists(),
-        "citations_md": force or not (out_dir / f"{stem}-citations.md").exists(),
-        "agent_state_json": force or not (out_dir / f"{stem}-agent-state.json").exists(),
-        "files_json": force or not (out_dir / f"{stem}-files.json").exists(),
-        "answer_md": force or not (out_dir / f"{stem}.md").exists(),
+        "response_json": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-response.json").exists(),
+        "citations_md": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-citations.md").exists(),
+        "agent_state_json": force
+        or task_set_unverified
+        or not (out_dir / f"{stem}-agent-state.json").exists(),
+        "files_json": force or task_set_unverified or not (out_dir / f"{stem}-files.json").exists(),
+        "answer_md": force or task_set_unverified or not (out_dir / f"{stem}.md").exists(),
     }
 
 
@@ -89,16 +117,19 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
 
     stem = _strip_meta_suffix(meta_path.name)
     out_dir = meta_path.parent
-    missing = needs_enrichment(out_dir, stem, force=force)
+    prior_task_set_verified = _agent_state_matches_task(out_dir, stem, task_id)
+    missing = needs_enrichment(out_dir, stem, force=force, task_id=task_id)
     if not any(missing.values()):
         return {"path": str(meta_path), "status": "already-complete", "wrote": []}
 
-    print(f"  + enriching {stem}  (missing: "
-          f"{[k for k, v in missing.items() if v]})", flush=True)
+    print(f"  + enriching {stem}  (missing: {[k for k, v in missing.items() if v]})", flush=True)
 
     if dry_run:
-        return {"path": str(meta_path), "status": "dry-run",
-                "would_write": [k for k, v in missing.items() if v]}
+        return {
+            "path": str(meta_path),
+            "status": "dry-run",
+            "would_write": [k for k, v in missing.items() if v],
+        }
 
     wrote: list[str] = []
 
@@ -137,15 +168,15 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
             merged["response"] = ec._safe_model_dump(normal)  # pylint: disable=protected-access
         if verbose is not None:
             merged["verbose"] = ec._safe_model_dump(verbose)  # pylint: disable=protected-access
-        (out_dir / f"{stem}-response.json").write_text(
-            json.dumps(merged, indent=2, default=str))
+        (out_dir / f"{stem}-response.json").write_text(json.dumps(merged, indent=2, default=str))
         wrote.append("response_json")
 
     if missing["citations_md"]:
         citations = ec.parse_citations(formatted_answer or answer)
         query = str(meta.get("query") or "")
         (out_dir / f"{stem}-citations.md").write_text(
-            ec.render_citations_md(citations, query=query))
+            ec.render_citations_md(citations, query=query)
+        )
         wrote.append("citations_md")
 
     if missing["agent_state_json"] and verbose is not None:
@@ -153,12 +184,18 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
         environment_frame = ec._safe_model_dump(getattr(verbose, "environment_frame", None))  # pylint: disable=protected-access
         verbose_metadata = ec._safe_model_dump(getattr(verbose, "metadata", None))  # pylint: disable=protected-access
         if any(x is not None for x in (agent_state, environment_frame, verbose_metadata)):
-            (out_dir / f"{stem}-agent-state.json").write_text(json.dumps({
-                "task_id": task_id,
-                "agent_state": agent_state,
-                "environment_frame": environment_frame,
-                "metadata": verbose_metadata,
-            }, indent=2, default=str))
+            (out_dir / f"{stem}-agent-state.json").write_text(
+                json.dumps(
+                    {
+                        "task_id": task_id,
+                        "agent_state": agent_state,
+                        "environment_frame": environment_frame,
+                        "metadata": verbose_metadata,
+                    },
+                    indent=2,
+                    default=str,
+                )
+            )
             wrote.append("agent_state_json")
 
     files_listing = None
@@ -170,17 +207,24 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
             files_listing = None
         if files_listing is not None:
             (out_dir / f"{stem}-files.json").write_text(
-                json.dumps(ec._safe_model_dump(files_listing),  # pylint: disable=protected-access
-                           indent=2, default=str))
+                json.dumps(
+                    ec._safe_model_dump(files_listing),  # pylint: disable=protected-access
+                    indent=2,
+                    default=str,
+                )
+            )
             wrote.append("files_json")
     # Pull named curation artifacts (separate from the files.json
     # inventory). Always attempt, even when files.json already exists,
     # so re-running picks up artifacts that were missed before.
     artifacts_manifest: list[dict[str, Any]] = []
-    if files_listing is None and (out_dir / f"{stem}-files.json").exists():
+    if (
+        files_listing is None
+        and prior_task_set_verified
+        and (out_dir / f"{stem}-files.json").exists()
+    ):
         try:
-            files_listing = json.loads(
-                (out_dir / f"{stem}-files.json").read_text())
+            files_listing = json.loads((out_dir / f"{stem}-files.json").read_text())
         except (OSError, json.JSONDecodeError):
             files_listing = None
     if files_listing is not None:
@@ -194,24 +238,44 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
             wrote.append("artifacts")
 
     # Refresh the meta yaml with the now-richer field set
+    if prior_task_set_verified:
+        attributable_sidecars = _attributable_sidecars(out_dir, stem, task_id)
+    else:
+        attributable_sidecars = ec._existing_sidecars(  # pylint: disable=protected-access
+            out_dir, stem, set(wrote)
+        )
+        if attributable_sidecars["agent_state_json"]:
+            attributable_sidecars["agent_state_json"] = _agent_state_matches_task(
+                out_dir, stem, task_id
+            )
+
     updates: dict[str, Any] = {
         "answer_chars": len(answer or ""),
         "formatted_answer_chars": len(formatted_answer or ""),
         "has_answer_reasoning": bool(getattr(primary, "answer_reasoning", None)),
         "answer_reasoning_chars": len(getattr(primary, "answer_reasoning", "") or ""),
         "citations_parsed": len(ec.parse_citations(formatted_answer or answer)),
-        "sidecar_files": ec._existing_sidecars(out_dir, stem),  # pylint: disable=protected-access
+        "sidecar_files": attributable_sidecars,
         "artifacts_fetched": [a for a in artifacts_manifest if a.get("status") == "fetched"],
         "artifacts_skipped": [a for a in artifacts_manifest if a.get("status") != "fetched"],
-        "enriched_at": ec._to_iso(__import__("datetime").datetime.now(  # pylint: disable=protected-access
-            __import__("datetime").timezone.utc)),
+        "enriched_at": ec._to_iso(
+            __import__("datetime").datetime.now(  # pylint: disable=protected-access
+                __import__("datetime").timezone.utc
+            )
+        ),
     }
     # Preserve existing query_sha256, but stamp it in if missing.
     if not meta.get("query_sha256") and meta.get("query"):
         updates["query_sha256"] = ec.query_sha256(str(meta["query"]))
     # Pull through fields we may not have captured originally.
-    for field in ("job_name", "user", "agent_name", "build_owner",
-                  "environment_name", "share_status"):
+    for field in (
+        "job_name",
+        "user",
+        "agent_name",
+        "build_owner",
+        "environment_name",
+        "share_status",
+    ):
         val = getattr(primary, field, None)
         if val is not None and meta.get(field) is None:
             updates[field] = val
@@ -220,22 +284,30 @@ def enrich_one(client: Any, meta_path: Path, *, force: bool, dry_run: bool) -> d
         updates["created_at"] = ec._to_iso(created_at)  # pylint: disable=protected-access
 
     meta.update(updates)
-    meta_path.write_text(yaml.safe_dump(meta, sort_keys=False,
-                                        allow_unicode=True, width=100))
+    meta_path.write_text(yaml.safe_dump(meta, sort_keys=False, allow_unicode=True, width=100))
 
     return {"path": str(meta_path), "status": "enriched", "wrote": wrote}
 
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--research-dir", type=Path, default=DEFAULT_RESEARCH_DIR,
-                    help="Directory containing *-edison-*-meta.yaml files.")
-    ap.add_argument("--pattern", default="*-edison-*-meta.yaml",
-                    help="Glob pattern for meta yamls to consider.")
-    ap.add_argument("--force", action="store_true",
-                    help="Re-write sidecars even if they already exist.")
-    ap.add_argument("--dry-run", action="store_true",
-                    help="Show what would be enriched without making API calls.")
+    ap.add_argument(
+        "--research-dir",
+        type=Path,
+        default=DEFAULT_RESEARCH_DIR,
+        help="Directory containing *-edison-*-meta.yaml files.",
+    )
+    ap.add_argument(
+        "--pattern", default="*-edison-*-meta.yaml", help="Glob pattern for meta yamls to consider."
+    )
+    ap.add_argument(
+        "--force", action="store_true", help="Re-write sidecars even if they already exist."
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be enriched without making API calls.",
+    )
     args = ap.parse_args(argv)
 
     if not args.research_dir.is_dir():
@@ -247,20 +319,21 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No metas matched {args.pattern} under {args.research_dir}")
         return 0
 
-    print(f"Considering {len(meta_paths)} meta yamls in "
-          f"{args.research_dir.relative_to(REPO_ROOT)}/")
+    print(
+        f"Considering {len(meta_paths)} meta yamls in {args.research_dir.relative_to(REPO_ROOT)}/"
+    )
 
     client = None
     if not args.dry_run:
         api_key = rme.load_api_key()
         from edison_client import EdisonClient
+
         client = EdisonClient(api_key=api_key)
 
     results: list[dict[str, Any]] = []
     try:
         for meta_path in meta_paths:
-            results.append(enrich_one(client, meta_path,
-                                      force=args.force, dry_run=args.dry_run))
+            results.append(enrich_one(client, meta_path, force=args.force, dry_run=args.dry_run))
     finally:
         if client is not None:
             client.close()

--- a/tests/test_deep_research_provider.py
+++ b/tests/test_deep_research_provider.py
@@ -520,3 +520,25 @@ def test_policy_filtered_empty_recommendation_names_the_actual_cause(monkeypatch
     out = _run_text(["--allow", "openai"])
     assert "no provider passes the current --allow/--no-paid filters" in out
     assert "configure a listed credential or CLI" not in out
+
+def test_all_negative_scores_keep_their_relative_order():
+    """Fit may floor at zero, but routing must still prefer the least-bad score."""
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+
+    # Deliberately make reverse-alphabetical order the raw-score order.  The
+    # old fit-only sort returned alphabetical order once every fit floored to 0.
+    expected = sorted(drp.PROVIDERS, reverse=True)
+    config["focuses"][focus_name]["provider_adjustments"] = {
+        provider: -(index + 1) for index, provider in enumerate(expected)
+    }
+
+    rows = drp.rank_stage(config, focus_name, stage_name)
+    assert all(row["fit"] == 0 for row in rows)
+    assert [row["provider"] for row in rows] == expected

--- a/tests/test_enrich_edison_response_provenance.py
+++ b/tests/test_enrich_edison_response_provenance.py
@@ -1,0 +1,123 @@
+"""Regression tests for task-aware Edison enrichment provenance."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+er = importlib.import_module("enrich_edison_response")
+
+STEM = "example-edison-literature"
+
+
+class _Response:
+    answer = "answer"
+    formatted_answer = "answer\n\nReferences\n\n1. Example\n"
+    answer_reasoning = None
+    created_at = None
+
+
+class _Client:
+    def __init__(self, *, fail_verbose: bool = False, fail_files: bool = False):
+        self.fail_verbose = fail_verbose
+        self.fail_files = fail_files
+        self.verbose_calls = 0
+
+    def get_task(self, *, task_id: str, verbose: bool):
+        if verbose:
+            self.verbose_calls += 1
+            if self.fail_verbose:
+                raise RuntimeError("fixture failure")
+            return type(
+                "Verbose",
+                (),
+                {"agent_state": [{"tool": "search"}], "environment_frame": None, "metadata": None},
+            )()
+        return _Response()
+
+    def list_files(self, *, trajectory_id: str):
+        if self.fail_files:
+            raise RuntimeError("fixture failure")
+        return []
+
+
+def _write_fixture(tmp_path: Path, *, trace_task: str = "task-OLD") -> Path:
+    meta_path = tmp_path / f"{STEM}-meta.yaml"
+    meta_path.write_text(yaml.safe_dump({"status": "success", "task_id": "task-NEW"}))
+    (tmp_path / f"{STEM}.md").write_text("answer")
+    (tmp_path / f"{STEM}-response.json").write_text("{}")
+    (tmp_path / f"{STEM}-citations.md").write_text("# Citations\n")
+    (tmp_path / f"{STEM}-agent-state.json").write_text(
+        json.dumps({"task_id": trace_task, "agent_state": []})
+    )
+    # files.json is deliberately absent so enrichment cannot early-return.
+    return meta_path
+
+
+def test_agent_state_presence_requires_the_current_task_id(tmp_path):
+    _write_fixture(tmp_path)
+    missing = er.needs_enrichment(tmp_path, STEM, force=False, task_id="task-NEW")
+    assert missing["agent_state_json"] is True
+    assert all(missing.values())
+
+    (tmp_path / f"{STEM}-agent-state.json").write_text(
+        json.dumps({"task_id": "task-NEW", "agent_state": []})
+    )
+    assert (
+        er.needs_enrichment(tmp_path, STEM, force=False, task_id="task-NEW")["agent_state_json"]
+        is False
+    )
+
+
+def test_enrichment_refetches_a_stale_trace_and_attributes_the_new_one(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    client = _Client()
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    assert client.verbose_calls == 1
+    trace = json.loads((tmp_path / f"{STEM}-agent-state.json").read_text())
+    assert trace["task_id"] == "task-NEW"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["sidecar_files"]["agent_state_json"] is True
+
+
+def test_failed_refetch_does_not_reassert_the_stale_trace(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    client = _Client(fail_verbose=True)
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    trace = json.loads((tmp_path / f"{STEM}-agent-state.json").read_text())
+    assert trace["task_id"] == "task-OLD"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["task_id"] == "task-NEW"
+    assert meta["sidecar_files"]["agent_state_json"] is False
+
+
+def test_task_mismatch_does_not_claim_any_sidecar_that_failed_to_refresh(tmp_path):
+    meta_path = _write_fixture(tmp_path)
+    (tmp_path / f"{STEM}-files.json").write_text('[{"name": "stale.yaml"}]')
+    client = _Client(fail_verbose=True, fail_files=True)
+
+    result = er.enrich_one(client, meta_path, force=False, dry_run=False)
+
+    assert result["status"] == "enriched"
+    meta = yaml.safe_load(meta_path.read_text())
+    assert meta["sidecar_files"] == {
+        "answer_md": True,
+        "response_json": True,
+        "citations_md": True,
+        "agent_state_json": False,
+        "files_json": False,
+    }
+    assert meta["artifacts_fetched"] == []
+    assert meta["artifacts_skipped"] == []

--- a/tests/test_provider_triage_contract.py
+++ b/tests/test_provider_triage_contract.py
@@ -1,0 +1,116 @@
+"""Fleet contract for shared provider-triage behavior.
+
+This suite performs only local scoring and status stubbing. It never invokes a
+research provider and cannot spend provider credits. Domain profiles and richer
+Mech-specific status models remain intentionally local.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+drp = importlib.import_module("deep_research_provider")
+CONFIG_PATH = REPO_ROOT / "conf" / "deep_research_provider.yaml"
+
+
+def _all_available(provider: str, environ=None) -> tuple[str, str]:
+    del provider, environ
+    return "available", "contract fixture; no provider call"
+
+
+def _first_stage(config):
+    focus_name = config["default_focus"]
+    stage_name = next(iter(config["focuses"][focus_name]["stages"]))
+    return focus_name, stage_name
+
+
+def test_policy_flags_are_a_shared_cli_contract():
+    args = drp.parse_args(["--config", str(CONFIG_PATH), "--allow", "asta", "--no-paid"])
+    assert args.allow == "asta"
+    assert args.no_paid is True
+
+
+def test_allowlist_and_no_paid_constrain_every_recommendation(monkeypatch):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    config = drp.load_config(CONFIG_PATH)
+    focus_name = config["default_focus"]
+
+    allowlisted = drp.build_report(config, focus_name, allow=frozenset({"asta"}), no_paid=False)
+    for stage in allowlisted["stages"]:
+        assert stage["recommended_available"]["provider"] == "asta"
+        assert stage["fallback_available"] is None
+
+    no_paid = drp.build_report(config, focus_name, no_paid=True)
+    for stage in no_paid["stages"]:
+        for key in ("recommended_available", "fallback_available"):
+            row = stage[key]
+            if row:
+                assert row["cost"] not in drp.PAID_COSTS
+
+
+def test_all_negative_scores_keep_their_relative_order(monkeypatch):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    config = copy.deepcopy(drp.load_config(CONFIG_PATH))
+    focus_name, stage_name = _first_stage(config)
+    stage = config["focuses"][focus_name]["stages"][stage_name]
+    stage["capabilities"] = {}
+    stage["synthesis_weight"] = 0
+    stage["speed_weight"] = 0
+    stage["cost_weight"] = 0
+
+    expected = sorted(drp.PROVIDERS, reverse=True)
+    config["focuses"][focus_name]["provider_adjustments"] = {
+        provider: -(index + 1) for index, provider in enumerate(expected)
+    }
+    rows = drp.rank_stage(config, focus_name, stage_name)
+
+    assert {row["fit"] for row in rows} == {0}
+    assert [row["provider"] for row in rows] == expected
+
+
+def test_provider_filtered_json_is_internally_consistent(monkeypatch, capsys):
+    monkeypatch.setattr(drp, "provider_status", _all_available)
+    assert (
+        drp.main(
+            [
+                "--config",
+                str(CONFIG_PATH),
+                "--provider",
+                "asta",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    report = json.loads(capsys.readouterr().out)
+    for stage in report["stages"]:
+        ranked = {row["provider"] for row in stage["ranking"]}
+        for key in ("recommended_available", "fallback_available"):
+            row = stage[key]
+            if row:
+                assert row["provider"] in ranked
+        if "selected" in stage:
+            assert stage["selected"]["provider"] == "asta"
+            assert "asta" in ranked
+        else:
+            assert ranked == {"asta"}
+
+
+def test_unknown_capability_is_rejected_before_scoring(tmp_path):
+    config = copy.deepcopy(drp.load_config(CONFIG_PATH))
+    focus_name, stage_name = _first_stage(config)
+    config["focuses"][focus_name]["stages"][stage_name]["capabilities"]["not_a_real_capability"] = 1
+    path = tmp_path / "bad-provider-profile.yaml"
+    path.write_text(yaml.safe_dump(config))
+
+    with pytest.raises(ValueError, match="unknown capability"):
+        drp.load_config(path)

--- a/tests/test_vendored_sync_contract.py
+++ b/tests/test_vendored_sync_contract.py
@@ -1,0 +1,26 @@
+"""Static contract tests for the public hub's vendored-sync checker."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_vendored_sync.sh"
+
+
+def test_checker_governs_itself_and_shared_edison_capture():
+    text = SCRIPT.read_text()
+    files_block = text.split("FILES=(", 1)[1].split(")", 1)[0]
+    assert "scripts/check_vendored_sync.sh" in files_block
+    assert "scripts/_edison_capture.py" in text
+    assert "existence-based" in text
+
+
+def test_checker_covers_both_shared_schemas():
+    text = SCRIPT.read_text()
+    assert "src/*/schema/mech_shared.yaml|src/culturemech/schema/mech_shared.yaml" in text
+    assert "src/*/schema/history.yaml|src/culturemech/schema/history.yaml" in text
+
+
+def test_every_canonical_fetch_has_a_timeout():
+    text = SCRIPT.read_text()
+    fetches = [line.strip() for line in text.splitlines() if "curl -fsSL" in line]
+    assert len(fetches) == 2
+    assert all("--max-time 10" in line for line in fetches)


### PR DESCRIPTION
Closes #292. Closes #298. Closes #315. Addresses #330.

This is the canonical hub change for the five-Mech adversarial follow-up.

- Edison enrichment treats a sidecar set as complete only when its embedded
  agent-state task id matches the meta task id. A stale, absent, or malformed
  trace invalidates the whole same-stem set; failed refetches remain unclaimed.
- Provider ranking preserves relative raw-score order when the absolute fit
  floor collapses every displayed fit to zero.
- A byte-identical, credit-free provider behavior contract now covers policy
  flags, allowlists, no-paid routing, negative-score ordering, invalid
  capabilities, and provider-filtered JSON consistency across all five Mechs.
- The public vendored-sync checker governs its own bytes and the contract test,
  covers both shared schemas, bounds every curl, and selects the Edison capture
  helper by repository identity rather than file existence.
- The Edison capture helper is normalized to the byte-identical version pinned
  in TraitMech, MediaIngredientMech, and CommunityMech.

Adversarial review found and fixed three traps:

1. checking only trace existence accepted a trace for another task;
2. refreshing only that trace could still claim other stale same-stem files;
3. selecting optional governed files by existence let deletion remove the file
   from the gate.

Verification:

- 51 focused tests passed;
- Ruff, shell syntax, and `git diff --check` passed;
- every Edison/provider test uses stubs or local configuration only;
- no research provider was called and no provider credits were spent.
