### PR TITLE
Emit each KGX edge once (#312)

### DIFF
--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -49,12 +49,14 @@ Legacy Edges (for backward compatibility):
 """
 
 import uuid
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
 
 try:
     import koza
     from koza import KozaTransform
+
     KOZA_AVAILABLE = True
 except ImportError:
     KOZA_AVAILABLE = False
@@ -80,7 +82,8 @@ HAS_SOLUTION_COMPONENT = "biolink:has_part"  # For medium→solution (also uses 
 # PURE TRANSFORM FUNCTION (testable without Koza)
 # ================================================================
 
-def transform(record: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+
+def transform(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """
     Pure transform function - testable without Koza.
 
@@ -216,7 +219,7 @@ class Node:
     """
 
     id: str
-    category: List[str]
+    category: list[str]
     name: str
     provided_by: str = KNOWLEDGE_SOURCE
 
@@ -260,16 +263,16 @@ class Edge:
     primary_knowledge_source: str = KNOWLEDGE_SOURCE
     knowledge_level: str = "knowledge_assertion"
     agent_type: str = "manual_validation_of_automated_agent"
-    publications: Optional[List[str]] = None
-    concentration: Optional[str] = None
-    role: Optional[str] = None
-    strain: Optional[str] = None
-    growth_phase: Optional[str] = None
-    attribute_type: Optional[str] = None
-    relationship_type: Optional[str] = None
+    publications: list[str] | None = None
+    concentration: str | None = None
+    role: str | None = None
+    strain: str | None = None
+    growth_phase: str | None = None
+    attribute_type: str | None = None
+    relationship_type: str | None = None
 
 
-def to_edge(edge_dict: Dict[str, Any]) -> Edge:
+def to_edge(edge_dict: dict[str, Any]) -> Edge:
     """Turn one ``transform`` dict into a writable KGX edge row.
 
     Unknown qualifier types are dropped rather than silently mangled into an
@@ -277,7 +280,7 @@ def to_edge(edge_dict: Dict[str, Any]) -> Edge:
     ``test_every_qualifier_type_has_a_column`` fails if the transform grows a
     type this does not cover.
     """
-    columns: Dict[str, Any] = {}
+    columns: dict[str, Any] = {}
     for qualifier in edge_dict.get("qualifiers") or []:
         column = _QUALIFIER_COLUMNS.get(qualifier.get("qualifier_type_id", ""))
         if column:
@@ -292,7 +295,7 @@ def to_edge(edge_dict: Dict[str, Any]) -> Edge:
     )
 
 
-def nodes(record: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """Every node this record mints, as dicts. Companion to ``transform``.
 
     Yields duplicates across records by design — ``culturemech:medium_type_COMPLEX``
@@ -313,54 +316,65 @@ def nodes(record: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
     yield asdict(Node(id=medium_id, category=medium_category, name=name))
 
     if medium_type:
-        yield asdict(Node(
-            id=f"culturemech:medium_type_{medium_type}",
-            category=type_category,
-            name=str(medium_type),
-        ))
+        yield asdict(
+            Node(
+                id=f"culturemech:medium_type_{medium_type}",
+                category=type_category,
+                name=str(medium_type),
+            )
+        )
 
     for solution in record.get("solutions", []) or []:
         preferred_term = solution.get("preferred_term")
         if preferred_term:
-            yield asdict(Node(
-                id=_create_solution_id(preferred_term),
-                category=[CHEMICAL_MIXTURE],
-                name=str(preferred_term),
-            ))
+            yield asdict(
+                Node(
+                    id=_create_solution_id(preferred_term),
+                    category=[CHEMICAL_MIXTURE],
+                    name=str(preferred_term),
+                )
+            )
 
     for application in record.get("applications", []) or []:
         if application:
-            yield asdict(Node(
-                id=f"culturemech:application_{_sanitize_id(str(application))}",
-                category=[ATTRIBUTE],
-                name=str(application),
-            ))
+            yield asdict(
+                Node(
+                    id=f"culturemech:application_{_sanitize_id(str(application))}",
+                    category=[ATTRIBUTE],
+                    name=str(application),
+                )
+            )
 
     physical_state = record.get("physical_state")
     if physical_state:
-        yield asdict(Node(
-            id=f"culturemech:state_{str(physical_state).lower()}",
-            category=[ATTRIBUTE],
-            name=str(physical_state),
-        ))
+        yield asdict(
+            Node(
+                id=f"culturemech:state_{str(physical_state).lower()}",
+                category=[ATTRIBUTE],
+                name=str(physical_state),
+            )
+        )
 
     # A variant is itself a medium, so it takes the generic medium category — the
     # variant entry carries no medium_type of its own to refine it with.
     for variant in record.get("variants", []) or []:
         variant_name = variant.get("name")
         if variant_name:
-            yield asdict(Node(
-                id=f"culturemech:{_sanitize_id(str(variant_name))}",
-                category=_DEFAULT_MEDIUM_CATEGORY,
-                name=str(variant_name),
-            ))
+            yield asdict(
+                Node(
+                    id=f"culturemech:{_sanitize_id(str(variant_name))}",
+                    category=_DEFAULT_MEDIUM_CATEGORY,
+                    name=str(variant_name),
+                )
+            )
 
 
 # ================================================================
 # EDGE EXTRACTION FUNCTIONS (following cmm-ai-automation semantic model)
 # ================================================================
 
-def organism_grows_in_medium_edge(organism: Dict, medium_id: str) -> Optional[dict]:
+
+def organism_grows_in_medium_edge(organism: dict, medium_id: str) -> dict | None:
     """
     Organism (NCBITaxon) → grows_in_medium (METPO:2000517) → Medium
 
@@ -380,18 +394,14 @@ def organism_grows_in_medium_edge(organism: Dict, medium_id: str) -> Optional[di
     # Add strain as qualifier if present
     strain = organism.get("strain")
     if strain:
-        qualifiers.append({
-            "qualifier_type_id": "biolink:strain",
-            "qualifier_value": strain
-        })
+        qualifiers.append({"qualifier_type_id": "biolink:strain", "qualifier_value": strain})
 
     # Add growth phase as qualifier if present
     growth_phase = organism.get("growth_phase")
     if growth_phase:
-        qualifiers.append({
-            "qualifier_type_id": "biolink:growth_phase",
-            "qualifier_value": growth_phase
-        })
+        qualifiers.append(
+            {"qualifier_type_id": "biolink:growth_phase", "qualifier_value": growth_phase}
+        )
 
     pubs, _ = _format_evidence(organism.get("evidence"))
 
@@ -404,7 +414,7 @@ def organism_grows_in_medium_edge(organism: Dict, medium_id: str) -> Optional[di
     )
 
 
-def medium_to_solution_edge(medium_id: str, solution: Dict) -> Optional[dict]:
+def medium_to_solution_edge(medium_id: str, solution: dict) -> dict | None:
     """
     Medium → has_solution_component (biolink:has_part) → Solution
 
@@ -430,10 +440,9 @@ def medium_to_solution_edge(medium_id: str, solution: Dict) -> Optional[dict]:
         val = concentration.get("value")
         unit = concentration.get("unit")
         if val and unit:
-            qualifiers.append({
-                "qualifier_type_id": "biolink:concentration",
-                "qualifier_value": f"{val} {unit}"
-            })
+            qualifiers.append(
+                {"qualifier_type_id": "biolink:concentration", "qualifier_value": f"{val} {unit}"}
+            )
 
     return _make_association(
         subject=medium_id,
@@ -443,7 +452,7 @@ def medium_to_solution_edge(medium_id: str, solution: Dict) -> Optional[dict]:
     )
 
 
-def solution_to_ingredient_edge(solution_id: str, ingredient: Dict) -> Optional[dict]:
+def solution_to_ingredient_edge(solution_id: str, ingredient: dict) -> dict | None:
     """
     Solution → has_part (biolink:has_part) → Ingredient (CHEBI)
 
@@ -468,10 +477,9 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: Dict) -> Optional[
         val = concentration.get("value")
         unit = concentration.get("unit")
         if val and unit:
-            qualifiers.append({
-                "qualifier_type_id": "biolink:concentration",
-                "qualifier_value": f"{val} {unit}"
-            })
+            qualifiers.append(
+                {"qualifier_type_id": "biolink:concentration", "qualifier_value": f"{val} {unit}"}
+            )
 
     # Combine role tokens across the three facet slots (facet vocabulary
     # replaced the retired flat `role: IngredientRoleEnum` slot). Preserves
@@ -484,10 +492,9 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: Dict) -> Optional[
         else:
             roles.append(slot_values)
     if roles:
-        qualifiers.append({
-            "qualifier_type_id": "biolink:role",
-            "qualifier_value": ", ".join(roles)
-        })
+        qualifiers.append(
+            {"qualifier_type_id": "biolink:role", "qualifier_value": ", ".join(roles)}
+        )
 
     return _make_association(
         subject=solution_id,
@@ -497,7 +504,7 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: Dict) -> Optional[
     )
 
 
-def medium_to_ingredient_edge(medium_id: str, ingredient: Dict) -> Optional[dict]:
+def medium_to_ingredient_edge(medium_id: str, ingredient: dict) -> dict | None:
     """
     Medium → has_part (biolink:has_part) → Ingredient (CHEBI)
 
@@ -523,10 +530,9 @@ def medium_to_ingredient_edge(medium_id: str, ingredient: Dict) -> Optional[dict
         val = concentration.get("value")
         unit = concentration.get("unit")
         if val and unit:
-            qualifiers.append({
-                "qualifier_type_id": "biolink:concentration",
-                "qualifier_value": f"{val} {unit}"
-            })
+            qualifiers.append(
+                {"qualifier_type_id": "biolink:concentration", "qualifier_value": f"{val} {unit}"}
+            )
 
     # Combine role tokens across the three facet slots (facet vocabulary
     # replaced the retired flat `role: IngredientRoleEnum` slot). Preserves
@@ -539,10 +545,9 @@ def medium_to_ingredient_edge(medium_id: str, ingredient: Dict) -> Optional[dict
         else:
             roles.append(slot_values)
     if roles:
-        qualifiers.append({
-            "qualifier_type_id": "biolink:role",
-            "qualifier_value": ", ".join(roles)
-        })
+        qualifiers.append(
+            {"qualifier_type_id": "biolink:role", "qualifier_value": ", ".join(roles)}
+        )
 
     pubs, _ = _format_evidence(ingredient.get("evidence"))
 
@@ -555,7 +560,7 @@ def medium_to_ingredient_edge(medium_id: str, ingredient: Dict) -> Optional[dict
     )
 
 
-def medium_to_type_edge(medium_id: str, medium_type: str) -> Optional[dict]:
+def medium_to_type_edge(medium_id: str, medium_type: str) -> dict | None:
     """
     Medium → has_attribute → Medium Type
 
@@ -572,14 +577,13 @@ def medium_to_type_edge(medium_id: str, medium_type: str) -> Optional[dict]:
         subject=medium_id,
         predicate="biolink:has_attribute",
         obj=type_id,
-        qualifiers=[{
-            "qualifier_type_id": "biolink:attribute_type",
-            "qualifier_value": "medium_type"
-        }],
+        qualifiers=[
+            {"qualifier_type_id": "biolink:attribute_type", "qualifier_value": "medium_type"}
+        ],
     )
 
 
-def ingredient_to_edge(medium_id: str, ingredient: Dict) -> Optional[dict]:
+def ingredient_to_edge(medium_id: str, ingredient: dict) -> dict | None:
     """
     Medium (culturemech:LB_Broth) → has_part → Glucose (CHEBI:17234)
 
@@ -599,10 +603,9 @@ def ingredient_to_edge(medium_id: str, ingredient: Dict) -> Optional[dict]:
         val = concentration.get("value")
         unit = concentration.get("unit")
         if val and unit:
-            qualifiers.append({
-                "qualifier_type_id": "biolink:concentration",
-                "qualifier_value": f"{val} {unit}"
-            })
+            qualifiers.append(
+                {"qualifier_type_id": "biolink:concentration", "qualifier_value": f"{val} {unit}"}
+            )
 
     pubs, _ = _format_evidence(ingredient.get("evidence"))
 
@@ -615,7 +618,7 @@ def ingredient_to_edge(medium_id: str, ingredient: Dict) -> Optional[dict]:
     )
 
 
-def organism_to_edge(medium_id: str, organism: Dict) -> Optional[dict]:
+def organism_to_edge(medium_id: str, organism: dict) -> dict | None:
     """
     LEGACY: Medium → supports_growth_of → Organism (NCBITaxon)
 
@@ -640,7 +643,7 @@ def organism_to_edge(medium_id: str, organism: Dict) -> Optional[dict]:
     )
 
 
-def application_to_edge(medium_id: str, application: str) -> Optional[dict]:
+def application_to_edge(medium_id: str, application: str) -> dict | None:
     """
     Medium → has_application → Use case
 
@@ -653,14 +656,13 @@ def application_to_edge(medium_id: str, application: str) -> Optional[dict]:
         subject=medium_id,
         predicate="biolink:has_attribute",
         obj=app_id,
-        qualifiers=[{
-            "qualifier_type_id": "biolink:attribute_type",
-            "qualifier_value": "application"
-        }],
+        qualifiers=[
+            {"qualifier_type_id": "biolink:attribute_type", "qualifier_value": "application"}
+        ],
     )
 
 
-def physical_state_to_edge(medium_id: str, physical_state: str) -> Optional[dict]:
+def physical_state_to_edge(medium_id: str, physical_state: str) -> dict | None:
     """
     Medium → has_physical_state → State
 
@@ -672,14 +674,13 @@ def physical_state_to_edge(medium_id: str, physical_state: str) -> Optional[dict
         subject=medium_id,
         predicate="biolink:has_attribute",
         obj=state_id,
-        qualifiers=[{
-            "qualifier_type_id": "biolink:attribute_type",
-            "qualifier_value": "physical_state"
-        }],
+        qualifiers=[
+            {"qualifier_type_id": "biolink:attribute_type", "qualifier_value": "physical_state"}
+        ],
     )
 
 
-def dataset_to_edge(medium_id: str, dataset: Dict) -> Optional[dict]:
+def dataset_to_edge(medium_id: str, dataset: dict) -> dict | None:
     """
     Dataset → uses_medium → Medium
 
@@ -693,14 +694,13 @@ def dataset_to_edge(medium_id: str, dataset: Dict) -> Optional[dict]:
         subject=dataset_id,
         predicate="biolink:related_to",
         obj=medium_id,
-        qualifiers=[{
-            "qualifier_type_id": "biolink:relationship_type",
-            "qualifier_value": "uses_medium"
-        }],
+        qualifiers=[
+            {"qualifier_type_id": "biolink:relationship_type", "qualifier_value": "uses_medium"}
+        ],
     )
 
 
-def database_reference_to_edge(medium_id: str, term: Dict) -> Optional[dict]:
+def database_reference_to_edge(medium_id: str, term: dict) -> dict | None:
     """
     Medium → has_database_reference → Database ID
 
@@ -717,7 +717,7 @@ def database_reference_to_edge(medium_id: str, term: Dict) -> Optional[dict]:
     )
 
 
-def variant_to_edge(medium_id: str, variant: Dict) -> Optional[dict]:
+def variant_to_edge(medium_id: str, variant: dict) -> dict | None:
     """
     Variant → variant_of → Base Medium
 
@@ -733,10 +733,9 @@ def variant_to_edge(medium_id: str, variant: Dict) -> Optional[dict]:
         subject=variant_id,
         predicate="biolink:subclass_of",
         obj=medium_id,
-        qualifiers=[{
-            "qualifier_type_id": "biolink:relationship_type",
-            "qualifier_value": "variant_of"
-        }],
+        qualifiers=[
+            {"qualifier_type_id": "biolink:relationship_type", "qualifier_value": "variant_of"}
+        ],
     )
 
 
@@ -744,13 +743,14 @@ def variant_to_edge(medium_id: str, variant: Dict) -> Optional[dict]:
 # HELPER FUNCTIONS
 # ================================================================
 
+
 def _make_edge_id(subject: str, predicate: str, obj: str) -> str:
     """Generate deterministic UUID5-based edge ID."""
     edge_string = f"{subject}|{predicate}|{obj}"
     return f"urn:uuid:{uuid.uuid5(NAMESPACE_UUID, edge_string)}"
 
 
-def _get_term_id(data: Dict, path: List[str]) -> Optional[str]:
+def _get_term_id(data: dict, path: list[str]) -> str | None:
     """Safely extract nested term ID."""
     current = data
     for key in path:
@@ -762,7 +762,7 @@ def _get_term_id(data: Dict, path: List[str]) -> Optional[str]:
     return current
 
 
-def _format_evidence(evidence_items: Optional[List[Dict]]) -> tuple:
+def _format_evidence(evidence_items: list[dict] | None) -> tuple:
     """Format evidence into publications list and supporting text."""
     pubs = []
     for e in evidence_items or []:
@@ -824,9 +824,9 @@ def _make_association(
     subject: str,
     predicate: str,
     obj: str,
-    qualifiers: Optional[List[Dict]] = None,
-    publications: Optional[List[str]] = None,
-) -> Dict:
+    qualifiers: list[dict] | None = None,
+    publications: list[str] | None = None,
+) -> dict:
     """Create an Association dictionary."""
     return {
         "id": _make_edge_id(subject, predicate, obj),
@@ -886,8 +886,9 @@ def reset_node_dedup() -> None:
 
 
 if KOZA_AVAILABLE:
+
     @koza.transform_record()
-    def koza_transform(koza_ctx: KozaTransform, record: Dict[str, Any]) -> None:
+    def koza_transform(koza_ctx: KozaTransform, record: dict[str, Any]) -> None:
         """Koza wrapper - handles I/O."""
         for node_dict in nodes(record):
             node_id = node_dict["id"]
@@ -912,9 +913,10 @@ if KOZA_AVAILABLE:
 # ================================================================
 
 if __name__ == "__main__":
-    import sys
-    import yaml
     import json
+    import sys
+
+    import yaml
 
     if len(sys.argv) < 2:
         print("Usage: python kgx_export.py <recipe.yaml>")

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -852,6 +852,22 @@ def _make_association(
 _EMITTED_NODE_IDS: set = set()
 
 
+# Edge ids already written in this run. `_make_edge_id` is a deterministic UUID5
+# over subject|predicate|object, so an identical triple emitted twice gets the
+# same id — and `transform()` walks each record's `solutions[]`, re-emitting a
+# shared stock solution's whole composition once per referencing medium.
+# `Seven vitamins solution` is referenced by 178 media, so each of its
+# `has_part` edges appeared 178 times: 45,464 surplus rows, 23% of the file
+# (#312). Every collision was an exact duplicate triple, so nothing is lost by
+# keeping the first.
+_EMITTED_EDGE_IDS: set = set()
+
+
+def reset_edge_dedup() -> None:
+    """Clear the run-scoped edge-id set. See `reset_node_dedup`."""
+    _EMITTED_EDGE_IDS.clear()
+
+
 def reset_node_dedup() -> None:
     """Clear the run-scoped node-id set.
 
@@ -884,6 +900,10 @@ if KOZA_AVAILABLE:
             # Deliberately NOT wrapped in biolink's Association: its `qualifiers`
             # slot is `list[str]`, so every qualified edge raised here and was
             # swallowed by the old except-and-print. Failures now stop the run.
+            edge_id = edge_dict["id"]
+            if edge_id in _EMITTED_EDGE_IDS:
+                continue
+            _EMITTED_EDGE_IDS.add(edge_id)
             koza_ctx.write(to_edge(edge_dict))
 
 

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -17,6 +17,7 @@ raised for every qualified edge and the wrapper swallowed it with a `print`. A
 These tests therefore drive the real koza runner over fixture records and assert
 on the files on disk. They are the only coverage of the path that actually ships.
 """
+
 from __future__ import annotations
 
 import csv
@@ -52,19 +53,19 @@ RECORD = {
         }
     ],
     "target_organisms": [
-        {"preferred_term": "Escherichia coli", "term": {"id": "NCBITaxon:562"},
-         "strain": "K-12"}
+        {"preferred_term": "Escherichia coli", "term": {"id": "NCBITaxon:562"}, "strain": "K-12"}
     ],
     "solutions": [
-        {"preferred_term": "Trace Elements",
-         "concentration": {"value": "1", "unit": "ML_PER_L"},
-         "composition": [{"preferred_term": "ZnSO4", "term": {"id": "CHEBI:32312"}}]}
+        {
+            "preferred_term": "Trace Elements",
+            "concentration": {"value": "1", "unit": "ML_PER_L"},
+            "composition": [{"preferred_term": "ZnSO4", "term": {"id": "CHEBI:32312"}}],
+        }
     ],
     "variants": [{"name": "Canary Medium agar"}],
 }
 
-DEFINED_RECORD = {"name": "Defined Canary", "medium_type": "DEFINED",
-                  "physical_state": "LIQUID"}
+DEFINED_RECORD = {"name": "Defined Canary", "medium_type": "DEFINED", "physical_state": "LIQUID"}
 
 
 # --- qualifier flattening -------------------------------------------------
@@ -84,14 +85,15 @@ def test_every_qualifier_type_the_transform_emits_has_a_column():
         for q in edge.get("qualifiers") or []
     }
     assert emitted, "fixture must exercise qualifiers or this test proves nothing"
-    assert emitted <= set(_QUALIFIER_COLUMNS), (
-        f"no TSV column for {emitted - set(_QUALIFIER_COLUMNS)}"
-    )
+    assert emitted <= set(
+        _QUALIFIER_COLUMNS
+    ), f"no TSV column for {emitted - set(_QUALIFIER_COLUMNS)}"
 
 
 def test_qualifier_values_survive_the_conversion_to_a_row():
     edge = next(
-        e for e in transform(RECORD)
+        e
+        for e in transform(RECORD)
         if e["object"] == "CHEBI:17234" and e["predicate"] == "biolink:has_part"
     )
     row = to_edge(edge)
@@ -100,11 +102,15 @@ def test_qualifier_values_survive_the_conversion_to_a_row():
 
 
 def test_an_unknown_qualifier_type_is_dropped_not_misfiled():
-    row = to_edge({
-        "id": "urn:uuid:x", "subject": "a", "predicate": "p", "object": "b",
-        "qualifiers": [{"qualifier_type_id": "biolink:invented",
-                        "qualifier_value": "v"}],
-    })
+    row = to_edge(
+        {
+            "id": "urn:uuid:x",
+            "subject": "a",
+            "predicate": "p",
+            "object": "b",
+            "qualifiers": [{"qualifier_type_id": "biolink:invented", "qualifier_value": "v"}],
+        }
+    )
     assert row.concentration is None and row.role is None
 
 
@@ -113,12 +119,20 @@ def test_edge_is_not_a_biolink_association():
     dicts through it raises and — with the old except-and-print — dropped the
     edge silently."""
     from biolink_model.datamodel.pydanticmodel_v2 import Association
+    from pydantic import ValidationError
 
-    with pytest.raises(Exception):
+    # ValidationError specifically, not a blind Exception: the point is that the
+    # QUALIFIER shape is rejected, and a bare `Exception` would pass just as
+    # happily on a typo in the field names below.
+    with pytest.raises(ValidationError, match="qualifiers"):
         Association(
-            id="urn:uuid:x", subject="a", predicate="p", object="b",
-            qualifiers=[{"qualifier_type_id": "biolink:concentration",
-                         "qualifier_value": "10 G_PER_L"}],
+            id="urn:uuid:x",
+            subject="a",
+            predicate="p",
+            object="b",
+            qualifiers=[
+                {"qualifier_type_id": "biolink:concentration", "qualifier_value": "10 G_PER_L"}
+            ],
         )
     assert isinstance(to_edge(next(iter(transform(RECORD)))), Edge)
 
@@ -131,7 +145,8 @@ def test_medium_and_type_categories_follow_the_consumer():
     loader does not recognise is worse than no node."""
     by_id = {n["id"]: n for n in nodes(RECORD)}
     assert by_id["culturemech:Canary_Medium"]["category"] == [
-        "biolink:GrowthMedium", "biolink:ComplexMolecularMixture"
+        "biolink:GrowthMedium",
+        "biolink:ComplexMolecularMixture",
     ]
     assert by_id["culturemech:medium_type_COMPLEX"]["category"] == [
         "biolink:ComplexMolecularMixture"
@@ -139,20 +154,17 @@ def test_medium_and_type_categories_follow_the_consumer():
 
     defined = {n["id"]: n for n in nodes(DEFINED_RECORD)}
     assert defined["culturemech:Defined_Canary"]["category"] == [
-        "biolink:GrowthMedium", "biolink:ChemicalMixture"
+        "biolink:GrowthMedium",
+        "biolink:ChemicalMixture",
     ]
-    assert defined["culturemech:medium_type_DEFINED"]["category"] == [
-        "biolink:ChemicalMixture"
-    ]
+    assert defined["culturemech:medium_type_DEFINED"]["category"] == ["biolink:ChemicalMixture"]
 
 
 def test_a_medium_type_outside_the_table_falls_back_rather_than_guessing():
     """BUFFER and NEGATIVE_CONTROL assert nothing about composition."""
     buffer_nodes = {n["id"]: n for n in nodes({"name": "B", "medium_type": "BUFFER"})}
     assert buffer_nodes["culturemech:B"]["category"] == ["biolink:GrowthMedium"]
-    assert buffer_nodes["culturemech:medium_type_BUFFER"]["category"] == [
-        "biolink:ChemicalMixture"
-    ]
+    assert buffer_nodes["culturemech:medium_type_BUFFER"]["category"] == ["biolink:ChemicalMixture"]
 
 
 def test_only_minted_ids_get_nodes():
@@ -165,7 +177,7 @@ def test_only_minted_ids_get_nodes():
 
 
 def test_ids_survive_kozas_asymmetric_sanitization():
-    r'''The two dangling references the full-corpus run produced.
+    r"""The two dangling references the full-corpus run produced.
 
     `TOGO_M1572_Ekho_Lake_Strains_Medium.yaml` carries the solution name
     `Mineral salt solution* (\"Hutner/Cohen-Bazire\")` — the backslash-quotes are
@@ -178,14 +190,14 @@ def test_ids_survive_kozas_asymmetric_sanitization():
 
     Stripping the characters at the source makes both sides agree no matter what
     koza does downstream.
-    '''
+    """
     from culturemech.export.kgx_export import _create_solution_id, _sanitize_id
 
-    assert _sanitize_id(r'Mineral salt solution* (\"Hutner/Cohen-Bazire\")') == (
+    assert _sanitize_id(r"Mineral salt solution* (\"Hutner/Cohen-Bazire\")") == (
         "Mineral_salt_solution_Hutner_Cohen-Bazire"
     )
     for char in '\\"*()':
-        assert char not in _create_solution_id(f'R2A Broth {char}DAIGO{char}')
+        assert char not in _create_solution_id(f"R2A Broth {char}DAIGO{char}")
 
     # Dropping a character must not leave a doubled or trailing separator behind.
     assert _sanitize_id("Test (variant)") == "Test_variant"
@@ -202,9 +214,9 @@ def test_ids_survive_kozas_asymmetric_sanitization():
     # And the medium id goes through the same sanitizer as the solution id --
     # before the fix it only replaced spaces, so a quoted medium name would drift
     # exactly the same way.
-    quoted = {n["id"] for n in nodes({'name': r'Foo \"Bar\"', "medium_type": "COMPLEX"})}
+    quoted = {n["id"] for n in nodes({"name": r"Foo \"Bar\"", "medium_type": "COMPLEX"})}
     edge_subjects = {
-        e["subject"] for e in transform({'name': r'Foo \"Bar\"', "medium_type": "COMPLEX"})
+        e["subject"] for e in transform({"name": r"Foo \"Bar\"", "medium_type": "COMPLEX"})
     }
     assert edge_subjects <= quoted
 
@@ -259,10 +271,15 @@ def exported_shared(tmp_path: Path) -> tuple[list[dict], list[dict]]:
     records_dir = tmp_path / "records" / "canary"
     records_dir.mkdir(parents=True)
     for i, name in enumerate(("Medium One", "Medium Two")):
-        (records_dir / f"record_{i}.yaml").write_text(yaml.safe_dump({
-            "name": name, "medium_type": "COMPLEX",
-            "solutions": [SHARED_SOLUTION],
-        }))
+        (records_dir / f"record_{i}.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": name,
+                    "medium_type": "COMPLEX",
+                    "solutions": [SHARED_SOLUTION],
+                }
+            )
+        )
 
     out = tmp_path / "out"
     export_kgx.run(tmp_path / "records", out)
@@ -286,7 +303,9 @@ def test_no_culturemech_id_in_the_edges_dangles(exported):
     node_rows, edge_rows = exported
     declared = {n["id"] for n in node_rows}
     referenced = {
-        end for e in edge_rows for end in (e["subject"], e["object"])
+        end
+        for e in edge_rows
+        for end in (e["subject"], e["object"])
         if end.startswith("culturemech:")
     }
     assert referenced - declared == set()
@@ -340,16 +359,20 @@ def test_shared_edges_are_written_once(exported_shared):
 def test_a_solution_shared_by_two_media_emits_its_composition_once(exported_shared):
     """The #312 shape itself, not just the absence of duplicates."""
     _node_rows, edge_rows = exported_shared
-    composition = [e for e in edge_rows
-                   if e["subject"].startswith("culturemech:solution_")
-                   and e["predicate"] == "biolink:has_part"]
+    composition = [
+        e
+        for e in edge_rows
+        if e["subject"].startswith("culturemech:solution_") and e["predicate"] == "biolink:has_part"
+    ]
     assert composition, "fixture must reference a shared solution"
     assert len(composition) == len({e["id"] for e in composition})
     # Both media still get their own medium -> solution edge: that one IS
     # per-medium and must not be collapsed.
-    to_solution = [e for e in edge_rows
-                   if e["object"].startswith("culturemech:solution_")
-                   and e["predicate"] == "biolink:has_part"]
+    to_solution = [
+        e
+        for e in edge_rows
+        if e["object"].startswith("culturemech:solution_") and e["predicate"] == "biolink:has_part"
+    ]
     assert len(to_solution) == 2, to_solution
 
 
@@ -372,9 +395,8 @@ def test_a_second_run_in_the_same_process_repeats_the_output(tmp_path):
     module and protecting nothing. If koza ever caches transform modules, this
     test fails and `reset_node_dedup()` becomes the fix.
     """
-    import yaml
-
     import export_kgx
+    import yaml
 
     records_dir = tmp_path / "records" / "canary"
     records_dir.mkdir(parents=True)

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -238,6 +238,42 @@ def exported(tmp_path: Path) -> tuple[list[dict], list[dict]]:
     return read("nodes"), read("edges")
 
 
+# Two media referencing ONE stock solution — the #312 shape. On the real corpus
+# `Seven vitamins solution` is referenced by 178 media.
+SHARED_SOLUTION = {
+    "preferred_term": "Seven vitamins solution",
+    "concentration": {"value": "1", "unit": "ML_PER_L"},
+    "composition": [
+        {"preferred_term": "Biotin", "term": {"id": "CHEBI:15956"}},
+        {"preferred_term": "Nicotinic acid", "term": {"id": "CHEBI:15940"}},
+    ],
+}
+
+
+@pytest.fixture
+def exported_shared(tmp_path: Path) -> tuple[list[dict], list[dict]]:
+    """Two media that reference the same stock solution."""
+    import export_kgx
+    import yaml
+
+    records_dir = tmp_path / "records" / "canary"
+    records_dir.mkdir(parents=True)
+    for i, name in enumerate(("Medium One", "Medium Two")):
+        (records_dir / f"record_{i}.yaml").write_text(yaml.safe_dump({
+            "name": name, "medium_type": "COMPLEX",
+            "solutions": [SHARED_SOLUTION],
+        }))
+
+    out = tmp_path / "out"
+    export_kgx.run(tmp_path / "records", out)
+
+    def read(kind: str) -> list[dict]:
+        with (out / f"culturemech_{kind}.tsv").open() as fh:
+            return list(csv.DictReader(fh, delimiter="\t"))
+
+    return read("nodes"), read("edges")
+
+
 def test_the_export_writes_a_node_and_edge_tsv_pair(exported):
     node_rows, edge_rows = exported
     assert node_rows and edge_rows
@@ -272,6 +308,49 @@ def test_qualified_edges_reach_the_tsv(exported):
     assert any(e["concentration"] for e in edge_rows)
     assert any(e["role"] for e in edge_rows)
     assert any(e["strain"] for e in edge_rows)
+
+
+def test_shared_edges_are_written_once(exported_shared):
+    """A stock solution's composition belongs to the solution, not to each medium.
+
+    `transform()` walks every record's `solutions[]`, so a shared solution
+    re-emitted its whole composition once per referencing medium. `Seven vitamins
+    solution` is referenced by 178 media, so each of its `has_part` edges appeared
+    178 times — 45,464 surplus rows, 23% of the file (#312).
+
+    Every collision was an exact duplicate triple, so keeping the first loses
+    nothing: on the real corpus, distinct edges before and after are both 153,372.
+
+    Uses `exported_shared` deliberately. Against the plain `exported` fixture this
+    assertion is vacuous — those two records share no solution, so no duplicate
+    can arise and the test passes with the dedup removed. Verified by reverting
+    the fix: only the shared-solution fixtures fail.
+    """
+    _node_rows, edge_rows = exported_shared
+    ids = [e["id"] for e in edge_rows]
+    assert len(ids) == len(set(ids)), "duplicate edge id in the edges file"
+
+    triples = [(e["subject"], e["predicate"], e["object"]) for e in edge_rows]
+    assert len(triples) == len(set(triples))
+    # ...and the id really is a function of the triple, which is what makes
+    # deduplicating on the id safe.
+    assert len(set(ids)) == len(set(triples))
+
+
+def test_a_solution_shared_by_two_media_emits_its_composition_once(exported_shared):
+    """The #312 shape itself, not just the absence of duplicates."""
+    _node_rows, edge_rows = exported_shared
+    composition = [e for e in edge_rows
+                   if e["subject"].startswith("culturemech:solution_")
+                   and e["predicate"] == "biolink:has_part"]
+    assert composition, "fixture must reference a shared solution"
+    assert len(composition) == len({e["id"] for e in composition})
+    # Both media still get their own medium -> solution edge: that one IS
+    # per-medium and must not be collapsed.
+    to_solution = [e for e in edge_rows
+                   if e["object"].startswith("culturemech:solution_")
+                   and e["predicate"] == "biolink:has_part"]
+    assert len(to_solution) == 2, to_solution
 
 
 def test_shared_nodes_are_written_once(exported):


### PR DESCRIPTION
Closes #312.

## The defect

The edges file carried **45,464 duplicate rows — 23% of it**:

```
edge rows          198,836
distinct edge ids  153,372
ids appearing >1    32,282
```

`_make_edge_id` is a deterministic UUID5 over `subject|predicate|object`, which is correct. The duplication is upstream: `transform()` walks each record's `solutions[]` and emits the solution's whole composition, so a **shared stock solution re-emits it once per referencing medium**. `Seven vitamins solution` is referenced by 178 media, so each of its `has_part` edges appeared 178 times.

The medium→solution edge *is* per-medium and is correctly repeated. The solution→ingredient edges are a property of the solution alone.

## The fix

The same run-scoped `seen` set that nodes have had since #294 — edges were simply never given it.

## Nothing is lost

Every collision was an **exact duplicate triple**, confirmed by `distinct triples == distinct ids`. On the full corpus the distinct edge count is **153,372 before and after**:

```
after: 153,372 rows == 153,372 ids == 153,372 triples
       0 dangling, 0 orphaned
```

The only id-level differences between the two runs are the 3 cholesterol regroundings from #316, which landed in between — verified by diffing the two exports, not assumed.

| predicate | edges |
|---|---:|
| `biolink:has_part` | 117,701 |
| `biolink:has_attribute` | 25,147 |
| `biolink:same_as` | 10,399 |
| `biolink:subclass_of` | 48 |
| `METPO:2000517` | 77 |

## On the tests

Two, **both verified to fail when the dedup is removed**. That check earned its keep: the first version asserted no-duplicate-ids against the standard fixture, whose two records share no solution — so no duplicate could arise and it **passed with the fix reverted**. It was a vacuous test with a docstring claiming #312 coverage.

Both now use a fixture where two media reference one solution — the actual #312 shape — and assert both halves: the composition is emitted **once**, and the per-medium medium→solution edge is still emitted **twice**.

## Notes

- 1,424 tests pass.
- The 55 ruff findings in the touched files are pre-existing and identical before and after.
- Worth knowing downstream: the edges file shrinks by 23%, so any prior benchmark or ingest sizing against it was measuring inflated input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
