### PR TITLE
Add fact-based-answers discipline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,16 @@ and across concurrent sessions.
 - Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
   a remembered issue list; `git log`/`git blame` over a recalled commit; a
   fresh `Read` over trusting an earlier read of the same file.
-- `data/merge_yaml/merged/`, `app/data.js`, `pages/normalized/`, and
-  `pages/media/` (see "Data authority" below) are generated from the
-  authoritative `data/normalized_yaml/` corpus and can lag it. `data/raw_yaml/`
-  is a different case — it precedes `normalized_yaml` in the pipeline, not
-  generated from it (see "Data authority"). Do not quote a count or a
-  record's current state from any derived file without confirming it against
-  its actual source or regenerating.
+- `app/data.js` and `pages/normalized/` (see "Data authority" below) are
+  generated directly from the authoritative `data/normalized_yaml/` corpus
+  and can lag it. `pages/media/` is one hop further downstream: it's
+  generated from `data/merge_yaml/merged/`, not `normalized_yaml/` directly
+  (per `docs/DATA_LAYERS.md`) — verify it against `merge_yaml/merged/`, which
+  can itself lag `normalized_yaml/` even when `pages/media/` is freshly
+  regenerated. `data/raw_yaml/` is a different case again — it precedes
+  `normalized_yaml` in the pipeline, not generated from it. Do not quote a
+  count or a record's current state from any derived file without confirming
+  it against its actual immediate source or regenerating.
 - This repo's own local checkout can lag its `origin/main`; verify against
   `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
   asserting what the repository currently contains.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,12 @@ and across concurrent sessions.
 - `pages/media/`: ignored CI output, generated from `data/merge_yaml/merged/`
   (not `data/normalized_yaml/` directly) — see `docs/DATA_LAYERS.md`. Never
   hand-edit or commit it.
-- Other generated page assets (`pages/index.html`, `pages/style.css`,
-  `pages/mermaid-init.js`, and per-domain page directories): ignored CI
-  outputs. Never hand-edit or commit them; see `docs/DATA_LAYERS.md` for the
-  full list.
+- Other generated page assets (`pages/index.html`, `pages/style.css`, and
+  `pages/mermaid-init.js`): ignored CI outputs. Never hand-edit or commit
+  them; see `docs/DATA_LAYERS.md` for the full list. `pages/bacterial/`,
+  `pages/algae/`, `pages/archaea/`, `pages/fungal/`, and `pages/specialized/`
+  are legacy per-category output the renderer no longer writes (see
+  `.gitignore`) — blocked from re-add, not actively regenerated.
 
 ## Required validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,11 @@ and across concurrent sessions.
 - Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
   a remembered issue list; `git log`/`git blame` over a recalled commit; a
   fresh `Read` over trusting an earlier read of the same file.
-- Derived artifacts can lag the source they were generated from, and that
-  source is not always `data/normalized_yaml/` directly (`pages/media/`, for
-  example, is generated from `data/merge_yaml/merged/`, not from
-  `normalized_yaml/`) — see "Data authority" below for the exact source of
-  each file. Do not quote a count or a record's current state from a derived
-  file without confirming it against its actual immediate source or
-  regenerating.
+- Derived artifacts can lag the source they were generated from — see "Data
+  authority" below for the exact source of each file; it is not always
+  `data/normalized_yaml/` directly. Do not quote a count or a record's
+  current state from a derived file without confirming it against its
+  actual immediate source or regenerating.
 - This repo's own local checkout can lag its `origin/main`; verify against
   `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
   asserting what the repository currently contains.
@@ -30,7 +28,7 @@ and across concurrent sessions.
   verify before asserting, and say "unresolved" rather than force a plausible
   guess.
 - If a claim cannot be verified this session, say so ("I did not check X" /
-  "I don't know") instead of presenting a plausible guess as fact.
+  "I do not know") instead of presenting a plausible guess as fact.
 - Re-verify rather than repeat: restating an earlier claim in this same
   conversation without re-checking it is exactly the failure mode this rule
   exists to prevent.
@@ -50,6 +48,10 @@ and across concurrent sessions.
 - `pages/media/`: ignored CI output, generated from `data/merge_yaml/merged/`
   (not `data/normalized_yaml/` directly) — see `docs/DATA_LAYERS.md`. Never
   hand-edit or commit it.
+- Other generated page assets (`pages/index.html`, `pages/style.css`,
+  `pages/mermaid-init.js`, and per-domain page directories): ignored CI
+  outputs. Never hand-edit or commit them; see `docs/DATA_LAYERS.md` for the
+  full list.
 
 ## Required validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,16 +15,13 @@ and across concurrent sessions.
 - Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
   a remembered issue list; `git log`/`git blame` over a recalled commit; a
   fresh `Read` over trusting an earlier read of the same file.
-- `app/data.js` and `pages/normalized/` (see "Data authority" below) are
-  generated directly from the authoritative `data/normalized_yaml/` corpus
-  and can lag it. `pages/media/` is one hop further downstream: it's
-  generated from `data/merge_yaml/merged/`, not `normalized_yaml/` directly
-  (per `docs/DATA_LAYERS.md`) — verify it against `merge_yaml/merged/`, which
-  can itself lag `normalized_yaml/` even when `pages/media/` is freshly
-  regenerated. `data/raw_yaml/` is a different case again — it precedes
-  `normalized_yaml` in the pipeline, not generated from it. Do not quote a
-  count or a record's current state from any derived file without confirming
-  it against its actual immediate source or regenerating.
+- Derived artifacts can lag the source they were generated from, and that
+  source is not always `data/normalized_yaml/` directly (`pages/media/`, for
+  example, is generated from `data/merge_yaml/merged/`, not from
+  `normalized_yaml/`) — see "Data authority" below for the exact source of
+  each file. Do not quote a count or a record's current state from a derived
+  file without confirming it against its actual immediate source or
+  regenerating.
 - This repo's own local checkout can lag its `origin/main`; verify against
   `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
   asserting what the repository currently contains.
@@ -32,7 +29,7 @@ and across concurrent sessions.
   and schema editing rules" below) is a special case of this same rule —
   verify before asserting, and say "unresolved" rather than force a plausible
   guess.
-- If a claim can't be verified this session, say so ("I did not check X" /
+- If a claim cannot be verified this session, say so ("I did not check X" /
   "I don't know") instead of presenting a plausible guess as fact.
 - Re-verify rather than repeat: restating an earlier claim in this same
   conversation without re-checking it is exactly the failure mode this rule
@@ -48,9 +45,11 @@ and across concurrent sessions.
   instead of fixing normalized inputs or merge rules.
 - `src/culturemech/schema/culturemech.yaml`: authoritative schema. Generated
   dataclasses and schema documentation must change in the same commit.
-- `app/data.js`, `pages/normalized/`, `pages/media/`, and generated page assets
-  are ignored CI outputs. Never hand-edit or commit them; see
-  `docs/DATA_LAYERS.md`.
+- `app/data.js`, `pages/normalized/`: ignored CI outputs, generated directly
+  from `data/normalized_yaml/`. Never hand-edit or commit them.
+- `pages/media/`: ignored CI output, generated from `data/merge_yaml/merged/`
+  (not `data/normalized_yaml/` directly) — see `docs/DATA_LAYERS.md`. Never
+  hand-edit or commit it.
 
 ## Required validation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,21 +9,24 @@ its procedure here.
 Never state a comparison, count, status, or historical claim without having
 verified it in the current conversation via a tool call (`gh`, `git`, `grep`,
 `Read`, etc.). "I recall," "this is typically the case," or a prior summary
-are not verification -- recipe data and repository state change between turns
+are not verification — recipe data and repository state change between turns
 and across concurrent sessions.
 
 - Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
   a remembered issue list; `git log`/`git blame` over a recalled commit; a
   fresh `Read` over trusting an earlier read of the same file.
-- Derived artifacts (see "Data authority" below for the current list) can lag
-  the authoritative `data/normalized_yaml/` corpus they were generated from.
-  Do not quote a count or a record's current state from a derived file
-  without confirming it against the normalized source or regenerating.
+- `data/merge_yaml/merged/`, `app/data.js`, `pages/normalized/`, and
+  `pages/media/` (see "Data authority" below) are generated from the
+  authoritative `data/normalized_yaml/` corpus and can lag it. `data/raw_yaml/`
+  is a different case — it precedes `normalized_yaml` in the pipeline, not
+  generated from it (see "Data authority"). Do not quote a count or a
+  record's current state from any derived file without confirming it against
+  its actual source or regenerating.
 - This repo's own local checkout can lag its `origin/main`; verify against
   `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
   asserting what the repository currently contains.
 - "Do not invent ontology IDs, labels, citations, or evidence" (see "Recipe
-  and schema editing rules" below) is a special case of this same rule --
+  and schema editing rules" below) is a special case of this same rule —
   verify before asserting, and say "unresolved" rather than force a plausible
   guess.
 - If a claim can't be verified this session, say so ("I did not check X" /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,10 @@ and across concurrent sessions.
 - Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
   a remembered issue list; `git log`/`git blame` over a recalled commit; a
   fresh `Read` over trusting an earlier read of the same file.
-- Derived artifacts (`data/merge_yaml/merged/`, `app/data.js`,
-  `pages/normalized/`, `pages/media/`) can lag the authoritative
-  `data/normalized_yaml/` corpus they were generated from -- see "Data
-  authority" below. Do not quote a count or a record's current state from a
-  derived file without confirming it against the normalized source or
-  regenerating.
+- Derived artifacts (see "Data authority" below for the current list) can lag
+  the authoritative `data/normalized_yaml/` corpus they were generated from.
+  Do not quote a count or a record's current state from a derived file
+  without confirming it against the normalized source or regenerating.
 - This repo's own local checkout can lag its `origin/main`; verify against
   `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
   asserting what the repository currently contains.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,36 @@ Use this file as the repository-level contract. Detailed workflows live in
 `.claude/skills/*/SKILL.md`; follow the relevant skill rather than duplicating
 its procedure here.
 
+## Fact-based answers only
+
+Never state a comparison, count, status, or historical claim without having
+verified it in the current conversation via a tool call (`gh`, `git`, `grep`,
+`Read`, etc.). "I recall," "this is typically the case," or a prior summary
+are not verification -- recipe data and repository state change between turns
+and across concurrent sessions.
+
+- Prefer a live check over memory: `gh api`/`gh pr view`/`gh issue view` over
+  a remembered issue list; `git log`/`git blame` over a recalled commit; a
+  fresh `Read` over trusting an earlier read of the same file.
+- Derived artifacts (`data/merge_yaml/merged/`, `app/data.js`,
+  `pages/normalized/`, `pages/media/`) can lag the authoritative
+  `data/normalized_yaml/` corpus they were generated from -- see "Data
+  authority" below. Do not quote a count or a record's current state from a
+  derived file without confirming it against the normalized source or
+  regenerating.
+- This repo's own local checkout can lag its `origin/main`; verify against
+  `gh api` or a fresh `git fetch`, not the working tree on disk alone, before
+  asserting what the repository currently contains.
+- "Do not invent ontology IDs, labels, citations, or evidence" (see "Recipe
+  and schema editing rules" below) is a special case of this same rule --
+  verify before asserting, and say "unresolved" rather than force a plausible
+  guess.
+- If a claim can't be verified this session, say so ("I did not check X" /
+  "I don't know") instead of presenting a plausible guess as fact.
+- Re-verify rather than repeat: restating an earlier claim in this same
+  conversation without re-checking it is exactly the failure mode this rule
+  exists to prevent.
+
 ## Data authority
 
 - `data/raw/`: immutable upstream captures. Large payloads are ignored; source


### PR DESCRIPTION
## Summary

- Adds a "Fact-based answers only" section to CLAUDE.md: never state a comparison, count, status, or historical claim without verifying it in the current conversation via a tool call.
- Direct user request, made after a separate session presented an unverified comparison as fact and had to redo the analysis. This is the CultureMech companion to CultureBotAI/culturebotai-claw#128, which added the same section to culturebotai-claw's CLAUDE.md.
- Adapted (not copied verbatim) to this repo: cross-references the existing "Data authority" section's normalized_yaml vs. derived-artifact layering (`data/merge_yaml/merged/`, `app/data.js`, `pages/normalized/`, `pages/media/` can lag `data/normalized_yaml/`), and cross-references the existing "do not invent ontology IDs, labels, citations, or evidence" rule under "Recipe and schema editing rules" rather than duplicating it.

Doc-only change; no code, schema, or data files touched.

## Test plan

- [x] `git status --short` confirmed only `CLAUDE.md` changed before commit.
- [ ] Human review of section wording/placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)