### PR TITLE
Resolve ingredient identities through pinned MIM label index

### DIFF
--- a/.claude/skills/manage-ingredient-hierarchy/SKILL.md
+++ b/.claude/skills/manage-ingredient-hierarchy/SKILL.md
@@ -17,6 +17,25 @@ version: 1.0.0
 
 **Scope**: Integration between MediaIngredientMech (source of truth for ingredient hierarchy) and CultureMech (consumer of hierarchy data).
 
+## Canonical ingredient identity resolution
+
+New publication consumers must use
+`culturemech.ingredients.mim_label_index`, backed by the immutable packaged MIM
+`label_index.csv` and adjacent pin metadata. Run `just check-mim-label-index`
+offline; preview a full-SHA dependency bump with
+`just refresh-mim-label-index <sha>` and apply it only with `--apply`.
+
+The resolver uses exact labels before a conservative whitespace/hyphen/underscore
+fallback, preserves hydrate counts and chemical punctuation, obeys MIM's
+per-label ambiguity verdict, and never fuzzy-matches. MIM `identifier` is the
+semantic value; `ontology_id` is diagnostic only. Local terms are fallback,
+except that explicit MIM `UNMAPPED` suppresses them.
+
+The loader/linker and mutating enrichment actions below are legacy migration
+tools. They may still be used for their documented hierarchy fields, but their
+moving-checkout, first-wins synonym, and fuzzy matching must not decide KGX or
+other published ingredient identity.
+
 ## When to Use This Skill
 
 Use this skill when:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The MIM pin is verified byte-for-byte against its immutable upstream artifact.
+# Preserve its CRLF bytes on every platform and keep review focused on metadata
+# and the semantic delta printed by scripts/refresh_mim_label_index.py.
+src/culturemech/data/mediaingredientmech/label_index.csv binary

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,8 @@ jobs:
             --file "$GITHUB_WORKSPACE/tests/fixtures/render_smoke.yaml" \
             --output-dir /tmp/culturemech-wheel-smoke/media \
             --index-dir /tmp/culturemech-wheel-smoke
+          "$GITHUB_WORKSPACE/.venv/bin/python" -c \
+            "from culturemech.ingredients import resolve_ingredient; assert resolve_ingredient({'preferred_term': 'EDTA'}).identifier == 'CHEBI:4735'"
 
   fast:
     name: Fast tests (Python ${{ matrix.python-version }})
@@ -108,11 +110,10 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v2
 
-      # `--extra dev` is required: pytest lives in [project.optional-dependencies]
-      # dev, which a plain `uv sync` does not install. The other workflows omit it
-      # because they only invoke runtime deps.
+      # `dev` supplies pytest. `koza` keeps the real KGX TSV path from silently
+      # skipping, including the MIM identity-resolution publication checks.
       - name: Sync dependencies
-        run: uv sync --frozen --extra dev
+        run: uv sync --frozen --extra dev --extra koza
 
       - name: Verify recipe ID lifecycle catalog
         run: just check-id-catalog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ and across concurrent sessions.
   instead of fixing normalized inputs or merge rules.
 - `src/culturemech/schema/culturemech.yaml`: authoritative schema. Generated
   dataclasses and schema documentation must change in the same commit.
+- `src/culturemech/data/mediaingredientmech/label_index.csv`: immutable,
+  packaged MIM ingredient-resolution snapshot. The adjacent metadata pins the
+  full source commit, hash, row count, and contract. Verify offline with
+  `just check-mim-label-index`; refreshes are preview-only unless `--apply` is
+  explicit and must use a full 40-character MIM SHA.
 - `app/data.js`, `pages/normalized/`: ignored CI outputs, generated directly
   from `data/normalized_yaml/`. Never hand-edit or commit them.
 - `pages/media/`: ignored CI output, generated from `data/merge_yaml/merged/`
@@ -64,6 +69,8 @@ Choose checks by changed surface:
 - One recipe: `just validate path/to/recipe.yaml` plus relevant semantic checks.
 - Corpus or schema: `just validate-strict`, `just assign-ids-check`, and
   `just validate-products`. Regenerate schema-derived files after schema edits.
+- MIM resolver or KGX ingredient identity: `just check-mim-label-index`, focused
+  resolver/KGX tests, and the installed-wheel resource smoke.
 - Merge inputs/rules: `just verify-merges` and `just audit-merge-freshness`.
 - Renderer/browser: renderer tests plus `python -m culturemech.web_artifacts`
   after generating browser data and normalized pages.
@@ -86,6 +93,10 @@ is the closed-schema corpus gate and rejects unknown fields.
 - Do not invent ontology IDs, labels, citations, or evidence. Verify ID/label
   correspondence and preserve primary-source provenance. Keep unresolved
   values explicit rather than forcing a plausible grounding.
+- For publication-time ingredient identity, use
+  `culturemech.ingredients.mim_label_index`; do not add a second fuzzy or
+  sibling-checkout resolver. Hydrate counts, digits, and formula punctuation
+  are identity-significant.
 
 ## External dependencies
 

--- a/docs/DATA_LAYERS.md
+++ b/docs/DATA_LAYERS.md
@@ -35,6 +35,21 @@ to require exact source, browser-record, and page coverage. The tracked
 `app/*.html`, JavaScript application code, root `index.html`, and
 `pages/media_growth_review.html` remain publication inputs.
 
+## Pinned external reference data
+
+`data/normalized_yaml/` remains authoritative for recipe content: labels,
+amounts, containment, preparation, and provenance. Published ingredient
+identity is resolved separately through the packaged MIM snapshot at
+`src/culturemech/data/mediaingredientmech/label_index.csv`, with its immutable
+source commit and SHA-256 recorded in adjacent metadata. This split lets MIM
+curation reach exports without rewriting 15,877 recipe records while keeping
+normal builds offline and reproducible.
+
+Use `just check-mim-label-index` for the offline integrity gate. A dependency
+bump is preview-only by default and requires a full MIM commit plus an explicit
+`--apply`; see
+[`mediaingredientmech_enrichment.md`](mediaingredientmech_enrichment.md).
+
 ---
 
 ## Layer 1: Raw Data (`raw/`)

--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -6,6 +6,13 @@ This document describes the semantic modeling used in CultureMech's KGX export, 
 
 The KGX export transforms CultureMech media recipes into a knowledge graph format with proper semantic relationships. The model focuses on creating meaningful edges between organisms, media, solutions, and ingredients using standardized ontology predicates.
 
+Ingredient objects are resolved at export time through CultureMech's immutable,
+packaged snapshot of MediaIngredientMech `label_index.csv`. MIM's `identifier`
+is authoritative when its per-label ambiguity verdict is safe; local recipe
+terms are fallback only. The result is not CHEBI-only: FOODON, BTO, NCIT, CAS,
+MeSH, and curated local identities can be valid ingredient objects. See
+[`mediaingredientmech_enrichment.md`](mediaingredientmech_enrichment.md).
+
 ## Entity Types
 
 ### Nodes
@@ -22,9 +29,9 @@ The KGX export transforms CultureMech media recipes into a knowledge graph forma
    - Pre-made stock solutions used in media preparation
    - Example: `culturemech:solution_Trace_Metal_Solution`
 
-4. **Ingredient** (`CHEBI:*`)
-   - Chemical entities in media or solutions
-   - Example: `CHEBI:17234` (Glucose)
+4. **Ingredient** (MIM-resolved external identity)
+   - Chemicals, food products, mixtures, and registry-identified materials in media or solutions
+   - Examples: `CHEBI:17234` (glucose), `FOODON:00004410` (beef heart food product)
 
 5. **Medium Type** (`culturemech:medium_type_*`)
    - Type classification nodes
@@ -106,7 +113,7 @@ culturemech:solution_Trace_Elements --[biolink:has_part]--> CHEBI:49976
 **Structure**:
 - **Subject**: Solution (culturemech solution ID)
 - **Predicate**: `biolink:has_part`
-- **Object**: Ingredient (CHEBI ID)
+- **Object**: Ingredient (MIM-resolved ontology or registry CURIE)
 
 **Qualifiers**:
 - `biolink:concentration` - Amount in solution (e.g., "0.07 g/L")
@@ -142,7 +149,7 @@ culturemech:LB_Broth --[biolink:has_part]--> CHEBI:17234
 **Structure**:
 - **Subject**: Medium (culturemech ID)
 - **Predicate**: `biolink:has_part`
-- **Object**: Ingredient (CHEBI ID)
+- **Object**: Ingredient (MIM-resolved ontology or registry CURIE)
 
 **Qualifiers**:
 - `biolink:concentration` - Amount in medium (e.g., "10 g/L")
@@ -244,6 +251,7 @@ just kgx-export
 
 - **NCBITaxon** - Taxonomic identifiers for organisms
 - **CHEBI** - Chemical Entities of Biological Interest
+- **FOODON/BTO/NCIT/MeSH/CAS** - Other identity spaces selected by MediaIngredientMech
 - **culturemech** - CultureMech internal identifiers
 - **METPO** - Metabolite Profiling Ontology
 

--- a/docs/SSSOM_PIPELINE.md
+++ b/docs/SSSOM_PIPELINE.md
@@ -10,6 +10,15 @@ The SSSOM pipeline consists of three main components:
 2. **SSSOM Generation** - Create SSSOM mapping file from existing CHEBI term assignments
 3. **OLS Enrichment** - Verify and expand mappings using the EBI Ontology Lookup Service API
 
+This pipeline describes CultureMech's local CHEBI mapping products and remains
+useful for diagnostics and curation. It is not the identity authority used by
+KGX publication. KGX resolves recipe labels through the immutable packaged MIM
+`label_index.csv`, whose `identifier` can be CHEBI or another ontology,
+registry, or curated local CURIE. See
+[`mediaingredientmech_enrichment.md`](mediaingredientmech_enrichment.md). The
+older `audit-mim-sssom` command is likewise an exactMatch/CHEBI-only divergence
+report, not a substitute for that resolver.
+
 ## Quick Start
 
 Run the complete pipeline:

--- a/docs/mediaingredientmech_enrichment.md
+++ b/docs/mediaingredientmech_enrichment.md
@@ -1,301 +1,129 @@
-# MediaIngredientMech Enrichment
+# MediaIngredientMech ingredient identity resolution
 
-This document describes the MediaIngredientMech enrichment pipeline for linking CultureMech ingredients to MediaIngredientMech identifiers.
+CultureMech publishes ingredient identities through MediaIngredientMech's
+per-label resolution artifact. Runtime resolution is deterministic and offline:
+the exact MIM artifact revision is vendored inside the CultureMech package.
 
-## Overview
+This is a publication-time decision. It does not rewrite curated recipe YAML,
+and it does not change which recipe contains an ingredient.
 
-The MediaIngredientMech enrichment pipeline adds `mediaingredientmech_term` fields to ingredient and solution descriptors in CultureMech recipe YAML files. This enables cross-referencing between CultureMech recipes and the MediaIngredientMech knowledge base.
+## Pinned dependency
 
-## Components
+The packaged files are:
 
-### 1. MediaIngredientMechLoader (`src/culturemech/enrich/mediaingredientmech_loader.py`)
+- `src/culturemech/data/mediaingredientmech/label_index.csv`
+- `src/culturemech/data/mediaingredientmech/label_index.metadata.json`
 
-Loads and indexes ingredient data from the MediaIngredientMech repository.
+The current pin is MIM commit
+`82694054f5bbf74b5392bf8858c9962c2152a35a`: 9,115 data rows, 854,426
+bytes, SHA-256
+`7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac`.
+Metadata also fixes the repository, source path, seven-column header, row count,
+and consumer-contract version. There is no moving-branch lookup in a normal
+build.
 
-**Features:**
-- Clones MediaIngredientMech repository from GitHub if not provided
-- Loads ingredient data from `unmapped_ingredients.yaml`
-- Builds indexes for efficient matching:
-  - By CHEBI ID
-  - By normalized ingredient name
-  - By synonyms
-- Implements fuzzy matching with configurable threshold
-
-**Matching Priority:**
-1. CHEBI ID (exact match)
-2. Exact name match (case-insensitive, normalized)
-3. Synonym match
-4. Fuzzy name match (default threshold: 0.95)
-
-### 2. MediaIngredientMechLinker (`src/culturemech/enrich/mediaingredientmech_linker.py`)
-
-Enriches CultureMech recipes with MediaIngredientMech identifiers.
-
-**Features:**
-- Processes ingredients at recipe level
-- Processes solution composition ingredients
-- Skips already-linked ingredients
-- Tracks detailed statistics:
-  - Files processed
-  - Ingredients matched
-  - Solutions with matched ingredients
-  - Match method breakdown
-  - Unmatched ingredients
-- Adds curation history entries
-
-### 3. CLI Script (`scripts/enrich_with_mediaingredientmech.py`)
-
-Command-line interface for running the enrichment pipeline.
-
-**Features:**
-- Automatic repository cloning
-- Category filtering
-- Dry-run mode
-- Limit for testing
-- JSON report generation
-
-## Usage
-
-### Basic Usage
+Verify the dependency without network access:
 
 ```bash
-# Dry run on first 10 files to test
-python scripts/enrich_with_mediaingredientmech.py --dry-run --limit 10
-
-# Process all bacterial media
-python scripts/enrich_with_mediaingredientmech.py --category bacterial
-
-# Process all media with JSON report
-python scripts/enrich_with_mediaingredientmech.py --report-output enrichment_report.json
+just check-mim-label-index
 ```
 
-### Advanced Usage
+The check rejects hash, size, header, enum, row-count, label-contiguity,
+group-ambiguity, and merge-tombstone drift.
+
+## Resolution contract
+
+`culturemech.ingredients.mim_label_index` returns a structured
+`GroundingDecision`. Its `identifier` is the semantic identity selected for KG
+publication; `ontology_id` is retained only as diagnostic publisher data.
+
+Resolution order is:
+
+1. Match a trimmed, Unicode-normalized, case-insensitive exact label group.
+2. If absent, try a conservative fallback that collapses whitespace, ASCII
+   hyphen, and underscore only. Digits and chemical punctuation remain intact.
+3. Trust MIM's first row only when `ambiguity` is `unique`,
+   `resolved:owned`, or `agree:same_substance`.
+4. Refuse `conflict:different_substances`,
+   `unresolved:partial_chemistry`, and `unresolved:no_chemistry`.
+5. Treat `UNMAPPED` as an authoritative absence, suppressing a conflicting
+   local term.
+6. Follow a `REJECTED` merge tombstone only when a live `MAPPED` row holds its
+   identifier. `UNMAPPED_NNNN` is the valid invalid-retirement exception; a
+   dangling ontology or registry identifier makes the artifact invalid.
+
+There is no fuzzy matching. In particular, hydrate counts and formula
+punctuation are never discarded: an anhydrous ingredient and its hydrate are
+different ordered substances.
+
+MIM `identifier` values are not CHEBI-only. FOODON, BTO, NCIT, CAS, MeSH, and
+curated local identities can be legitimate answers and are retained.
+
+## Local fallback and source identity
+
+When MIM has no usable verdict, the resolver prefers:
+
+1. `chebi_term.id`
+2. a non-`mediadive.compound:*` `term.id`
+
+A MediaDive compound identifier is preserved separately as
+`source_compound_id`; it is not promoted to semantic identity. An unsafe MIM
+ambiguity may retain a local identity only as the explicitly labelled
+`ambiguous_local_fallback` result. An explicit MIM `UNMAPPED` verdict never
+falls back locally.
+
+Examples pinned by tests:
+
+| recipe label | local value | publication decision |
+|---|---|---|
+| `EDTA` | `CHEBI:64755` EDTA(2−) | `CHEBI:4735` free acid |
+| `Beef heart` | `UBERON:0000948` organ | `FOODON:00004410` food product |
+| `Calf brains` | `UBERON:0000955` organ | no identity; MIM explicitly unmapped |
+| `Infusion from Potatoes` | unrelated FOODON term | no identity; MIM explicitly unmapped |
+
+## Consumers
+
+KGX is the first production consumer. Direct medium ingredients and ingredients
+inside a referenced solution are resolved through this shared code before a
+`biolink:has_part` edge is emitted. An explicit authoritative-unmapped result
+omits the ingredient edge.
+
+The resolver is injectable into the pure `transform()` function for isolated
+tests. Koza uses the verified packaged default lazily. A wheel smoke test loads
+it from `/tmp`, proving an installed distribution does not rely on the source
+checkout.
+
+The occurrence pipeline tracked by #337 must import this same resolver. That
+issue owns structural traversal, including the distinction between
+`MediaRecipe.ingredients` and root `SolutionRecipe.composition`, stable
+occurrence coordinates, placeholder exclusion, uncapped outputs, and parse
+errors. #260 deliberately does not conceal the existing root-solution traversal
+gap inside KGX.
+
+## Refreshing the pin
+
+A refresh is an explicit dependency review. A full lowercase 40-character MIM
+commit SHA is required; branch names and short SHAs are rejected.
 
 ```bash
-# Use existing MediaIngredientMech repository
-python scripts/enrich_with_mediaingredientmech.py \
-  --mim-repo /path/to/MediaIngredientMech
+# Preview only (default): download, validate, and report answer changes
+just refresh-mim-label-index <full-mim-sha>
 
-# Custom fuzzy matching threshold
-python scripts/enrich_with_mediaingredientmech.py \
-  --fuzzy-threshold 0.90
-
-# Verbose logging
-python scripts/enrich_with_mediaingredientmech.py \
-  --verbose --dry-run --limit 5
+# Apply after reviewing added, removed, and changed labels
+just refresh-mim-label-index <full-mim-sha> --apply
 ```
 
-### Command-Line Options
+The metadata is deterministic and intentionally has no retrieval timestamp.
+Both files must be committed together.
 
-```
---yaml-dir PATH           Directory containing recipe YAML files
-                         (default: data/normalized_yaml)
+## Legacy enrichment tools
 
---mim-repo PATH          Path to existing MediaIngredientMech repository
-                         (if not provided, will clone from GitHub)
+`MediaIngredientMechLoader`, `MediaIngredientMechLinker`, and
+`scripts/enrich_with_mediaingredientmech.py` remain temporarily for legacy
+migrations. They are not the publication authority: they can read a moving
+checkout, use first-wins synonym and fuzzy matching, and can materialize answers
+into recipe YAML. Do not extend or advertise that path for new exports.
 
---category CATEGORY      Process only specified category
-                         (bacterial, fungal, archaea, algae, specialized, imported)
-
---limit N                Limit number of files to process (for testing)
-
---dry-run                Show what would be done without modifying files
-
---report-output PATH     Save JSON report with statistics
-
---fuzzy-threshold FLOAT  Fuzzy matching threshold 0.0-1.0 (default: 0.95)
-
---verbose                Enable verbose logging
-```
-
-## MediaIngredientMech Data Format
-
-The pipeline expects a `unmapped_ingredients.yaml` file in the MediaIngredientMech repository with the following structure:
-
-```yaml
-- id: MediaIngredientMech:000001
-  name: Glucose
-  chebi_id: CHEBI:17234
-  synonyms:
-    - D-Glucose
-    - Dextrose
-    - Grape sugar
-
-- id: MediaIngredientMech:000002
-  name: Yeast Extract
-  synonyms:
-    - Yeast extract powder
-    - YE
-
-- id: MediaIngredientMech:000003
-  name: Sodium chloride
-  chebi_id: CHEBI:26710
-  synonyms:
-    - NaCl
-    - Table salt
-    - Salt
-```
-
-**Required fields:**
-- `id`: MediaIngredientMech identifier (format: `MediaIngredientMech:XXXXXX`)
-- `name`: Primary ingredient name
-
-**Optional fields:**
-- `chebi_id`: CHEBI identifier (with or without `CHEBI:` prefix)
-- `synonyms`: List of alternative names
-
-## Output Format
-
-The enrichment adds `mediaingredientmech_term` fields to ingredients:
-
-### Before:
-```yaml
-ingredients:
-- preferred_term: Glucose
-  term:
-    id: CHEBI:17234
-    label: glucose
-  concentration:
-    value: '10'
-    unit: G_PER_L
-```
-
-### After:
-```yaml
-ingredients:
-- preferred_term: Glucose
-  term:
-    id: CHEBI:17234
-    label: glucose
-  mediaingredientmech_term:
-    id: MediaIngredientMech:000001
-    label: Glucose
-  concentration:
-    value: '10'
-    unit: G_PER_L
-```
-
-## Curation History
-
-Each enriched file gets a curation history entry:
-
-```yaml
-curation_history:
-- timestamp: '2026-03-13T21:45:00.000000Z'
-  curator: mediaingredientmech-enrichment-v1.0
-  action: Added MediaIngredientMech links
-  notes: Linked ingredients to MediaIngredientMech identifiers
-```
-
-## Statistics Report
-
-The JSON report includes:
-
-```json
-{
-  "parameters": {
-    "yaml_dir": "data/normalized_yaml",
-    "category": "bacterial",
-    "limit": null,
-    "dry_run": false,
-    "fuzzy_threshold": 0.95
-  },
-  "statistics": {
-    "files_processed": 150,
-    "ingredients_matched": 450,
-    "solutions_matched": 25,
-    "already_linked": 10,
-    "no_match": 50,
-    "errors": 0,
-    "match_methods": {
-      "chebi_id": 300,
-      "exact_name": 100,
-      "synonym": 40,
-      "fuzzy_0.96": 10
-    }
-  },
-  "unmatched_ingredients": [
-    {
-      "name": "Unknown ingredient",
-      "chebi_id": "N/A"
-    }
-  ]
-}
-```
-
-## Testing
-
-Run the test suite:
-
-```bash
-python tests/test_mediaingredientmech_enrichment.py
-```
-
-Or use pytest:
-
-```bash
-pytest tests/test_mediaingredientmech_enrichment.py -v
-```
-
-## Dependencies
-
-The enrichment pipeline requires:
-- `rapidfuzz>=3.0.0` - Fuzzy string matching
-- `pyyaml>=6.0` - YAML parsing
-- Standard library: `pathlib`, `subprocess`, `tempfile`, `logging`
-
-## Integration with CultureMech Schema
-
-The schema has been updated to support MediaIngredientMech identifiers:
-
-1. **IngredientDescriptor** - Added `mediaingredientmech_term` slot
-2. **SolutionDescriptor** - Added `mediaingredientmech_term` slot
-3. **MediaIngredientMechTerm** - New term class with pattern validation
-
-Schema pattern: `^MediaIngredientMech:\\d{6}$`
-
-## Best Practices
-
-1. **Always run dry-run first** to preview changes:
-   ```bash
-   python scripts/enrich_with_mediaingredientmech.py --dry-run --limit 10
-   ```
-
-2. **Start with a category** for incremental enrichment:
-   ```bash
-   python scripts/enrich_with_mediaingredientmech.py --category bacterial
-   ```
-
-3. **Generate reports** to track unmatched ingredients:
-   ```bash
-   python scripts/enrich_with_mediaingredientmech.py \
-     --report-output report.json
-   ```
-
-4. **Review unmatched ingredients** and add to MediaIngredientMech
-
-5. **Re-run enrichment** after updating MediaIngredientMech data
-
-## Troubleshooting
-
-### Repository clone fails
-- Check network connectivity
-- Verify repository URL
-- Use `--mim-repo` to provide local path
-
-### No matches found
-- Check MediaIngredientMech data format
-- Review ingredient names and synonyms
-- Adjust `--fuzzy-threshold` if needed
-
-### Permission errors
-- Ensure write access to YAML directory
-- Check file permissions
-
-## Future Enhancements
-
-- Support for alternative data sources
-- Machine learning-based matching
-- Automatic synonym generation
-- Batch processing optimization
-- Integration with CHEBI resolver
+Similarly, `audit_mim_sssom_divergence.py` remains useful as a historical
+CHEBI-only diagnostic. Its exactMatch-only sibling-checkout input is not a
+substitute for the pinned label resolver.

--- a/project.justfile
+++ b/project.justfile
@@ -428,19 +428,21 @@ audit-unparsed-composition *args="":
     uv run --extra dev python scripts/audit_unparsed_composition.py \
         --max-allowed 64 --max-exported 0 {{args}}
 
-# Compare our ingredient groundings against MIM's published SSSOM (#256).
+# Historical CHEBI-only diagnostic against a sibling MIM SSSOM (#256).
+# KGX identity now comes from the pinned label-index resolver (#260); this report
+# remains useful for recipe-local curation but does not decide publication.
 #
-# This has to live here rather than in MIM: kg-microbe resolves an ingredient
-# with `best_primary([chebi_id, culturemech_term_id, mim_id, ...])`, so OUR
-# `term.id` outranks MIM's. When MIM corrects a mapping the consumer still picks
-# ours, and MIM can only fix rows we hold no opinion on.
+# Before #260, kg-microbe's priority path let our stale `term.id` outrank MIM.
+# The resolver retires that publication defect; this audit still finds local
+# drift worth curating.
 #
 # Baselines are names, not rows -- one regrounding decision fixes every row of a
 # name. Today: 12 divergent, 75 internally split. Lower them as the backlog is
 # curated; never raise one to make a run pass.
 #
 # Needs MediaIngredientMech checked out beside this repo; pass --sssom otherwise.
-# Adopt MIM's published grounding where we hold none (#308).
+# Legacy recipe-local migration where we hold no CHEBI grounding (#308).
+# KGX publication no longer requires materializing this into recipe YAML.
 #
 # Applies only the audit's MISSING_GROUNDING finding. DIVERGENT runs both ways
 # and INTERNAL_SPLIT needs someone to pick a side, so neither is applied here.
@@ -453,6 +455,19 @@ apply-mim-groundings *args="":
 audit-mim-sssom *args="":
     uv run --extra dev python scripts/audit_mim_sssom_divergence.py \
         --max-divergent 12 --max-split 75 {{args}}
+
+# Verify the immutable MediaIngredientMech label-index dependency used by KGX.
+# Entirely offline: hash, source pin, header, enums, row count, and label-group
+# contiguity all have to agree with the checked-in metadata.
+[group('QC')]
+check-mim-label-index:
+    uv run python scripts/check_mim_label_index.py
+
+# Explicit dependency bump. A moving branch or short SHA is rejected; review
+# the printed label-resolution delta in the default preview, then pass --apply.
+[group('Curation')]
+refresh-mim-label-index commit *args="":
+    uv run python scripts/refresh_mim_label_index.py "{{commit}}" {{args}}
 
 # Merge locally-completed Edison runs (research/media/*-meta.yaml, gitignored)
 # into the tracked researched-media manifest. This is the only step that reads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 culturemech = [
+    "data/mediaingredientmech/*.csv",
+    "data/mediaingredientmech/*.json",
     "schema/*.yaml",
     "templates/*.j2",
     "templates/*.html",

--- a/scripts/check_mim_label_index.py
+++ b/scripts/check_mim_label_index.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Verify CultureMech's vendored MediaIngredientMech label-index pin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from culturemech.ingredients.mim_label_index import MIMLabelIndex
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESOURCE_DIR = REPO_ROOT / "src" / "culturemech" / "data" / "mediaingredientmech"
+INDEX_PATH = RESOURCE_DIR / "label_index.csv"
+METADATA_PATH = RESOURCE_DIR / "label_index.metadata.json"
+
+
+def main() -> int:
+    index = MIMLabelIndex.from_paths(INDEX_PATH, METADATA_PATH)
+    answers = index.semantic_answers()
+    states: dict[str, int] = {}
+    for _identifier, state, _ambiguity in answers.values():
+        states[state] = states.get(state, 0) + 1
+
+    print(
+        "MIM label index OK: "
+        f"{len(index.rows):,} rows, {len(answers):,} labels, "
+        f"commit {index.metadata['source_commit']}"
+    )
+    print("Decisions: " + ", ".join(f"{key}={states[key]:,}" for key in sorted(states)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_mim_label_index.py
+++ b/scripts/refresh_mim_label_index.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Refresh the vendored MIM label index from one immutable Git commit.
+
+This is an explicit dependency bump, not part of ordinary builds.  It requires
+a full 40-character SHA, validates the downloaded artifact before writing, and
+reports semantic answer changes for review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from culturemech.ingredients.mim_label_index import (
+    CONTRACT_VERSION,
+    INDEX_HEADER,
+    MIM_REPOSITORY,
+    MIM_SOURCE_PATH,
+    MIMLabelIndex,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESOURCE_DIR = REPO_ROOT / "src" / "culturemech" / "data" / "mediaingredientmech"
+INDEX_PATH = RESOURCE_DIR / "label_index.csv"
+METADATA_PATH = RESOURCE_DIR / "label_index.metadata.json"
+RAW_URL = (
+    "https://raw.githubusercontent.com/CultureBotAI/MediaIngredientMech/{commit}/" + MIM_SOURCE_PATH
+)
+FULL_SHA = re.compile(r"[0-9a-f]{40}\Z")
+
+
+def download(commit: str) -> bytes:
+    """Download the publisher artifact at an immutable revision."""
+
+    url = RAW_URL.format(commit=commit)
+    request = urllib.request.Request(url, headers={"User-Agent": "CultureMech-MIM-pin-refresh"})
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return bytes(response.read())
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise SystemExit(f"failed to download {url}: {exc}") from exc
+
+
+def build_metadata(commit: str, data: bytes, row_count: int) -> dict[str, object]:
+    """Build deterministic provenance and integrity metadata."""
+
+    return {
+        "byte_count": len(data),
+        "consumer_contract_version": CONTRACT_VERSION,
+        "data_row_count": row_count,
+        "header": list(INDEX_HEADER),
+        "repository": MIM_REPOSITORY,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "source_commit": commit,
+        "source_path": MIM_SOURCE_PATH,
+    }
+
+
+def semantic_delta(
+    old: MIMLabelIndex, new: MIMLabelIndex
+) -> tuple[list[str], list[str], list[str]]:
+    """Return added, removed, and changed normalized label keys."""
+
+    old_answers = old.semantic_answers()
+    new_answers = new.semantic_answers()
+    added = sorted(new_answers.keys() - old_answers.keys())
+    removed = sorted(old_answers.keys() - new_answers.keys())
+    changed = sorted(
+        key
+        for key in old_answers.keys() & new_answers.keys()
+        if old_answers[key] != new_answers[key]
+    )
+    return added, removed, changed
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _display(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def refresh(commit: str, data: bytes, *, apply: bool = False) -> tuple[int, int, int]:
+    """Validate, report impact, and optionally replace the vendored pin."""
+
+    if not FULL_SHA.fullmatch(commit):
+        raise SystemExit("commit must be a full lowercase 40-character Git SHA")
+
+    new_unverified = MIMLabelIndex.from_csv_bytes(data)
+    metadata = build_metadata(commit, data, len(new_unverified.rows))
+    new = MIMLabelIndex.from_csv_bytes(data, metadata=metadata, verify_metadata=True)
+    old = MIMLabelIndex.from_paths(INDEX_PATH, METADATA_PATH)
+    added, removed, changed = semantic_delta(old, new)
+
+    print(
+        f"MIM pin {old.metadata['source_commit']} -> {commit}: "
+        f"labels +{len(added)} -{len(removed)} changed={len(changed)}"
+    )
+    for kind, labels in (("ADDED", added), ("REMOVED", removed), ("CHANGED", changed)):
+        for label in labels[:20]:
+            print(f"{kind}\t{label}")
+        if len(labels) > 20:
+            print(f"{kind}\t... {len(labels) - 20} more")
+
+    if not apply:
+        print("Preview only: vendored artifact not changed. Pass --apply to update the pin.")
+        return len(added), len(removed), len(changed)
+
+    metadata_bytes = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    old_data = INDEX_PATH.read_bytes()
+    old_metadata = METADATA_PATH.read_bytes()
+    try:
+        _atomic_write(INDEX_PATH, data)
+        _atomic_write(METADATA_PATH, metadata_bytes)
+        MIMLabelIndex.from_paths(INDEX_PATH, METADATA_PATH)
+    except Exception:
+        # A two-file dependency update must not intentionally leave one half of
+        # the old pin beside one half of the new pin.
+        _atomic_write(INDEX_PATH, old_data)
+        _atomic_write(METADATA_PATH, old_metadata)
+        raise
+    print(f"Updated {_display(INDEX_PATH)} and {_display(METADATA_PATH)}")
+    return len(added), len(removed), len(changed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("commit", help="full immutable MediaIngredientMech Git SHA")
+    parser.add_argument(
+        "--apply", action="store_true", help="replace the vendored artifact after validation"
+    )
+    args = parser.parse_args()
+
+    if not FULL_SHA.fullmatch(args.commit):
+        parser.error("commit must be a full lowercase 40-character Git SHA")
+    refresh(args.commit, download(args.commit), apply=args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/culturemech/data/mediaingredientmech/label_index.csv
+++ b/src/culturemech/data/mediaingredientmech/label_index.csv
@@ -1,0 +1,9116 @@
+label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
+#Ar,synonym,CHEBI:49474,argon,CHEBI:49474,MAPPED,unique
+#N2,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+#N2O,synonym,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
+((2)H2)water,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+((amino(imino)methyl)(methyl)amino)acetic acid,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+"(+)-(R,R)-tartaric acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(+)-1,4,5,6-tetrahydro-2-methyl-4-pyrimidinecarboxylic acid",synonym,CHEBI:27592,Ectoine,CHEBI:27592,MAPPED,unique
+(+)-abscisic acid,ontology_label,CHEBI:2365,Abscisic acid,CHEBI:2365,MAPPED,unique
+(+)-alpha-Lipoic acid,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+(+)-Arabinogalactan,preferred_term,CHEBI:27569,(+)-Arabinogalactan,CHEBI:27569,MAPPED,unique
+(+)-carvone,ontology_label,CHEBI:15399,D(+)-Carvone,CHEBI:15399,MAPPED,unique
+"(+)-cis-Hexahydro-2-oxo-1H-thieno[3,4]imidazole-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+(+)-D-glucose,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+(+)-D-glycogen,synonym,CHEBI:28087,Glycogen,CHEBI:28087,MAPPED,unique
+(+)-L-lyxitol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+(+)-L-tartaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+(+)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+(+)-lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+(+)-Tartaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+(+)-tartrate,synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+(+)-Tetrandrine,ontology_label,CHEBI:49,Tetrandrine,CHEBI:49,MAPPED,unique
+(+)-Weinsaeure,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+(+-)-Aspartic acid,synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+(+/-)-Verapamil hydrochloride,preferred_term,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
+(-)-(S)-proline,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(-)-2-pyrrolidinecarboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(-)-alpha-amino-p-hydroxyhydrocinnamic acid,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(-)-alpha-bisabolol,preferred_term,CHEBI:125,(-)-alpha-bisabolol,CHEBI:125,MAPPED,unique
+(-)-anisomycin,preferred_term,CHEBI:338412,(-)-anisomycin,CHEBI:338412,MAPPED,unique
+(-)-beta-caryophyllene,ontology_label,CHEBI:10357,Caryophyllene [T(-)],CHEBI:10357,MAPPED,unique
+(-)-D-fructose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+(-)-D-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+(-)-epigallocatechin,ontology_label,CHEBI:42255,Epigallocatechin,CHEBI:42255,MAPPED,unique
+(-)-epigallocatechin 3-gallate,ontology_label,CHEBI:4806,(-)-Epigallocatechin gallate,CHEBI:4806,MAPPED,unique
+(-)-Epigallocatechin gallate,preferred_term,CHEBI:4806,(-)-Epigallocatechin gallate,CHEBI:4806,MAPPED,unique
+(-)-Epinephrine,preferred_term,CHEBI:28918,(-)-Epinephrine,CHEBI:28918,MAPPED,unique
+(-)-fucose,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+(-)-gambogic acid,ontology_label,CHEBI:67521,Gambogic Acid,CHEBI:67521,MAPPED,unique
+(-)-menthol,ontology_label,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+(-)-methyl jasmonate,ontology_label,CHEBI:15929,methyl jasmonate,CHEBI:15929,MAPPED,unique
+(-)-Norepinephrine,preferred_term,CHEBI:18357,(-)-Norepinephrine,CHEBI:18357,MAPPED,unique
+(-)-proline,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(-)-Quebrachitol,ontology_label,CHEBI:111,Quebrachitol,CHEBI:111,MAPPED,unique
+(-)-quinic Acid,preferred_term,CHEBI:17521,(-)-quinic Acid,CHEBI:17521,MAPPED,unique
+(-)-Salsoline,ontology_label,CHEBI:112,Salsoline,CHEBI:112,MAPPED,unique
+(-)-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+(1)  Ca(NO3)2.4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+"(1,4-beta-D-glucosyl)(n)",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+"(1,4-beta-D-Glucosyl)n",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+"(1,4-beta-D-Glucosyl)n+1",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+"(1,4-beta-D-Glucosyl)n-1",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+"(1,4-beta-D-Xylan)n+1",synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
+"(1,6-alpha-D-Glucosyl)m",synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+"(1,6-alpha-D-Glucosyl)m+1",synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+"(1,6-alpha-D-Glucosyl)n+1",synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+(1->3)-beta-D-glucan,ontology_label,CHEBI:37671,3-beta-d-glucan,CHEBI:37671,MAPPED,unique
+(1->4)-2-acetamido-2-deoxy-beta-D-glucan,synonym,CHEBI:17029,Chitin,CHEBI:17029,MAPPED,unique
+(1->4)-2-amino-2-deoxy-beta-D-glucan,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+"(1->4)-3,6-anhydro-alpha-L-galactopyranosyl-(1->3)-beta-D-galactopyranan",synonym,CHEBI:2511,Agarose,CHEBI:2511,MAPPED,unique
+(1->4)-alpha-D-glucopyranan,synonym,CHEBI:28102,Amylose from potato,CHEBI:28102,MAPPED,unique
+(1->4)-beta-D-glucan,synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+(1->4)-beta-D-glucopyranan,synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+(1->4)-beta-D-xylan,ontology_label,CHEBI:15447,Xylan from Beechwood,CHEBI:15447,MAPPED,unique
+(1->4)-beta-D-xylopyranan,synonym,CHEBI:15447,Xylan from Beechwood,CHEBI:15447,MAPPED,unique
+"(13E,17E,21E,29E)-48-(8-aminooctan-2-yl)-8,10,16,20,24,26,28,32,36,38,40,42,44,46-tetradecahydroxy-9,15,17,19,21,25,31,33,39,41,47-undecamethyl-23-[(2S,3S,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxy-1-oxacyclooctatetraconta-13,17,21,29-tetraen-2-one",synonym,CHEBI:201539,monazomycin,CHEBI:201539,MAPPED,unique
+"(1aR,2Z,4E,14R,15aR)-8-chloro-9,11-dihydroxy-14-methyl-1a,14,15,15a-tetrahydro-6H-oxireno[e][2]benzoxacyclotetradecine-6,12(7H)-dione",synonym,CHEBI:556075,Radicicol,CHEBI:556075,MAPPED,unique
+"(1aR,4E,7aS,10aS,10bR)-1a,5-dimethyl-8-methylidene-2,3,6,7,7a,8,10a,10b-octahydrooxireno[9,10]cyclodeca[1,2-b]furan-9(1aH)-one",synonym,CHEBI:7939,Parthenolide,CHEBI:7939,MAPPED,unique
+"(1E)-prop-1-ene-1,2,3-tricarboxylic acid",synonym,CHEBI:32806,trans-aconitic acid,CHEBI:32806,MAPPED,unique
+"(1E,6E)-1,7-bis(4-hydroxy-3-methoxyphenyl)hepta-1,6-diene-3,5-dione",synonym,CHEBI:3962,Curcumin,CHEBI:3962,MAPPED,unique
+(1R)-1-carboxy-2-sulfanylethan-1-aminium chloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+(1R)-1-carboxy-2-sulfanylethan-1-aminium chloride--water (1/1),synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+(1R)-1-carboxy-2-sulfanylethan-1-aminium chloride--water (1/1),synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+"(1r,2r,3r,4r,5r,6r)-cyclohexane-1,2,3,4,5,6-hexol",synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+"(1R,2R,3S,4R,6S)-4,6-diamino-2-{[3-O-(2,6-diamino-2,6-dideoxy-beta-L-idopyranosyl)-beta-D-ribofuranosyl]oxy}-3-hydroxycyclohexyl 2-amino-2-deoxy-alpha-D-glucopyranoside sulfate",synonym,CHEBI:7935,Paromomycin sulfate salt,CHEBI:7935,MAPPED,unique
+"(1r,2R,3S,4s,5R,6S)-cyclohexane-1,2,3,4,5,6-hexol",synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+"(1R,2R,4R,6S,7S,10R,11R)-6-(uran-3-yl)-17-hydroxy-1,7,11,15,15-pentamethyl-3-oxapentacyclo[8.8.0.02,4.02,7.011,16]octadeca-12,16-diene-14,18-dione",synonym,CHEBI:197237,Cedrelone,CHEBI:197237,MAPPED,unique
+"(1R,2S)-1-(6-bromo-2-methoxyquinolin-3-yl)-4-(dimethylamino)-2-(1-naphthyl)-1-phenylbutan-2-ol",synonym,CHEBI:72292,Bedaquiline,CHEBI:72292,MAPPED,unique
+"(1R,2S,3R,5S,6R)-3-amino-2,6-dihydroxy-5-(methylamino)cyclohexyl O-6-amino-6-deoxy-L-glycero-D-galacto-heptopyranosylidene-(1->2-3)-beta-D-talopyranoside",synonym,CHEBI:16976,Hygromycin B,CHEBI:16976,MAPPED,unique
+"(1R,2S,3S,4R,6S)-4,6-diamino-3-[3-deoxy-4-C-methyl-3-(methylamino)-beta-L-arabinopyranosyloxy]-2-hydroxycyclohexyl 2-amino-2,7-dideoxy-D-glycero-alpha-D-gluco-heptopyranoside",synonym,CHEBI:42768,Geneticin G418,CHEBI:42768,MAPPED,unique
+"(1R,2S,5R)-5-methyl-2-(propan-2-yl)cyclohexan-1-ol",synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+"(1R,3R,5S,8S,9R,12S,13R,14R)-1-hydroxy-13-methyl-14-(prop-1-en-2-yl)-4,7,10-trioxapentacyclo[6.4.1.1(9,12).0(3,5).0(5,13)]tetradecane-6,11-dione",synonym,CHEBI:8206,Picrotoxinin,CHEBI:8206,MAPPED,unique
+"(1R,3S,5R,6R,9R,11R,15S,16R,17R,18S,19E,21E,23E,25E,27E,29E,31E,33R,35S,36R,37S)-33-[(3-amino-3,6-dideoxy-beta-D-mannopyranosyl)oxy]-1,3,5,6,9,11,17,37-octahydroxy-15,16,18-trimethyl-13-oxo-14,39-dioxabicyclo[33.3.1]nonatriaconta-19,21,23,25,27,29,31-heptaene-36-carboxylic acid",synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+"(1R,4E,9S)-4,11,11-trimethyl-8-methylidenebicyclo[7.2.0]undec-4-ene",synonym,CHEBI:10357,Caryophyllene [T(-)],CHEBI:10357,MAPPED,unique
+"(1R,5S)-1,2,3,4,5,6-hexahydro-8H-1,5-methanopyrido[1,2-a][1,5]diazocin-8-one",synonym,CHEBI:4055,Cytisine,CHEBI:4055,MAPPED,unique
+"(1S)-1,5-anhydro-1-[4,5-dihydroxy-2-(hydroxymethyl)-10-oxo-9,10-dihydroanthracen-9-yl]-D-glucitol",synonym,CHEBI:73222,Aloin,CHEBI:73222,MAPPED,unique
+"(1S,3R,7S,8S,8aR)-8-{2-[(2R,4R)-4-hydroxy-6-oxotetrahydro-2H-pyran-2-yl]ethyl}-3,7-dimethyl-1,2,3,7,8,8a-hexahydronaphthalen-1-yl (2S)-2-methylbutanoate",synonym,CHEBI:40303,Lovastatin,CHEBI:40303,MAPPED,unique
+"(1S,3R,7S,8S,8aR)-8-{2-[(2R,4R)-4-hydroxy-6-oxotetrahydro-2H-pyran-2-yl]ethyl}-3,7-dimethyl-1,2,3,7,8,8a-hexahydronaphthalen-1-yl 2,2-dimethylbutanoate",synonym,CHEBI:9150,Simvastatin,CHEBI:9150,MAPPED,unique
+(2)-d-fructose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+(2)-D-lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+(2)-D-lyxose,synonym,CHEBI:62318,D-lyxose,CHEBI:62318,MAPPED,unique
+"(2,1-beta-D-Fructosyl)n",synonym,CHEBI:15443,Inulin,CHEBI:15443,MAPPED,unique
+"(2,5-Dioxo-4-imidazolidinyl)urea",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+(2->1)-beta-D-fructofuranan,synonym,CHEBI:15443,Inulin,CHEBI:15443,MAPPED,unique
+(2->6)-beta-D-fructan,ontology_label,CHEBI:16703,Levan - from Erwinia herbicola,CHEBI:16703,MAPPED,unique
+(2->6)-beta-D-fructofuranan,synonym,CHEBI:16703,Levan - from Erwinia herbicola,CHEBI:16703,MAPPED,unique
+(2-Hydroxyethyl)trimethylammonium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+"(2E)-1-(2,4-dihydroxyphenyl)-3-(4-hydroxyphenyl)prop-2-en-1-one",synonym,CHEBI:310312,Isoliquiritigenin,CHEBI:310312,MAPPED,unique
+(2E)-2-butenedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+(2E)-2-butenoate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+(2E)-2-butenoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+(2E)-2-methylbut-2-enoic acid,synonym,CHEBI:9592,Trans-2-methyl-2-butenoic acid,CHEBI:9592,MAPPED,unique
+"(2E)-3,7-dimethylocta-2,6-dien-1-ol",synonym,CHEBI:17447,Geraniol,CHEBI:17447,MAPPED,unique
+"(2E)-3-(4-hydroxy-3,5-dimethoxyphenyl)prop-2-enal",synonym,CHEBI:27949,sinapinaldehyde,CHEBI:27949,MAPPED,unique
+(2E)-3-(4-hydroxyphenyl)-1-phenylprop-2-en-1-one,synonym,CHEBI:34423,4-hydroxychalcone,CHEBI:34423,MAPPED,unique
+(2E)-3-(4-hydroxyphenyl)prop-2-enoic acid,synonym,CHEBI:32374,p-Coumaric acid,CHEBI:32374,MAPPED,unique
+(2E)-3-[4-(acetyloxy)-3-methoxyphenyl]prop-2-enoic acid,synonym,CHEBI:86582,4-Acetoxy-3-methoxycinnamic acid,CHEBI:86582,MAPPED,unique
+(2E)-3-phenyl-2-propenoic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+(2E)-3-phenylacrylic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+(2E)-3-phenylprop-2-enoic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+(2E)-but-2-enedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+(2E)-but-2-enoate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+(2E)-but-2-enoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+(2E)-pent-2-enoic acid,synonym,CHEBI:38366,trans-2-Pentenoic acid,CHEBI:38366,MAPPED,unique
+"(2E,6E,10E,14E,18E,22E,26E,30E)-3,7,11,15,19,23,27,31,35-nonamethylhexatriaconta-2,6,10,14,18,22,26,30,34-nonaen-1-ol",synonym,CHEBI:26718,Solanesol,CHEBI:26718,MAPPED,unique
+"(2R)-2,3-dihydroxypropyl 2-(trimethylammonio)ethyl phosphate",synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+"(2R)-2,3-dihydroxypropyl 2-(trimethylazaniumyl)ethyl phosphate",synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+"(2R)-2,3-dihydroxypropyl dihydrogen phosphate",synonym,cas:17989-41-2,sn-Glycerol 3-phosphate lithium salt,CHEBI:15978,MAPPED,conflict:different_substances
+"(2R)-2,3-dihydroxypropyl dihydrogen phosphate",synonym,cas:29849-82-9,sn-Glycerol 3-phosphate bis(cyclohexylammonium) salt,CHEBI:15978,MAPPED,conflict:different_substances
+"(2R)-2,6-diaminohexanoic acid",synonym,CHEBI:16855,D-Lysine,CHEBI:16855,MAPPED,unique
+(2R)-2-amino-3-mercaptopropanoic acid,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+(2R)-2-Amino-3-sulfanyl-propanoic acid hydrochloride monohydrate,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+(2R)-2-Amino-3-sulfanyl-propanoic acid hydrochloride monohydrate,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+(2R)-2-amino-3-sulfanylpropanoic acid,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+(2R)-2-aminobutanedioic acid,synonym,CHEBI:17364,D-Aspartic Acid,CHEBI:17364,MAPPED,unique
+(2R)-2-aminobutanoic acid,synonym,CHEBI:28797,D-2-Aminobutyric acid,CHEBI:28797,MAPPED,unique
+(2R)-2-aminopentanedioic acid,synonym,CHEBI:15966,D-Glutamic Acid,CHEBI:15966,MAPPED,unique
+(2R)-2-ammonio-3-mercaptopropanoate,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+(2R)-2-ammonio-3-sulfanylpropanoate,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,agree:same_substance
+(2R)-2-ammonio-3-sulfanylpropanoate,synonym,CHEBI:35235,L-cysteine zwitterion,CHEBI:35235,MAPPED,agree:same_substance
+"(2R,2'R)-3,3'-disulfanediylbis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"(2R,3R)-2,3,4-trihydroxybutanal",synonym,CHEBI:27904,D-erythrose,CHEBI:27904,MAPPED,unique
+"(2R,3R)-2,3-Dihydroxybernsteinsaeure",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(2R,3R)-2,3-dihydroxybutanedioate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+"(2R,3R)-2,3-dihydroxybutanedioic acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(2R,3R)-2,3-dihydroxysuccinate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+"(2R,3R)-2,3-dihydroxysuccinic acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(2R,3R)-2-(3,4,5-trihydroxyphenyl)-3,4-dihydro-2H-chromene-3,5,7-triol",synonym,CHEBI:42255,Epigallocatechin,CHEBI:42255,MAPPED,unique
+"(2R,3R)-3,5,7-trihydroxy-2-[(2R,3R)-3-(4-hydroxy-3-methoxyphenyl)-2-(hydroxymethyl)-2,3-dihydro-1,4-benzodioxin-6-yl]-2,3-dihydro-4H-chromen-4-one",synonym,CHEBI:9144,Silibinin,CHEBI:9144,MAPPED,unique
+"(2R,3R)-5,7-dihydroxy-2-(3,4,5-trihydroxyphenyl)-3,4-dihydro-2H-chromen-3-yl 3,4,5-trihydroxybenzoate",synonym,CHEBI:4806,(-)-Epigallocatechin gallate,CHEBI:4806,MAPPED,unique
+"(2R,3R)-Tartaric acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(2R,3R)-tartrate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+"(2R,3R,4R,5R)-Hexane-1,2,3,4,5,6-hexaol",synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+"(2R,3R,4R,5R)-hexane-1,2,3,4,5,6-hexol",synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+"(2R,3R,4R,5S)-hexane-1,2,3,4,5,6-hexol",synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+"(2R,3R,4S)-Pentane-1,2,3,4,5-pentaol",synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+"(2R,3r,4S)-pentane-1,2,3,4,5-pentol",synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+"(2R,3R,4S,5R)-2-(6-aminopurin-9-yl)-5-(hydroxymethyl)oxolane-3,4-diol",synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+"(2R,3R,4S,5S,6S)-2-[[(2R,3S,4R,4aR,6S,7R,8aS)-7-amino-6-[(1R,2R,3S,4R,6S)-4,6-diamino-2,3-dihydroxycyclohexyl]oxy-4-hydroxy-3-(methylamino)-2,3,4,4a,6,7,8,8a-octahydropyrano[3,2-b]pyran-2-yl]oxy]-5-amino-6-(hydroxymethyl)oxane-3,4-diol;suluric acid",synonym,cas:65710-07-8,Apramycin sulfate salt,CHEBI:190734,MAPPED,unique
+"(2R,3S)-3-[(4E,7E)-nona-4,7-dienoyl]oxirane-2-carboxamide",synonym,CHEBI:171741,Cerulenin,CHEBI:171741,MAPPED,unique
+"(2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanal",synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+"(2R,3S,4R,5R)-2-(hydroxymethyl)-5-(6-hydroxy-9H-purin-9-yl)tetrahydrofuran-3,4-diol",synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+"(2R,3S,4R,5S)-2,3,4,5-tetrahydroxyhexanedioic acid",synonym,CHEBI:30852,Mucic acid,CHEBI:30852,MAPPED,unique
+"(2R,3S,4S,5R,6R)-2-(hydroxymethyl)-6-[(2R,3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxyoxane-3,4,5-triol;dihydrate",synonym,CHEBI:232797,D-Trehalose dihydrate,CHEBI:232797,MAPPED,unique
+"(2R,3S,4S,5S)-2,3,4,5-tetrahydroxyhexanedioic acid",synonym,CHEBI:16002,D-Glucaric acid,CHEBI:16002,MAPPED,unique
+"(2R,3S,6S,7R,8R)-3-[(3-formamido-2-hydroxybenzoyl)amino]-8-hexyl-2,6-dimethyl-4,9-dioxo-1,5-dioxonan-7-yl 3-methylbutanoate",synonym,CHEBI:2762,Antimycin A,CHEBI:2762,MAPPED,unique
+"(2R,4aR,5aR,6S,7S,8R,9S,9aR,10aS)-4a,7,9-trihydroxy-2-methyl-6,8-bis(methylamino)decahydro-4H-pyrano[2,3-b][1,4]benzodioxin-4-one dihydrochloride pentahydrate",synonym,CHEBI:9217,Spectinomycin dihydrochloride pentahydrate,CHEBI:9217,MAPPED,unique
+"(2R,4aR,5aR,6S,7S,8R,9S,9aR,10aS)-4a,7,9-trihydroxy-2-methyl-6,8-bis(methylamino)decahydro-4H-pyrano[2,3-b][1,4]benzodioxin-4-one dihydrochloride--water (1/5)",synonym,CHEBI:9217,Spectinomycin dihydrochloride pentahydrate,CHEBI:9217,MAPPED,unique
+"(2R,4aR,5aR,6S,7S,8R,9S,9aR,10aS)-4a,7,9-trihydroxy-N,N',2-trimethyl-4-oxodecahydro-2H-pyrano[2,3-b][1,4]benzodioxine-6,8-diaminium dichloride--water (1/5)",synonym,CHEBI:9217,Spectinomycin dihydrochloride pentahydrate,CHEBI:9217,MAPPED,unique
+"(2R,4aS,6aS,12bS,14aS,14bR)-10,11-dihydroxy-2,4a,6a,9,12b,14a-hexamethyl-1,2,3,4,4a,5,6,6a,8,12b,13,14,14a,14b-tetradecahydropicene-2-carboxylic acid",synonym,CHEBI:132340,Dihydrocelastrol,CHEBI:132340,MAPPED,unique
+"(2R,4S,5R,6R)-5-Acetamido-2-[(2R,3S,4R,5S)-5-acetamido-4-[(2R,3R,4R,5S,6R)-3-acetamido-6-(hydroxymethyl)-5-[(2S,3R,4S,5R,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxy-4-[(2S,3S,4R,5S,6S)-3,4,5-trihydroxy-6-methyloxan-2-yl]oxyoxan-2-yl]oxy-2,3,6-trihydroxyhexoxy]-4-hydroxy-6-[(1R,2R)-1,2,3-trihydroxypropyl]oxane-2-carboxylic acid",synonym,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
+"(2R,6aS,12aS)-8,9-dimethoxy-2-(prop-1-en-2-yl)-1,2,12,12a-tetrahydrochromeno[3,4-b]furo[2,3-h]chromen-6(6aH)-one",synonym,CHEBI:28201,Rotenone,CHEBI:28201,MAPPED,unique
+"(2S)-2,4-diamino-4-oxobutanoic acid",synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+"(2S)-2,5-diaminopentanoic acid",synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+"(2S)-2,5-diaminopentanoic acid;hydrochloride",synonym,CHEBI:195690,L-ornithine monohydrochloride,CHEBI:195690,MAPPED,unique
+"(2S)-2,6-diaminohexanoic acid",synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+"(2S)-2-(4-{[(2-amino-4-oxo-3,4-dihydropteridin-6-yl)methyl]amino}benzamido)pentanedioic acid",synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+(2S)-2-(acetylamino)-5-amino-5-oxopentanoic acid,synonym,CHEBI:21553,N-Acetyl-L-glutamine,CHEBI:21553,MAPPED,unique
+(2S)-2-(acetylamino)-6-aminohexanoic acid,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+(2S)-2-acetamidobutanedioic acid,synonym,CHEBI:21547,N-Acetyl-L-aspartic acid,CHEBI:21547,MAPPED,unique
+(2S)-2-acetamidopentanedioic acid,synonym,CHEBI:17533,N-Acetyl-L-Glutamic Acid,CHEBI:17533,MAPPED,unique
+(2S)-2-amino-3-(1H-imidazol-4-yl)propanoic acid,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+(2S)-2-amino-3-(1H-indol-3-yl)propanoic acid,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+"(2S)-2-amino-3-(3,4-dihydroxyphenyl)propanoic acid",synonym,CHEBI:15765,Levodopa,CHEBI:15765,MAPPED,unique
+(2S)-2-amino-3-(3-hydroxyphenyl)propanoic acid,synonym,cas:587-33-7,L-Meta-tyrosine,CHEBI:44303,MAPPED,unique
+(2S)-2-amino-3-(4-hydroxyphenyl)propanoic acid,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(2S)-2-amino-3-carbamoylpropanoic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+(2S)-2-amino-3-hydroxypropanoic acid,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+(2S)-2-amino-3-methylbutanoic acid,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+(2S)-2-amino-3-phenylpropanoic acid,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+(2S)-2-amino-4-(methylsulfanyl)butanoic acid,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+(2S)-2-amino-4-carbamoylbutanoic acid,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+(2S)-2-amino-4-methylpentanoic acid,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+(2S)-2-amino-5-(carbamimidamido)pentanoic acid,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+(2S)-2-amino-5-(carbamoylamino)pentanoic acid,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+(2S)-2-amino-5-guanidinopentanoic acid,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+(2S)-2-aminobutanedioic acid,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,conflict:different_substances
+(2S)-2-aminobutanedioic acid,synonym,cas:1115-63-5,L-Aspartic acid potassium salt,CHEBI:17053,MAPPED,conflict:different_substances
+(2S)-2-aminobutanedioic acid,synonym,cas:323194-76-9,L-Aspartic acid sodium salt monohydrate,CHEBI:17053,MAPPED,conflict:different_substances
+(2S)-2-aminobutanoic acid,synonym,CHEBI:35619,L-2-Aminobutyric acid,CHEBI:35619,MAPPED,unique
+(2S)-2-aminohexanedioic acid,synonym,CHEBI:37023,DL-2-Aminoadipic acid,CHEBI:37023,MAPPED,unique
+(2S)-2-aminopentanedioate,synonym,CHEBI:64243,Na-glutamate,CHEBI:64243,REJECTED,unique
+(2S)-2-aminopentanedioic acid,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,conflict:different_substances
+(2S)-2-aminopentanedioic acid,synonym,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydrate,CHEBI:16015,MAPPED,conflict:different_substances
+(2S)-2-aminopropanoic acid,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+(2S)-2-ammonio-3-(1H-indol-3-yl)propanoate,synonym,CHEBI:57912,DL-Tryptophan,CHEBI:57912,MAPPED,unique
+(2S)-2-azaniumyl-3-(1H-indol-3-yl)propanoate,synonym,CHEBI:57912,DL-Tryptophan,CHEBI:57912,MAPPED,unique
+(2S)-2-hydroxybutanedioic acid,synonym,CHEBI:30797,L-Malic acid,CHEBI:30797,MAPPED,unique
+(2S)-2-hydroxypropanoate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+(2S)-3-(2-mercapto-1H-imidazol-5-yl)-2-(trimethylazaniumyl)propanoate,synonym,CHEBI:4828,L-(+)-Ergothioneine,CHEBI:4828,MAPPED,unique
+"(2S)-4-amino-N-[(1R,2S,3S,4R,5S)-5-amino-2-(3-amino-3-deoxy-alpha-D-glucopyranosyloxy)-4-(6-amino-6-deoxy-alpha-D-glucopyranosyloxy)-3-hydroxycyclohexyl]-2-hydroxybutanamide disulfate",synonym,CHEBI:2638,Amikacin disulfate salt,CHEBI:2638,MAPPED,unique
+"(2S)-5-hydroxy-2-(3-hydroxy-4-methoxyphenyl)-4-oxo-3,4-dihydro-2H-chromen-7-yl 6-O-(6-deoxy-alpha-L-mannopyranosyl)-beta-D-glucopyranoside",synonym,CHEBI:28775,Hesperidin,CHEBI:28775,MAPPED,unique
+"(2S)-5-hydroxy-2-(4-hydroxyphenyl)-4-oxo-3,4-dihydro-2H-chromen-7-yl 2-O-(6-deoxy-alpha-L-mannopyranosyl)-beta-D-glucopyranoside",synonym,CHEBI:28819,Naringin,CHEBI:28819,MAPPED,unique
+(2S)-5-oxopyrrolidine-2-carboxylic acid,synonym,CHEBI:18183,L-Pyroglutamic acid,CHEBI:18183,MAPPED,unique
+(2S)-alpha-2-Amino-4-methylvaleric acid,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+(2S)-alpha-Leucine,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+(2S)-piperidine-2-carboxylic acid,synonym,CHEBI:30913,L-Pipecolic Acid,CHEBI:30913,MAPPED,unique
+(2S)-pyrrolidine-2-carboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(2S)-threonine,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+"(2S,2'S)-2,2'-(ethane-1,2-diyldiimino)dibutan-1-ol",synonym,CHEBI:4877,Ethambutol,CHEBI:4877,MAPPED,unique
+"(2S,2'S)-5,5'-[disulfanediylbis({(2R)-3-[(carboxymethyl)amino]-3-oxopropane-1,2-diyl}imino)]bis(2-amino-5-oxopentanoic acid)",synonym,CHEBI:17858,Glutathione oxidized,CHEBI:17858,MAPPED,unique
+"(2S,3R)-(-)-Threonine",synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+"(2S,3R)-2-amino-3-hydroxybutanoic acid",synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+"(2S,3R,4S)-4-[(2S,5R,7S,8R,9S)-2-{(2S,2'R,3'S,5R,5'R)-2-ethyl-5'-[(2S,3S,5R,6R)-6-hydroxy-6-(hydroxymethyl)-3,5-dimethyltetrahydro-2H-pyran-2-yl]-3'-methyloctahydro-2,2'-bifuran-5-yl}-9-hydroxy-2,8-dimethyl-1,6-dioxaspiro[4.5]dec-7-yl]-3-methoxy-2-methylpentanoic acid",synonym,CHEBI:27617,Monensin,CHEBI:27617,MAPPED,unique
+"(2S,3R,4S,5R,6R)-2-[[(2R,3S,4S,5R,6R)-6-[(2S,3S,4S,5R)-3,4-dihydroxy-2,5-bis(hydroxymethyl)oxolan-2-yl]oxy-3,4,5-trihydroxyoxan-2-yl]methoxy]-6-(hydroxymethyl)oxane-3,4,5-triol;pentahydrate",synonym,cas:17629-30-0,D-Raffinose pentahydrate,CHEBI:189430,MAPPED,unique
+"(2S,3S)-2-amino-3-methylpentanoic acid",synonym,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
+"(2S,3S)-3-{(2Z)-2-(2-ammonio-1,3-thiazol-4-yl)-2-[(2-carboxypropan-2-yloxy)imino]acetamido}-2-methyl-4-oxoazetidine-1-sulfonate",synonym,CHEBI:161680,Aztreonam,CHEBI:161680,MAPPED,unique
+"(2S,3S,4R,5R,6R)-5-{[(2S,3R,4R,5S,6R)-3-acetamido-5-{[(2S,3R,4R,5S,6R)-3-acetamido-4-hydroxy-6-methyl-5-({(2R,3R,4S,5R,6S)-3,4,5-trihydroxy-6-[(2-hydroxy-5-oxocyclopent-1-en-1-yl)carbamoyl]tetrahydro-2H-pyran-2-yl}oxy)tetrahydro-2H-pyran-2-yl]oxy}-4-hydroxy-6-({[(2R,3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)tetrahydro-2H-pyran-2-yl]oxy}methyl)tetrahydro-2H-pyran-2-yl]oxy}-4-(carbamoyloxy)-6-({[(2R)-2-carboxy-2-{[(2E,6E,13E)-3,8,8,14,18-pentamethyl-11-methylenenonadeca-2,6,13,17-tetraen-1-yl]oxy}ethoxy](hydroxy)phosphoryl}oxy)-3-hydroxy-3-methyltetrahydro-2H-pyran-2-carboxylic acid",synonym,CHEBI:28908,Flavomycin,CHEBI:28908,MAPPED,unique
+"(2S,3S,4R,5S,6S)-2-[(3R,4R,5S,6R)-2,3-Dihydroxy-6-(hydroxymethyl)-5-[(2R,3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-yl]oxyoxan-4-yl]oxy-6-methyloxane-3,4,5-triol",synonym,cas:150-90-3,Sodium succinate dibasic,CHEBI:63675,MAPPED,unique
+"(2S,4R)-4-hydroxy-2-pyrrolidinecarboxylic acid",synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"(2S,4R)-N-[(1R,2R)-2-hydroxy-1-[(2R,3R,4S,5R,6R)-3,4,5-trihydroxy-6-methylsulanyloxan-2-yl]propyl]-1-methyl-4-propylpyrrolidine-2-carboxamide;hydrochloride",synonym,CHEBI:182465,Lincomycin hydrochloride,CHEBI:182465,MAPPED,unique
+"(2S,4R)-trans-4-hydroxyproline",synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"(2S,5R,6R)-6-{[(2R)-2-amino-2-phenylacetyl]amino}-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo[3.2.0]heptane-2-carboxylic acid",synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+"(2S,5R,6R)-6-{[(2R)-2-AMINO-2-PHENYLETHANOYL]AMINO}-3,3-DIMETHYL-7-OXO-4-THIA-1-AZABICYCLO[3.2.0]HEPTANE-2-CARBOXYLIC ACID",synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+"(2S,6R)-6-{[(2R)-2-amino-2-phenylethanoyl]amino}-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo[3.2.0]heptane-2-carboxylic acid",synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+"(2Z)-2-[(17Z)-16beta-acetoxy-3alpha,11alpha-dihydroxy-4alpha,8alpha,10,14beta-tetramethyl-5alpha,9beta,13alpha-gonan-17-ylidene]-6-methylhept-5-enoic acid",synonym,cas:751-94-0,Fusidic acid sodium salt,CHEBI:29013,MAPPED,unique
+(2Z)-2-methylbut-2-enedioic acid,synonym,CHEBI:17626,Citraconic acid,CHEBI:17626,MAPPED,unique
+"(2Z)-3,7-dimethylocta-2,6-dien-1-ol",synonym,CHEBI:29452,Nerol,CHEBI:29452,MAPPED,unique
+(2Z)-but-2-enedioic acid,synonym,CHEBI:18300,Maleic acid,CHEBI:18300,MAPPED,unique
+"(2Z,4E)-5-[(1S)-1-hydroxy-2,6,6-trimethyl-4-oxocyclohex-2-en-1-yl]-3-methylpenta-2,4-dienoic acid",synonym,CHEBI:2365,Abscisic acid,CHEBI:2365,MAPPED,unique
+"(3,5-dibromo-4-hydroxyphenyl)(2-ethyl-1-benzofuran-3-yl)methanone",synonym,CHEBI:3023,Benzbromarone,CHEBI:3023,MAPPED,unique
+"(3aR,4S,7R,7aS)-3a,7a-dimethylhexahydro-4,7-epoxy-2-benzofuran-1,3-dione",synonym,CHEBI:64213,Cantharidin,CHEBI:64213,MAPPED,unique
+"(3aR,5S,8aR,9aR)-5,8a-dimethyl-3-methylidene-3a,5,6,7,8,8a,9,9a-octahydronaphtho[2,3-b]furan-2(3H)-one",synonym,CHEBI:2540,Helenine,CHEBI:2540,MAPPED,unique
+"(3aS,4R,5S,6S,8R,9R,9aR,10R)-5-hydroxy-4,6,9,10-tetramethyl-1-oxo-6-vinyldecahydro-3a,9-propanocyclopenta[8]annulen-8-yl {[2-(diethylamino)ethyl]sulfanyl}acetate",synonym,CHEBI:44137,Tiamulin,CHEBI:44137,MAPPED,unique
+"(3aS,4S,6aR)-Hexahydro-2-oxo-1H-thieno[3,4-d]imidazole-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+(3beta)-lup-20(29)-en-3-ol,synonym,CHEBI:6570,Lupeol,CHEBI:6570,MAPPED,unique
+"(3beta,14beta,17alpha)-cholest-5-en-3-ol",synonym,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,unique
+"(3beta,25R)-spirost-5-en-3-ol",synonym,CHEBI:4629,Diosgenin,CHEBI:4629,MAPPED,unique
+"(3E,4S)-4-hydroxy-3-{2-[(1R,4aS,5R,6R,8aS)-6-hydroxy-5-(hydroxymethyl)-5,8a-dimethyl-2-methylidenedecahydronaphthalen-1-yl]ethylidene}dihydrofuran-2(3H)-one",synonym,CHEBI:65408,Andrographolide,CHEBI:65408,MAPPED,unique
+"(3R)-3-hydroxy-4,4-dimethyldihydrofuran-2(3H)-one",synonym,CHEBI:16719,D-(-)-Pantolactone,CHEBI:16719,MAPPED,unique
+(3R)-3-hydroxy-4-(trimethylammonio)butanoate,synonym,CHEBI:16347,L-Carnitine,CHEBI:16347,MAPPED,unique
+(3R)-3-hydroxybutanoate,synonym,CHEBI:10983,(R)-3-hydroxybutyrate,CHEBI:10983,MAPPED,unique
+"(3R,4R,5R,6R)-3-amino-6-(hydroxymethyl)oxane-2,4,5-triol;hydrochloride",synonym,CHEBI:181432,D-(+)-Galactosamine hydrochloride,CHEBI:181432,MAPPED,unique
+"(3R,4S,5R)-3,4,5-trihydroxycyclohex-1-ene-1-carboxylic acid",synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+"(3R,4S,5S,6R)-3,4,5-trihydroxy-6-(hydroxymethyl)oxan-2-one",synonym,CHEBI:16217,D-(+)-Gluconic acid gamma-lactone,CHEBI:16217,MAPPED,unique
+"(3R,5R)-7-[(1S,2S,6R,8S,8aR)-8-(2,2-dimethylbutanoyloxy)-2,6-dimethyl-1,2,6,7,8,8a-hexahydronaphthalen-1-yl]-3,5-dihydroxyheptanoic acid",synonym,cas:139893-43-9,Simvastatin Hydroxy Acid Ammonium Salt,CHEBI:169041,MAPPED,unique
+(3S)-3-hydroxybutanoate,synonym,CHEBI:11047,(S)-3-hydroxybutyrate,CHEBI:11047,MAPPED,unique
+"(3S)-9-fluoro-3-methyl-10-(4-methylpiperazin-1-yl)-7-oxo-2,3-dihydro-7H-[1,4]oxazino[2,3,4-ij]quinoline-6-carboxylic acid",synonym,CHEBI:63598,Levofloxacin,CHEBI:63598,MAPPED,unique
+"(3S,4R,5S)-1,3,4,5,6-pentahydroxyhexan-2-one",synonym,CHEBI:17266,L-(-)-sorbose,CHEBI:17266,MAPPED,unique
+"(4-(4-Dimethylaminobenzhydriylidene)cyclohexa-2,5-dienylidene)dimethylammonium chloride",synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+"(4-(alpha-(4-Dimethylamino)phenyl)benzylidene)cyclohexa-2,5-dien-1-ylidene dimethylammonium chloride",synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+(4-ethenylphenyl) 4-hydroxy-3-nitrosobenzoate;iron(2+),synonym,CHEBI:219729,ferroverdin,CHEBI:219729,MAPPED,unique
+(4-formyl-5-hydroxy-6-methylpyridin-3-yl)methyl dihydrogen phosphate,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+(4-Hydroxy-3-methoxyphenyl)ethanol,ontology_label,CHEBI:173769,homovanillyl alcohol,CHEBI:173769,MAPPED,unique
+(4-hydroxyphenyl)acetic acid,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+"(4aR,5aS,8aR,13aS,15aS,15bR)-4a,5,5a,7,8,13a,15,15a,15b,16-decahydro-2H-4,6-methanoindolo[3,2,1-ij]oxepino[2,3,4-de]pyrrolo[2,3-h]quinolin-14-one;sulfuric acid",synonym,CHEBI:233239,Strychnine Sulfate,CHEBI:233239,MAPPED,unique
+"(4aS,6aR,8aR,8bR,9aS,12R,12aS,14aR,14bR)-12-(3-furyl)-6,6,8a,12a-tetramethyldecahydro-3H-oxireno[d]pyrano[4',3':3,3a][2]benzofuro[5,4-f]isochromene-3,8,10(6H,9aH)-trione",synonym,CHEBI:16226,Limonin,CHEBI:16226,MAPPED,unique
+(4R)-4-aminoisoxazolidin-3-one,synonym,CHEBI:40009,D-Cycloserine,CHEBI:40009,MAPPED,unique
+(4R)-4-hydroxy-L-proline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"(4S)-2-methyl-1,4,5,6-tetrahydropyrimidine-4-carboxylic acid",synonym,CHEBI:27592,Ectoine,CHEBI:27592,MAPPED,unique
+"(4S)-4-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S,3S)-2-[(2-aminoacetyl)amino]-3-methylpentanoyl]amino]acetyl]amino]hexanoyl]amino]-3-phenylpropanoyl]amino]-4-methylpentanoyl]amino]-3-(1H-imidazol-5-yl)propanoyl]amino]-3-hydroxypropanoyl]amino]propanoyl]amino]acetyl]amino]hexanoyl]amino]-3-phenylpropanoyl]amino]acetyl]amino]hexanoyl]amino]propanoyl]amino]-3-phenylpropanoyl]amino]-3-methylbutanoyl]amino]acetyl]amino]-5-[[(2S,3S)-1-[[(2S)-1-[[(2S)-6-amino-1-[[(1S)-1-carboxy-2-hydroxyethyl]amino]-1-oxohexan-2-yl]amino]-4-methylsulanyl-1-oxobutan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-5-oxopentanoic acid",synonym,CHEBI:201898,Magainin I,CHEBI:201898,MAPPED,unique
+"(4S)-4-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-2-[[(2S)-1-[2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S,3S)-2-[[2-[[(2S)-4-amino-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-4-amino-2-[[(2S)-2-[[2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-6-amino-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2,6-diaminohexanoyl]amino]-3-(1H-indol-3-yl)propanoyl]amino]hexanoyl]amino]-3-methylbutanoyl]amino]-3-phenylpropanoyl]amino]hexanoyl]amino]hexanoyl]amino]-3-methylpentanoyl]amino]-4-carboxybutanoyl]amino]hexanoyl]amino]-4-methylsulanylbutanoyl]amino]acetyl]amino]-5-carbamimidamidopentanoyl]amino]-4-oxobutanoyl]amino]-3-methylpentanoyl]amino]-5-carbamimidamidopentanoyl]amino]-4-oxobutanoyl]amino]acetyl]amino]-3-methylpentanoyl]amino]-3-methylbutanoyl]amino]hexanoyl]amino]propanoyl]amino]acetyl]pyrrolidine-2-carbonyl]amino]propanoyl]amino]-3-methylpentanoyl]amino]propanoyl]amino]-3-methylbutanoyl]amino]-4-methylpentanoyl]amino]acetyl]amino]-5-[[(2S)-1-[[(2S)-6-amino-1-[[(2S)-1-[[(2S)-1-amino-4-methyl-1-oxopentan-2-yl]amino]-1-oxopropan-2-yl]amino]-1-oxohexan-2-yl]amino]-1-oxopropan-2-yl]amino]-5-oxopentanoic acid",synonym,CHEBI:201469,Cecropin B,CHEBI:201469,MAPPED,unique
+"(4S)-4-ethyl-4-hydroxy-1H-pyrano[3',4':6,7]indolizino[1,2-b]quinoline-3,14(4H,12H)-dione",synonym,CHEBI:27656,Camptothecin,CHEBI:27656,MAPPED,unique
+"(4S)-5-[[(2S)-6-amino-1-[[(2S)-1-[[2-[[(2S)-5-amino-1-[[(2S)-4-amino-1-[[(2S,3S)-1-[[(2S)-1-[[(2S)-1-[[2-[[(2S,3S)-1-[[(2S,3S)-1-[[(2S)-6-amino-1-[[(2S)-1-[[2-[(2S)-2-[[(2S)-1-[[(2S)-1-[[(2S)-1-[[(2S)-1-[[(2S)-1-[[2-[[(2S)-5-amino-1-[[(2S)-1-[[(2S,3R)-1-[[(2S)-5-amino-1-[[(2S,3S)-1-[[(2S)-1-[[(2S)-1,6-diamino-1-oxohexan-2-yl]amino]-1-oxopropan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-1,5-dioxopentan-2-yl]amino]-3-hydroxy-1-oxobutan-2-yl]amino]-1-oxopropan-2-yl]amino]-1,5-dioxopentan-2-yl]amino]-2-oxoethyl]amino]-3-methyl-1-oxobutan-2-yl]amino]-3-methyl-1-oxobutan-2-yl]amino]-1-oxopropan-2-yl]amino]-3-methyl-1-oxobutan-2-yl]amino]-1-oxopropan-2-yl]carbamoyl]pyrrolidin-1-yl]-2-oxoethyl]amino]-1-oxopropan-2-yl]amino]-1-oxohexan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-2-oxoethyl]amino]-3-carboxy-1-oxopropan-2-yl]amino]-5-carbamimidamido-1-oxopentan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-1,4-dioxobutan-2-yl]amino]-1,5-dioxopentan-2-yl]amino]-2-oxoethyl]amino]-3-methyl-1-oxobutan-2-yl]amino]-1-oxohexan-2-yl]amino]-4-[[(2S,3S)-2-[[(2S)-6-amino-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2,6-diaminohexanoyl]amino]-3-(1H-indol-3-yl)propanoyl]amino]hexanoyl]amino]-4-methylpentanoyl]amino]-3-phenylpropanoyl]amino]hexanoyl]amino]hexanoyl]amino]-3-methylpentanoyl]amino]-5-oxopentanoic acid",synonym,CHEBI:201428,Cecropin A,CHEBI:201428,MAPPED,unique
+"(4S)-p-mentha-1(6),8-dien-2-one",synonym,CHEBI:15399,D(+)-Carvone,CHEBI:15399,MAPPED,unique
+"(4S,4aS,12aR)-4-(dimethylamino)-1,10,11,12a-tetrahydroxy-6-methyl-3,12-dioxo-4a,5-dihydro-4H-tetracene-2-carboxamide;hydrochloride",synonym,CHEBI:201752,Anhydrotetracycline hydrochloride,CHEBI:201752,MAPPED,unique
+"(4S,4aS,5aR,12aS)-4,7-bis(dimethylamino)-3,10,12,12a-tetrahydroxy-1,11-dioxo-1,4,4a,5,5a,6,11,12a-octahydrotetracene-2-carboxamide hydrochloride",synonym,CHEBI:50697,Minocycline hydrochloride,CHEBI:50697,MAPPED,unique
+"(4S,4aS,5aS,6S,12aS)-4-(dimethylamino)-3,6,10,12,12a-pentahydroxy-6-methyl-1,11-dioxo-1,4,4a,5,5a,6,11,12a-octahydrotetracene-2-carboxamide",synonym,CHEBI:27902,Tetracycline,CHEBI:27902,MAPPED,unique
+(5)  Sodium metasilicate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+"(5R)-5-[(1S)-1,2-dihydroxyethyl]-3,4-dihydroxyfuran-2(5H)-one",synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+"(5R,5aS,8aR,9R)-9-hydroxy-5-(3,4,5-trimethoxyphenyl)-5,8,8a,9-tetrahydrofuro[3',4':6,7]naphtho[2,3-d][1,3]dioxol-6(5aH)-one",synonym,CHEBI:75251,Picropodophyllin,CHEBI:75251,MAPPED,unique
+"(5R,6S)-6-[(1R)-1-hydroxyethyl]-3-({2-[(iminomethyl)amino]ethyl}sulfanyl)-7-oxo-1-azabicyclo[3.2.0]hept-2-ene-2-carboxylic acid--water (1/1)",synonym,CHEBI:51799,Impenum monohydrate,CHEBI:51799,MAPPED,unique
+"(5R,9R,11E)-5-amino-11-ethylidene-7-methyl-5,6,9,10-tetrahydro-5,9-methanocycloocta[b]pyridin-2(1H)-one",synonym,CHEBI:78330,Huperzine A,CHEBI:78330,MAPPED,unique
+(5S)-2-methyl-5-(prop-1-en-2-yl)cyclohex-2-en-1-one,synonym,CHEBI:15399,D(+)-Carvone,CHEBI:15399,MAPPED,unique
+"(5S,6R)-5-hydroxy-6-methyl-3-[(2S,3S)-3-methyloxiran-2-yl]-5,6-dihydro-2H-pyran-2-one",synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+(5z)-4-bromo-5-(bromomethylene)-2(5h)-furanone,preferred_term,cas:247167-54-0,(5z)-4-bromo-5-(bromomethylene)-2(5h)-furanone,cas:247167-54-0,MAPPED,unique
+"(6aS)-3,6a,10-trihydroxy-6a,7-dihydrobenzo[b]indeno[1,2-d]pyran-9(6H)-one",synonym,CHEBI:69196,Brazilein,CHEBI:69196,MAPPED,unique
+(6E)-N-(4-hydroxy-3-methoxybenzyl)-8-methylnon-6-enamide,synonym,CHEBI:3374,capsaicin,CHEBI:3374,MAPPED,unique
+"(6R,7R)-7-{[(2R)-2-amino-2-phenylacetyl]amino}-3-chloro-8-oxo-5-thia-1-azabicyclo[4.2.0]oct-2-ene-2-carboxylic acid",synonym,CHEBI:3478,Cefaclor,CHEBI:3478,MAPPED,unique
+"(6S)-2-{[(3S,5S)-5-(dimethylcarbamoyl)pyrrolidin-3-yl]sulfanyl}-6-[(1R)-1-hydroxyethyl]-1beta-methyl-2,3-didehydro-1-carbapenam-3-carboxylic acid",synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
+"(7S,9E,11S,12R,13S,14R,15R,16R,17S,18S,19E,21Z)-2,15,17,27,29-pentahydroxy-11-methoxy-3,7,12,14,16,18,22-heptamethyl-26-{(E)-[(4-methylpiperazin-1-yl)imino]methyl}-6,23-dioxo-8,30-dioxa-24-azatetracyclo[23.3.1.1(4,7).0(5,28)]triaconta-1(28),1(29),2,4,9,19,21,25,27-nonaen-13-yl acetate",synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+(9Z)-octadec-9-enoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+(9Z)-Octadecenoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+(9Z-octadecenoyl)-glycerol,synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+(alpha-methylguanido)acetic acid,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+(beta-Hydroxyethyl)trimethylammonium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+(carbamimidamido)acetic acid,synonym,CHEBI:16344,Glycocyamine,CHEBI:16344,MAPPED,unique
+(CH3)2SO,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+(CH3)3N,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+(CH3)3N.HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+(Deoxyribonucleotide)m,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+(Deoxyribonucleotide)n,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+(Deoxyribonucleotide)n+m,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+(DL)-alpha-Lipoic acid,preferred_term,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+(E)-2-butenedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+(E)-2-butenoate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+(E)-2-Butenoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+(E)-3-phenyl-2-propenoic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+(E)-4-Aminostyryl acetate,synonym,kgmicrobe.compound:e_4_aminostyryl_acetate,E 4 Aminostyryl Acetate,kgmicrobe.compound:e_4_aminostyryl_acetate,MAPPED,unique
+(E)-4-coumaric acid methyl ester,ontology_label,cas:19367-38-5,methyl-trans-p-coumarate,CHEBI:194094,MAPPED,unique
+(E)-but-2-enoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+(E)-cinnamic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+(E)-crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+(E)-Crotonic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+(E)-sinapaldehyde,ontology_label,CHEBI:27949,sinapinaldehyde,CHEBI:27949,MAPPED,unique
+"(ethane-1,2-diyldinitrilo)tetraacetatoferrate(1-)",synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+"(ethane-1,2-diyldinitrilo)tetraacetatoferrate(III)",synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+"(ethane-1,2-diyldinitrilo)tetraacetic acid",synonym,CHEBI:4735,EDTA (acid form),CHEBI:4735,REJECTED,unique
+(ethylenedinitrilo)tetraacetic acid trisodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+(isothiocyanatomethyl)benzene,synonym,CHEBI:17484,Benzyl isothiocyanate,CHEBI:17484,MAPPED,unique
+(methanesulfinyl)methane,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+(methylsulfanyl)ethane,synonym,CHEBI:231886,ethyl methyl sulfide,CHEBI:231886,MAPPED,unique
+(METHYLSULFANYL)METHANE,synonym,CHEBI:17437,Dimethyl sulfide,CHEBI:17437,MAPPED,unique
+(N-methylcarbamimidamido)acetic acid,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+(NH4) citrate,synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+(NH4)2 citrate,preferred_term,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+(NH4)2 SO4,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+(NH4)2HPO4,preferred_term,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+(NH4)2HPO4(Fisher A686),synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+(NH4)2MoO4,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+(NH4)2Ni(SO4)2,preferred_term,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2 x 6 H2O,preferred_term,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2 x 6 H2O (0.1% w/v),synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2.6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2·6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2•6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2•6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2・6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2S4,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+(NH4)2SO4,preferred_term,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+(NH4)2SO4(Fisher A 702),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+(NH4)3 citrate,preferred_term,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+(NH4)6Mo7O24,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+(NH4)6Mo7O24 x 4 H2O,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+(NH4)Cl,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+(NH4)H2PO4,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+(NH4)HCO3,synonym,CHEBI:184335,NH4HCO3,CHEBI:184335,MAPPED,unique
+(NH4)NO3,preferred_term,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+(p-hydroxyphenyl)acetic acid,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+(R)-(+)-Lipoate,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+(R)-(+)-lipoic acid,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+"(R)-1,2-Dithiolane-3-pentanoic acid",synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+"(R)-1,2-dithiolane-3-valeric acid",synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+(R)-2-acetamido-3-O-(1-carboxyethyl)-2-deoxy-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+(R)-2-acetamido-3-O-(1-carboxyethyl)-2-deoxy-D-glucose,synonym,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
+(R)-2-amino-3-mercaptopropanoic acid,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+(R)-3-hydroxybutyrate,preferred_term,CHEBI:10983,(R)-3-hydroxybutyrate,CHEBI:10983,MAPPED,unique
+"(R)-6,8-thioctic acid",synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+(R)-adrenaline,ontology_label,CHEBI:28918,(-)-Epinephrine,CHEBI:28918,MAPPED,unique
+(R)-amygdalin,preferred_term,CHEBI:17019,(R)-amygdalin,CHEBI:17019,MAPPED,unique
+(R)-carnitine,ontology_label,CHEBI:16347,L-Carnitine,CHEBI:16347,MAPPED,unique
+(R)-Cysteine hydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+(R)-lactate,preferred_term,CHEBI:16004,(R)-lactate,CHEBI:16004,MAPPED,unique
+(R)-lipoic acid,ontology_label,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+(R)-malate(2-),ontology_label,CHEBI:15588,D-malate,CHEBI:15588,MAPPED,unique
+(R)-malic Acid,preferred_term,CHEBI:30796,(R)-malic Acid,CHEBI:30796,MAPPED,unique
+(R)-noradrenaline,ontology_label,CHEBI:18357,(-)-Norepinephrine,CHEBI:18357,MAPPED,unique
+(R)-pantolactone,ontology_label,CHEBI:16719,D-(-)-Pantolactone,CHEBI:16719,MAPPED,unique
+"(R*,R*)-1,4-dimercapto-2,3-butanediol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+"(R,R)-(+)-tartaric acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(R,R)-3,3'-dithiobis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"(R,R)-Tartaric acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"(R,R)-Tartrate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+"(R,S)-Aspartic acid",synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+"(R-(R*,R*))-2,3-dihydroxybutanedioic acid, disodium salt",synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+"(R-(R*,R*))-3,3'-Dithiobis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+(S)-(+)-leucine,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+(S)-(-)-lipoic acid,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+(S)-(-)-serine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+(S)-(-)-Tyrosine,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+"(S)-1,2-dithiolane-3-pentanoic acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+"(S)-2,5-diamino-5-oxopentanoic acid",synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+"(S)-2,5-Diaminopentanoate",synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+"(S)-2,5-Diaminopentanoic acid",synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+"(S)-2,5-diaminovaleric acid",synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+"(S)-2,6-diaminohexanoic acid",synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+"(S)-2,6-Diaminohexanoic acid monohydrochloride",synonym,CHEBI:53633,L-Lysine HCl,CHEBI:53633,MAPPED,unique
+(S)-2-Amino-3-(p-hydroxyphenyl)propionic acid,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(S)-2-amino-3-carbamoylpropanoic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+(S)-2-amino-3-hydroxypropanoic acid,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+(S)-2-Amino-3-phenylpropionic acid,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+(S)-2-amino-4-(methylthio)butanoic acid,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+(S)-2-amino-4-(methylthio)butyric acid,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+(S)-2-amino-5-guanidinopentanoic acid,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+(S)-2-Amino-5-guanidinovaleric acid,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+(S)-2-Amino-5-ureidopentanoic acid,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+(S)-2-aminobutanedioic acid,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,unique
+(S)-2-aminopentanedioic acid,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+(S)-2-aminopropanoic acid,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+(S)-2-aminosuccinic acid,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,unique
+(S)-2-carboxypyrrolidine,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(S)-2-pyrrolidinecarboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(S)-3-(p-Hydroxyphenyl)alanine,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(S)-3-hydroxybutyrate,preferred_term,CHEBI:11047,(S)-3-hydroxybutyrate,CHEBI:11047,MAPPED,unique
+(S)-4-(2-Amino-2-carboxyethyl)imidazole,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+(S)-alanine,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+"(S)-alpha,delta-diaminovaleric acid",synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+"(S)-alpha,epsilon-diaminocaproic acid",synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+(S)-alpha-amino-1H-Imidazole-4-propanoic acid,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+(S)-alpha-Amino-1H-imidazole-4-propionic acid,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+(S)-alpha-amino-1H-indole-3-propanoic acid,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+(S)-alpha-amino-4-hydroxybenzenepropanoic acid,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(S)-alpha-Amino-beta-(3-indolyl)-propionic acid,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+(S)-alpha-Amino-beta-hydroxypropionic acid,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+(S)-alpha-Amino-beta-phenylpropionic acid,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+(S)-alpha-lipoic acid,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+(S)-Asparagine,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+(S)-azetidine-2-carboxylic Acid,preferred_term,CHEBI:6198,(S)-azetidine-2-carboxylic Acid,CHEBI:6198,MAPPED,unique
+(S)-disodium malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+(S)-glutamic acid,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+(S)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+(S)-leucine,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+(S)-lipoic acid,ontology_label,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+(S)-lysine,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+(S)-malate(2-),ontology_label,CHEBI:15589,L-malate,CHEBI:15589,MAPPED,unique
+(S)-malic acid,ontology_label,CHEBI:30797,L-Malic acid,CHEBI:30797,MAPPED,unique
+(S)-mandelic Acid,preferred_term,CHEBI:32800,(S)-mandelic Acid,CHEBI:32800,MAPPED,unique
+(S)-methionine,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+(S)-ornithine,synonym,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+(S)-pyrrolidine-2-carboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+(S)-serine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+(S)-tryptophan,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+(S)-Tyrosine,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+(S)-valine,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+(SiO2)n,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+(SP-4-2)-diamminedichloridoplatinum,synonym,CHEBI:27899,Cisplatin,CHEBI:27899,MAPPED,unique
+(SP-4-2)-diamminedichloroplatinum,synonym,CHEBI:27899,Cisplatin,CHEBI:27899,MAPPED,unique
+(trimethylammonio)acetate,synonym,cas:590-46-5,Betaine hydrochloride,CHEBI:17750,MAPPED,conflict:different_substances
+(trimethylammonio)acetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,conflict:different_substances
+(trimethylammoniumyl)acetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+(Z)-Octadec-9-enoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+-Asp-,synonym,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+.MgSO4,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+.MgSO4 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+.MgSO4 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+0.2% Thiamine pyrophosphate,preferred_term,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+"0.5 M Nitrilotriacetic acid, disodium salt",preferred_term,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+0129 (2,preferred_term,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,0129 (2,,REJECTED,unique
+0129 (2,synonym,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
+1 % Sodium Lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+1 M Sodium acetate,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+1 M Sodium butyrate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+1 M Sodium lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+1 M Sodium pyruvate*,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+1% Sodium Chloride,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+"1,1',6,6',7,7'-hexahydroxy-3,3'-dimethyl-5,5'-di(propan-2-yl)[2,2'-binaphthalene]-8,8'-dicarbaldehyde",synonym,CHEBI:28584,Gossypol,CHEBI:28584,MAPPED,unique
+"1,1'-dimethyl-[4,4'-bipyridin]-1,1'-diium dichloride",synonym,CHEBI:28786,Paraquat dichloride,CHEBI:28786,MAPPED,unique
+"1,1'-oxydiethane",synonym,CHEBI:35702,diethyl ether,CHEBI:35702,MAPPED,unique
+"1,1,1-tris(hydroxymethyl)methanamine",synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+"1,1,2,2-Tetrachloroethane",preferred_term,CHEBI:36026,"1,1,2,2-Tetrachloroethane",CHEBI:36026,MAPPED,unique
+"1,1,2,2-tetrachloroethylene",synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+"1,1,2-Trichloraethan",synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+"1,1,2-trichlorethane",synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+"1,1,2-Trichloroethane",preferred_term,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+"1,1,2-trichloroethene",synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+"1,1-bis(2-aminoethyl)-2-hydroxy-3-oxotriazane",ontology_label,CHEBI:50154,DETA/NO,CHEBI:50154,MAPPED,unique
+"1,1-dichloro-2-chloroethylene",synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+"1,1-diethyl-2-hydroxy-3-oxotriazane--N-ethylethanamine (1/1)",synonym,cas:372965-00-9,DEANONOate,CHEBI:77707,MAPPED,unique
+"1,2,2-trichloroethane",synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+"1,2,3,4,5,6-cyclohexanehexol",synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+"1,2,3,4,5,6-hexachlorocyclohexane",synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+"1,2,3,4,5,6-HEXAHYDROXY-CYCLOHEXANE",synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+"1,2,3,4,6-pentakis-O-{3,4-dihydroxy-5-[(3,4,5-trihydroxybenzoyl)oxy]benzoyl}-D-glucopyranose",synonym,CHEBI:75211,tannic acid,CHEBI:75211,MAPPED,unique
+"1,2,3,5/4,6-cyclohexanehexol",synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+"1,2,3-Propanetriol",synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+"1,2,3-Propanetriol",synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+"1,2,3-trichloropropane",preferred_term,CHEBI:34036,"1,2,3-trichloropropane",CHEBI:34036,MAPPED,unique
+"1,2,3-Trihydroxypropane",synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+"1,2,3-Trihydroxypropane",synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+"1,2-benzacenaphthylene",synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
+"1,2-Benzenediol",synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+"1,2-benzisothiazol-3(2H)-one 1,1-dioxide",synonym,CHEBI:32111,Saccharin,CHEBI:32111,MAPPED,unique
+"1,2-dichloroethane",preferred_term,CHEBI:27789,"1,2-dichloroethane",CHEBI:27789,MAPPED,unique
+"1,2-Dichloropropane",preferred_term,CHEBI:82163,"1,2-Dichloropropane",CHEBI:82163,MAPPED,unique
+"1,2-Dihydro-1,5-dimethyl-2-phenyl-3H-pyrazol-3-one",synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+"1,2-Dihydroxybenzene",synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+"1,2-Dihydroxyethane",synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+"1,2-dimethyl-5-nitro-1H-imidazole",synonym,CHEBI:141155,Dimetridazole,CHEBI:141155,MAPPED,unique
+"1,2-dimethyl-5-nitroimidazole",synonym,CHEBI:141155,Dimetridazole,CHEBI:141155,MAPPED,unique
+"1,2-dithiolane-3-pentanoic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"1,2-dithiolane-3-valeric acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"1,2-ethanedicarboxylic acid",synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+"1,2-ETHANEDIOL",synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+"1,2-Propanediol",preferred_term,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
+"1,3,4-trihydroxybutan-2-one",synonym,CHEBI:23958,L-(+)-Erythrulose,CHEBI:23958,MAPPED,unique
+"1,3,5/2,4,6-cyclohexanehexol",synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+"1,3,7-trimethyl-3,7-dihydro-1H-purine-2,6-dione",synonym,CHEBI:27732,Caffeine,CHEBI:27732,MAPPED,unique
+"1,3,8-trihydroxy-6-methylanthra-9,10-quinone",synonym,CHEBI:42223,Emodin,CHEBI:42223,MAPPED,unique
+"1,3-Butandiol",synonym,CHEBI:52683,"1,3-Butanediol",CHEBI:52683,MAPPED,unique
+"1,3-Butanediol",preferred_term,CHEBI:52683,"1,3-Butanediol",CHEBI:52683,MAPPED,unique
+"1,3-Dihydroxypropan-2-one",synonym,CHEBI:16016,Dihydroxyacetone,CHEBI:16016,MAPPED,unique
+"1,3-dihydroxypropan-2-yl octadecanoate",synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+"1,3-dihydroxypropan-2-yl stearate",synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+"1,3-dimethyl-3,7-dihydro-1H-purine-2,6-dione",synonym,CHEBI:28177,Theophylline,CHEBI:28177,MAPPED,unique
+"1,3-Dimethylbenzene",synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+"1,3-Dimethylbenzol",synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+"1,3-Hexanediol",preferred_term,cas:21531-91-9,"1,3-Hexanediol",cas:21531-91-9,MAPPED,unique
+"1,3-Propanediol",preferred_term,CHEBI:16109,"1,3-Propanediol",CHEBI:16109,MAPPED,unique
+"1,3-Xylene",synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+"1,4,7,10,13,16-hexaoxacyclooctadecane",synonym,CHEBI:32397,18-Crown-6,CHEBI:32397,MAPPED,unique
+"1,4-B-D-Galactobiose",preferred_term,cas:2152-98-9,"1,4-B-D-Galactobiose",CHEBI:36226,MAPPED,unique
+"1,4-Butanediamine",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+"1,4-Butanediol",preferred_term,CHEBI:41189,"1,4-Butanediol",CHEBI:41189,MAPPED,unique
+"1,4-butylenediamine",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+"1,4-DIAMINOBUTANE",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+"1,4-Diaminobutane dihydrochloride",ontology_label,cas:333-93-7,Putrescine Dihydrochloride,CHEBI:201718,MAPPED,unique
+"1,4-dihydro-1,4-diketonaphthalene",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+"1,4-dimethyl-7-(propan-2-yl)azulene",synonym,CHEBI:5550,Guaiazulene,CHEBI:5550,MAPPED,unique
+"1,4-dithiothreitol",ontology_label,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+"1,4-Naphthalenedione",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+"1,4-Naphthoquinone",preferred_term,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+"1,4-NQ",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+"1,4-tetramethylenediamine",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+"1,5,10-triazadecane",synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+"1,5-dimethyl-2-phenyl-1,2-dihydro-3H-pyrazol-3-one",synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+"1,5-Pentanediol",preferred_term,CHEBI:185431,"1,5-Pentanediol",CHEBI:185431,MAPPED,unique
+"1,6-Hexanediamine",preferred_term,cas:124-09-4,"1,6-Hexanediamine",cas:124-09-4,MAPPED,unique
+"1,7,7-trimethylbicyclo[2.2.1]heptan-2-ol",synonym,CHEBI:28093,Borneol,CHEBI:28093,MAPPED,unique
+"1,7-dihydro-6H-purin-6-one",synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+"1,8-dihydroxy-3-methoxy-6-methylanthracene-9,10-dione",synonym,CHEBI:38167,Physcion,CHEBI:38167,MAPPED,unique
+"1,8-dihydroxy-3-methyl-9,10-anthraquinone",synonym,CHEBI:3687,Chrysophanol,CHEBI:3687,MAPPED,unique
+"1,8-dihydroxy-3-methylanthracen-9(10H)-one",synonym,CHEBI:3686,Chrysarobin,CHEBI:3686,MAPPED,unique
+"1-(1H-indol-3-yl)-N,N-dimethylmethanamine",synonym,CHEBI:28948,Gramine,CHEBI:28948,MAPPED,unique
+"1-(2-deoxy-beta-D-erythro-pentofuranosyl)-5-methylpyrimidine-2,4(1H,3H)-dione",synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+1-(2-deoxy-beta-D-erythro-pentofuranosyl)uracil,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
+"1-(2-hydroxy-4,6-dimethoxy-3-methylphenyl)ethanone",synonym,cas:23121-32-6,Methylxanthoxylin,CHEBI:169463,MAPPED,unique
+"1-(4-hydroxy-3,5-dimethoxyphenyl)ethan-1-one",synonym,CHEBI:2404,Acetosyringone,CHEBI:2404,MAPPED,unique
+1-(4-hydroxy-3-methoxyphenyl)ethan-1-one,synonym,CHEBI:2781,Acetovanillone,CHEBI:2781,MAPPED,unique
+1-(4-Hydroxyphenyl)-2-(methylamino)ethanol,synonym,CHEBI:29081,Oxedrine,CHEBI:29081,MAPPED,unique
+1-(4-hydroxyphenyl)ethanone,synonym,CHEBI:28032,4-Hydroxyacetophenone,CHEBI:28032,MAPPED,unique
+1-(beta-D-ribofuranosyl)thymine,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+1-4-D-Xylobiose,synonym,CHEBI:28309,Xylobiose,CHEBI:28309,MAPPED,unique
+1-[(2-chlorophenyl)(diphenyl)methyl]-1H-imidazole,synonym,CHEBI:3764,Clotrimazole,CHEBI:3764,MAPPED,unique
+"1-[(2E,4E)-5-(1,3-benzodioxol-5-yl)penta-2,4-dienoyl]piperidine",synonym,CHEBI:28821,Piperine,CHEBI:28821,MAPPED,unique
+1-[(4-amino-2-methylpyrimidin-5-yl)methyl]-3-(2-{[hydroxy(phosphonooxy)phosphoryl]oxy}ethyl)-2-methylpyridinium,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+1-alpha-D-Glucopyranosyl-2-beta-D-fructofuranoside,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+1-alpha-D-Glucopyranosyl-4-alpha-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+1-Amino-4-carboxybenzene,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+1-aminocyclopropane-1-carboxylate,preferred_term,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
+1-Aminocyclopropane-1-carboxylic acid,synonym,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
+1-aminocyclopropanecarboxylic acid,ontology_label,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
+1-beta-D-Galactopyranosyl-4-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+1-beta-D-Glucopyranosyl-4-D-glucopyranose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+1-beta-D-Ribofuranosylcytosine,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+"1-beta-D-ribofuranosylpyrimidine-2,4(1H,3H)-dione",synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+1-beta-D-ribofuranosyluracil,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+1-butanecarboxylic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+1-butanoic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+1-butanol+CO2,preferred_term,kgmicrobe.ingredient:1_butanol_co2,1-butanol+CO2,kgmicrobe.ingredient:1_butanol_co2,MAPPED,unique
+1-butyric acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+"1-carboxy-N,N,N-trimethylmethanaminium inner salt",synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+1-chlorobutane,preferred_term,CHEBI:747005,1-chlorobutane,CHEBI:747005,MAPPED,unique
+1-chloropropane,preferred_term,CHEBI:747004,1-chloropropane,CHEBI:747004,MAPPED,unique
+"1-cyclopropyl-6-fluoro-4-oxo-7-(piperazin-1-yl)-1,4-dihydroquinoline-3-carboxylic acid hydrochloride--water (1/1)",synonym,CHEBI:59936,Ciprofloxacin Hydrochloride,CHEBI:59936,MAPPED,unique
+"1-cyclopropyl-6-fluoro-8-methoxy-7-[(4aS,7aS)-octahydro-6H-pyrrolo[3,4-b]pyridin-6-yl]-4-oxo-1,4-dihydroquinoline-3-carboxylic acid",synonym,CHEBI:63611,Moxifloxacin,CHEBI:63611,MAPPED,unique
+"1-deoxy-1-(7,8-dimethyl-2,4-dioxo-3,4-dihydrobenzo[g]pteridin-10(2H)-yl)-D-ribitol",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"1-deoxy-1-(7,8-dimethyl-2,4-dioxo-3,4-dihydrobenzo[g]pteridin-10(2H)-yl)pentitol",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"1-deoxy-1-[8-(dimethylamino)-7-methyl-2,4-dioxo-3,4-dihydrobenzo[g]pteridin-10(2H)-yl]-D-ribitol",synonym,CHEBI:72346,Roseoflavin,CHEBI:72346,MAPPED,unique
+1-ethyl-3-methyl-1H-imidazol-3-ium,synonym,CHEBI:61326,1-ethyl-3-methylimidazolium lysine,CHEBI:61326,MAPPED,conflict:different_substances
+1-ethyl-3-methyl-1H-imidazol-3-ium,synonym,cas:143314-17-4,1-ethyl-3-methylimidazolium acetate,CHEBI:61326,MAPPED,conflict:different_substances
+1-ethyl-3-methyl-1H-imidazol-3-ium chloride,synonym,CHEBI:61327,1-ethyl-3-methylimidazolium chloride,CHEBI:61327,MAPPED,unique
+1-ethyl-3-methylimidazolium,ontology_label,CHEBI:61326,1-ethyl-3-methylimidazolium lysine,CHEBI:61326,MAPPED,conflict:different_substances
+1-ethyl-3-methylimidazolium,ontology_label,cas:143314-17-4,1-ethyl-3-methylimidazolium acetate,CHEBI:61326,MAPPED,conflict:different_substances
+1-ethyl-3-methylimidazolium acetate,preferred_term,cas:143314-17-4,1-ethyl-3-methylimidazolium acetate,CHEBI:61326,MAPPED,unique
+1-ethyl-3-methylimidazolium chloride,preferred_term,CHEBI:61327,1-ethyl-3-methylimidazolium chloride,CHEBI:61327,MAPPED,unique
+1-ethyl-3-methylimidazolium lysine,preferred_term,CHEBI:61326,1-ethyl-3-methylimidazolium lysine,CHEBI:61326,MAPPED,unique
+"1-ethyl-6,8-difluoro-7-(3-methylpiperazin-1-yl)-4-oxo-1,4-dihydroquinoline-3-carboxylic acid hydrochloride",synonym,CHEBI:6518,Lomefloxacin hydrochloride,CHEBI:6518,MAPPED,unique
+"1-ethyl-6-fluoro-4-oxo-7-(piperazin-1-yl)-1,4-dihydroquinoline-3-carboxylic acid",synonym,CHEBI:100246,Norfloxacin,CHEBI:100246,MAPPED,unique
+"1-ethyl-7-methyl-4-oxo-1,4-dihydro-1,8-naphthyridine-3-carboxylic acid",synonym,cas:3374-05-8,Nalidixic acid sodium salt,CHEBI:100147,MAPPED,unique
+1-hexanoic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+1-hydroxyethane,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+1-Kestose,preferred_term,CHEBI:16885,1-Kestose,CHEBI:16885,MAPPED,unique
+1-methoxy-4-(prop-1-en-1-yl)benzene,synonym,CHEBI:2716,Anethole,CHEBI:2716,MAPPED,unique
+1-methoxy-4-(prop-2-en-1-yl)benzene,synonym,CHEBI:4867,Estragole,CHEBI:4867,MAPPED,unique
+"1-methyl-4,9-dihydro-3H-pyrido[3,4-b]indol-7-ol",synonym,CHEBI:27943,Harmalol,CHEBI:27943,MAPPED,unique
+1-methyl-9H-beta-carbolin-7-ol,synonym,CHEBI:192558,Harmol,CHEBI:192558,MAPPED,unique
+"1-methyl-9H-pyrido[3,4-b]indole",synonym,CHEBI:5623,Harmane,CHEBI:5623,MAPPED,unique
+1-methylethanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+1-methylethyl alcohol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+1-Methylglycocyamidine,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+1-Methylhydantoin,synonym,CHEBI:16354,N-methylhydantoin,CHEBI:16354,MAPPED,unique
+1-Methylhydantoin-2-imide,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+"1-methylimidazolidine-2,4-dione",synonym,CHEBI:16354,N-methylhydantoin,CHEBI:16354,MAPPED,unique
+1-methylphenanthrene,preferred_term,CHEBI:35860,1-methylphenanthrene,CHEBI:35860,MAPPED,unique
+1-methylpyridin-1-ium-3-carboxylic acid;chloride,synonym,CHEBI:229203,Trigonelline HCl,CHEBI:229203,MAPPED,unique
+1-naphthaleneacetic acid,ontology_label,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+1-Naphthylacetic acid,preferred_term,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+1-naphthylacetic acid,synonym,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+1-Naphtylacetic Acid,synonym,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+1-o-methyl Alpha-galactopyranoside,preferred_term,CHEBI:55507,1-o-methyl Alpha-galactopyranoside,CHEBI:55507,MAPPED,unique
+1-octen-3-ol,preferred_term,CHEBI:34118,1-octen-3-ol,CHEBI:34118,MAPPED,unique
+1-pentanecarboxylic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+1-Pentanol,preferred_term,CHEBI:44884,1-Pentanol,CHEBI:44884,MAPPED,unique
+1-phenazinecarboxamide,preferred_term,CHEBI:62240,1-phenazinecarboxamide,CHEBI:62240,MAPPED,unique
+1-propanecarboxylic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+1-propanol+CO2,preferred_term,kgmicrobe.ingredient:1_propanol_co2,1-propanol+CO2,kgmicrobe.ingredient:1_propanol_co2,MAPPED,unique
+1-pyridin-3-ylethanone,synonym,CHEBI:166501,3-acetylpyridine,CHEBI:166501,MAPPED,unique
+1-THIOETHANESULFONIC ACID,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+1-undecene,ontology_label,CHEBI:77444,undecene,CHEBI:77444,MAPPED,unique
+"1-{2-[(4-chlorobenzyl)oxy]-2-(2,4-dichlorophenyl)ethyl}-1H-imidazole nitrate",synonym,CHEBI:4755,Econazole nitrate salt,CHEBI:4755,MAPPED,unique
+"1-{[(5-nitro-2-furyl)methylene]amino}imidazolidine-2,4-dione",synonym,CHEBI:71415,Nitrofurantoin,CHEBI:71415,MAPPED,unique
+10-[2-(1-methylpiperidin-2-yl)ethyl]-2-(methylsulfanyl)-10H-phenothiazine hydrochloride,synonym,CHEBI:48566,Thioridazine hydrochloride,CHEBI:48566,MAPPED,unique
+100,synonym,CHEBI:9177,sodium Deoxycholate,CHEBI:9177,MAPPED,unique
+"11,12-dihydroxyabieta-8,11,13-trien-20-oic acid",synonym,CHEBI:65585,Carnosic Acid,CHEBI:65585,MAPPED,unique
+13-cyclopent-2-en-1-yltridecanoic acid,synonym,CHEBI:27939,Chaulmoogric acid,CHEBI:27939,MAPPED,unique
+16S,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+1728,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+18-Crown-6,preferred_term,CHEBI:32397,18-Crown-6,CHEBI:32397,MAPPED,unique
+18:0,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+18:1 n-9,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+18:1Delta9cis,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+1beta-D-ribofuranosylcytosine,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+1D-myo-Inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+1H-indol-3-ylacetic acid,synonym,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
+1H-indole,ontology_label,CHEBI:16881,Indole,CHEBI:16881,MAPPED,unique
+"1H-pyrazolo[3,4-d]pyrimidin-4-ol",synonym,CHEBI:40279,Allopurinol,CHEBI:40279,MAPPED,unique
+1H-pyrrole-2-carboxylic acid,synonym,CHEBI:36751,Pyrrole-2-carboxylic acid,CHEBI:36751,MAPPED,unique
+1L-chiro-inositol,ontology_label,CHEBI:27374,L-inositol,CHEBI:27374,MAPPED,unique
+1L-myo-Inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+"2',2'-Bisepigallocatechin Digallate",preferred_term,UNMAPPED_0190,"2',2'-Bisepigallocatechin Digallate",,UNMAPPED,unique
+"2',5'-Dihydroxy-4-Methoxychalcone",preferred_term,cas:6342-92-3,"2',5'-Dihydroxy-4-Methoxychalcone",cas:6342-92-3,MAPPED,unique
+2'-deoxy-5'-adenylic acid,synonym,CHEBI:17713,2-Deoxyadenosine 5-monophosphate,CHEBI:17713,MAPPED,unique
+2'-deoxy-5'-cytidylic acid,synonym,CHEBI:15918,2-Deoxycytidine 5-monophosphate,CHEBI:15918,MAPPED,unique
+2'-deoxy-5-methyluridine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+2'-deoxyadenosine,ontology_label,CHEBI:17256,2-deoxyadenosine,CHEBI:17256,MAPPED,conflict:different_substances
+2'-deoxyadenosine,ontology_label,cas:16373-93-6,2-Deoxyadenosine monohydrate,CHEBI:17256,MAPPED,conflict:different_substances
+2'-deoxyadenosine 5'-monophosphate,ontology_label,CHEBI:17713,2-Deoxyadenosine 5-monophosphate,CHEBI:17713,MAPPED,unique
+2'-Deoxycytidine,preferred_term,CHEBI:15698,2'-Deoxycytidine,CHEBI:15698,MAPPED,unique
+2'-deoxycytosine 5'-monophosphate,ontology_label,CHEBI:15918,2-Deoxycytidine 5-monophosphate,CHEBI:15918,MAPPED,unique
+2'-Deoxyinosine,preferred_term,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
+2'-deoxythymidine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+2'-Deoxyuridine,preferred_term,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
+2'-fucosyllactose,preferred_term,CHEBI:147155,2'-fucosyllactose,CHEBI:147155,MAPPED,unique
+"2'-Hydroxy-4',6'-dimethoxy-3'-methylacetophenone",ontology_label,cas:23121-32-6,Methylxanthoxylin,CHEBI:169463,MAPPED,unique
+2'-thymidine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+2(3H)-imino-9-beta-D-ribofuranosyl-9H-purin-6(1H)-one,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+"2,2',2'',2'''-(ethane-1,2-diyldiammonio)tetraacetate",synonym,CHEBI:4735,EDTA,CHEBI:4735,MAPPED,unique
+"2,2',2'',2'''-(ethane-1,2-diyldiazaniumyl)tetraacetate",synonym,CHEBI:4735,EDTA,CHEBI:4735,MAPPED,unique
+"2,2',2''-nitrilotriacetate",synonym,CHEBI:25548,Nitrilotriacetate,CHEBI:25548,MAPPED,unique
+"2,2',2''-NITRILOTRIETHANOL",synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+"2,2',2''-nitrilotris(ethanol)",synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+"2,2'-bipyridine",ontology_label,CHEBI:30351,"2,2'-Dipyridyl",CHEBI:30351,MAPPED,unique
+"2,2'-Dipyridyl",preferred_term,CHEBI:30351,"2,2'-Dipyridyl",CHEBI:30351,MAPPED,unique
+"2,2,4,4,6,8,8-Heptamethylnonane",preferred_term,CHEBI:131383,"2,2,4,4,6,8,8-Heptamethylnonane",CHEBI:131383,MAPPED,unique
+"2,2-bis(hydroxymethyl)-2,2',2''-nitrilotriethanol",synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+"2,2-dibromo-2-cyanoacetamide",preferred_term,cas:10222-01-2,"2,2-dibromo-2-cyanoacetamide",cas:10222-01-2,MAPPED,unique
+"2,2-dichloro-N-[(1R,2R)-2-hydroxy-1-(hydroxymethyl)-2-(4-nitrophenyl)ethyl]acetamide",synonym,CHEBI:17698,Chloramphenicol,CHEBI:17698,MAPPED,unique
+"2,2-dimethyl-3,4-dihydro-2H-benzo[h]chromene-5,6-dione",synonym,CHEBI:10429,Beta-Lapachone,CHEBI:10429,MAPPED,unique
+"2,2-dimethylacetic acid",synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+"2,3 DHB",synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+"2,3,5-triphenyl-2H-tetrazol-3-ium chloride",synonym,CHEBI:78019,"2,3,5-Triphenyltetrazolium chloride",CHEBI:78019,MAPPED,unique
+"2,3,5-Triphenyltetrazolium chloride",preferred_term,CHEBI:78019,"2,3,5-Triphenyltetrazolium chloride",CHEBI:78019,MAPPED,unique
+"2,3,9,10-tetramethoxy-5,6-dihydroisoquino[3,2-a]isoquinolinium",synonym,CHEBI:16096,Palmatine,CHEBI:16096,MAPPED,unique
+"2,3-butanediol",preferred_term,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"2,3-Butylene glycol",synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"2,3-DIHYDROXY-BENZOIC ACID",synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+"2,3-dihydroxybenzoic acid",preferred_term,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+"2,3-Dihydroxybutane",synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"2,3-dihydroxypropanal",synonym,CHEBI:5445,DL-glyceraldehyde,CHEBI:5445,MAPPED,unique
+"2,3-dihydroxypropyl dihydrogen phosphate",synonym,cas:17603-42-8,DL-Glycerol 1-phosphate sodium salt hydrate,CHEBI:14336,MAPPED,unique
+"2,3-Dimethyl-1-phenyl-5-pyrazolone",synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+"2,3-dimethylsuccinic acid",ontology_label,CHEBI:167506,2-dimethylsuccinic Acid,CHEBI:167506,MAPPED,unique
+"2,3-dioxido-1,4-dioxy-2,3-disulfy-[4]catenate(2-)",synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+"2,4(1H,3H)-pyrimidinedione",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+"2,4-diamino-4-oxobutanoic acid",synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+"2,4-diamino-6,7-di-iso-propylpteridine phosphate",preferred_term,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
+"2,4-diamino-6,7-diisopropylpteridine",ontology_label,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unresolved:partial_chemistry
+"2,4-diamino-6,7-diisopropylpteridine",ontology_label,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unresolved:partial_chemistry
+"2,4-dihydroxy-5-methylpyrimidine",synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+"2,4-Dinitrophenol",preferred_term,CHEBI:42017,"2,4-Dinitrophenol",CHEBI:42017,MAPPED,unique
+"2,4-Dioxopyrimidine",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+"2,4-Pyrimidinedione",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+"2,5,8,11,14,17,20,23,26-nonaoxaoctacosan-28-ol",synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+"2,5-didehydro-D-gluconic acid",preferred_term,CHEBI:18281,"2,5-didehydro-D-gluconic acid",CHEBI:18281,MAPPED,unique
+"2,5-Dihydroxybenzoate",synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+"2,5-Dihydroxybenzoic acid",synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+"2,5-Dioxo-4-imidazolidinyl-urea",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+"2,6-diacetyl-3,7,9-trihydroxy-8,9b-dimethyldibenzo[b,d]furan-1(9bH)-one",synonym,CHEBI:38319,Usnic Acid,CHEBI:38319,MAPPED,unique
+"2,6-diaminoheptanedioic acid",synonym,CHEBI:23673,Diaminopimelic acid,CHEBI:23673,MAPPED,unique
+"2,6-diaminopimelic acid",ontology_label,CHEBI:23673,Diaminopimelic acid,CHEBI:23673,MAPPED,unique
+"2,6-dihydroxybenzoic acid",preferred_term,cas:303-07-1,"2,6-dihydroxybenzoic acid",cas:303-07-1,MAPPED,unique
+"2,6-dihydroxypurine",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+"2,6-dioxo-1,2,3,6-tetrahydropurine",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+"2,6-dioxo-1,2,3,6-tetrahydropyrimidine-4-carboxylic acid",synonym,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
+"2,8-dibenzyl-6-(4-hydroxyphenyl)imidazo[1,2-a]pyrazin-3-yl sulfate",synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+2-(1H-imidazol-4-yl)ethanamine,synonym,CHEBI:18295,Histamine,CHEBI:18295,MAPPED,unique
+2-(1H-INDOL-3-YL)ETHANAMINE,synonym,CHEBI:16765,Tryptamine,CHEBI:16765,MAPPED,unique
+"2-(2,4-dihydroxyphenyl)-3,5,7-trihydroxy-4H-chromen-4-one",synonym,CHEBI:75092,Morin,CHEBI:75092,MAPPED,unique
+2-(2-methyl-5-nitro-1H-imidazol-1-yl)ethanol,synonym,CHEBI:6909,Metronidazole,CHEBI:6909,MAPPED,unique
+"2-(3,4-dihydroxyphenyl)-3,5,7,8-tetrahydroxy-4H-chromen-4-one",synonym,CHEBI:16400,Gossypetin,CHEBI:16400,MAPPED,unique
+"2-(3,4-dihydroxyphenyl)-3,5,7-trihydroxy-4H-chromen-4-one",synonym,CHEBI:16243,Quercetin,CHEBI:16243,MAPPED,unique
+"2-(3,4-dihydroxyphenyl)-5,7-dihydroxy-4-oxo-4H-chromen-3-yl 6-O-(6-deoxy-alpha-L-mannopyranosyl)-beta-D-glucopyranoside",synonym,CHEBI:28527,Rutin,CHEBI:28527,MAPPED,unique
+"2-(3,4-dimethoxyphenyl)-5,6,7,8-tetramethoxy-4H-1-benzopyran-4-one",synonym,CHEBI:7602,Nobiletin,CHEBI:7602,MAPPED,unique
+2-(4-hydroxy-3-methoxyphenyl)acetic acid,synonym,CHEBI:545959,homovanillic acid,CHEBI:545959,MAPPED,unique
+2-(4-methoxyphenyl)-1-benzopyran-4-one,ontology_label,cas:4143-74-2,4'-Methoxyflavone,CHEBI:114194,MAPPED,unique
+2-(4-morpholinyl)ethanesulfonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+2-(acetylamino)-3-O-[(1R)-1-carboxyethyl]-2-deoxy-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+2-(acetylamino)-5-amino-5-oxopentanoic acid,synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+2-(aminoacetamido)acetic acid,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+"2-(bis(2-hydroxyethyl)amino)-2-(hydroxymethyl)-1,3-propanediol",synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+2-(methylsulfanyl)ethanol,synonym,CHEBI:63861,2-(Methylthio)ethanol,CHEBI:63861,MAPPED,unique
+2-(Methylthio)ethanol,preferred_term,CHEBI:63861,2-(Methylthio)ethanol,CHEBI:63861,MAPPED,unique
+2-(morpholin-4-yl)ethanesulfonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+2-(N-Morpholino)aethansulfonsaeure,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+2-(N-morpholino)ethanesulfonic acid,ontology_label,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unresolved:partial_chemistry
+2-(N-morpholino)ethanesulfonic acid,ontology_label,cas:145224-94-8,MES Hydrat,CHEBI:39005,MAPPED,unresolved:partial_chemistry
+2-(N-Morpholino)ethanesulfonic acid sodium salt,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+2-(N-Morpholino)ethansulfonsaeure,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+2-6-dihydroxybenzoic acid,synonym,cas:303-07-1,"2,6-dihydroxybenzoic acid",cas:303-07-1,MAPPED,unique
+2-[(2-amino-2-oxoethyl)amino]ethanesulfonic acid,synonym,CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,CHEBI:39060,MAPPED,unique
+2-[(2-aminoacetyl)amino]butanedioic acid,synonym,cas:79731-35-4,Gly-DL-Asp,CHEBI:193741,MAPPED,unique
+"2-[(3S,3aS,4R,5R,7R,7aR)-7-(2-aminopurin-9-yl)-3,3a,4-trihydroxy-2,3,4,5,7,7a-hexahydrouro[2,3-c]pyran-5-yl]-2-[[2-amino-5-[carbamimidoyl(hydroxy)amino]pentanoyl]amino]acetic acid",synonym,CHEBI:216282,miharamycin A,CHEBI:216282,MAPPED,unique
+2-[(5-nitro-2-furyl)methylene]hydrazinecarboxamide,synonym,CHEBI:44368,Nitrofurazone,CHEBI:44368,MAPPED,unique
+2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid,ontology_label,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+"2-[[(4R)-4-[(3R,5S,7R,9S,10S,12S,13R,14S,17R)-3,7,12-trihydroxy-10,13-dimethyl-2,3,4,5,6,7,8,9,11,12,14,15,16,17-tetradecahydro-1H-cyclopenta[a]phenanthren-17-yl]pentanoyl]amino]acetic acid",synonym,CHEBI:182320,Glycocholic acid hydrate,CHEBI:182320,MAPPED,unique
+"2-[bis(2-hydroxyethyl)amino]-2-(hydroxymethyl)propane-1,3-diol",synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+"2-[BIS-(2-HYDROXY-ETHYL)-AMINO]-2-HYDROXYMETHYL-PROPANE-1,3-DIOL",synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+2-acetamido-2-deoxy-D-galactopyranose,synonym,CHEBI:28037,N-Acetyl-D-galactosamine,CHEBI:28037,MAPPED,unique
+2-acetamido-2-deoxy-D-glucopyranose,synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
+2-acetamido-2-deoxy-D-glucopyranose 6-(dihydrogen phosphate),synonym,CHEBI:15784,N-Acetyl-D-glucosamine 6-phosphate sodium salt,CHEBI:15784,MAPPED,unique
+2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-aldehydo-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-aldehydo-D-glucose,synonym,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
+2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+2-acetamidopentanedioic acid,synonym,CHEBI:172431,N-Acetyl-glutamic acid,CHEBI:172431,MAPPED,unique
+2-Acetylpyrrole,preferred_term,CHEBI:59981,2-Acetylpyrrole,CHEBI:59981,MAPPED,unique
+"2-amino-1,5-dihydro-1-methyl-4H-Imidazol-4-one",synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+"2-amino-1,9-dihydro-6H-purin-6-one",synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
+"2-amino-1,9-dihydro-9-beta-D-ribofuranosyl-6H-purin-6-one",synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+2-Amino-1-methylimidazolin-4-one,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+"2-Amino-2-(hydroxymethyl)-1,3-propanediol",synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+"2-amino-2-(hydroxymethyl)propane-1,3-diol",synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+"2-amino-2-(hydroxymethyl)propane-1,3-diol acetate",synonym,CHEBI:66869,Tris Acetate Stock Solution,CHEBI:66869,MAPPED,unique
+2-amino-2-deoxy-D-gluconic acid,ontology_label,CHEBI:17784,D-glucosaminic Acid,CHEBI:17784,MAPPED,unique
+2-amino-2-deoxy-D-glucose 6-(dihydrogen phosphate),synonym,CHEBI:12962,D-Glucosamine 6-phosphate,CHEBI:12962,MAPPED,unique
+2-amino-3-(1H-imidazol-4-yl)propanoic acid,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
+2-amino-3-(1H-indol-3-yl)propanoic acid,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+2-amino-3-(4-chlorophenyl)propanoic acid,ontology_label,cas:7424-00-2,Parachlorophenylalanine,CHEBI:110187,MAPPED,unique
+2-amino-3-carbamoylpropanoic acid,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+2-Amino-3-hydroxybutyric acid,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+2-amino-3-mercaptopropanoic acid,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+2-Amino-3-mercaptopropionic acid,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+2-Amino-3-methylbutyric acid,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+2-Amino-3-methylvaleric acid,synonym,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
+2-amino-3-sulfanylpropanoic acid,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+"2-amino-4,6-dimethyl-3-oxo-1-N,9-N-bis-[(18aS)-10c,14,17-trimethyl-5,8,12,15,18-pentaoxo-6c,13t-di(propan-2-yl)-18ar-hexadecahydro-1H-pyrrolo[2,1-i][1,4,7,10,13]oxatetraazacyclohexadecin-9c-yl]-3H-phenoxazine-1,9-dicarboxamide",synonym,CHEBI:27666,Actinomycin D,CHEBI:27666,MAPPED,unique
+2-amino-4-(methylsulfanyl)butanoic acid,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+2-amino-4-(methylthio)butanoic acid,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+2-Amino-4-(methylthio)butyric acid,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+2-Amino-4-hydroxy-6-pteridinecarboxylic acid,ontology_label,CHEBI:88937,Pterin-6-Carboxylic Acid,CHEBI:88937,MAPPED,unique
+2-Amino-4-methylvaleric acid,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+2-amino-5-(carbamimidamido)pentanoic acid,synonym,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+2-amino-5-guanidinopentanoic acid,synonym,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+2-Amino-5-guanidinovaleric acid,synonym,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+2-Amino-5-ureidovaleric acid,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+2-Amino-6-hydroxypurine,synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
+2-amino-6-oxopurine,synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
+"2-amino-9-beta-D-ribofuranosyl-1,9-dihydro-6H-purin-6-one",synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+2-Aminobenzamide,ontology_label,CHEBI:193638,anthranilamide,CHEBI:193638,MAPPED,unique
+2-aminobenzoate,preferred_term,CHEBI:16567,2-aminobenzoate,CHEBI:16567,MAPPED,unique
+2-AMINOBENZOIC ACID,synonym,CHEBI:30754,anthranilic acid,CHEBI:30754,MAPPED,unique
+2-aminobutanedioic acid,synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+2-aminobutanoic acid,synonym,CHEBI:35621,DL-2-Aminobutyric acid,CHEBI:35621,MAPPED,unique
+2-aminobutyrate,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+2-Aminoethanesulfinic acid,synonym,CHEBI:16668,Hypotaurine,CHEBI:16668,MAPPED,unique
+2-Aminoethanesulfonic acid,synonym,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+2-aminoethanol,synonym,CHEBI:16000,Ethanolamine,CHEBI:16000,MAPPED,unique
+2-aminoethyl dihydrogen phosphate,synonym,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
+2-aminoethyl sulfonate,synonym,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+2-aminopentanedioic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+2-aminopentanoic Acid,preferred_term,CHEBI:19475,2-aminopentanoic Acid,CHEBI:19475,MAPPED,unique
+2-Aminosuccinamic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+2-Aminosuccinic acid,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,unique
+2-Azetidinone,preferred_term,CHEBI:327119,2-Azetidinone,CHEBI:327119,MAPPED,unique
+"2-beta-D-glucopyranosyl-1,3,6,7-tetrahydroxy-9H-xanthen-9-one",synonym,CHEBI:6682,Mangiferin,CHEBI:6682,MAPPED,unique
+"2-bromo-2-nitro-1,3-propanediol",preferred_term,CHEBI:31306,"2-bromo-2-nitro-1,3-propanediol",CHEBI:31306,MAPPED,unique
+2-butanol+CO2,preferred_term,kgmicrobe.ingredient:2_butanol_co2,2-butanol+CO2,kgmicrobe.ingredient:2_butanol_co2,MAPPED,unique
+2-butoxy-N-[2-(diethylamino)ethyl]quinoline-4-carboxamide,synonym,CHEBI:247956,Dibucaine,CHEBI:247956,MAPPED,unique
+2-carboxyfuran,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+2-Carene-3-One,preferred_term,UNMAPPED_0196,2-Carene-3-One,,UNMAPPED,unique
+"2-chloro-4-ethylamino-6-isopropylamino-1,3,5-triazine",synonym,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
+"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",preferred_term,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
+2-dehydro-D-gluconate,preferred_term,CHEBI:16808,2-dehydro-D-gluconate,CHEBI:16808,MAPPED,resolved:owned
+2-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_2-dehydro-d-gluconate,Potassium 2-dehydro-D-gluconate,CHEBI:16808,MAPPED,resolved:owned
+2-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_2-ketogluconate,Potassium 2-ketogluconate,CHEBI:16808,MAPPED,resolved:owned
+2-dehydro-D-gluconic acid,ontology_label,cas:1040352-40-6,2-Keto-D-gluconic acid hemicalcium salt hydrate,CHEBI:27469,MAPPED,unresolved:partial_chemistry
+2-dehydro-D-gluconic acid,ontology_label,cas:3470-37-9,2-Keto-D-gluconic acid hemicalcium salt monohydrate,CHEBI:27469,MAPPED,unresolved:partial_chemistry
+2-Deoxy-D-arabino-hexose,synonym,CHEBI:15866,2-Deoxy-D-glucose,CHEBI:15866,MAPPED,unique
+2-deoxy-D-erythro-pentonic acid,synonym,cas:7284-15-3,2-Deoxy-D-ribonic acid lithium salt,CHEBI:86350,MAPPED,unique
+2-deoxy-D-erythro-pentose,synonym,CHEBI:28816,2-Deoxy-D-Ribose,CHEBI:28816,MAPPED,unique
+2-Deoxy-D-glucose,preferred_term,CHEBI:15866,2-Deoxy-D-glucose,CHEBI:15866,MAPPED,unique
+2-deoxy-D-ribonic acid,ontology_label,cas:7284-15-3,2-Deoxy-D-ribonic acid lithium salt,CHEBI:86350,MAPPED,unique
+2-Deoxy-D-ribonic acid lithium salt,preferred_term,cas:7284-15-3,2-Deoxy-D-ribonic acid lithium salt,CHEBI:86350,MAPPED,unique
+2-Deoxy-D-Ribose,preferred_term,CHEBI:28816,2-Deoxy-D-Ribose,CHEBI:28816,MAPPED,unique
+2-deoxyadenosine,preferred_term,CHEBI:17256,2-deoxyadenosine,CHEBI:17256,MAPPED,unique
+2-Deoxyadenosine 5-monophosphate,preferred_term,CHEBI:17713,2-Deoxyadenosine 5-monophosphate,CHEBI:17713,MAPPED,unique
+2-Deoxyadenosine monohydrate,preferred_term,cas:16373-93-6,2-Deoxyadenosine monohydrate,CHEBI:17256,MAPPED,unique
+2-Deoxycytidine 5-monophosphate,preferred_term,CHEBI:15918,2-Deoxycytidine 5-monophosphate,CHEBI:15918,MAPPED,unique
+2-deoxythymidine-5'-4-nitrophenyl Phosphate,preferred_term,kgmicrobe.compound:2-deoxythymidine-5-4-nitrophenyl_phosphate,2-deoxythymidine-5'-4-nitrophenyl Phosphate,kgmicrobe.compound:2-deoxythymidine-5-4-nitrophenyl_phosphate,MAPPED,unique
+2-Deoxyuridine,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
+2-dichloroethane,synonym,CHEBI:27789,"1,2-dichloroethane",CHEBI:27789,MAPPED,unique
+2-dichloropropane,synonym,CHEBI:82163,"1,2-Dichloropropane",CHEBI:82163,MAPPED,unique
+2-dimethylsuccinic Acid,preferred_term,CHEBI:167506,2-dimethylsuccinic Acid,CHEBI:167506,MAPPED,unique
+2-ethylhexan-1-ol,ontology_label,CHEBI:16011,2-Ethylhexanol,CHEBI:16011,MAPPED,unique
+2-Ethylhexanol,preferred_term,CHEBI:16011,2-Ethylhexanol,CHEBI:16011,MAPPED,unique
+2-ethylpyridine-4-carbothioamide,synonym,CHEBI:4885,Ethionamide,CHEBI:4885,MAPPED,unique
+2-Furancarboxylic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+2-furanoic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+2-Furfuraldehyde,preferred_term,CHEBI:34768,2-Furfuraldehyde,CHEBI:34768,MAPPED,unique
+2-Furoic acid,preferred_term,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+2-heptyl-4-hydroxyquinoline N-oxide,ontology_label,CHEBI:28362,2-n-Heptyl-4-hydroxyquinoline N-oxide,CHEBI:28362,MAPPED,unique
+2-heptylquinolin-4-ol 1-oxide,synonym,CHEBI:28362,2-n-Heptyl-4-hydroxyquinoline N-oxide,CHEBI:28362,MAPPED,unique
+"2-Hydroxy-1,2,3-propanetricarboxylic acid",synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+"2-Hydroxy-1,2,3-propanetricarboxylic acid triammonium salt",synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+"2-hydroxy-1,2,3-propanetricarboxylic acid trisodium salt dihydrate",synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+"2-hydroxy-1,2,3-propanetricarboxylic acid, ammonium salt (1:3)",synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+"2-Hydroxy-1,2,3-propanetricarboxylic acid, diammonium salt",synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+2-hydroxy-2-(4-hydroxy-3-methoxyphenyl)acetic acid,synonym,CHEBI:20106,vanillylmandelic acid,CHEBI:20106,MAPPED,unique
+"2-Hydroxy-3,4-Dimethoxybenzoic Acid",preferred_term,CHEBI:184501,"2-Hydroxy-3,4-Dimethoxybenzoic Acid",CHEBI:184501,MAPPED,unique
+"2-hydroxy-3,5-dinitrobenzoic acid",synonym,CHEBI:53648,"3,5-Dinitrosalicylic acid",CHEBI:53648,MAPPED,unique
+"2-hydroxy-3-(3-methylbut-2-en-1-yl)naphthalene-1,4-dione",synonym,CHEBI:6377,Lapachol,CHEBI:6377,MAPPED,unique
+2-hydroxy-3-oxopropyl dihydrogen phosphate,synonym,CHEBI:17138,DL-Glyceraldehyde 3-phosphate,CHEBI:17138,MAPPED,unique
+"2-hydroxy-5-methoxy-3-[(8Z,11Z)-pentadeca-8,11,14-trien-1-yl]cyclohexa-2,5-diene-1,4-dione",synonym,CHEBI:61117,Sorgoleone,CHEBI:61117,MAPPED,unique
+2-hydroxy-5-{[4-(pyridin-2-ylsulfamoyl)phenyl]diazenyl}benzoic acid,synonym,CHEBI:9334,Sulfasalazine,CHEBI:9334,MAPPED,unique
+"2-Hydroxy-N,N,N,-trimethylethanaminium chloride",synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+"2-hydroxy-N,N,N-trimethylethanaminium",synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+"2-hydroxy-N,N,N-trimethylethanaminium chloride",synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+2-HYDROXYBENZOIC ACID,synonym,CHEBI:16914,Salicylic acid,CHEBI:16914,MAPPED,unique
+2-Hydroxybutanedioic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+2-hydroxybutanoic acid,synonym,cas:5094-24-6,2-Hydroxybutyric acid sodium salt,CHEBI:1148,MAPPED,unique
+2-hydroxybutyrate,preferred_term,CHEBI:64552,2-hydroxybutyrate,CHEBI:64552,MAPPED,unique
+2-hydroxybutyric acid,ontology_label,cas:5094-24-6,2-Hydroxybutyric acid sodium salt,CHEBI:1148,MAPPED,unique
+2-Hydroxybutyric acid sodium salt,preferred_term,cas:5094-24-6,2-Hydroxybutyric acid sodium salt,CHEBI:1148,MAPPED,unique
+"2-Hydroxyethane-1,2-dicarboxylic acid",synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+2-Hydroxyethanol,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+"2-hydroxynaphthalene-1,4-dione",synonym,CHEBI:44401,Lawsone,CHEBI:44401,MAPPED,unique
+2-hydroxyphenol,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+2-hydroxypropane,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+"2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,unique
+"2-hydroxypropane-1,2,3-tricarboxylic acid",synonym,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,unique
+"2-hydroxypropane-1,2,3-tricarboxylic acid",synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+2-hydroxypropanoate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+"2-Hydroxypropanoic acid, monosodium salt",synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+2-hydroxypropionate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+2-Hydroxypyridine,preferred_term,CHEBI:16540,2-Hydroxypyridine,CHEBI:16540,MAPPED,unique
+2-Hydroxysuccinic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+2-Hydroxytricarballylic acid,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+2-imino-1-methylimidazolidin-4-one,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+2-Keto-D-gluconic acid hemicalcium salt hydrate,preferred_term,cas:1040352-40-6,2-Keto-D-gluconic acid hemicalcium salt hydrate,CHEBI:27469,MAPPED,unique
+2-Keto-D-gluconic acid hemicalcium salt monohydrate,preferred_term,cas:3470-37-9,2-Keto-D-gluconic acid hemicalcium salt monohydrate,CHEBI:27469,MAPPED,unique
+2-Ketoglutaric acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+2-ketopropionic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+2-Mercaptoethanesulfonate,preferred_term,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-Mercaptoethanesulfonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-mercaptoethanesulphonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-Mercaptoethanol,preferred_term,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
+2-Mercaptopyridine N-oxide sodium salt,preferred_term,CHEBI:201738,2-Mercaptopyridine N-oxide sodium salt,CHEBI:201738,MAPPED,unique
+2-methoxy-4-(prop-2-en-1-yl)phenol,synonym,CHEBI:4917,Eugenol,CHEBI:4917,MAPPED,unique
+2-methoxyphenol,synonym,CHEBI:28591,Guaiacol,CHEBI:28591,MAPPED,unique
+2-methybutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+"2-methyl-1,2-thiazol-3(2H)-one",synonym,CHEBI:53620,2-methyl-4-isothizaolin-3-one,CHEBI:53620,MAPPED,unique
+"2-methyl-1,4-naphthalenedione",synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+"2-Methyl-1,4-naphthochinon",synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+"2-methyl-1,4-naphthoquinone",synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+2-methyl-1-butanol,preferred_term,CHEBI:48945,2-methyl-1-butanol,CHEBI:48945,MAPPED,unique
+"2-Methyl-3-(3,7,11,15-tetramethyl-2-hexadecenyl)-1,4-naphthalenedione",synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"2-Methyl-3-[(2E)-3,7,11,15-tetramethyl-2-hexadecenyl]naphthoquinone",synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"2-methyl-3-[(2E,7R,11R)-3,7,11,15-tetramethylhexadec-2-en-1-yl]naphthalene-1,4-dione",synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"2-methyl-3-hydroxy-4,5-bis(hydroxymethyl)pyridine",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"2-methyl-3-hydroxy-4,5-bis(hydroxymethyl)pyridine hydrochloride",synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+"2-methyl-3-hydroxy-4,5-di(hydroxymethyl)pyridine",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"2-Methyl-3-hydroxy-4,5-dihydroxymethyl-pyridin",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"2-methyl-3-hydroxy-4,5-dihydroxymethylpyridine",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+2-Methyl-3-hydroxy-4-aminomethyl-5-hydroxymethylpyridene dihydrochloride,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+2-Methyl-3-hydroxy-4-formyl-5-hydroxymethylpyridine hydrochloride,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+"2-Methyl-3-phytyl-1,4-naphthochinon",synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"2-methyl-3-phytyl-1,4-naphthoquinone",synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"2-methyl-4,5-bis(hydroxymethyl)-3-hydroxypyridine",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"2-methyl-4,5-dimethylol-pyridin-3-ol",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+2-methyl-4-isothizaolin-3-one,preferred_term,CHEBI:53620,2-methyl-4-isothizaolin-3-one,CHEBI:53620,MAPPED,unique
+"2-methyl-5-(propan-2-yl)cyclohexa-2,5-diene-1,4-dione",synonym,CHEBI:113532,Thymoquinone,CHEBI:113532,MAPPED,unique
+2-Methyl-butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+2-METHYL-PROPIONIC ACID,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+2-methyladeninyl cobamide,preferred_term,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
+2-methyladeninylcobamide,synonym,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
+2-methylbutan-1-ol,ontology_label,CHEBI:48945,2-methyl-1-butanol,CHEBI:48945,MAPPED,unique
+2-methylbutanoic acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+2-Methylbutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+2-methylidenebutanedioic acid,synonym,CHEBI:30838,Itaconic Acid,CHEBI:30838,MAPPED,unique
+"2-methylnaphthalene-1,4-dione",synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+2-methylnaphthoquinone,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+2-methylpropan-1-ol,synonym,CHEBI:46645,Isobutyl alcohol,CHEBI:46645,MAPPED,unique
+2-methylpropanamide,synonym,CHEBI:193555,Isobutyramide,CHEBI:193555,MAPPED,unique
+2-Methylpropanoate,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+2-Methylpropanoic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+2-Methylpropionsaeure,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+2-methylthioethanol,ontology_label,CHEBI:63861,2-(Methylthio)ethanol,CHEBI:63861,MAPPED,unique
+2-morpholin-4-ylethanesulfonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+2-morpholinoethanesulphonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+"2-N,N,N-trimethylammonio acetate",synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+2-n-Heptyl-4-hydroxyquinoline N-oxide,preferred_term,CHEBI:28362,2-n-Heptyl-4-hydroxyquinoline N-oxide,CHEBI:28362,MAPPED,unique
+2-naphthyl Dihydrogen Phosphate,preferred_term,CHEBI:91043,2-naphthyl Dihydrogen Phosphate,CHEBI:91043,MAPPED,unique
+2-naphthyl Tetradecanoate,preferred_term,CHEBI:90249,2-naphthyl Tetradecanoate,CHEBI:90249,MAPPED,unique
+2-nitroimidazole,ontology_label,CHEBI:67135,Azomycin,CHEBI:67135,MAPPED,unique
+2-nitrophenyl beta-D-galactoside,ontology_label,CHEBI:90144,O-nitrophenyl-beta-D-galactopyranosid,CHEBI:90144,MAPPED,unique
+2-O-alpha-L-rhamnosyl-alpha-L-rhamnosyl-3-hydroxydecanoyl-3-hydroxydecanoic acid,ontology_label,CHEBI:62570,Rhamnolipid,CHEBI:62570,MAPPED,unique
+2-octadecanoylglycerol,synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+"2-octadecanoyloxy-propane-1,3-diol",synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+2-Oxobutanedioic acid,synonym,CHEBI:30744,Oxaloacetic acid,CHEBI:30744,MAPPED,unique
+2-oxobutanoate,preferred_term,CHEBI:16763,2-oxobutanoate,CHEBI:16763,MAPPED,resolved:owned
+2-oxobutanoate,ontology_label,cas:2013-26-5,2-oxobutyric acid sodium salt,CHEBI:16763,MAPPED,resolved:owned
+2-oxobutyric acid sodium salt,preferred_term,cas:2013-26-5,2-oxobutyric acid sodium salt,CHEBI:16763,MAPPED,unique
+2-oxogluconate,synonym,CHEBI:16808,2-dehydro-D-gluconate,CHEBI:16808,MAPPED,unique
+2-Oxoglutarate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+2-oxoglutarate(2-),ontology_label,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+2-oxoglutaric acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,conflict:different_substances
+2-oxoglutaric acid,ontology_label,cas:305-72-6,a-Ketoglutaric acid disodium salt hydrate,CHEBI:30915,MAPPED,conflict:different_substances
+2-oxopentanedioate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+2-oxopentanedioic acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+2-oxopentanoate,preferred_term,CHEBI:28644,2-oxopentanoate,CHEBI:28644,MAPPED,unique
+2-Oxopropanal,synonym,CHEBI:17158,methylglyoxal,CHEBI:17158,MAPPED,unique
+2-oxopropanoate,synonym,CHEBI:15361,Pyruvate,CHEBI:15361,MAPPED,unique
+2-Oxopropanoic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+2-Oxopropansaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+2-Oxopropionsaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+2-pentyl-furan,preferred_term,CHEBI:89197,2-pentyl-furan,CHEBI:89197,MAPPED,unique
+2-pentylfuran,ontology_label,CHEBI:89197,2-pentyl-furan,CHEBI:89197,MAPPED,unique
+"2-phenyl-1,2-benzoselenazol-3(2H)-one",synonym,CHEBI:77543,Ebselen,CHEBI:77543,MAPPED,unique
+2-PHENYL-4H-CHROMEN-4-ONE,synonym,CHEBI:42491,Flavone,CHEBI:42491,MAPPED,unique
+2-phenylethanamine,synonym,CHEBI:18397,2-phenylethylamine,CHEBI:18397,MAPPED,unique
+2-phenylethylamine,preferred_term,CHEBI:18397,2-phenylethylamine,CHEBI:18397,MAPPED,unique
+2-Piperidinone,preferred_term,CHEBI:77761,2-Piperidinone,CHEBI:77761,MAPPED,unique
+2-propandiol,synonym,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
+2-Propanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+2-propanol+CO2,preferred_term,kgmicrobe.ingredient:2_propanol_co2,2-propanol+CO2,kgmicrobe.ingredient:2_propanol_co2,MAPPED,unique
+2-pyrocatechuic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+2-Pyrrolidinecarboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+2-stearoylglycerol,ontology_label,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+"2-stearoyloxy-propane-1,3-diol",synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+2-sulfanylethanesulfonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-sulfanylethanol,synonym,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
+2-sulfanylethylsulfonate,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-Sulfobenzoic acid,preferred_term,mesh:C028805,2-Sulfobenzoic acid,mesh:C028805,MAPPED,unique
+2-tetrachloroethane,synonym,CHEBI:36026,"1,1,2,2-Tetrachloroethane",CHEBI:36026,MAPPED,unique
+2-trichloroethane,synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+2-undecanol,preferred_term,CHEBI:77930,2-undecanol,CHEBI:77930,MAPPED,unique
+"2-{1-[5,7-dihydroxy-3-(3,4,5-trihydroxybenzoyloxy)-3,4-dihydro-2H-1-benzopyran-2-yl]-3,4,6-trihydroxy-5-oxo-5H-benzo[7]annulen-8-yl}-5,7-dihydroxy-3,4-dihydro-2H-1-benzopyran-3-yl 3,4,5-trihydroxybenzoate",ontology_label,cas:30462-35-2,Theaflavin Digallate,CHEBI:185495,MAPPED,unique
+"2-{3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-4-methyl-1,3-thiazol-3-ium-5-yl}ethyl dihydrogen diphosphate",synonym,CHEBI:45931,Thiamin pyrophosphate,CHEBI:45931,MAPPED,unique
+"2-{[(2R)-2,3-dihydroxypropoxy](hydroxy)phosphoryloxy}-N,N,N-trimethylethanaminium",synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+20AA_mix,preferred_term,kgmicrobe.ingredient:20aa_mix,20AA_mix,kgmicrobe.ingredient:20aa_mix,MAPPED,unique
+26Fe,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+2Na-EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+"3',3''-Dimethylphenolsulfonephthalein",synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+"3',4'-dimethoxyflavone",ontology_label,CHEBI:232299,"3,4'-Dimethoxyflavone",CHEBI:232299,MAPPED,unique
+"3',5'-cyclic AMP",ontology_label,CHEBI:17489,"Adenosine 3,5-Cyclic Monophosphate",CHEBI:17489,MAPPED,unique
+"3',6-Dihydroxyflavone",preferred_term,kgmicrobe.compound:36-dihydroxyflavone,"3',6-Dihydroxyflavone",CHEBI:24698,MAPPED,unique
+"3'-deoxy-N,N-dimethyl-3'-[(O-methyl-L-tyrosyl)amino]adenosine dihydrochloride",synonym,CHEBI:8642,Puromycin dihydrochloride,CHEBI:8642,MAPPED,unique
+3'-fucosyllactose,preferred_term,cas:41312-47-4,3'-fucosyllactose,CHEBI:90065,MAPPED,unique
+"3'-phosphoadenosine 5'-{3-[(3R)-3-hydroxy-2,2-dimethyl-4-oxo-4-({3-oxo-3-[(2-sulfanylethyl)amino]propyl}amino)butyl] dihydrogen diphosphate}",synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+3'-phosphoadenosine-(5')diphospho(4')pantatheine,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+3'-sialyllactose sodium salt,preferred_term,cas:128596-80-5,3'-sialyllactose sodium salt,CHEBI:26714,MAPPED,unique
+"3,3'-azanediyldi(propanamine)",synonym,CHEBI:16841,Bis(3-aminopropyl)amine,CHEBI:16841,MAPPED,unique
+"3,3'-Dithiobis-L-alanine",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"3,3-bis(3-bromo-4-hydroxy-5-methylphenyl)-2,1lambda(6)-benzoxathiole-1,1(3H)-dione",synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+"3,3-bis(4-hydroxy-5-methylphenyl)-2,1lambda(6)-benzoxathiole-1,1(3H)-dione",synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+"3,3-bis(p-hydroxyphenyl)-3H-2,1-benzoxathiole 1,1-dioxide",synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+"3,3-bis[3-bromo-4-hydroxy-2-methyl-5-(propan-2-yl)phenyl]-2,1lambda(6)-benzoxathiole-1,1(3H)-dione",synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
+"3,4'-Dihydroxyflavone",preferred_term,cas:14919-49-4,"3,4'-Dihydroxyflavone",mesh:C559991,MAPPED,unique
+"3,4'-Dimethoxyflavone",preferred_term,CHEBI:232299,"3,4'-Dimethoxyflavone",CHEBI:232299,MAPPED,unique
+"3,4,5-trihydroxy-1,8-bis[(2R,3R)-3,5,7-trihydroxy-3,4-dihydro-2H-chromen-2-yl]-6H-benzocyclohepten-6-one",synonym,CHEBI:136609,Theaflavin,CHEBI:136609,MAPPED,unique
+"3,4,5-Trihydroxy-1-cyclohexenecarboxylic acid",synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+"3,4,5-Trihydroxybenzoic acid",synonym,CHEBI:30778,Gallic Acid,CHEBI:30778,MAPPED,unique
+"3,4,5-trimethoxybenzoate",preferred_term,CHEBI:58989,"3,4,5-trimethoxybenzoate",CHEBI:58989,MAPPED,unique
+"3,4,5-trimethoxybenzoic acid",ontology_label,CHEBI:454991,Eudesmic Acid,CHEBI:454991,MAPPED,unique
+"3,4-dihydroxy-5-methoxybenzoic acid",synonym,CHEBI:28647,3-O-methylgallate,CHEBI:28647,MAPPED,unique
+"3,4-dihydroxybenzaldehyde",ontology_label,CHEBI:50205,Protocatechualdehyde,CHEBI:50205,MAPPED,unique
+"3,4-dihydroxybenzoate",ontology_label,CHEBI:36241,Protocatechuate,CHEBI:36241,MAPPED,unique
+"3,4-dihydroxybenzoic acid",ontology_label,CHEBI:36062,Protocatechuic Acid,CHEBI:36062,MAPPED,unique
+"3,4-dimethoxybenzoic acid",ontology_label,CHEBI:296881,Veratric Acid,CHEBI:296881,MAPPED,unique
+"3,5,7-trihydroxy-2-(3,4,5-trihydroxyphenyl)-4H-chromen-4-one",synonym,CHEBI:18152,Myricetin,CHEBI:18152,MAPPED,unique
+"3,5-dihydroxy-2-[3-(4-hydroxyphenyl)propanoyl]phenyl beta-D-glucopyranoside",synonym,CHEBI:8113,Phloridzin,CHEBI:8113,MAPPED,unique
+"3,5-Dinitrosalicylic acid",preferred_term,CHEBI:53648,"3,5-Dinitrosalicylic acid",CHEBI:53648,MAPPED,unique
+"3,7,11-trimethyldodeca-1,6,10-trien-3-ol",synonym,CHEBI:7524,Nerolidol,CHEBI:7524,MAPPED,unique
+"3,7,11-trimethyldodeca-2,6,10-trien-1-ol",synonym,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
+"3,7-bis(dimethylamino)phenothiazin-5-ium chloride",synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+"3,7-dimethyl-3,7-dihydro-1H-purine-2,6-dione",synonym,CHEBI:28946,Theobromine,CHEBI:28946,MAPPED,unique
+"3,7-Dimethylocta-1,6-dien-3-ol",synonym,CHEBI:17580,Linalool,CHEBI:17580,MAPPED,unique
+"3,8-diamino-5-ethyl-6-phenylphenanthridinium bromide",synonym,CHEBI:4883,Ethidium Bromide,CHEBI:4883,MAPPED,unique
+"3,8-diamino-5-{3-[diethyl(methyl)ammonio]propyl}-6-phenylphenanthridinium diiodide",synonym,CHEBI:51240,Propidium iodide,CHEBI:51240,MAPPED,unique
+"3,9-dihydro-1H-purine-2,6-dione",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+3-(((4-Methyl-1-piperazinyl)imino)methyl)rifamycin SV,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+"3-((R)-2-((1S,3S,5S)-3,5-dimethyl-2-oxocyclohexyl)-2-hydroxyethyl)glutarimide",synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+"3-(1-naphthyl)-2,5-diphenyl-2H-tetrazol-3-ium chloride",synonym,CHEBI:75193,Tetrazolium violet,CHEBI:75193,MAPPED,unique
+3-(1H-indol-3-yl)propanoic acid,ontology_label,CHEBI:43580,Indole-3-propionic acid,CHEBI:43580,MAPPED,unique
+"3-(2,4-dihydroxy-3,3-dimethylbutanamido)propanoate",synonym,CHEBI:16454,Pantothenate,CHEBI:16454,MAPPED,unique
+"3-(2,4-dihydroxy-3,3-dimethylbutanamido)propanoic acid",synonym,CHEBI:7916,Pantothenic acid,CHEBI:7916,MAPPED,unique
+3-(2-Aminoethyl)-1H-indol-5-ol,synonym,CHEBI:28790,Serotonin,CHEBI:28790,MAPPED,unique
+"3-(2-chloro-10H-phenothiazin-10-yl)-N,N-dimethylpropan-1-amine hydrochloride",synonym,CHEBI:3649,Chlorpromazine hydrochloride,CHEBI:3649,MAPPED,unique
+"3-(3,4-dichlorophenyl)-1,1-dimethylurea",synonym,CHEBI:116509,DCMU,CHEBI:116509,MAPPED,unique
+"3-(3,4-dihydroxyphenyl)-2-[(2E)-3-(3,4-dihydroxyphenyl)prop-2-enoyloxy]propanoic acid",synonym,CHEBI:17226,Rosmarinic acid,CHEBI:17226,MAPPED,unique
+"3-(3,4-dihydroxyphenyl)prop-2-enoic acid",synonym,CHEBI:36281,caffeic acid,CHEBI:36281,MAPPED,unique
+3-(4-AMINO-2-METHYL-PYRIMIDIN-5-YLMETHYL)-5-(2-HYDROXY-ETHYL)-4-METHYL-THIAZOL-3-IUM,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+"3-(4-hydroxy-3,5-dimethoxyphenyl)prop-2-enoic acid",synonym,CHEBI:77131,sinapic acid,CHEBI:77131,MAPPED,unique
+3-(4-hydroxy-3-methoxyphenyl)prop-2-enal,synonym,CHEBI:16547,coniferyl aldehyde,CHEBI:16547,MAPPED,unique
+3-(4-hydroxy-3-methoxyphenyl)prop-2-enoic acid,synonym,CHEBI:193350,Ferulic Acid,CHEBI:193350,MAPPED,unique
+"3-(4-hydroxyphenyl)-1-(2,4,6-trihydroxyphenyl)propan-1-one",synonym,CHEBI:17276,Phloretin,CHEBI:17276,MAPPED,unique
+3-(4-hydroxyphenyl)propanoic acid,synonym,CHEBI:32980,4-Hydroxyphenylpropionic acid,CHEBI:32980,MAPPED,unique
+3-(4-iodophenyl)-2-(4-nitrophenyl)-5-phenyl-2H-tetrazol-3-ium chloride,synonym,CHEBI:75421,Iodonitrotetrazolium chloride,CHEBI:75421,MAPPED,unique
+3-(cyclohexylamino)-2-hydroxy-1-propanesulfonic acid,synonym,CHEBI:183882,CAPSO,CHEBI:183882,MAPPED,unique
+3-(cyclohexylamino)-2-hydroxypropane-1-sulonic acid,synonym,CHEBI:183882,CAPSO,CHEBI:183882,MAPPED,unique
+3-(cyclohexylamino)propane-1-sulonic acid,synonym,CHEBI:191088,CAPS buffer,CHEBI:191088,MAPPED,unique
+3-(dimethylsulfonio)propanoate,synonym,CHEBI:16457,Dimethylsulfoniopropionate hydrochloride,CHEBI:16457,MAPPED,unique
+3-(N-morpholino)propanesulfonic acid,preferred_term,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+"3-[(2R)-2,4-dihydroxy-3,3-dimethylbutanamido]propanoate",synonym,CHEBI:31345,Ca-pantothenate,CHEBI:31345,REJECTED,unique
+3-[(3-{[6-deoxy-2-O-(6-deoxy-alpha-L-mannopyranosyl)-alpha-L-mannopyranosyl]oxy}decanoyl)oxy]decanoic acid,synonym,CHEBI:62570,Rhamnolipid,CHEBI:62570,MAPPED,unique
+"3-[(4-amino-2-methyl-5-pyrimidinyl)methyl]-4-methyl-5-(4,6,6-trihydroxy-4,6-dioxido-3,5-dioxa-4,6-diphosphahex-1-yl)thiazolium",synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-diphosphoethyl)-4-methyl-1,3-thiazolium chloride",synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-hydroxyethyl)-4-methyl-1,3-thiazol-3-ium",synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-hydroxyethyl)-4-methyl-1,3-thiazol-3-ium chloride hydrochloride",synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-hydroxyethyl)-4-methyl-1,3-thiazol-3-ium chloride hydrochloride--water (1/2)",synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-{[hydroxy(phosphonooxy)phosphoryl]oxy}ethyl)-4-methyl-1,3-thiazol-3-ium",synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-(2-{[hydroxy(phosphonooxy)phosphoryl]oxy}ethyl)-4-methyl-1,3-thiazol-3-ium chloride",synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-[2-(diphosphooxy)ethyl]-4-methyl-1,3-thiazol-3-ium",synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+"3-[(4-amino-2-methylpyrimidin-5-yl)methyl]-5-[2-(diphosphooxy)ethyl]-4-methyl-1,3-thiazol-3-ium chloride",synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+"3-[(4-azaniumyl-2-methylpyrimidin-5-yl)methyl]-5-(2-hydroxyethyl)-4-methyl-1,3-thiazol-3-ium chloride--water (1/2)",synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+"3-[(4-azaniumyl-2-methylpyrimidin-5-yl)methyl]-5-(2-hydroxyethyl)-4-methyl-1,3-thiazol-3-ium dichloride",synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+3-[(S)-prop-2-ene-1-sulfinyl]-L-alanine,synonym,CHEBI:2596,L-alliin,CHEBI:2596,MAPPED,unique
+"3-[[1,3-dihydroxy-2-(hydroxymethyl)propan-2-yl]amino]-2-hydroxypropane-1-sulfonic acid",synonym,cas:68399-81-5,TAPSO,cas:68399-81-5,MAPPED,unique
+3-acetylpyridine,preferred_term,CHEBI:166501,3-acetylpyridine,CHEBI:166501,MAPPED,unique
+3-amino-2-methylpropanoic acid,synonym,CHEBI:27389,DL-3-Aminoisobutyric acid,CHEBI:27389,MAPPED,unique
+3-aminobenzoate,preferred_term,CHEBI:30761,3-aminobenzoate,CHEBI:30761,MAPPED,unique
+3-aminobutanoic acid,ontology_label,CHEBI:37081,3-aminobutyric acid,CHEBI:37081,MAPPED,unique
+3-aminobutyrate,preferred_term,CHEBI:87997,3-aminobutyrate,CHEBI:87997,MAPPED,unique
+3-aminobutyric acid,preferred_term,CHEBI:37081,3-aminobutyric acid,CHEBI:37081,MAPPED,unique
+3-aminoisobutyric acid,ontology_label,CHEBI:27389,DL-3-Aminoisobutyric acid,CHEBI:27389,MAPPED,unique
+3-aminopropanoic acid,synonym,CHEBI:16958,Beta-alanine,CHEBI:16958,MAPPED,unique
+3-Aminopropionitrile Fumarate,preferred_term,CHEBI:91084,3-Aminopropionitrile Fumarate,CHEBI:91084,MAPPED,unique
+3-beta-d-glucan,preferred_term,CHEBI:37671,3-beta-d-glucan,CHEBI:37671,MAPPED,unique
+3-butanediol,synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+3-C-(hydroxymethyl)-D-glycero-tetrose,synonym,CHEBI:16689,D-apiose,CHEBI:16689,MAPPED,unique
+3-carbamoylpyridine,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+"3-Carboxy-3-hydroxypentane-1,5-dioic acid",synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+3-carboxylpyridine,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+3-carboxyphenol,synonym,CHEBI:30764,3-Hydroxybenzoic acid,CHEBI:30764,MAPPED,unique
+3-carboxypyridine,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+3-Chloro-L-tyrosine,preferred_term,CHEBI:53678,3-Chloro-L-tyrosine,CHEBI:53678,MAPPED,unique
+3-dehydro-D-gluconate,preferred_term,CHEBI:85256,3-dehydro-D-gluconate,CHEBI:85256,MAPPED,unique
+3-fucosyllactose,ontology_label,cas:41312-47-4,3'-fucosyllactose,CHEBI:90065,MAPPED,unique
+3-hydroxy 2-butanone,synonym,CHEBI:15688,Acetoin,CHEBI:15688,MAPPED,unique
+3-hydroxy-2-methyl-5-[(phosphonooxy)methyl]-4-pyridinecarboxaldehyde,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+"3-hydroxy-2-picoline-4,5-dimethanol",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"3-hydroxy-4,5-bis(hydroxymethyl)-2-methylpyridine",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"3-hydroxy-4,5-dimethylol-alpha-picoline",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"3-hydroxy-4,5-dimethylol-alpha-picoline hydrochloride",synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+3-hydroxy-4-(trimethylammonio)butanoate,synonym,CHEBI:17126,DL-carnitine,CHEBI:17126,MAPPED,agree:same_substance
+3-hydroxy-4-(trimethylammonio)butanoate,synonym,cas:461-06-3,Carnitine (Dl) Hydrochloride,CHEBI:17126,MAPPED,agree:same_substance
+3-hydroxy-4-methoxybenzaldehyde,synonym,CHEBI:193161,Isovanillin,CHEBI:193161,MAPPED,unique
+3-hydroxy-5-(hydroxymethyl)-2-methylisonicotinaldehyde 5-phosphate,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+"3-Hydroxy-5-(hydroxymethyl)-2-methylisonicotinaldehyde, hydrochloride",synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+3-hydroxy-5-(hydroxymethyl)-2-methylpyridine-4-carbaldehyde hydrochloride,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+3-hydroxy-5-(hydroxymethyl)-2-methylpyridine-4-carboxylic acid,synonym,CHEBI:17405,4-Pyridoxic acid,CHEBI:17405,MAPPED,unique
+3-hydroxy-L-phenylalanine,synonym,cas:587-33-7,L-Meta-tyrosine,CHEBI:44303,MAPPED,unique
+3-hydroxybenzoate,preferred_term,CHEBI:16193,3-hydroxybenzoate,CHEBI:16193,MAPPED,unique
+3-Hydroxybenzoic acid,preferred_term,CHEBI:30764,3-Hydroxybenzoic acid,CHEBI:30764,MAPPED,unique
+3-hydroxybutanoic acid,synonym,CHEBI:20067,3-hydroxybutyric acid,CHEBI:20067,MAPPED,conflict:different_substances
+3-hydroxybutanoic acid,synonym,cas:29435-48-1,Poly(3-hydroxybutyric acid),CHEBI:20067,MAPPED,conflict:different_substances
+3-Hydroxybutanoic acid homopolymer,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+3-hydroxybutyrate,preferred_term,CHEBI:37054,3-hydroxybutyrate,CHEBI:37054,MAPPED,unique
+3-hydroxybutyric acid,preferred_term,CHEBI:20067,3-hydroxybutyric acid,CHEBI:20067,MAPPED,resolved:owned
+3-hydroxybutyric acid,ontology_label,cas:29435-48-1,Poly(3-hydroxybutyric acid),CHEBI:20067,MAPPED,resolved:owned
+3-Hydroxydecanoic acid,preferred_term,CHEBI:132983,3-Hydroxydecanoic acid,CHEBI:132983,MAPPED,unique
+3-Hydroxyhexanoic acid,preferred_term,CHEBI:37035,3-Hydroxyhexanoic acid,CHEBI:37035,MAPPED,unique
+3-hydroxyisobutyric acid,ontology_label,cas:1219589-99-7,DL-3-Hydroxyisobutyric acid sodium salt,CHEBI:18064,MAPPED,unique
+3-hydroxypentanoic acid,ontology_label,CHEBI:139272,rac-3-Hydroxypentanoic Acid,CHEBI:139272,MAPPED,unique
+3-hydroxypropanoate,synonym,CHEBI:16510,3-Hydroxypropionate,CHEBI:16510,MAPPED,unique
+3-Hydroxypropionate,preferred_term,CHEBI:16510,3-Hydroxypropionate,CHEBI:16510,MAPPED,unique
+3-hydroxysalicylic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+3-Indolyl acetic acid,preferred_term,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
+"3-methoxy-2-phenyluro[2,3-h]chromen-4-one",synonym,CHEBI:166631,Karanjin,CHEBI:166631,MAPPED,unique
+"3-methyl-1,4-naphthoquinone",synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+3-methyl-1-butanol,preferred_term,CHEBI:15837,3-methyl-1-butanol,CHEBI:15837,MAPPED,unique
+3-methyl-2-butenol,preferred_term,CHEBI:16019,3-methyl-2-butenol,CHEBI:16019,MAPPED,unique
+3-Methyl-2-Oxobutanoic Acid,preferred_term,CHEBI:16530,3-Methyl-2-Oxobutanoic Acid,CHEBI:16530,MAPPED,unique
+3-Methyl-2-oxobutanoic acid sodium salt,preferred_term,CHEBI:189431,3-Methyl-2-oxobutanoic acid sodium salt,CHEBI:189431,MAPPED,unique
+3-methyl-2-oxopentanoic acid,preferred_term,CHEBI:35932,3-methyl-2-oxopentanoic acid,CHEBI:35932,MAPPED,unique
+3-methyl-2-oxovaleric acid,ontology_label,CHEBI:35932,3-methyl-2-oxopentanoic acid,CHEBI:35932,MAPPED,unique
+3-methyl-3-butenol,preferred_term,CHEBI:62898,3-methyl-3-butenol,CHEBI:62898,MAPPED,unique
+3-Methyl-butyric acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+3-methyl-n-butyric acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+3-methylacetate,preferred_term,UNMAPPED_0736,3-methylacetate,,REJECTED,unique
+3-methylacrylate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+"3-methylbenzene-1,2-diol",synonym,CHEBI:18404,3-Methylcatechol,CHEBI:18404,MAPPED,unique
+3-methylbut-2-en-1-ol,synonym,CHEBI:16019,3-methyl-2-butenol,CHEBI:16019,MAPPED,unique
+3-methylbut-3-en-1-ol,synonym,CHEBI:62898,3-methyl-3-butenol,CHEBI:62898,MAPPED,unique
+3-methylbutan-1-ol,synonym,CHEBI:15837,3-methyl-1-butanol,CHEBI:15837,MAPPED,unique
+3-Methylbutanoic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+3-Methylbuttersaeure,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+3-Methylbutyric acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+3-Methylcatechol,preferred_term,CHEBI:18404,3-Methylcatechol,CHEBI:18404,MAPPED,unique
+3-methylglucose,synonym,CHEBI:73918,3-O-methyl-glucose,CHEBI:73918,MAPPED,unique
+3-Methylglutaric acid,preferred_term,CHEBI:68566,3-Methylglutaric acid,CHEBI:68566,MAPPED,unique
+3-methylpentanedioic acid,synonym,CHEBI:68566,3-Methylglutaric acid,CHEBI:68566,MAPPED,unique
+3-morpholin-4-ylpropane-1-sulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+3-morpholinopropanesulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+3-nitropropanoate,preferred_term,CHEBI:59899,3-nitropropanoate,CHEBI:59899,MAPPED,unique
+3-O-methyl Alpha-D-glucopyranoside,preferred_term,kgmicrobe.compound:3-o-methyl_alpha-d-glucopyranoside,3-O-methyl Alpha-D-glucopyranoside,kgmicrobe.compound:3-o-methyl_alpha-d-glucopyranoside,MAPPED,unique
+3-O-Methyl-D-glucopyranose,preferred_term,cas:13224-94-7,3-O-Methyl-D-glucopyranose,cas:13224-94-7,MAPPED,unique
+3-O-methyl-D-glucose,ontology_label,CHEBI:73918,3-O-methyl-glucose,CHEBI:73918,MAPPED,unique
+3-O-methyl-glucose,preferred_term,CHEBI:73918,3-O-methyl-glucose,CHEBI:73918,MAPPED,unique
+3-O-methylgallate,preferred_term,CHEBI:28647,3-O-methylgallate,CHEBI:28647,MAPPED,unique
+3-O-methylgallic acid,ontology_label,CHEBI:28647,3-O-methylgallate,CHEBI:28647,MAPPED,unique
+3-octanone,preferred_term,CHEBI:80946,3-octanone,CHEBI:80946,MAPPED,unique
+3-oxo-N-(2-oxotetrahydrofuran-3-yl)hexanamide,synonym,CHEBI:29640,N-(3-oxohexanoyl)-DL-homoserine lactone,CHEBI:29640,MAPPED,unique
+3-phenyl-L-alanine,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+3-phenylprop-2-enoic acid,synonym,CHEBI:27386,Cinnamic acid,CHEBI:27386,MAPPED,unique
+3-Phenylpropanoic acid,synonym,CHEBI:28631,Phenyl propionic acid,CHEBI:28631,MAPPED,unique
+3-phenylpropionate,preferred_term,CHEBI:51057,3-phenylpropionate,CHEBI:51057,MAPPED,unique
+3-phenylpropionic acid,ontology_label,CHEBI:28631,Phenyl propionic acid,CHEBI:28631,MAPPED,unique
+3-phytylmenadione,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+3-pyridinecarboxamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+3-pyridinecarboxylic acid,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+3-Pyridinesulfonic acid,preferred_term,cas:636-73-7,3-Pyridinesulfonic acid,cas:636-73-7,MAPPED,unique
+3-Pyridylcarboxylic acid,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+3-trehalosamine,preferred_term,CHEBI:223561,3-trehalosamine,CHEBI:223561,MAPPED,unique
+3-trichloropropane,synonym,CHEBI:34036,"1,2,3-trichloropropane",CHEBI:34036,MAPPED,unique
+3-xylene,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+"30-hydroxy-11,30-dioxoolean-12-en-3beta-yl (2-O-beta-D-glucopyranosyluronic acid)-alpha-D-glucopyranosiduronic acid",synonym,CHEBI:15939,"Glycyrrhizic Acid, Ammonium Salt",CHEBI:15939,MAPPED,unique
+3[N-MORPHOLINO]PROPANE SULFONIC ACID,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+"3alpha,12alpha-dihydroxy-5beta-cholan-24-oic acid",synonym,CHEBI:28834,Deoxycholic acid,CHEBI:28834,MAPPED,unique
+"3alpha,4alpha,5beta-trihydroxy-1-cyclohexene-1-carboxylic acid",synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+"3alpha,7alpha,12alpha-trihydroxy-5beta-cholan-24-oic acid",synonym,CHEBI:16359,Cholic acid,CHEBI:16359,MAPPED,unique
+"3alpha,7alpha-dihydroxy-5beta-cholan-24-oic acid",synonym,CHEBI:16755,Chenodeoxycholic acid,CHEBI:16755,MAPPED,unique
+3alpha-hydroxy-5beta-cholan-24-oic acid,synonym,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
+"3beta,12beta,14-trihydroxy-5beta-card-20(22)-enolide",synonym,CHEBI:42098,Digoxigenin,CHEBI:42098,MAPPED,unique
+3beta-hydroxy-5alpha-androstan-17-one,synonym,CHEBI:541975,Epiandrosterone,CHEBI:541975,MAPPED,unique
+3Beta-Hydroxydeoxodihydrodeoxygedunin,preferred_term,UNMAPPED_0195,3Beta-Hydroxydeoxodihydrodeoxygedunin,,UNMAPPED,unique
+4 Carbon Mix,preferred_term,kgmicrobe.ingredient:4_carbon_mix,4 Carbon Mix,kgmicrobe.ingredient:4_carbon_mix,MAPPED,unique
+4'-hydroxyacetophenone,ontology_label,CHEBI:28032,4-Hydroxyacetophenone,CHEBI:28032,MAPPED,unique
+4'-Methoxyflavone,preferred_term,cas:4143-74-2,4'-Methoxyflavone,CHEBI:114194,MAPPED,unique
+"4,4'-(1,1-dioxido-3H-2,1-benzoxathiole-3,3-diyl)diphenol",synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+"4,4'-(2,9-dimethyl-1,10-phenanthroline-4,7-diyl)dibenzenesulfonic acid",synonym,cas:52698-84-7,Bathocuproine disulfonic acid disodium salt,CHEBI:63934,MAPPED,unique
+"4,4'-(3H-2,1-Benzoxathiol-3-ylidene)bis(2-bromo-3-methyl-6-(1-methylethyl)phenol) S,S-dioxide",synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
+"4,4'-(3H-2,1-benzoxathiol-3-ylidene)bisphenol S,S-dioxide",synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+"4,4'-dihydroxybiphenyl",preferred_term,CHEBI:34367,"4,4'-dihydroxybiphenyl",CHEBI:34367,MAPPED,unique
+"4,4'-Dimethoxydalbergione",preferred_term,UNMAPPED_0194,"4,4'-Dimethoxydalbergione",,UNMAPPED,unique
+"4,5-bis(hydroxymethyl)-2-methyl-pyridin-3-ol",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"4,5-bis(hydroxymethyl)-2-methylpyridin-3-ol",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"4,5-bis(hydroxymethyl)-2-methylpyridin-3-ol hydrochloride",synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+4-(1H-indol-3-yl)butanoic acid,synonym,CHEBI:33070,Indole-3-butyric acid,CHEBI:33070,MAPPED,unique
+4-(2-Hydroxyethyl)-1-piperazineethane sulfonic acid,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+4-(2-hydroxyethyl)-2-methoxyphenol,synonym,CHEBI:173769,homovanillyl alcohol,CHEBI:173769,MAPPED,unique
+4-(alpha-D-glucosido)-D-glucose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+4-(AMINOMETHYL)-5-(HYDROXYMETHYL)-2-METHYLPYRIDIN-3-OL,synonym,CHEBI:16410,Pyridoxamine,CHEBI:16410,MAPPED,unique
+4-(aminomethyl)-5-(hydroxymethyl)-2-methylpyridin-3-ol dihydrochloride,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+4-(aminomethyl)-5-(hydroxymethyl)-2-methylpyridin-3-ol hydrochloride,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+4-(Aminomethyl)-5-hydroxy-6-methyl-3-pyridinemethanol dihydrochloride,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+4-(Aminomethyl)-5-hydroxy-6-methyl-3-pyridinemethanol hydrochloride,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+4-(azaniumylmethyl)-3-hydroxy-5-(hydroxymethyl)-2-methylpyridin-1-ium dichloride,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+4-(beta-D-galactosido)-D-glucose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+4-(beta-D-glucosido)-D-glucose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+4-(carbamimidamido)butanoic acid,synonym,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+4-(hydroxymethyl)-2-methoxyphenol,synonym,CHEBI:18353,Vanillyl Alcohol,CHEBI:18353,MAPPED,unique
+4-(prop-1-en-2-yl)cyclohex-1-ene-1-carboxylic acid,synonym,CHEBI:36999,Perillic Acid (-),CHEBI:36999,MAPPED,unique
+4-2-hydroxyethyl-1-piperazineethanesulfonic acid,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+4-[(1E)-3-hydroxyprop-1-en-1-yl]-2-methoxyphenol,synonym,CHEBI:17745,coniferyl alcohol,CHEBI:17745,MAPPED,unique
+"4-[(1R)-1-hydroxy-2-(methylamino)ethyl]benzene-1,2-diol",synonym,CHEBI:28918,(-)-Epinephrine,CHEBI:28918,MAPPED,unique
+"4-[(1R)-2-amino-1-hydroxyethyl]benzene-1,2-diol",synonym,CHEBI:18357,(-)-Norepinephrine,CHEBI:18357,MAPPED,unique
+"4-[(2R,3S)-4-(3,4-dihydroxyphenyl)-2,3-dimethylbutyl]benzene-1,2-diol",synonym,CHEBI:73468,Nordihydroguaretic Acid,CHEBI:73468,MAPPED,unique
+"4-[(E)-2-(3,5-dimethoxyphenyl)ethenyl]phenol",synonym,CHEBI:8630,Pterostilbene,CHEBI:8630,MAPPED,unique
+4-Acetoxy-3-methoxycinnamic acid,preferred_term,CHEBI:86582,4-Acetoxy-3-methoxycinnamic acid,CHEBI:86582,MAPPED,unique
+4-acetoxyphenol,preferred_term,CHEBI:31128,4-acetoxyphenol,CHEBI:31128,MAPPED,unique
+"4-amino-1-beta-D-ribofuranosyl-1,3,5-triazin-2(1H)-one",synonym,CHEBI:2038,5-Azacytidine,CHEBI:2038,MAPPED,unique
+4-AMINO-1-BETA-D-RIBOFURANOSYL-2(1H)-PYRIMIDINONE,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+4-amino-1-beta-D-ribofuranosylpyrimidin-2(1H)-one,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+4-amino-1beta-D-ribofuranosyl-2(1H)-pyrimidinone,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+4-amino-2(1H)-pyrimidinone,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+"4-amino-2-hydroxy-N,N,N-trimethyl-4-oxobutan-1-aminium chloride",synonym,kgmicrobe.compound:carnitine_hydrochloride,Carnitine Hydrochloride,CHEBI:17126,MAPPED,unique
+4-amino-2-hydroxybenzoic acid,synonym,CHEBI:27565,para-aminosalicylic acid,CHEBI:27565,MAPPED,unique
+4-amino-2-hydroxypyrimidine,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+4-Amino-benzoic acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-amino-N-(2-quinoxalinyl)benzenesulfonamide,ontology_label,cas:59-40-5,Sulfaquinoxaline,CHEBI:94719,MAPPED,unique
+"4-amino-N-(5-methyl-1,2-oxazol-3-yl)benzenesulfonamide",synonym,CHEBI:9332,Sulfamethoxazole,CHEBI:9332,MAPPED,unique
+"4-amino-N-(5-methyl-1,3,4-thiadiazol-2-yl)benzenesulfonamide",synonym,CHEBI:9331,Sulfamethizole,CHEBI:9331,MAPPED,unique
+4-aminobenzenesulfonamide,synonym,CHEBI:45373,Sulfanilamide,CHEBI:45373,MAPPED,unique
+4-Aminobenzoate,preferred_term,CHEBI:17836,4-Aminobenzoate,CHEBI:17836,MAPPED,unique
+4-Aminobenzoesaeure,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-Aminobenzoic Acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-Aminobutanoic acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+4-aminobutyrate,preferred_term,CHEBI:30566,4-aminobutyrate,CHEBI:30566,MAPPED,unique
+4-Aminobutyric acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+4-aminopyrimidin-2(1H)-one,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+4-aminosalicylic acid,ontology_label,CHEBI:27565,para-aminosalicylic acid,CHEBI:27565,MAPPED,unique
+4-aminovalerate,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+4-aminovaleric acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+4-Anisaldehyde,preferred_term,CHEBI:28235,4-Anisaldehyde,CHEBI:28235,MAPPED,unique
+4-azaoctamethylenediamine,synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+"4-azaoctane-1,8-diamine",synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+4-azido-L-phenylalanine,preferred_term,CHEBI:228211,4-azido-L-phenylalanine,CHEBI:228211,MAPPED,unique
+4-benzoyl-L-phenylalanine,preferred_term,CHEBI:44718,4-benzoyl-L-phenylalanine,CHEBI:44718,MAPPED,unique
+4-beta-D-glucopyranosyl-D-glucopyranose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+4-carbamimidamidobutanoic acid,synonym,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+4-Carboxyaniline,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-carboxyphenol,synonym,CHEBI:30763,4-Hydroxybenzoic acid,CHEBI:30763,MAPPED,unique
+4-Carboxyphenylamine,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-coumarate,preferred_term,CHEBI:32373,4-coumarate,CHEBI:32373,MAPPED,unique
+4-coumaric acid methyl ester,ontology_label,CHEBI:86904,methyl-cis-p-coumarate,CHEBI:86904,MAPPED,unique
+4-Deoxypyridoxine,preferred_term,CHEBI:65083,4-Deoxypyridoxine,CHEBI:65083,MAPPED,unique
+4-Diamino-6,preferred_term,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,4-Diamino-6,,REJECTED,unique
+4-Diamino-6,synonym,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
+4-dihydroxy-biphenyl,synonym,CHEBI:34367,"4,4'-dihydroxybiphenyl",CHEBI:34367,MAPPED,unique
+4-diol,preferred_term,CHEBI:41189,4-diol,,REJECTED,unique
+4-diol,synonym,CHEBI:41189,"1,4-Butanediol",CHEBI:41189,MAPPED,unique
+4-diol,synonym,CHEBI:41189,"Butane-1,4-diol",CHEBI:41189,REJECTED,unique
+4-ethenylphenol,synonym,CHEBI:1883,4-vinylphenol,CHEBI:1883,MAPPED,unique
+4-formyl-3-hydroxy-5-(hydroxymethyl)-2-methylpyridin-1-ium chloride,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+4-guanidinobutanoic acid,synonym,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+4-Guanidinobutyric acid,preferred_term,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+"4-hydroxy-3,5-dimethoxybenzaldehyde",synonym,CHEBI:67380,syringaldehyde,CHEBI:67380,MAPPED,unique
+"4-hydroxy-3,5-dimethoxybenzoic acid",synonym,CHEBI:68329,Syringic Acid,CHEBI:68329,MAPPED,unique
+4-Hydroxy-3-methoxybenzaldehyde,synonym,CHEBI:18346,Vanillin,CHEBI:18346,MAPPED,unique
+4-Hydroxy-3-methoxybenzoic acid,synonym,CHEBI:30816,Vanillic Acid,CHEBI:30816,MAPPED,unique
+4-hydroxy-L-phenylalanine,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+4-hydroxy-L-proline,preferred_term,CHEBI:18240,4-hydroxy-L-proline,CHEBI:18240,MAPPED,unique
+4-Hydroxyacetophenone,preferred_term,CHEBI:28032,4-Hydroxyacetophenone,CHEBI:28032,MAPPED,unique
+4-Hydroxybenzaldehyde,preferred_term,CHEBI:17597,4-Hydroxybenzaldehyde,CHEBI:17597,MAPPED,unique
+4-hydroxybenzoate,synonym,CHEBI:17879,p-Hydroxybenzoate,CHEBI:17879,MAPPED,unique
+4-Hydroxybenzoic acid,preferred_term,CHEBI:30763,4-Hydroxybenzoic acid,CHEBI:30763,MAPPED,unique
+4-Hydroxybutanoic acid,synonym,CHEBI:30830,4-hydroxybutyric acid,CHEBI:30830,MAPPED,unique
+4-hydroxybutyrate,preferred_term,CHEBI:16724,4-hydroxybutyrate,CHEBI:16724,MAPPED,unique
+4-hydroxybutyric acid,preferred_term,CHEBI:30830,4-hydroxybutyric acid,CHEBI:30830,MAPPED,unique
+4-hydroxychalcone,preferred_term,CHEBI:34423,4-hydroxychalcone,CHEBI:34423,MAPPED,unique
+4-hydroxymandelic acid,ontology_label,cas:184901-84-6,4-Hydroxymandelic acid monohydrate,CHEBI:16388,MAPPED,unique
+4-Hydroxymandelic acid monohydrate,preferred_term,cas:184901-84-6,4-Hydroxymandelic acid monohydrate,CHEBI:16388,MAPPED,unique
+4-Hydroxynonanoic acid,preferred_term,CHEBI:165411,4-Hydroxynonanoic acid,CHEBI:165411,MAPPED,unique
+4-hydroxynonanoic acid,synonym,CHEBI:165411,4-Hydroxynonanoic acid,CHEBI:165411,MAPPED,unique
+4-Hydroxynonenal,preferred_term,CHEBI:142593,4-Hydroxynonenal,CHEBI:142593,MAPPED,unique
+4-Hydroxypelargonic acid,ontology_label,CHEBI:165411,4-Hydroxynonanoic acid,CHEBI:165411,MAPPED,unique
+4-hydroxyphenyl acetate,ontology_label,CHEBI:31128,4-acetoxyphenol,CHEBI:31128,MAPPED,unique
+4-Hydroxyphenyl acetic acid,preferred_term,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+4-Hydroxyphenylacetate,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+4-hydroxyphenylacetic acid,ontology_label,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+4-Hydroxyphenylpropionic acid,preferred_term,CHEBI:32980,4-Hydroxyphenylpropionic acid,CHEBI:32980,MAPPED,unique
+4-hydroxystyrene,ontology_label,CHEBI:1883,4-vinylphenol,CHEBI:1883,MAPPED,unique
+"4-methoxy-7-methyl-5H-furo[3,2-g]chromen-5-one",synonym,CHEBI:10002,Visnagin,CHEBI:10002,MAPPED,unique
+"4-methoxy-7H-furo[3,2-g]chromen-7-one",synonym,CHEBI:18293,Bergapten,CHEBI:18293,MAPPED,unique
+4-methoxybenzaldehyde,synonym,CHEBI:28235,4-Anisaldehyde,CHEBI:28235,MAPPED,unique
+4-methyl-1H-imidazole,synonym,CHEBI:40035,4-Methylimidazole,CHEBI:40035,MAPPED,unique
+4-Methyl-2-oxopentanoate,synonym,CHEBI:48430,4-Methyl-2-oxovaleric acid,CHEBI:48430,MAPPED,conflict:different_substances
+4-Methyl-2-oxopentanoate,synonym,cas:4502-00-5,4-Methyl-2-oxopentanoic acid sodium salt,CHEBI:48430,MAPPED,conflict:different_substances
+4-methyl-2-oxopentanoic acid,ontology_label,CHEBI:48430,4-Methyl-2-oxovaleric acid,CHEBI:48430,MAPPED,conflict:different_substances
+4-methyl-2-oxopentanoic acid,ontology_label,cas:4502-00-5,4-Methyl-2-oxopentanoic acid sodium salt,CHEBI:48430,MAPPED,conflict:different_substances
+4-Methyl-2-oxopentanoic acid sodium salt,preferred_term,cas:4502-00-5,4-Methyl-2-oxopentanoic acid sodium salt,CHEBI:48430,MAPPED,unique
+4-Methyl-2-oxovaleric acid,preferred_term,CHEBI:48430,4-Methyl-2-oxovaleric acid,CHEBI:48430,MAPPED,unique
+4-Methylimidazole,preferred_term,CHEBI:40035,4-Methylimidazole,CHEBI:40035,MAPPED,unique
+4-methylumbelliferone Beta-d-glucuronide,preferred_term,CHEBI:1904,4-methylumbelliferone Beta-d-glucuronide,CHEBI:1904,MAPPED,unique
+4-morpholineethanesulfonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+"4-Morpholineethanesulfonic acid, sodium salt",synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+"4-Morpholineethanesulfonic acid, sodium salt (1:1)",synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+4-morpholinethanesulfonic acid,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+4-nitrophenyl 6-O-phosphono-beta-D-galactoside,preferred_term,CHEBI:90128,4-nitrophenyl 6-O-phosphono-beta-D-galactoside,CHEBI:90128,MAPPED,unique
+4-nitrophenyl Alpha-D-galactoside,preferred_term,CHEBI:546840,4-nitrophenyl Alpha-D-galactoside,CHEBI:546840,MAPPED,unique
+4-nitrophenyl Alpha-D-glucopyranoside,preferred_term,CHEBI:91122,4-nitrophenyl Alpha-D-glucopyranoside,CHEBI:91122,MAPPED,unique
+4-nitrophenyl alpha-D-glucoside,ontology_label,CHEBI:91122,4-nitrophenyl Alpha-D-glucopyranoside,CHEBI:91122,MAPPED,unique
+4-nitrophenyl beta-D-galactopyranoside,preferred_term,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
+4-nitrophenyl Beta-D-galactopyranoside Hydrolysate,preferred_term,UNMAPPED_0651,4-nitrophenyl Beta-D-galactopyranoside Hydrolysate,,REJECTED,unique
+4-nitrophenyl Beta-D-glucopyranoside,preferred_term,CHEBI:90259,4-nitrophenyl Beta-D-glucopyranoside,CHEBI:90259,MAPPED,unique
+4-nitrophenyl beta-D-glucoside,ontology_label,CHEBI:90259,4-nitrophenyl Beta-D-glucopyranoside,CHEBI:90259,MAPPED,unique
+4-nitrophenyl Beta-D-glucuronide,preferred_term,CHEBI:90146,4-nitrophenyl Beta-D-glucuronide,CHEBI:90146,MAPPED,unique
+4-nitrophenyl Beta-D-xylopyranoside,preferred_term,CHEBI:90148,4-nitrophenyl Beta-D-xylopyranoside,CHEBI:90148,MAPPED,unique
+4-nitrophenyl beta-D-xyloside,ontology_label,CHEBI:90148,4-nitrophenyl Beta-D-xylopyranoside,CHEBI:90148,MAPPED,unique
+4-nitrophenyl N-acetyl-beta-D-glucosaminide,preferred_term,CHEBI:90343,4-nitrophenyl N-acetyl-beta-D-glucosaminide,CHEBI:90343,MAPPED,unique
+4-nitrophenyl Phosphate,preferred_term,CHEBI:17440,4-nitrophenyl Phosphate,CHEBI:17440,MAPPED,unique
+4-nitrophenyl-beta-D-galactopyranoside,synonym,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
+4-nitrophenyl-beta-D-galactoside,ontology_label,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
+4-O-alpha-D-glucopyranosyl-alpha-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+4-O-alpha-D-glucopyranosyl-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+4-O-beta-D-galactopyranosyl-beta-D-fructofuranose,synonym,CHEBI:6359,Lactulose,CHEBI:6359,MAPPED,unique
+4-O-beta-D-galactopyranosyl-beta-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+4-O-beta-D-galactopyranosyl-D-glucitol,synonym,CHEBI:75323,Lactitol,CHEBI:75323,MAPPED,unique
+4-O-beta-D-galactopyranosyl-D-glucose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+4-O-beta-D-glucopyranosyl-D-glucopyranose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+4-oxopentanoate,preferred_term,CHEBI:39150,4-oxopentanoate,CHEBI:39150,MAPPED,unique
+4-oxopentanoic acid,ontology_label,CHEBI:45630,Levulinic Acid,CHEBI:45630,MAPPED,unique
+4-Pyridoxic acid,preferred_term,CHEBI:17405,4-Pyridoxic acid,CHEBI:17405,MAPPED,unique
+"4-ureido-2,5-imidazolidinedione",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+4-vinylphenol,preferred_term,CHEBI:1883,4-vinylphenol,CHEBI:1883,MAPPED,unique
+"4-{(2R)-2-[(1S,3S,5S)-3,5-dimethyl-2-oxocyclohexyl]-2-hydroxyethyl}piperidine-2,6-dione",synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+"4-{[4-(dimethylamino)phenyl](phenyl)methylene}-N,N-dimethylcyclohexa-2,5-dien-1-iminium chloride",synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+"4-{bis[4-(dimethylamino)phenyl]methylene}-N,N-dimethylcyclohexa-2,5-dien-1-iminium chloride",synonym,CHEBI:41688,Crystal Violet,CHEBI:41688,MAPPED,unique
+4:0,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+4Abu,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+"4alpha,10beta-bis(acetyloxy)-13alpha-[(2S,3S)-3-benzamido-2-hydroxy-3-phenylpropanoyloxy]-1,7beta-dihydroxy-9-oxo-5beta,20-epoxytax-11-en-2alpha-yl benzoate",synonym,CHEBI:45863,Paclitaxel,CHEBI:45863,MAPPED,unique
+4h-pyran-4-one,preferred_term,CHEBI:37966,4h-pyran-4-one,CHEBI:37966,MAPPED,unique
+"5',5""""-dibromo-o-cresolsulfophthalein",synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+5'-cytidylic acid,synonym,CHEBI:17361,Cytidine 5'-Monophosphate,CHEBI:17361,MAPPED,unique
+5'-deoxy-5'-(methylsulfanyl)adenosine,synonym,CHEBI:17509,5'-Deoxy-5'-(methylthio)adenosine,CHEBI:17509,MAPPED,unique
+5'-Deoxy-5'-(methylthio)adenosine,preferred_term,CHEBI:17509,5'-Deoxy-5'-(methylthio)adenosine,CHEBI:17509,MAPPED,unique
+5'-deoxy-5-fluoro-N-[(pentyloxy)carbonyl]cytidine,synonym,CHEBI:31348,Capecitabine,CHEBI:31348,MAPPED,unique
+5'-Deoxy-5-fluorocytidine,preferred_term,CHEBI:80627,5'-Deoxy-5-fluorocytidine,CHEBI:80627,MAPPED,unique
+5'-hydroxystreptomycin,ontology_label,CHEBI:24750,Hydroxystreptomycin,CHEBI:24750,MAPPED,unique
+5'-S-methyl-5'-thioadenosine,ontology_label,CHEBI:17509,5'-Deoxy-5'-(methylthio)adenosine,CHEBI:17509,MAPPED,unique
+"5,6,7,8-tetramethoxy-2-(4-methoxyphenyl)-4H-chromen-4-one",synonym,CHEBI:9400,Tangeritin,CHEBI:9400,MAPPED,unique
+"5,6,7-trihydroxy-2-phenyl-4H-chromen-4-one",synonym,CHEBI:2979,Baicalein,CHEBI:2979,MAPPED,unique
+"5,6-dihydro-5-azathymidine",preferred_term,mesh:C014480,"5,6-dihydro-5-azathymidine",mesh:C014480,MAPPED,unique
+"5,6-Dihydro-5-fluorouracil",ontology_label,CHEBI:80624,"5-Fluorodihydropyrimidine-2,4-dione",CHEBI:80624,MAPPED,unique
+"5,6-dihydroxy-2-(4-hydroxyphenyl)-4-oxo-4H-chromen-7-yl beta-D-glucopyranosiduronic acid",synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+"5,6-dihydroxy-2-(4-hydroxyphenyl)-4-oxo-4H-chromen-7-yl beta-D-glucopyranosiduronic acid",synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+"5,7,4'-Trimethoxyisoflavone",preferred_term,cas:1162-82-9,"5,7,4'-Trimethoxyisoflavone",cas:1162-82-9,MAPPED,unique
+"5,7-dihydroxy-2-(4-hydroxyphenyl)-2,3-dihydro-4H-chromen-4-one",synonym,CHEBI:50202,Naringenin,CHEBI:50202,MAPPED,unique
+"5,7-dihydroxy-2-(4-hydroxyphenyl)-4H-chromen-4-one",synonym,CHEBI:18388,Apigenin,CHEBI:18388,MAPPED,unique
+"5,7-dihydroxy-2-(4-methoxyphenyl)-4H-chromen-4-one",synonym,CHEBI:15335,Acacetin,CHEBI:15335,MAPPED,unique
+"5,7-dihydroxy-4'-methoxyflavone",ontology_label,CHEBI:15335,Acacetin,CHEBI:15335,MAPPED,unique
+"5-(1,2-dithiolan-3-yl)pentanoic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"5-(1,2-dithiolan-3-yl)valeric acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"5-(2-oxohexahydro-1H-thieno[3,4-d]imidazol-4-yl)pentanoic acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+5-(2-thienyl)-pentanoic acid,preferred_term,cas:21010-06-0,5-(2-thienyl)-pentanoic acid,cas:21010-06-0,MAPPED,unique
+"5-(3,4,5-trimethoxybenzyl)pyrimidine-2,4-diamine",synonym,CHEBI:45924,Trimethoprim,CHEBI:45924,MAPPED,unique
+"5-(4-chlorophenyl)-6-ethylpyrimidine-2,4-diamine",synonym,CHEBI:8673,Pyrimethamine,CHEBI:8673,MAPPED,unique
+5-(dithiolan-3-yl)valeric acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"5-(hydroxymethyl)-2,4-dimethylpyridin-3-ol",synonym,CHEBI:65083,4-Deoxypyridoxine,CHEBI:65083,MAPPED,unique
+5-(hydroxymethyl)-4-(methoxymethyl)-2-methylpyridin-3-ol,synonym,CHEBI:166575,Ginkgotoxin,CHEBI:166575,MAPPED,unique
+5-(hydroxymethyl)furan-2-carbaldehyde,synonym,CHEBI:412516,5-Hydroxymethylfurfural,CHEBI:412516,MAPPED,unique
+"5-[(3aS,4S,6aR)-2-oxohexahydro-1H-thieno[3,4-d]imidazol-4-yl]pentanoic acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+"5-[(3R)-1,2-dithiolan-3-yl]pentanoic acid",synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+"5-[(3S)-1,2-dithiolan-3-yl]pentanoic acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+"5-[2-(4-hydroxyphenyl)ethenyl]benzene-1,3-diol",synonym,CHEBI:27881,Resveratrol,CHEBI:27881,MAPPED,unique
+"5-[3-(1,2-dithiolanyl)]pentanoic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"5-acetamido-3,5-dideoxy-D-glycero-D-galacto-non-2-ulopyranosonic acid",synonym,CHEBI:17012,N-acetylneuraminic acid,CHEBI:17012,MAPPED,unique
+"5-allyl-1,3-benzodioxole",synonym,CHEBI:8994,Safrole,CHEBI:8994,MAPPED,unique
+5-Amino-4-oxopentanoate,synonym,CHEBI:17549,5-Aminolevulinic acid,CHEBI:17549,MAPPED,unique
+5-amino-4-oxopentanoic acid,synonym,CHEBI:17549,5-Aminolevulinic acid,CHEBI:17549,MAPPED,unique
+"5-amino-6-(7-amino-6-methoxy-5,8-dioxo-5,8-dihydroquinolin-2-yl)-4-(2-hydroxy-3,4-dimethoxyphenyl)-3-methylpyridine-2-carboxylic acid",synonym,CHEBI:9287,Streptonigrin,CHEBI:9287,MAPPED,unique
+5-amino-n-valeric acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+5-Aminolevulinic acid,preferred_term,CHEBI:17549,5-Aminolevulinic acid,CHEBI:17549,MAPPED,unique
+5-Aminopentanoate,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+5-Aminopentanoic acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+5-Aminovaleric acid,preferred_term,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+5-Azacytidine,preferred_term,CHEBI:2038,5-Azacytidine,CHEBI:2038,MAPPED,unique
+"5-chloro-2-(2,4-dichlorophenoxy)phenol",synonym,CHEBI:164200,Irgasan,CHEBI:164200,MAPPED,unique
+5-dehydro-D-gluconate,preferred_term,CHEBI:58143,5-dehydro-D-gluconate,CHEBI:58143,MAPPED,resolved:owned
+5-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_5-dehydro-d-gluconate,Potassium 5-dehydro-D-gluconate,CHEBI:58143,MAPPED,resolved:owned
+5-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_5-ketogluconate,Potassium 5-ketogluconate,CHEBI:58143,MAPPED,resolved:owned
+5-dehydro-D-gluconic acid,ontology_label,cas:91446-96-7,5-Keto-D-Gluconic Acid potassium salt,CHEBI:17426,MAPPED,unique
+"5-deoxy-5-(7,8-dimethyl-2,4-dioxo-3,4-dihydrobenzo[g]pteridin-10(2H)-yl)-D-ribitol",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+5-didehydro-D-gluconate,synonym,CHEBI:58143,5-dehydro-D-gluconate,CHEBI:58143,MAPPED,unique
+5-didehydro-D-gluconic Acid,synonym,CHEBI:18281,"2,5-didehydro-D-gluconic acid",CHEBI:18281,MAPPED,unique
+"5-fluoro-2,6-dioxo-1,2,3,6-tetrahydropyrimidine-4-carboxylic acid",synonym,cas:207291-81-4,5-Fluoroorotic acid hydrate,CHEBI:74498,MAPPED,unique
+"5-Fluorodihydropyrimidine-2,4-dione",preferred_term,CHEBI:80624,"5-Fluorodihydropyrimidine-2,4-dione",CHEBI:80624,MAPPED,unique
+5-fluoroorotic acid,ontology_label,cas:207291-81-4,5-Fluoroorotic acid hydrate,CHEBI:74498,MAPPED,unique
+5-Fluoroorotic acid hydrate,preferred_term,cas:207291-81-4,5-Fluoroorotic acid hydrate,CHEBI:74498,MAPPED,unique
+"5-fluoropyrimidine-2,4(1H,3H)-dione",synonym,CHEBI:46345,5-fluorouracil,CHEBI:46345,MAPPED,unique
+5-fluorouracil,preferred_term,CHEBI:46345,5-fluorouracil,CHEBI:46345,MAPPED,unique
+5-formyltetrahydrofolic acid,ontology_label,CHEBI:15640,Folinic acid,CHEBI:15640,MAPPED,unique
+"5-Hydroxy-1,4-naphthoquinone",synonym,CHEBI:15794,Juglone,CHEBI:15794,MAPPED,unique
+"5-hydroxy-2-methylnaphthalene-1,4-dione",synonym,CHEBI:8273,Plumbagin,CHEBI:8273,MAPPED,unique
+"5-hydroxy-6-methyl-3,4-pyridinedimethanol",synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+"5-hydroxy-6-methyl-3,4-pyridinedimethanol hydrochloride",synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+5-hydroxy-octanoic acid,ontology_label,CHEBI:180039,5-Hydroxyoctanoate,CHEBI:180039,MAPPED,unique
+5-Hydroxydodecanoate,preferred_term,CHEBI:195418,5-Hydroxydodecanoate,CHEBI:195418,MAPPED,unique
+5-hydroxydodecanoate,synonym,CHEBI:195418,5-Hydroxydodecanoate,CHEBI:195418,MAPPED,unique
+5-hydroxylaurate,synonym,CHEBI:195418,5-Hydroxydodecanoate,CHEBI:195418,MAPPED,unique
+5-Hydroxymethylfurfural,preferred_term,CHEBI:412516,5-Hydroxymethylfurfural,CHEBI:412516,MAPPED,unique
+5-Hydroxyoctanoate,preferred_term,CHEBI:180039,5-Hydroxyoctanoate,CHEBI:180039,MAPPED,unique
+5-hydroxyoctanoic acid,synonym,CHEBI:180039,5-Hydroxyoctanoate,CHEBI:180039,MAPPED,unique
+5-hydroxysalicylic acid,synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+5-Keto-D-Gluconic Acid potassium salt,preferred_term,cas:91446-96-7,5-Keto-D-Gluconic Acid potassium salt,CHEBI:17426,MAPPED,unique
+5-L-Glutamyl-L-cysteinylglycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+5-MeBza-Cba,synonym,UNMAPPED_0179,5-methylbenzimidazolyl cobamide,,UNMAPPED,unique
+5-methoxybenzimidazolyl cobamide,preferred_term,UNMAPPED_0180,5-methoxybenzimidazolyl cobamide,,UNMAPPED,unique
+5-methoxypsoralen,ontology_label,CHEBI:18293,Bergapten,CHEBI:18293,MAPPED,unique
+5-methyl-2'-deoxyuridine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+"5-methyl-2,4(1H,3H)-pyrimidinedione",synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+5-methylbenzimidazolyl cobamide,preferred_term,UNMAPPED_0179,5-methylbenzimidazolyl cobamide,,UNMAPPED,unique
+5-methylphenazin-5-ium methyl sulfate,synonym,CHEBI:8055,Phenazine methosulfate,CHEBI:8055,MAPPED,unique
+5-methylphenazin-5-ium-1-olate,synonym,CHEBI:8653,Pyocyanin,CHEBI:8653,MAPPED,unique
+5-methylphenazinium methyl sulfate,ontology_label,CHEBI:8055,Phenazine methosulfate,CHEBI:8055,MAPPED,unique
+"5-methylpyrimidine-2,4(1H,3H)-dione",synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+5-Methyluracil,synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+5-methyluridine,preferred_term,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+5-nitroquinolin-8-ol,synonym,CHEBI:67121,8-hydroxy-nitroquinoline,CHEBI:67121,MAPPED,unique
+5-oxo-L-proline,ontology_label,CHEBI:18183,L-Pyroglutamic acid,CHEBI:18183,MAPPED,unique
+5-oxo-L-proline 2-naphthylamide,ontology_label,CHEBI:90601,L-pyroglutamic Acid 2-naphthylamide,CHEBI:90601,MAPPED,unique
+5-oxoproline,preferred_term,CHEBI:16010,5-oxoproline,CHEBI:16010,MAPPED,unique
+5-trimethoxybenzoate,synonym,CHEBI:58989,"3,4,5-trimethoxybenzoate",CHEBI:58989,MAPPED,unique
+"5-Ureido-2,4-imidazolidindione",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+5-Ureidohydantoin,synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+5-valerolactone,ontology_label,CHEBI:16545,Valerolactone,CHEBI:16545,MAPPED,unique
+6'-O-sialyllactose sodium salt,preferred_term,cas:157574-76-0,6'-O-sialyllactose sodium salt,CHEBI:26714,MAPPED,unique
+6(1H)-purinone,synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+"6,7,8-trimethoxy-1-benzopyran-2-one",ontology_label,cas:6035-49-0,Dimethylfraxetin,CHEBI:93172,MAPPED,unique
+"6,7-dimethyl-9-D-ribitylisoalloxazine",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"6,8-thioctic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"6,8-thiotic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+"6-(D-(2-amino-2-phenylacetamido))-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo(3.2.0)heptane-2-carboxylic acid",synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+6-Amino-9-beta-D-ribofuranosyl-9H-purine,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+6-aminohexanoic acid,ontology_label,CHEBI:16586,e-Amino-N-Caproic Acid,CHEBI:16586,MAPPED,unique
+6-ammonio-L-norleucine,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+6-butyloxan-2-one,synonym,CHEBI:171747,Delta-Nonalactone,CHEBI:171747,MAPPED,unique
+6-Butyltetrahydro-2H-pyran-2-one,ontology_label,CHEBI:171747,Delta-Nonalactone,CHEBI:171747,MAPPED,unique
+"6-chloro-N-ethyl-N'-(propan-2-yl)-1,3,5-triazine-2,4-diamine",synonym,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
+6-deoxy-alpha-L-galacto-hexopyranosyl-(1->3)-[alpha-D-gluco-hexopyranosyl-(1->4)]-D-galacto-hexopyranose,synonym,cas:150-90-3,Sodium succinate dibasic,CHEBI:63675,MAPPED,unique
+6-deoxy-alpha-L-galactopyranosyl-(1->2)-beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:147155,2'-fucosyllactose,CHEBI:147155,MAPPED,unique
+6-deoxy-alpha-L-galactopyranosyl-(1->3)-[beta-D-galactopyranosyl-(1->4)]-D-glucopyranose,synonym,cas:41312-47-4,3'-fucosyllactose,CHEBI:90065,MAPPED,unique
+"6-deoxy-alpha-L-mannopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->6)-1-O-(2alpha,3beta,23-trihydroxy-28-oxours-12-en-28-yl)-beta-D-glucopyranose",synonym,CHEBI:79928,Asiaticoside,CHEBI:79928,MAPPED,unique
+6-deoxy-d-galactose,preferred_term,CHEBI:2179,6-deoxy-d-galactose,CHEBI:2179,MAPPED,unique
+6-deoxy-L-galactose,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+6-Deoxygalactose,synonym,CHEBI:33984,Fucose,CHEBI:33984,MAPPED,unique
+6-heptyloxan-2-one,synonym,CHEBI:171817,Delta-Dodecalactone,CHEBI:171817,MAPPED,unique
+6-hexyloxan-2-one,synonym,CHEBI:171846,Delta-Undecalactone,CHEBI:171846,MAPPED,unique
+6-Hexyltetrahydro-2H-pyran-2-one,ontology_label,CHEBI:171846,Delta-Undecalactone,CHEBI:171846,MAPPED,unique
+6-Hydroxyflavone,preferred_term,CHEBI:34472,6-Hydroxyflavone,CHEBI:34472,MAPPED,unique
+6-hydroxynicotinic acid,ontology_label,CHEBI:16168,6-hydroxypyridine-3-carboxylic acid,CHEBI:16168,MAPPED,unique
+6-hydroxypyridine-3-carboxylic acid,preferred_term,CHEBI:16168,6-hydroxypyridine-3-carboxylic acid,CHEBI:16168,MAPPED,unique
+6-methoxy-2(3H)-benzoxazolone,preferred_term,CHEBI:173101,6-methoxy-2(3H)-benzoxazolone,CHEBI:173101,MAPPED,unique
+"6-methoxy-3H-1,3-benzoxazol-2-one",synonym,CHEBI:173101,6-methoxy-2(3H)-benzoxazolone,CHEBI:173101,MAPPED,unique
+6-methylnicotinate,preferred_term,UNMAPPED_0320,6-methylnicotinate,,UNMAPPED,unique
+6-methylnicotinic acid,synonym,UNMAPPED_0320,6-methylnicotinate,,UNMAPPED,unique
+6-n-Pentyl-alpha-pyrone,ontology_label,cas:27593-23-3,6-Pentyl-2H-pyran-2-one,CHEBI:66729,MAPPED,unique
+6-O-(alpha-D-Galactopyranosyl)-D-glucopyranose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+6-O-acetyl-D-glucopyranose,synonym,CHEBI:17901,6-O-Acetyl-D-glucose,CHEBI:17901,MAPPED,unique
+6-O-Acetyl-D-glucose,preferred_term,CHEBI:17901,6-O-Acetyl-D-glucose,CHEBI:17901,MAPPED,unique
+6-O-alpha-D-galactopyranosyl-D-glucopyranose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+6-O-alpha-D-glucopyranosyl-D-fructofuranose,ontology_label,CHEBI:18394,Palatinose,CHEBI:18394,MAPPED,conflict:different_substances
+6-O-alpha-D-glucopyranosyl-D-fructofuranose,ontology_label,cas:343336-76-5,palatinose hydrate,CHEBI:18394,MAPPED,conflict:different_substances
+6-oxopurine,synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+6-Pentyl-2H-pyran-2-one,preferred_term,cas:27593-23-3,6-Pentyl-2H-pyran-2-one,CHEBI:66729,MAPPED,unique
+6-pentyloxan-2-one,ontology_label,CHEBI:87327,Delta-Decalactone,CHEBI:87327,MAPPED,unique
+6-thioctic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+6-thiotic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+6:0,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+"6beta-(2-carboxy-2-phenylacetamido)-2,2-dimethylpenam-3alpha-carboxylic acid",synonym,CHEBI:3393,Carbenicillin,CHEBI:3393,MAPPED,unique
+"6beta-[(2R)-2-amino-2-(4-hydroxyphenyl)acetamido]-2,2-dimethylpenam-3alpha-carboxylic acid",synonym,CHEBI:2676,Amoxicillin,CHEBI:2676,MAPPED,unique
+"6beta-[(2R)-2-amino-2-phenylacetamido]-2,2-dimethylpenam-3alpha-carboxylic acid",synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+"6beta-{[(azepan-1-yl)methylidene]amino}-2,2-dimethylpenam-3alpha-carboxylic acid",synonym,CHEBI:51208,Mecillinam,CHEBI:51208,MAPPED,unique
+6G-alpha-D-galactosylsucrose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+"7,10-dihydroxy-2-(2-methoxypropan-2-yl)-8-(2-methylbut-3-en-2-yl)-6H-furo[3,2-c]xanthen-6-one",synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+"7,12-diethenyl-3,8,13,17-tetramethylporphyrin-2,18-dipropanoic acid",synonym,CHEBI:15430,Protoporphyrin,CHEBI:15430,MAPPED,unique
+"7,2'-Dihydroxyflavone",preferred_term,cas:77298-66-9,"7,2'-Dihydroxyflavone",CHEBI:94071,MAPPED,unique
+"7,2'-Dimethoxyflavone",preferred_term,UNMAPPED_0199,"7,2'-Dimethoxyflavone",,UNMAPPED,unique
+"7,4'-Dimethoxyisoflavone",preferred_term,UNMAPPED_0189,"7,4'-Dimethoxyisoflavone",,UNMAPPED,unique
+"7,8-dihydroxy-6-methoxy-2H-chromen-2-one",synonym,CHEBI:5169,Fraxetin,CHEBI:5169,MAPPED,unique
+"7,8-dimethyl-10-(D-ribo-2,3,4,5-tetrahydroxypentyl)benzo[g]pteridine-2,4(3H,10H)-dione",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"7,8-dimethyl-10-(D-ribo-2,3,4,5-tetrahydroxypentyl)isoalloxazine",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"7,8-dimethyl-10-[(2S,3S,4R)-2,3,4,5-tetrahydroxypentyl]benzo[g]pteridine-2,4(3H,10H)-dione",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"7,8-dimethyl-10-ribitylisoalloxazine",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"7,8-dimethylbenzo[g]pteridine-2,4(1H,3H)-dione",synonym,CHEBI:17781,Lumichrome,CHEBI:17781,MAPPED,unique
+7-di-iso-propylpteridine Phosphate),synonym,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
+7-Hydro-8-methylpteroylglutamylglutamic acid,preferred_term,mesh:C052093,7-Hydro-8-methylpteroylglutamylglutamic acid,mesh:C052093,MAPPED,unique
+7-hydroxy-2-(2-hydroxyphenyl)-1-benzopyran-4-one,ontology_label,cas:77298-66-9,"7,2'-Dihydroxyflavone",CHEBI:94071,MAPPED,unique
+7-hydroxy-2-oxo-2H-chromen-6-yl beta-D-glucopyranoside,synonym,CHEBI:4853,Esculin Monohydrate,CHEBI:4853,MAPPED,unique
+7-hydroxy-2-phenyl-4H-chromen-4-one,synonym,CHEBI:2268,7-hydroxyflavone,CHEBI:2268,MAPPED,unique
+7-hydroxy-3-(4-hydroxyphenyl)-4H-chromen-4-one,synonym,CHEBI:28197,Daidzein,CHEBI:28197,MAPPED,unique
+7-hydroxy-6-methoxy-2H-chromen-2-one,synonym,CHEBI:17488,Scopoletin,CHEBI:17488,MAPPED,unique
+7-hydroxyflavone,preferred_term,CHEBI:2268,7-hydroxyflavone,CHEBI:2268,MAPPED,unique
+"7-methoxy-1-methyl-4,9-dihydro-3H-pyrido[3,4-b]indole",synonym,CHEBI:28172,Harmaline,CHEBI:28172,MAPPED,unique
+"7-methoxy-1-methyl-9H-pyrido[3,4-b]indole",synonym,CHEBI:28121,Harmine,CHEBI:28121,MAPPED,unique
+7-methoxy-4-methyl-1-benzopyran-2-one,ontology_label,cas:2555-28-4,Hymecromone Methyl Ether,CHEBI:107662,MAPPED,unique
+7-oxolithocholic acid,ontology_label,CHEBI:82679,Nutriacholic Acid,CHEBI:82679,MAPPED,unique
+"7-{[(2E)-3,7-dimethylocta-2,6-dien-1-yl]oxy}-2H-1-benzopyran-2-one",synonym,CHEBI:134355,Auraptene,CHEBI:134355,MAPPED,unique
+"7beta-[(2R)-2-(cyclohexa-1,4-dienyl)-2-phenylacetamido]-3-methyl-3,4-didehydrocepham-4-carboxylic acid",synonym,CHEBI:3547,Cephradine,CHEBI:3547,MAPPED,unique
+"7beta-[(2R)-2-amino-2-phenylacetamido]-3-methyl-3,4-didehydrocepham-4-carboxylic acid",synonym,CHEBI:3534,Cephalexin,CHEBI:3534,MAPPED,unique
+"7beta-{[(2R)-2-amino-2-phenylacetyl]amino}-3-chloro-3,4-didehydrocepham-4-carboxylic acid",synonym,CHEBI:3478,Cefaclor,CHEBI:3478,MAPPED,unique
+7beta-{[(cyanomethyl)sulfanyl]acetamido}-7alpha-methoxy-3-{[(1-methyl-1H-tetrazol-5-yl)sulfanyl]methyl}ceph-3-em-4-carboxylic acid,synonym,CHEBI:3489,Cefmetazole,CHEBI:3489,MAPPED,unique
+"8-(acetyloxy)-20-formyl-3,13,15alpha-trihydroxy-1alpha,6alpha,16beta-trimethoxy-4-(methoxymethyl)aconitan-14alpha-yl benzoate",synonym,CHEBI:132646,Oxonitine,CHEBI:132646,MAPPED,unique
+8-azaguanine,preferred_term,CHEBI:63486,8-azaguanine,CHEBI:63486,MAPPED,unique
+8-hydroxy-nitroquinoline,preferred_term,CHEBI:67121,8-hydroxy-nitroquinoline,CHEBI:67121,MAPPED,unique
+"8-methoxy-6-nitro-2H-phenanthro[3,4-d][1,3]dioxole-5-carboxylic acid",synonym,CHEBI:2825,Aristolochic Acid,CHEBI:2825,MAPPED,unique
+84 g/L NaHCO3 solution,preferred_term,kgmicrobe.ingredient:84_gl_nahco3_solution,84 g/L NaHCO3 solution,CHEBI:32139,MAPPED,unique
+"9,10-dimethoxy-5,6-dihydro[1,3]dioxolo[4,5-g]isoquino[3,2-a]isoquinolin-7-ium",synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
+9-(2-deoxy-beta-D-erythro-pentofuranosyl)-9H-purin-6-ol,synonym,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
+9-(beta-D-ribofuranosyl)-9H-purin-6-ol,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+"9-[(2R,4S,5R)-4-hydroxy-5-(hydroxymethyl)tetrahydrofuran-2-yl]-9H-purin-6-ol",synonym,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
+9-beta-D-Ribofuranosidoadenine,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+"9-beta-D-ribofuranosyl-3,9-dihydro-1H-purine-2,6-dione",synonym,CHEBI:18107,Xanthosine,CHEBI:18107,MAPPED,unique
+9-beta-D-Ribofuranosyl-9H-purin-6-amine,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+9-beta-D-ribofuranosyl-9H-purin-6-ol,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+9-beta-D-ribofuranosyl-guanine,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+9-beta-D-ribofuranosyladenine,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+9-beta-D-ribofuranosylhypoxanthine,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+9-beta-D-Ribofuranosylxanthine,synonym,CHEBI:18107,Xanthosine,CHEBI:18107,MAPPED,unique
+9H-beta-carboline,synonym,CHEBI:109895,Norharman,CHEBI:109895,MAPPED,unique
+9H-purin-6(1H)-one,synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+9H-purin-6-amine,synonym,CHEBI:16708,Adenine,CHEBI:16708,MAPPED,unique
+"9H-purine-2,6-(1H,3H)-dione",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+9H-xanthine,synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+"[(10E,12S,13S,14R,16S)-7,14-dihydroxy-6,10,12,16-tetramethyl-2,9,15,21-tetraoxo-20-oxa-18-azatetracyclo[14.3.1.14,19.03,8]henicosa-1(19),3,5,7,10-pentaen-13-yl] 3-hydroxy-6-[(4-hydroxy-7-methoxy-2-oxochromen-3-yl)carbamoyl]pyridine-2-carboxylate",synonym,CHEBI:223718,rubradirin,CHEBI:223718,MAPPED,unique
+"[(1aS,8S,8aR,8bS)-6-amino-8a-methoxy-5-methyl-4,7-dioxo-1,1a,2,4,7,8,8a,8b-octahydroazirino[2',3':3,4]pyrrolo[1,2-a]indol-8-yl]methyl carbamate",synonym,CHEBI:27504,Mitomycin C,CHEBI:27504,MAPPED,unique
+[(2R)-3-carboxy-2-hydroxypropyl]-trimethylazanium;chloride,synonym,CHEBI:233463,L-Carnitine hydrochloride,CHEBI:233463,MAPPED,unique
+"[(2R,3S,4R,5R)-5-(6-amino-9H-purin-9-yl)-4-hydroxy-3-(phosphonooxy)tetrahydrofuran-2-yl]methyl (3R)-3-hydroxy-4-({3-oxo-3-[(2-sulfanylethyl)amino]propyl}amino)-2,2-dimethyl-4-oxobutyl dihydrogen diphosphate",synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+[(2S)-2-amino-2-carboxyethyl]-hydroxyimino-oxidoazanium,synonym,CHEBI:221124,alanosine,CHEBI:221124,MAPPED,unique
+[(aminoacetyl)amino]acetic acid,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+"[1,4]naphthoquinon",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+"[2-[1-[5,7-dihydroxy-3-(3,4,5-trihydroxybenzoyl)oxy-3,4-dihydro-2H-chromen-2-yl]-3,4,5-trihydroxy-6-oxobenzo[7]annulen-8-yl]-5,7-dihydroxy-3,4-dihydro-2H-chromen-3-yl] 3,4,5-trihydroxybenzoate",synonym,cas:30462-35-2,Theaflavin Digallate,CHEBI:185495,MAPPED,unique
+"[2-hydroxy-2-[3-hydroxy-4-[(4E,6E,12E,14Z)-10-hydroxy-3,15-dimethoxy-7,9,11,13-tetramethyl-16-oxo-1-oxacyclohexadeca-4,6,12,14-tetraen-2-yl]pentan-2-yl]-5-methyl-6-propan-2-yloxan-4-yl] (E)-4-[(2-hydroxy-5-oxocyclopenten-1-yl)amino]-4-oxobut-2-enoate",synonym,CHEBI:199416,Bafilomycin B1,CHEBI:199416,MAPPED,unique
+"[2-hydroxypropane-1,2,3-tricarboxylato(3-)-kappa(3)O(1),O(2),O(3)]iron",synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+[2-MeAde]Cba,synonym,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
+[3-hydroxy-5-(hydroxymethyl)-2-methylpyridin-4-yl]methanaminium chloride,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+"[3R-(3alpha,4alpha,5beta)]-3,4,5-trihydroxy-1-cyclohexene-1-carboxylic acid",synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+"[4)-3,6-An-alpha-L-Galp-(1->3)-beta-D-Galp-(1->]n",synonym,CHEBI:2511,Agarose,CHEBI:2511,MAPPED,unique
+[4)-beta-D-GlcpN(1->]n,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+[4-(prop-1-en-2-yl)cyclohex-1-en-1-yl]methanol,synonym,CHEBI:15420,Perillyl Alcohol,CHEBI:15420,MAPPED,unique
+[AlCl3],synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+[B(OH)3],synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+[CaCl2],synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
+[CeCl3],synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
+[CH2Me(OH)],synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+[CO2],synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+[dodecanoyl(methyl)amino] acetate,synonym,CHEBI:183704,N-lauroylsarcosine sodium salt,CHEBI:183704,MAPPED,unique
+[dodecanoyl(methyl)amino]acetate,ontology_label,CHEBI:183704,N-lauroylsarcosine sodium salt,CHEBI:183704,MAPPED,unique
+[FeCl2],synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,unique
+[FeCl3],synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
+[HCl],synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+[KCl],synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+[MgCl2],synonym,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,unique
+[MoO3],synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
+[NH4]Cl,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+[NiCl2],synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
+[OD2],synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+[OEtH],synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+[OH2],synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+[S(OH)2O2],synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+[SeO(OH)2],synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+[SiO2],synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+[SO2(OH)2],synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+[WO2(OH)2],synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+A+ Trace Components,preferred_term,kgmicrobe.ingredient:a_trace_components,A+ Trace Components,kgmicrobe.ingredient:a_trace_components,MAPPED,unique
+A+ Trace Components (sterilize before adding),synonym,kgmicrobe.ingredient:a_trace_components,A+ Trace Components,kgmicrobe.ingredient:a_trace_components,MAPPED,unique
+a-Cyclodextrin,preferred_term,CHEBI:40585,a-Cyclodextrin,CHEBI:40585,MAPPED,unique
+a-Ketoglutaric acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,conflict:different_substances
+a-Ketoglutaric acid,synonym,cas:305-72-6,a-Ketoglutaric acid disodium salt hydrate,CHEBI:30915,MAPPED,conflict:different_substances
+a-Ketoglutaric acid disodium salt hydrate,preferred_term,cas:305-72-6,a-Ketoglutaric acid disodium salt hydrate,CHEBI:30915,MAPPED,unique
+ABEE,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+"abieta-7,13-dien-18-oic acid",synonym,CHEBI:28987,Abietic Acid,CHEBI:28987,MAPPED,unique
+Abietic Acid,preferred_term,CHEBI:28987,Abietic Acid,CHEBI:28987,MAPPED,unique
+Abikoviromycin,preferred_term,CHEBI:210557,Abikoviromycin,CHEBI:210557,MAPPED,unique
+ABPC,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+abromine,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Abscisic acid,preferred_term,CHEBI:2365,Abscisic acid,CHEBI:2365,MAPPED,unique
+Aburamycin A,preferred_term,kgmicrobe.compound:aburamycin_a,Aburamycin A,kgmicrobe.compound:aburamycin_a,MAPPED,unique
+Abyssomicin B,preferred_term,kgmicrobe.compound:abyssomicin_b,Abyssomicin B,kgmicrobe.compound:abyssomicin_b,MAPPED,unique
+abyssomicin C,ontology_label,mesh:C509797,Atrop Abyssomicin C,mesh:C509797,MAPPED,unique
+Abyssomicin D,preferred_term,mesh:C512805,Abyssomicin D,mesh:C512805,MAPPED,unique
+Abyssomicin G,preferred_term,kgmicrobe.compound:abyssomicin_g,Abyssomicin G,kgmicrobe.compound:abyssomicin_g,MAPPED,unique
+Abyssomicin H,preferred_term,kgmicrobe.compound:abyssomicin_h,Abyssomicin H,kgmicrobe.compound:abyssomicin_h,MAPPED,unique
+Acacetin,preferred_term,CHEBI:15335,Acacetin,CHEBI:15335,MAPPED,unique
+Aceglutamide [INN],synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+ACES,preferred_term,CHEBI:39060,ACES,CHEBI:39060,REJECTED,unique
+ACES,synonym,CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,CHEBI:39060,MAPPED,unique
+acetaldehyde,preferred_term,CHEBI:15343,acetaldehyde,CHEBI:15343,MAPPED,unique
+Acetamide,preferred_term,CHEBI:27856,Acetamide,CHEBI:27856,MAPPED,unique
+Acetate,preferred_term,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+acetate,ontology_label,CHEBI:30089,Acetate (carbon source),CHEBI:30089,REJECTED,unique
+Acetate (carbon source),preferred_term,CHEBI:30089,Acetate (carbon source),CHEBI:30089,REJECTED,unique
+Acetate (carbon source),synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+ACETATE ION,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+Acetate-replacing factor,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Acetic acid,preferred_term,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+acetic acid magnesium salt,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+"acetic acid, ammonium salt",synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+"Acetic acid, magnesium salt (2:1)",synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+"acetic acid, sodium salt",synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Acetoacetate,preferred_term,CHEBI:13705,Acetoacetate,CHEBI:13705,MAPPED,unique
+Acetoin,preferred_term,CHEBI:15688,Acetoin,CHEBI:15688,MAPPED,unique
+Acetomycin,preferred_term,CHEBI:209246,Acetomycin,CHEBI:209246,MAPPED,unique
+acetone,preferred_term,CHEBI:15347,acetone,CHEBI:15347,MAPPED,unique
+Acetosyringone,preferred_term,CHEBI:2404,Acetosyringone,CHEBI:2404,MAPPED,unique
+Acetovanillone,preferred_term,CHEBI:2781,Acetovanillone,CHEBI:2781,MAPPED,unique
+acetyl xylan,synonym,CHEBI:134431,Acetylated xylan,CHEBI:134431,MAPPED,unique
+Acetyl-Dihydro-7-Epikhivorin,preferred_term,UNMAPPED_0197,Acetyl-Dihydro-7-Epikhivorin,,UNMAPPED,unique
+Acetyl-Glu,synonym,CHEBI:172431,N-Acetyl-glutamic acid,CHEBI:172431,MAPPED,unique
+Acetylated xylan,preferred_term,CHEBI:134431,Acetylated xylan,CHEBI:134431,MAPPED,unique
+Acetylene,preferred_term,CHEBI:27518,Acetylene,CHEBI:27518,MAPPED,unique
+acetylene trichloride,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Acetylformic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+Acetylglutamine,synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+acetylmuramic acid,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+Acetylspiramycin,synonym,CHEBI:31168,Spiramycin II,CHEBI:31168,MAPPED,unique
+Acfol,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Achromoviromycin,preferred_term,kgmicrobe.compound:achromoviromycin,Achromoviromycin,kgmicrobe.compound:achromoviromycin,MAPPED,unique
+Achromycin,synonym,CHEBI:27902,Tetracycline,CHEBI:27902,MAPPED,unique
+Acid blue 74,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Acid hydrolysate of casein,synonym,MICRO:0001366,Casein hydrolysate,MICRO:0001366,MAPPED,unique
+Acid-hydrolyzed casein,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+acide 2-furoique,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+acide acetique,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+acide ascorbique,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+acide butanedioique,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+acide butanoique,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+acide butyrique,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+acide carbolique,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+acide folique,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Acide formique,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+acide glutamique,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+acide gras,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+acide nicotinique,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+acide octadecanoique,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+acide phenique,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+acide propanoique,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+acide propionique,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+acide pyruvique,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+acide stearique,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+acide succinique,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Acide sulfurique,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+acides gras,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+acido 2-furoico,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+acido ascorbico,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+acido folico,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+acido glutamico,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+acido graso,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+acido nicotinico,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Acido sulfurico,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+acidol,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+acidos grasos,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+acidum ascorbicum,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+acidum ascorbinicum,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+acidum folicum,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+acidum glutamicum,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+acidum nicotinicum,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+acidum succinicum,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Acidum sulfuricum,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+AcOH,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+AcOK,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+AcONH4,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+Aconitate,preferred_term,CHEBI:22210,Aconitate,CHEBI:22210,MAPPED,unique
+aconitate(3-),ontology_label,CHEBI:22210,Aconitate,CHEBI:22210,MAPPED,unique
+acqua,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Acridine orange,preferred_term,CHEBI:51739,Acridine orange,CHEBI:51739,MAPPED,unique
+Acriflavine,preferred_term,cas:8048-52-0,Acriflavine,NCIT:C76253,MAPPED,unique
+Actein,preferred_term,CHEBI:70241,Actein,CHEBI:70241,MAPPED,unique
+Actilight,preferred_term,UNMAPPED_0224,Actilight,,UNMAPPED,unique
+Actinohivin,preferred_term,kgmicrobe.compound:actinohivin,Actinohivin,kgmicrobe.compound:actinohivin,MAPPED,unique
+Actinomycetin,preferred_term,kgmicrobe.compound:actinomycetin,Actinomycetin,kgmicrobe.compound:actinomycetin,MAPPED,unique
+actinomycin,ontology_label,kgmicrobe.compound:actinomycin_a,Actinomycin A,CHEBI:15369,MAPPED,unique
+Actinomycin A,preferred_term,kgmicrobe.compound:actinomycin_a,Actinomycin A,CHEBI:15369,MAPPED,unique
+Actinomycin D,preferred_term,CHEBI:27666,Actinomycin D,CHEBI:27666,MAPPED,unique
+Actinomycin X,preferred_term,mesh:C041783,Actinomycin X,mesh:C041783,MAPPED,unique
+Actinotiocin,preferred_term,mesh:C006403,Actinotiocin,mesh:C006403,MAPPED,unique
+Activated charcoal,preferred_term,NCIT:C77524,Activated charcoal,NCIT:C77524,MAPPED,unique
+Ade-Rib,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+Adenine,preferred_term,CHEBI:16708,Adenine,CHEBI:16708,MAPPED,resolved:owned
+adenine,ontology_label,cas:2922-28-3,Adenine hydrochloride hydrate,CHEBI:16708,MAPPED,resolved:owned
+Adenine hydrochloride hydrate,preferred_term,cas:2922-28-3,Adenine hydrochloride hydrate,CHEBI:16708,MAPPED,unique
+adenine riboside,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+adeninyl cobamide,preferred_term,UNMAPPED_0181,adeninyl cobamide,,UNMAPPED,unique
+Adenocard,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+Adenocor,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+Adenomycin,preferred_term,NCIT:C221830,Adenomycin,NCIT:C221830,MAPPED,unique
+Adenoscan,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+Adenosin,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+Adenosine,preferred_term,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+"adenosine 3',5'-(hydrogen phosphate)",synonym,CHEBI:17489,"Adenosine 3,5-Cyclic Monophosphate",CHEBI:17489,MAPPED,unique
+"Adenosine 3',5'-phosphate",synonym,CHEBI:17489,"Adenosine 3,5-Cyclic Monophosphate",CHEBI:17489,MAPPED,unique
+"Adenosine 3,5-Cyclic Monophosphate",preferred_term,CHEBI:17489,"Adenosine 3,5-Cyclic Monophosphate",CHEBI:17489,MAPPED,unique
+"adenosine 5'-(3-{D-ribo-5-[7,8-dimethyl-2,4-dioxo-3,4-dihydrobenzo[g]pteridin-10(2H)-yl]-2,3,4-trihydroxypentyl} dihydrogen diphosphate)",synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+"Adenosine 5'-(trihydrogen pyrophosphate), 5'-5'-ester with riboflavine",synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+adenosine 5'-[3-(riboflavin-5'-yl) dihydrogen diphosphate],synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+Adenosine 5'-monophosphate,preferred_term,CHEBI:16027,Adenosine 5'-monophosphate,CHEBI:16027,MAPPED,unique
+"adenosine 5'-{3-[1-(3-carbamoylpyridinio)-1,4-anhydro-D-ribitol-5-yl] dihydrogen diphosphate}",synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+Adipate,preferred_term,CHEBI:17128,Adipate,CHEBI:17128,MAPPED,unique
+adipate(2-),ontology_label,CHEBI:17128,Adipate,CHEBI:17128,MAPPED,unique
+Adipic acid,preferred_term,CHEBI:30832,Adipic acid,CHEBI:30832,MAPPED,unique
+Aepfelsaeure,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+Aescin,ontology_label,CHEBI:2500,Escin,CHEBI:2500,MAPPED,unique
+Aesculetin,preferred_term,cas:305-01-1,Aesculetin,cas:305-01-1,MAPPED,unique
+Aethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Aethylalkohol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Aetzkali,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+Aetznatron,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+Agar,preferred_term,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agarose,preferred_term,CHEBI:2511,Agarose,CHEBI:2511,MAPPED,unique
+Agave,preferred_term,FOODON:00005198,Agave,FOODON:00005198,MAPPED,unique
+Agelasine,preferred_term,UNMAPPED_0198,Agelasine,,UNMAPPED,unique
+agua,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+air-dried garden soil,preferred_term,ENVO:00002263,air-dried garden soil,ENVO:00002263,MAPPED,unique
+Al2(SO4)3 x 18 H2O,preferred_term,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+Al2(SO4)3.18H2O,synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+Ala-Gly,ontology_label,CHEBI:73757,L-alanylglycine,CHEBI:73757,MAPPED,unique
+Alanine,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+alanosine,preferred_term,CHEBI:221124,alanosine,CHEBI:221124,MAPPED,unique
+alantolactone,ontology_label,CHEBI:2540,Helenine,CHEBI:2540,MAPPED,unique
+Alazopeptin,preferred_term,CHEBI:222816,Alazopeptin,CHEBI:222816,MAPPED,unique
+Alboverticillin,preferred_term,kgmicrobe.compound:alboverticillin,Alboverticillin,kgmicrobe.compound:alboverticillin,MAPPED,unique
+AlCl3,preferred_term,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+AlCl3 . 6H2O,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+AlCl3 x 6 H2O,preferred_term,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+AlCl3.6H2O,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+AlCl3·6H2O,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+AlCl3・6H2O,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+alcohol etilico,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+alcool ethylique,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+aldehydo-D-gluco-hexose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+aldehydo-D-gluco-hexose,synonym,CHEBI:17234,glucose,CHEBI:17234,REJECTED,unique
+aldehydo-D-lyxose,ontology_label,CHEBI:62318,D-(-)-lyxose,CHEBI:16789,REJECTED,unique
+aldehydo-N-acetylmuramic acid,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+aldehydo-N-acetylmuramic acid,synonym,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
+alfoscerate de choline,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+alfoscerato de colina,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Algal Trace Elements Solution,preferred_term,MICRO:0000455,Algal Trace Elements Solution,MICRO:0000455,MAPPED,unique
+Algiline,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Algin,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Alginate,preferred_term,CHEBI:58187,Alginate,CHEBI:58187,MAPPED,unique
+AlK(SO4)2,preferred_term,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+AlK(SO4)2 . 12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2 12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2 x 12 H2O,preferred_term,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2 x 12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2.12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2·12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlK(SO4)2・12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+AlKCl2,synonym,cas:74978-20-4,Potassium aluminum chloride,NCIT:C83530,MAPPED,unique
+Alkohol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Allantoin,preferred_term,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+Allen Medium,preferred_term,UNMAPPED_0070,Allen Medium,,UNMAPPED,unique
+alliin,ontology_label,CHEBI:2596,L-alliin,CHEBI:2596,MAPPED,unique
+Allopurinol,preferred_term,CHEBI:40279,Allopurinol,CHEBI:40279,MAPPED,unique
+Allura Red AC,preferred_term,CHEBI:172687,Allura Red AC,CHEBI:172687,MAPPED,unique
+Aloin,preferred_term,CHEBI:73222,Aloin,CHEBI:73222,MAPPED,unique
+"alpha,alpha',alpha''-trimethylaminetricarboxylic acid",synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+"alpha-(5,6-dimethylbenzimidazolyl)cobamide",synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+alpha-Amino-1H-imidazole-4-propionic acid,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
+alpha-Amino-beta-(3-indolyl)-propionic acid,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+alpha-amino-beta-3-indolepropionic acid,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+alpha-amino-beta-methylvaleric acid,synonym,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
+alpha-amino-delta-ureidovaleric acid,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+alpha-amino-gamma-methylmercaptobutyric acid,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+Alpha-aminobutyrate,preferred_term,CHEBI:86508,Alpha-aminobutyrate,CHEBI:86508,MAPPED,unique
+alpha-aminobutyric acid,ontology_label,CHEBI:35621,DL-2-Aminobutyric acid,CHEBI:35621,MAPPED,unique
+alpha-aminosuccinamic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+alpha-butenoate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+alpha-crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+alpha-cyclodextrin,ontology_label,CHEBI:40585,a-Cyclodextrin,CHEBI:40585,MAPPED,unique
+alpha-D-Gal-(1->6)-D-Glc,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+alpha-D-galactopyranosyl-(1->6)-alpha-D-glucopyranosyl beta-D-fructofuranoside,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+alpha-D-galactopyranosyl-(1->6)-D-glucopyranose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+alpha-D-galactose 1-phosphate,ontology_label,cas:19046-60-7,Galactose 1-phosphate dipotassium salt pentahydrate,CHEBI:17973,MAPPED,unique
+alpha-D-galactosyl-(1->6)-D-glucose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+alpha-D-Galp-(1->6)-alpha-D-Glcp-(1<->2)-beta-D-Fruf,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+alpha-D-Galp-(1->6)-D-Glcp,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+alpha-D-Glc,synonym,CHEBI:17925,alpha-D-Glucose,CHEBI:17925,MAPPED,unique
+alpha-D-Glcp-(1->4)-alpha-D-Glcp,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+alpha-D-Glcp-(1->4)-D-Glcp,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+alpha-D-glucopyranose,synonym,CHEBI:17925,alpha-D-Glucose,CHEBI:17925,MAPPED,unique
+alpha-D-glucopyranosyl-(1->3)-D-fructose,synonym,CHEBI:32528,D-(+)-Turanose,CHEBI:32528,MAPPED,unique
+alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranose,synonym,CHEBI:17306,maltose,CHEBI:17306,REJECTED,unique
+alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:27445,Maltohexaose,CHEBI:27445,MAPPED,unique
+alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:28460,Maltotetraose,CHEBI:28460,MAPPED,unique
+alpha-D-glucopyranosyl-(1->4)-D-glucitol,synonym,CHEBI:68428,Maltitol,CHEBI:68428,MAPPED,unique
+alpha-D-Glucopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,conflict:different_substances
+alpha-D-glucopyranosyl-(1->4)-D-glucopyranose,synonym,cas:6363-53-7,D-Maltose monohydrate,CHEBI:17306,MAPPED,conflict:different_substances
+alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,conflict:different_substances
+alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,cas:6363-53-7,D-Maltose monohydrate,CHEBI:17306,MAPPED,conflict:different_substances
+alpha-D-glucopyranosyl-(1->6)-D-glucopyranose,synonym,CHEBI:28189,Isomaltose,CHEBI:28189,MAPPED,unique
+alpha-D-Glucose,preferred_term,CHEBI:17925,alpha-D-Glucose,CHEBI:17925,MAPPED,unique
+Alpha-D-glucose 6-phosphate,preferred_term,CHEBI:17665,Alpha-D-glucose 6-phosphate,CHEBI:17665,MAPPED,unique
+alpha-dextrose,synonym,CHEBI:17925,alpha-D-Glucose,CHEBI:17925,MAPPED,unique
+alpha-furancarboxylic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+alpha-furoic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+alpha-Glycerophosphorylcholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+alpha-hydro-omega-hydroxypoly(oxyethylene),synonym,CHEBI:46793,Polyethylene glycol,CHEBI:46793,MAPPED,unique
+"alpha-hydroxy-alpha,alpha-bis(p-hydroxyphenyl)-o-toluenesulfonic acid gamma-sultone",synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+Alpha-hydroxybutyrate,synonym,CHEBI:64552,2-hydroxybutyrate,CHEBI:64552,MAPPED,unique
+Alpha-hydroxyglutarate-gamma-lactone,preferred_term,kgmicrobe.compound:alpha-hydroxyglutarate-gamma-lactone,Alpha-hydroxyglutarate-gamma-lactone,kgmicrobe.compound:alpha-hydroxyglutarate-gamma-lactone,MAPPED,unique
+alpha-hydroxyphenol,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+alpha-hydroxysuccinic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+alpha-isobutyric acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+alpha-ketoglutamate,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+alpha-ketoglutarate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+alpha-ketoglutaric acid,preferred_term,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+alpha-ketopropionic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+alpha-L-arabinofuranosyl-(1->5)-alpha-L-arabinofuranosyl-(1->5)-alpha-L-arabinofuranose,synonym,cas:89315-59-3,Arabinotriose,CHEBI:62799,MAPPED,unique
+alpha-L-Araf-(1->5)-alpha-L-Araf-(1->5)-alpha-L-Araf,ontology_label,cas:89315-59-3,Arabinotriose,CHEBI:62799,MAPPED,unique
+alpha-L-rhamnopyranose,ontology_label,CHEBI:27907,Alpha-L-rhamnose,CHEBI:27907,MAPPED,unique
+Alpha-L-rhamnose,preferred_term,CHEBI:27907,Alpha-L-rhamnose,CHEBI:27907,MAPPED,unique
+alpha-Lactose,preferred_term,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
+Alpha-lactose monohydrate,ontology_label,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
+alpha-lipoic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+alpha-Liponsaeure,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+alpha-methyl butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+alpha-Methylbutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+alpha-Methylguanidino acetic acid,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+alpha-methylpropanoic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+alpha-methylpropionic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+alpha-naphthoquinone,synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+alpha-Oxopropionsaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+alpha-phylloquinone,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+alpha-Pinene,synonym,CHEBI:17187,pinene,CHEBI:17187,MAPPED,unique
+Alpha-Toxicarol (Dl),preferred_term,CHEBI:9643,Alpha-Toxicarol (Dl),CHEBI:9643,MAPPED,unique
+Althiomycin,preferred_term,CHEBI:157683,Althiomycin,CHEBI:157683,MAPPED,unique
+aluminium chloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+aluminium chloride--water (1/6),synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+Aluminium potassium bis(sulphate),synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+aluminium potassium sulfate (1/1/2),synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+aluminium potassium sulfate--water (1/12),synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Aluminium sulfate,preferred_term,CHEBI:74772,Aluminium sulfate,CHEBI:74772,MAPPED,unique
+aluminium sulfate octadecahydrate,synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+aluminium sulfate--water (1/18),synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+aluminium sulfate.18H2O,synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+aluminium trichloride,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+aluminium trichloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+aluminium(3+) chloride,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+aluminium(III) chloride,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+aluminium(III) chloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+Aluminum Chloride,ontology_label,cas:10124-27-3,Aluminum chloride hydrate,NCIT:C83530,MAPPED,unresolved:partial_chemistry
+Aluminum Chloride,ontology_label,cas:74978-20-4,Potassium aluminum chloride,NCIT:C83530,MAPPED,unresolved:partial_chemistry
+aluminum chloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+Aluminum chloride hydrate,preferred_term,cas:10124-27-3,Aluminum chloride hydrate,NCIT:C83530,MAPPED,unique
+Aluminum potassium alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Aluminum potassium disulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Aluminum potassium disulfate dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Aluminum potassium sulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+aluminum potassium sulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Aluminum potassium sulfate dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+aluminum sulfate.18H2O,synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
+Aluminum trichloride,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+aluminum trichloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
+Aluminum-NTA,preferred_term,UNMAPPED_0157,Aluminum-NTA,,UNMAPPED,unique
+AmB,synonym,UNMAPPED_0325,Amphotericin,,UNMAPPED,unique
+amber acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Ameisensaeure,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+amfotericina B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+Amicoumacin B,preferred_term,CHEBI:216618,Amicoumacin B,CHEBI:216618,MAPPED,unique
+amidon,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Amidon (starch),synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Amikacin,preferred_term,CHEBI:2637,Amikacin,CHEBI:2637,MAPPED,unique
+amikacin disulfate,ontology_label,CHEBI:2638,Amikacin disulfate salt,CHEBI:2638,MAPPED,unique
+Amikacin disulfate salt,preferred_term,CHEBI:2638,Amikacin disulfate salt,CHEBI:2638,MAPPED,unique
+aminic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Amino Acid,preferred_term,CHEBI:33709,Amino Acid,CHEBI:33709,MAPPED,unique
+Aminoacetic acid,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Aminoacids,preferred_term,kgmicrobe.ingredient:aminoacids,Aminoacids,kgmicrobe.ingredient:aminoacids,MAPPED,unique
+aminobenzylpenicillin,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+Aminoessigsaeure,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+aminoethanoic acid,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Aminoethylsulfonic acid,synonym,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+Aminoglycoside Antibiotic,preferred_term,CHEBI:22507,Aminoglycoside Antibiotic,CHEBI:22507,MAPPED,unique
+aminomethane,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+Aminophenazone,preferred_term,CHEBI:160246,Aminophenazone,CHEBI:160246,MAPPED,unique
+aminotris(hydroxymethyl)methane,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Aminovalerate,preferred_term,kgmicrobe.compound:aminovalerate,Aminovalerate,kgmicrobe.compound:aminovalerate,MAPPED,unique
+Ammonia,preferred_term,CHEBI:16134,Ammonia,CHEBI:16134,MAPPED,unique
+Ammonium,preferred_term,CHEBI:28938,Ammonium,CHEBI:28938,MAPPED,unique
+Ammonium acetate,preferred_term,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+Ammonium acid phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Ammonium bicarbonate,synonym,CHEBI:184335,NH4HCO3,CHEBI:184335,MAPPED,unique
+Ammonium biphosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+ammonium carbonate,ontology_label,CHEBI:229630,NH42CO3,CHEBI:229630,MAPPED,unique
+Ammonium Chloride,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+ammonium chloride,ontology_label,CHEBI:31206,Ammonium chloride (nitrogen source),CHEBI:31206,REJECTED,unique
+Ammonium chloride (nitrogen source),preferred_term,CHEBI:31206,Ammonium chloride (nitrogen source),CHEBI:31206,REJECTED,unique
+Ammonium chloride (nitrogen source),synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+Ammonium citrate (3:1),synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+ammonium citrate dibasic,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+ammonium citrate tribasic,synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+"Ammonium citrate, dibasic",synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Ammonium diacid phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Ammonium dihydrogen orthophosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+ammonium dihydrogen phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Ammonium dihydrophosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+ammonium ethanoate,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+Ammonium ferric citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+Ammonium ferrous sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Ammonium heptamolybdate tetrahydrate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+ammonium hydrogen citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+ammonium iron(2+) sulfate--water (1/6),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+ammonium iron(II) sulfate heptahydrate,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+ammonium iron(II) sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+ammonium iron(III) citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+ammonium magnesium phosphate,ontology_label,CHEBI:149425,NH4MgPO,CHEBI:149425,MAPPED,unique
+Ammonium Molybdate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,conflict:different_substances
+ammonium molybdate,ontology_label,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,conflict:different_substances
+ammonium molybdate tetrahydrate,preferred_term,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+Ammonium molybdate(VI),synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+Ammonium monobasic phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Ammonium monohydrogen citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Ammonium monohydrogencitrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Ammonium monophosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+ammonium nickel sulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+ammonium nickel sulfate hexahydrate,ontology_label,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
+Ammonium nickel(2+) sulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+ammonium nickel(2+) sulfate--water (2/1/2/6),synonym,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
+ammonium nickel(2+) sulfate--water (2/1/2/6),synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+ammonium nickel(II) sulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+Ammonium Nitrate,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Ammonium nitricum,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+ammonium orthomolybdate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+Ammonium orthophosphate dihydrogen,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+ammonium oxalate,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+ammonium persulfate,preferred_term,CHEBI:156543,ammonium persulfate,CHEBI:156543,MAPPED,unique
+Ammonium saltpeter,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Ammonium Sulfamate,preferred_term,CHEBI:81950,Ammonium Sulfamate,CHEBI:81950,MAPPED,unique
+Ammonium Sulfate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+ammonium sulfate (2:1),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+ammonium sulfide,ontology_label,cas:12135-76-1,ammonium sulfide solution,mesh:C027711,MAPPED,unique
+ammonium sulfide solution,preferred_term,cas:12135-76-1,ammonium sulfide solution,mesh:C027711,MAPPED,unique
+ammonium sulfite,ontology_label,cas:7783-11-1,Ammonium sulfite monohydrate,mesh:C048169,MAPPED,unique
+Ammonium sulfite monohydrate,preferred_term,cas:7783-11-1,Ammonium sulfite monohydrate,mesh:C048169,MAPPED,unique
+ammonium sulphate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+Ammonium(I) nitrate (1:1),synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Ammoniumchlorid,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+Ammothamnine,ontology_label,CHEBI:2672,Oxymatrine,CHEBI:2672,MAPPED,unique
+amorphous fe(iii) oxyhydroxid,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+amorphous iron (iii) oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+Amoxicillin,preferred_term,CHEBI:2676,Amoxicillin,CHEBI:2676,MAPPED,unique
+Amp,synonym,CHEBI:16027,Adenosine 5'-monophosphate,CHEBI:16027,MAPPED,unique
+AMPH-B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+Amphomycin,preferred_term,CHEBI:201652,Amphomycin,CHEBI:201652,MAPPED,unique
+Amphotericin,preferred_term,UNMAPPED_0325,Amphotericin,,UNMAPPED,unique
+Amphotericin A,preferred_term,mesh:C041989,Amphotericin A,mesh:C041989,MAPPED,unique
+Amphotericin B,preferred_term,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,resolved:owned
+amphotericin B,synonym,UNMAPPED_0325,Amphotericin,,UNMAPPED,resolved:owned
+Amphotericine B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+amphotericinum B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+ampicilina,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+Ampicillin,preferred_term,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+ampicillin acid,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+ampicillin natrium,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+Ampicillin sodium,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+ampicillin sodium,ontology_label,CHEBI:34535,Ampicillin sodium salt,CHEBI:34535,REJECTED,unique
+Ampicillin sodium salt,preferred_term,CHEBI:34535,Ampicillin sodium salt,CHEBI:34535,REJECTED,unique
+Ampicillin sodium salt,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+ampicilline,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+ampicillinum,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+Amygdalin,preferred_term,CHEBI:27613,Amygdalin,CHEBI:27613,MAPPED,unique
+amylopectin,ontology_label,kgmicrobe.ingredient:amylopectin_from_maize,amylopectin from maize,CHEBI:28057,MAPPED,unique
+amylopectin from maize,preferred_term,kgmicrobe.ingredient:amylopectin_from_maize,amylopectin from maize,CHEBI:28057,MAPPED,unique
+amylose,ontology_label,CHEBI:28102,Amylose from potato,CHEBI:28102,MAPPED,unique
+Amylose from potato,preferred_term,CHEBI:28102,Amylose from potato,CHEBI:28102,MAPPED,unique
+amylum,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Anabasine Hydrochloride,preferred_term,cas:53912-89-3,Anabasine Hydrochloride,NCIT:C216370,MAPPED,unique
+Anaerobe Basal Broth CM0957,preferred_term,UNMAPPED_0327,Anaerobe Basal Broth CM0957,,UNMAPPED,unique
+Andirobin,preferred_term,cas:6488-63-7,Andirobin,cas:6488-63-7,MAPPED,unique
+Andrographolide,preferred_term,CHEBI:65408,Andrographolide,CHEBI:65408,MAPPED,unique
+Anethole,preferred_term,CHEBI:2716,Anethole,CHEBI:2716,MAPPED,unique
+Aneurin,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Angolamycin,preferred_term,mesh:C002547,Angolamycin,mesh:C002547,MAPPED,unique
+Angustmycin,preferred_term,CHEBI:8612,Angustmycin,CHEBI:8612,MAPPED,unique
+anh. sodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Anhydrotetracycline hydrochloride,preferred_term,CHEBI:201752,Anhydrotetracycline hydrochloride,CHEBI:201752,MAPPED,unique
+anhydrous calcium chloride,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+anhydrous calcium chloride,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+anhydrous gypsum,synonym,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+anhydrous manganese chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+anhydrous sodium acetate,synonym,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
+anhydrous sodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Anhydrous sodium sulfite,synonym,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,unique
+animal manure,ontology_label,kgmicrobe.ingredient:dry_cow-manure,Dry cow-manure,ENVO:00003031,MAPPED,unique
+Anisodamine Hydrobromide,ontology_label,cas:17659-49-3,Anisodamine Hydrobromide (),NCIT:C221850,MAPPED,unique
+Anisodamine Hydrobromide (),preferred_term,cas:17659-49-3,Anisodamine Hydrobromide (),NCIT:C221850,MAPPED,unique
+Anthracene,preferred_term,CHEBI:35298,Anthracene,CHEBI:35298,MAPPED,unique
+Anthracycline Antibiotic,preferred_term,CHEBI:49322,Anthracycline Antibiotic,CHEBI:49322,MAPPED,unique
+anthranilamide,preferred_term,CHEBI:193638,anthranilamide,CHEBI:193638,MAPPED,unique
+anthranilate,ontology_label,CHEBI:16567,2-aminobenzoate,CHEBI:16567,MAPPED,unique
+anthranilic acid,preferred_term,CHEBI:30754,anthranilic acid,CHEBI:30754,MAPPED,unique
+"anthraquinone-2,6-disulfonate",synonym,cas:853-68-9,AQDS,cas:853-68-9,MAPPED,unique
+anti-pellagra vitamin,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Antiberiberi factor,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Antimonate,preferred_term,CHEBI:30295,Antimonate,CHEBI:30295,MAPPED,unique
+antimonate(3-),ontology_label,CHEBI:30295,Antimonate,CHEBI:30295,MAPPED,unique
+Antimycin A,preferred_term,CHEBI:2762,Antimycin A,CHEBI:2762,MAPPED,unique
+Antimycin A3,preferred_term,CHEBI:197950,Antimycin A3,CHEBI:197950,MAPPED,unique
+Antipyrine,preferred_term,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+Aphidicolin,preferred_term,CHEBI:2766,Aphidicolin,CHEBI:2766,MAPPED,unique
+apidaecin,ontology_label,mesh:C061361,Apidaecin IB,mesh:C061361,MAPPED,unique
+Apidaecin IB,preferred_term,mesh:C061361,Apidaecin IB,mesh:C061361,MAPPED,unique
+Apigenin,preferred_term,CHEBI:18388,Apigenin,CHEBI:18388,MAPPED,unique
+Apigenin Dimethyl Ether,preferred_term,cas:5728-44-9,Apigenin Dimethyl Ether,CHEBI:28887,MAPPED,unique
+Apiole,preferred_term,CHEBI:70353,Apiole,CHEBI:70353,MAPPED,unique
+apo-yersiniabactin,preferred_term,UNMAPPED_0239,apo-yersiniabactin,,UNMAPPED,unique
+apocynin,ontology_label,CHEBI:2781,Acetovanillone,CHEBI:2781,MAPPED,unique
+apple acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+Apramycin,preferred_term,CHEBI:2790,Apramycin,CHEBI:2790,MAPPED,unique
+Apramycin sulfate,ontology_label,cas:65710-07-8,Apramycin sulfate salt,CHEBI:190734,MAPPED,unique
+Apramycin sulfate salt,preferred_term,cas:65710-07-8,Apramycin sulfate salt,CHEBI:190734,MAPPED,unique
+AQDS,preferred_term,cas:853-68-9,AQDS,cas:853-68-9,MAPPED,unique
+aqua,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Aqua-Flave,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Aquakay,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Aquinone,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Ar,synonym,CHEBI:49474,argon,CHEBI:49474,MAPPED,unique
+Arabinan from Sugar Beet,preferred_term,cas:11078-27-6,Arabinan from Sugar Beet,FOODON:00003412,MAPPED,unique
+Arabinitol,preferred_term,CHEBI:22605,Arabinitol,CHEBI:22605,MAPPED,unique
+arabino-hex-2-ulose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+arabino-Hexulose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+arabino-pentose,synonym,CHEBI:22599,Arabinose,CHEBI:22599,MAPPED,unique
+Arabinobiose,preferred_term,cas:78088-21-8,Arabinobiose,mesh:C434937,MAPPED,unique
+arabinogalactan,ontology_label,CHEBI:27569,(+)-Arabinogalactan,CHEBI:27569,MAPPED,unique
+Arabinose,preferred_term,CHEBI:22599,Arabinose,CHEBI:22599,MAPPED,unique
+Arabinotriose,preferred_term,cas:89315-59-3,Arabinotriose,CHEBI:62799,MAPPED,unique
+arabinoxylan,ontology_label,CHEBI:28427,Wheat Arabinoxylan,CHEBI:28427,MAPPED,unique
+Arabinoxylan (Rye Flour),preferred_term,FOODON:03302492,Arabinoxylan (Rye Flour),FOODON:03302492,MAPPED,unique
+Arabitol,preferred_term,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+Arbutin,preferred_term,NCIT:C87429,Arbutin,NCIT:C87429,MAPPED,unique
+Arcrane,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Ardacin,ontology_label,kgmicrobe.compound:ardacin_a,Ardacin A,NCIT:C169786,MAPPED,unresolved:no_chemistry
+Ardacin,ontology_label,kgmicrobe.compound:ardacin_b,Ardacin B,NCIT:C169786,MAPPED,unresolved:no_chemistry
+Ardacin,ontology_label,kgmicrobe.compound:ardacin_c,Ardacin C,NCIT:C169786,MAPPED,unresolved:no_chemistry
+Ardacin A,preferred_term,kgmicrobe.compound:ardacin_a,Ardacin A,NCIT:C169786,MAPPED,unique
+Ardacin B,preferred_term,kgmicrobe.compound:ardacin_b,Ardacin B,NCIT:C169786,MAPPED,unique
+Ardacin C,preferred_term,kgmicrobe.compound:ardacin_c,Ardacin C,NCIT:C169786,MAPPED,unique
+Arecoline Hydrobromide,preferred_term,CHEBI:233150,Arecoline Hydrobromide,CHEBI:233150,MAPPED,unique
+arene,ontology_label,CHEBI:33658,Aromatic hydrocarbon,CHEBI:33658,MAPPED,unique
+Arginin,synonym,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+Arginine,preferred_term,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+Arginine hydrochloride,synonym,CHEBI:31235,L-Arginine x HCl,CHEBI:31235,MAPPED,unique
+argon,preferred_term,CHEBI:49474,argon,CHEBI:49474,MAPPED,unique
+argon(0),ontology_label,CHEBI:49474,argon,CHEBI:49474,MAPPED,unique
+Aristolochic Acid,preferred_term,CHEBI:2825,Aristolochic Acid,CHEBI:2825,MAPPED,unique
+aristolochic acid A,ontology_label,CHEBI:2825,Aristolochic Acid,CHEBI:2825,MAPPED,unique
+Aromatic compound,preferred_term,CHEBI:33655,Aromatic compound,CHEBI:33655,MAPPED,unique
+aromatic compounds,synonym,CHEBI:33655,Aromatic compound,CHEBI:33655,MAPPED,unique
+Aromatic hydrocarbon,preferred_term,CHEBI:33658,Aromatic hydrocarbon,CHEBI:33658,MAPPED,unique
+aromatic molecular entity,synonym,CHEBI:33655,Aromatic compound,CHEBI:33655,MAPPED,unique
+Arsenate,preferred_term,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+Arsenate ion,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+arsenate(3-),ontology_label,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+arsorate,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+Artepaulin,preferred_term,cas:13902-54-0,Artepaulin,cas:13902-54-0,MAPPED,unique
+Artificial Sea Salt,preferred_term,MICRO:0001647,Artificial Sea Salt,MICRO:0001647,MAPPED,unique
+Ascoltin,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+Ascomycin,preferred_term,CHEBI:29582,Ascomycin,CHEBI:29582,MAPPED,unique
+Ascophyllum,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Ascorbate,preferred_term,CHEBI:22651,Ascorbate,CHEBI:22651,MAPPED,unique
+ascorbate de sodium,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Ascorbic acid,preferred_term,CHEBI:22652,Ascorbic acid,CHEBI:22652,MAPPED,unique
+ascorbic acid sodium salt,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Ascorbicap,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+Ascorbinsaeure,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+Ascosin,preferred_term,kgmicrobe.compound:ascosin,Ascosin,kgmicrobe.compound:ascosin,MAPPED,unique
+Asialofetuin,preferred_term,mesh:C017029,Asialofetuin,mesh:C017029,MAPPED,unique
+Asiaticoside,preferred_term,CHEBI:79928,Asiaticoside,CHEBI:79928,MAPPED,unique
+Asolectin from soybean,preferred_term,UNMAPPED_0232,Asolectin from soybean,,UNMAPPED,unique
+Asparagin,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+asparagina,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+Asparagine,preferred_term,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,resolved:owned
+ASPARAGINE,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,resolved:owned
+Asparagine Monohydrate,ontology_label,cas:5794-13-8,L-Asparagine monohydrate,NCIT:C87433,MAPPED,unique
+Aspartamic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+Aspartate,preferred_term,CHEBI:29995,Aspartate,CHEBI:29995,MAPPED,unique
+aspartate(2-),ontology_label,CHEBI:29995,Aspartate,CHEBI:29995,MAPPED,unique
+ASPARTIC ACID,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,conflict:different_substances
+ASPARTIC ACID,synonym,cas:1115-63-5,L-Aspartic acid potassium salt,CHEBI:17053,MAPPED,conflict:different_substances
+ASPARTIC ACID,synonym,cas:323194-76-9,L-Aspartic acid sodium salt monohydrate,CHEBI:17053,MAPPED,conflict:different_substances
+aspartic acid,ontology_label,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,conflict:different_substances
+aspyrone,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+Astaxanthin,preferred_term,CHEBI:40968,Astaxanthin,CHEBI:40968,MAPPED,unique
+Astromicin,preferred_term,CHEBI:37923,Astromicin,CHEBI:37923,MAPPED,unique
+asuccin,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+ATCC Wolfe's mineral mix,preferred_term,kgmicrobe.ingredient:atcc_wolfes_mineral_mix,ATCC Wolfe's mineral mix,kgmicrobe.ingredient:atcc_wolfes_mineral_mix,MAPPED,unique
+ATCC Wolfe's mineral mix minus iron,preferred_term,kgmicrobe.ingredient:atcc_wolfes_mineral_mix_minus_iron,ATCC Wolfe's mineral mix minus iron,kgmicrobe.ingredient:atcc_wolfes_mineral_mix_minus_iron,MAPPED,unique
+ATCC Wolfe's vitamin mix,preferred_term,kgmicrobe.ingredient:atcc_wolfes_vitamin_mix,ATCC Wolfe's vitamin mix,kgmicrobe.ingredient:atcc_wolfes_vitamin_mix,MAPPED,unique
+Atorvastatin calcium salt trihydrate,preferred_term,CHEBI:2911,Atorvastatin calcium salt trihydrate,CHEBI:2911,MAPPED,unique
+atorvastatin calcium trihydrate,ontology_label,CHEBI:2911,Atorvastatin calcium salt trihydrate,CHEBI:2911,MAPPED,unique
+Atrazin,preferred_term,cas:1924-24-9,Atrazin,cas:1924-24-9,MAPPED,unique
+atrazine,synonym,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
+Atrop Abyssomicin C,preferred_term,mesh:C509797,Atrop Abyssomicin C,mesh:C509797,MAPPED,unique
+atrop-abyssomicin C,synonym,mesh:C509797,Atrop Abyssomicin C,mesh:C509797,MAPPED,unique
+Auraptene,preferred_term,CHEBI:134355,Auraptene,CHEBI:134355,MAPPED,unique
+Aureothricin,preferred_term,CHEBI:156452,Aureothricin,CHEBI:156452,MAPPED,unique
+Auryxia,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Austrapen,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+"autoclaved, Galactan from Potato",synonym,UNMAPPED_0238,Galactan from Potato,,UNMAPPED,unique
+"autoclaved, Glucomannan (konjac)",synonym,cas:11078-31-2,Glucomannan (konjac),CHEBI:17020,MAPPED,unique
+"autoclaved, Glycogen",synonym,CHEBI:28087,Glycogen,CHEBI:28087,MAPPED,unique
+"autoclaved, Mucin from porcine stomach type II",synonym,cas:84082-64-4,"Mucin from porcine stomach,Type II",cas:84082-64-4,MAPPED,unique
+"autoclaved, polygalacturonic acid",synonym,CHEBI:62969,polygalacturonic acid,CHEBI:62969,MAPPED,unique
+Avantafiber,preferred_term,UNMAPPED_0221,Avantafiber,,UNMAPPED,unique
+Avermectin,preferred_term,CHEBI:50344,Avermectin,CHEBI:50344,MAPPED,unique
+Avidin,preferred_term,cas:1405-69-2,Avidin,mesh:D001360,MAPPED,unique
+Avocadene,preferred_term,CHEBI:172520,Avocadene,CHEBI:172520,MAPPED,unique
+Avocadyne,preferred_term,CHEBI:168507,Avocadyne,CHEBI:168507,MAPPED,unique
+Avocatin A,preferred_term,UNMAPPED_0187,Avocatin A,,UNMAPPED,unique
+Avocatin B,preferred_term,mesh:C000709627,Avocatin B,mesh:C000709627,MAPPED,unique
+Avoparcin,preferred_term,NCIT:C169798,Avoparcin,NCIT:C169798,MAPPED,unique
+Azacolutin,preferred_term,kgmicrobe.compound:azacolutin,Azacolutin,kgmicrobe.compound:azacolutin,MAPPED,unique
+Azadirachtin,preferred_term,CHEBI:38473,Azadirachtin,CHEBI:38473,MAPPED,unique
+azanium acetate,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+azanium chloride,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+azanium;hydrogen carbonate,synonym,CHEBI:184335,NH4HCO3,CHEBI:184335,MAPPED,unique
+Azaserine,preferred_term,CHEBI:74846,Azaserine,CHEBI:74846,MAPPED,unique
+Azelaate,preferred_term,CHEBI:132955,Azelaate,CHEBI:132955,MAPPED,unique
+Azelaic acid,preferred_term,CHEBI:48131,Azelaic acid,CHEBI:48131,MAPPED,unique
+azepan-2-one,synonym,CHEBI:28579,Caprolactam,CHEBI:28579,MAPPED,unique
+Azetat,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+azetidin-2-one,ontology_label,CHEBI:327119,2-Azetidinone,CHEBI:327119,MAPPED,unique
+Azithromycin,preferred_term,CHEBI:2955,Azithromycin,CHEBI:2955,MAPPED,unique
+azlocillin sodium,ontology_label,CHEBI:51864,Azlocillin sodium salt,CHEBI:51864,MAPPED,unique
+Azlocillin sodium salt,preferred_term,CHEBI:51864,Azlocillin sodium salt,CHEBI:51864,MAPPED,unique
+Azomycin,preferred_term,CHEBI:67135,Azomycin,CHEBI:67135,MAPPED,unique
+azoperoxoite,synonym,CHEBI:25941,peroxynitrite,CHEBI:25941,MAPPED,unique
+Aztreonam,preferred_term,CHEBI:161680,Aztreonam,CHEBI:161680,MAPPED,unique
+azufre,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+azul de metileno,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Azureomycin,preferred_term,kgmicrobe.compound:azureomycin,Azureomycin,kgmicrobe.compound:azureomycin,MAPPED,unique
+B(OH)3,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+B-alanine,synonym,CHEBI:16958,Beta-alanine,CHEBI:16958,MAPPED,unique
+b-glucan from Barley,preferred_term,UNMAPPED_0247,b-glucan from Barley,,UNMAPPED,unique
+"b-Glucan from Beet (1,2-b-Glucan)",preferred_term,UNMAPPED_0237,"b-Glucan from Beet (1,2-b-Glucan)",,UNMAPPED,unique
+b-Glucan from Oat,preferred_term,CHEBI:28793,b-Glucan from Oat,CHEBI:28793,MAPPED,unique
+B-glucan from yeast,preferred_term,UNMAPPED_0235,B-glucan from yeast,,UNMAPPED,unique
+b-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+b-Mannan borohydrate reduced carob seed,preferred_term,cas:9036-88-8,b-Mannan borohydrate reduced carob seed,cas:9036-88-8,MAPPED,unique
+Bacillomycin,preferred_term,kgmicrobe.compound:bacillomycin,Bacillomycin,kgmicrobe.compound:bacillomycin,MAPPED,unique
+Bacitracin,preferred_term,CHEBI:28669,Bacitracin,CHEBI:28669,MAPPED,unique
+BaCl2,preferred_term,CHEBI:63317,BaCl2,CHEBI:63317,MAPPED,unique
+BaCl2 x 2 H2O,preferred_term,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+BaCl2.2H2O,synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+BaCl2·2H2O,synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+BaCl2・2H2O,synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+Bacteriochlorophyll A,preferred_term,CHEBI:30033,Bacteriochlorophyll A,CHEBI:30033,MAPPED,unique
+Bacteriochlorophyll Alpha,synonym,CHEBI:30033,Bacteriochlorophyll A,CHEBI:30033,MAPPED,unique
+Bacteriocin Isk 1,preferred_term,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
+bacteriocin ISK-1,synonym,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
+bacteriocin ISK-I,synonym,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
+Bacteriological Agar,synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Bacteriological peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto beef extract,synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Bacto Beef Extract (Difco),synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Bacto Bitone,preferred_term,UNMAPPED_0330,Bacto Bitone,,UNMAPPED,unique
+Bacto brain heart infusion,preferred_term,MICRO:0000193,Bacto brain heart infusion,MICRO:0000193,MAPPED,unique
+Bacto Casitone (Difco),synonym,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
+Bacto Heart Infusion Broth,preferred_term,UNMAPPED_0332,Bacto Heart Infusion Broth,,UNMAPPED,unique
+Bacto m TGE broth,preferred_term,UNMAPPED_0333,Bacto m TGE broth,,UNMAPPED,unique
+Bacto Malt Extract (Difco),synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
+Bacto Middlebrook 7H10 agar,preferred_term,UNMAPPED_0115,Bacto Middlebrook 7H10 agar,,UNMAPPED,unique
+Bacto Panton,preferred_term,UNMAPPED_0334,Bacto Panton,,UNMAPPED,unique
+Bacto peptone,preferred_term,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto Peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto peptone (BD--Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto peptone (BD-Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto Peptone (Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto Proteose Peptone No. 3 (Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Bacto Proteose Peptone No.3 (Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Bacto Soytone,preferred_term,FOODON:03315720,Bacto Soytone,FOODON:03315720,REJECTED,unique
+Bacto Soytone,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Bacto Tryptic Soy Agar,preferred_term,MICRO:0000114,Bacto Tryptic Soy Agar,MICRO:0000114,MAPPED,unique
+Bacto Tryptic Soy Agar (Difco),preferred_term,MICRO:0000114,Bacto Tryptic Soy Agar (Difco),MICRO:0000114,REJECTED,unique
+Bacto Tryptic Soy Agar (Difco),synonym,MICRO:0000114,Bacto Tryptic Soy Agar,MICRO:0000114,MAPPED,unique
+Bacto Tryptic Soy Broth,preferred_term,MICRO:0000113,Bacto Tryptic Soy Broth,MICRO:0000113,MAPPED,unique
+Bacto Tryptic Soy Broth (Difco),preferred_term,MICRO:0000113,Bacto Tryptic Soy Broth (Difco),MICRO:0000113,REJECTED,unique
+Bacto Tryptic Soy Broth (Difco),synonym,MICRO:0000113,Bacto Tryptic Soy Broth,MICRO:0000113,MAPPED,unique
+Bacto Tryptone,synonym,MICRO:0000182,Bacto-tryptone,MICRO:0000182,MAPPED,unique
+Bacto Tryptone,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Bacto tryptone,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Bacto Tryptone (DIfco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Bacto Tryptone (Difco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Bacto Yeast  Extract (Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Bacto yeast extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Bacto Yeast Extract (Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Bacto-Peptone (BD),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Bacto-tryptone,preferred_term,MICRO:0000182,Bacto-tryptone,MICRO:0000182,MAPPED,unique
+bacto-tryptone,synonym,MICRO:0000182,Bacto-tryptone,MICRO:0000182,MAPPED,unique
+Bacto-yeast extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Bafilomycin,preferred_term,kgmicrobe.compound:bafilomycin,Bafilomycin,kgmicrobe.compound:bafilomycin,MAPPED,unique
+Bafilomycin B1,preferred_term,CHEBI:199416,Bafilomycin B1,CHEBI:199416,MAPPED,unique
+Baicalein,preferred_term,CHEBI:2979,Baicalein,CHEBI:2979,MAPPED,unique
+Baker's yeast,preferred_term,FOODON:03413797,Baker's yeast,FOODON:03413797,MAPPED,unique
+baking soda,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Balhimycin,preferred_term,CHEBI:47250,Balhimycin,CHEBI:47250,MAPPED,unique
+bambermycin,ontology_label,CHEBI:28908,Flavomycin,CHEBI:28908,MAPPED,unique
+Bandamycin,preferred_term,kgmicrobe.compound:bandamycin,Bandamycin,kgmicrobe.compound:bandamycin,MAPPED,unique
+barium chloride,synonym,CHEBI:63317,BaCl2,CHEBI:63317,MAPPED,unique
+barium chloride dihydrate,synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+barium chloride--water (1/2),synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+barium dichloride,synonym,CHEBI:63317,BaCl2,CHEBI:63317,MAPPED,unique
+Barium dichloride dihydrate,synonym,CHEBI:86153,BaCl2 x 2 H2O,CHEBI:86153,MAPPED,unique
+Barley grains,preferred_term,UNMAPPED_0096,Barley grains,,UNMAPPED,unique
+Barley grains autoclaved,preferred_term,UNMAPPED_0104,Barley grains autoclaved,,UNMAPPED,unique
+Barley grains(add after dH2O),synonym,UNMAPPED_0096,Barley grains,,UNMAPPED,unique
+Basal mineral NaCl medium,preferred_term,UNMAPPED_0336,Basal mineral NaCl medium,,UNMAPPED,unique
+Basic Blue 9,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Basic Green 4,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+bathocuproine disulfonic acid,ontology_label,cas:52698-84-7,Bathocuproine disulfonic acid disodium salt,CHEBI:63934,MAPPED,unique
+Bathocuproine disulfonic acid disodium salt,preferred_term,cas:52698-84-7,Bathocuproine disulfonic acid disodium salt,CHEBI:63934,MAPPED,unique
+Bathocuproinedisulfonic acid disodium salt,synonym,cas:52698-84-7,Bathocuproine disulfonic acid disodium salt,CHEBI:63934,MAPPED,unique
+Bathophenanthrolinedisulfonic acid disodium salt hydrate,preferred_term,kgmicrobe.compound:bathophenanthrolinedisulfonic_acid_disodium_salt_hydrate,Bathophenanthrolinedisulfonic acid disodium salt hydrate,CHEBI:78157,MAPPED,unique
+BC Lignin Sorghum,preferred_term,UNMAPPED_0169,BC Lignin Sorghum,,UNMAPPED,unique
+BCYE agar,preferred_term,UNMAPPED_0113,BCYE agar,,UNMAPPED,unique
+Bedaquiline,preferred_term,CHEBI:72292,Bedaquiline,CHEBI:72292,MAPPED,unique
+Beef,preferred_term,NCIT:C71932,Beef,NCIT:C71932,MAPPED,unique
+beef (ground),ontology_label,FOODON:00001282,Ground beef,FOODON:00001282,MAPPED,unique
+beef brain,ontology_label,kgmicrobe.ingredient:beef_brain_powder,Beef brain powder,FOODON:02020911,MAPPED,unique
+Beef brain powder,preferred_term,kgmicrobe.ingredient:beef_brain_powder,Beef brain powder,FOODON:02020911,MAPPED,unique
+Beef extract,preferred_term,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Beef Extract,synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+beef extract,synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Beef extract (BBL),synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Beef extract (BD-Difco),synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Beef extract(Sigma B-4888),synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Beef heart,preferred_term,FOODON:00004410,Beef heart,FOODON:00004410,MAPPED,resolved:owned
+beef heart,ontology_label,kgmicrobe.ingredient:beef_heart_infusion,Beef Heart Infusion,FOODON:00004410,MAPPED,resolved:owned
+Beef Heart Infusion,preferred_term,kgmicrobe.ingredient:beef_heart_infusion,Beef Heart Infusion,FOODON:00004410,MAPPED,unique
+Beflavin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Beflavine,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Beijerinck's Solution,preferred_term,kgmicrobe.ingredient:beijerincks_solution,Beijerinck's Solution,kgmicrobe.ingredient:beijerincks_solution,MAPPED,unique
+Benzalkonium Chloride,preferred_term,CHEBI:3020,Benzalkonium Chloride,CHEBI:3020,MAPPED,unique
+Benzbromarone,preferred_term,CHEBI:3023,Benzbromarone,CHEBI:3023,MAPPED,unique
+Benzene,preferred_term,CHEBI:16716,Benzene,CHEBI:16716,MAPPED,unique
+"benzene-1,2,3-triol",synonym,CHEBI:16164,Pyrogallol,CHEBI:16164,MAPPED,unique
+"benzene-1,2-diol",synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+"Benzene-1,4-diol",synonym,CHEBI:17594,Hydroquinone,CHEBI:17594,MAPPED,unique
+Benzeneacrylic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+benzenediamine,synonym,CHEBI:51402,Phenylenediamine,CHEBI:51402,MAPPED,unique
+Benzenol,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Benzethonium chloride,preferred_term,CHEBI:31264,Benzethonium chloride,CHEBI:31264,MAPPED,unique
+benzimidazolyl cobamide,preferred_term,UNMAPPED_0178,benzimidazolyl cobamide,,UNMAPPED,unique
+"benzo[j,k]acenaphthylene",synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
+benzo[jk]fluorene,synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
+Benzoate,preferred_term,CHEBI:16150,Benzoate,CHEBI:16150,MAPPED,unique
+benzoic acid,preferred_term,CHEBI:30746,benzoic acid,CHEBI:30746,MAPPED,unique
+"Benzoic acid, sodium salt",synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+Benzoin,preferred_term,CHEBI:17682,Benzoin,CHEBI:17682,MAPPED,unique
+Benzyl Alcohol,preferred_term,CHEBI:17987,Benzyl Alcohol,CHEBI:17987,MAPPED,unique
+Benzyl cyanide,synonym,CHEBI:25979,Benzylcyanide,CHEBI:25979,MAPPED,unique
+Benzyl isothiocyanate,preferred_term,CHEBI:17484,Benzyl isothiocyanate,CHEBI:17484,MAPPED,unique
+Benzylcyanide,preferred_term,CHEBI:25979,Benzylcyanide,CHEBI:25979,MAPPED,unique
+Benzylhydrazine Hydrochloride,preferred_term,cas:3287-99-8,Benzylhydrazine Hydrochloride,cas:3287-99-8,MAPPED,unique
+benzylpenicillin sodium,ontology_label,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
+Berberine,preferred_term,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
+Berberine chloride (TN),ontology_label,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
+Bergapten,preferred_term,CHEBI:18293,Bergapten,CHEBI:18293,MAPPED,unique
+Bergenin,preferred_term,CHEBI:69499,Bergenin,CHEBI:69499,MAPPED,unique
+Bernsteinsaeure,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+beryllium sulfate tetrahydrate,preferred_term,CHEBI:53502,beryllium sulfate tetrahydrate,CHEBI:53502,MAPPED,unique
+beryllium sulfate--water (1/4),synonym,CHEBI:53502,beryllium sulfate tetrahydrate,CHEBI:53502,MAPPED,unique
+Bet,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+beta lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Beta Lipomycin,synonym,mesh:C000601869,beta-Lipomycin,mesh:C000601869,MAPPED,unique
+"beta,beta'-diamino-beta,beta'-dicarboxydiethyl disulfide",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"beta,beta'-dithiodialanine",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"beta-1,4-Poly-D-glucosamine",synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+beta-3-indolylalanine,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+Beta-alanine,preferred_term,CHEBI:16958,Beta-alanine,CHEBI:16958,MAPPED,unique
+beta-aminoethylsulfonic acid,synonym,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+beta-aminopropionitrile hemifumarate,ontology_label,CHEBI:91084,3-Aminopropionitrile Fumarate,CHEBI:91084,MAPPED,unique
+Beta-Amyrin,preferred_term,CHEBI:10352,Beta-Amyrin,CHEBI:10352,MAPPED,unique
+beta-carboline,ontology_label,CHEBI:109895,Norharman,CHEBI:109895,MAPPED,unique
+beta-CD,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+beta-cycloamylose,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+beta-cyclodextrin,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+beta-D-adenosine,synonym,CHEBI:16335,Adenosine,CHEBI:16335,MAPPED,unique
+beta-D-arabino-Hexulose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+beta-D-cellohexaose,ontology_label,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
+beta-D-fructofuranose,ontology_label,cas:308066-66-2,Fructooligosaccharides (FOS),CHEBI:28645,MAPPED,unique
+beta-D-fructofuranosyl alpha-D-galactopyranosyl-(1->6)-alpha-D-galactopyranosyl-(1->6)-alpha-D-galactopyranosyl-(1->6)-alpha-D-glucopyranoside,synonym,CHEBI:28586,Verbascose,CHEBI:28586,MAPPED,unique
+beta-D-fructofuranosyl alpha-D-galactopyranosyl-(1->6)-alpha-D-galactopyranosyl-(1->6)-alpha-D-glucopyranoside,synonym,CHEBI:17164,Stachyose - 70%,CHEBI:17164,MAPPED,unique
+beta-D-fructofuranosyl alpha-D-galactopyranosyl-(1->6)-alpha-D-glucopyranoside,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+beta-D-fructofuranosyl alpha-D-glucopyranoside,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+beta-D-fructofuranosyl alpha-D-glucopyranoside,synonym,CHEBI:17992,D-Sucrose,CHEBI:17992,REJECTED,unique
+beta-D-fructofuranosyl-(2->1)-beta-D-fructofuranosyl alpha-D-glucopyranoside,synonym,CHEBI:16885,1-Kestose,CHEBI:16885,MAPPED,unique
+beta-D-Fructose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+beta-D-Fruf-(2<->1)-alpha-D-Glcp,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Beta-D-fucose,preferred_term,CHEBI:27442,Beta-D-fucose,CHEBI:27442,MAPPED,unique
+beta-D-Gal-(1->3)-beta-D-GlcNAc-(1->3)-beta-D-Gal-(1->4)-D-Glc,ontology_label,cas:14116-68-8,Lacto-N-tetraose,CHEBI:30248,MAPPED,unique
+beta-D-Gal-(1->4)-beta-D-GlcNAc-(1->3)-beta-D-Gal-(1->4)-D-Glc,ontology_label,CHEBI:60239,Lacto-N-neotetraose,CHEBI:60239,MAPPED,unique
+beta-D-Gal-(1->4)-D-Glc,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Beta-D-galacto-pyranosyl-D-arabinose,preferred_term,kgmicrobe.compound:beta-d-galacto-pyranosyl-d-arabinose,Beta-D-galacto-pyranosyl-D-arabinose,kgmicrobe.compound:beta-d-galacto-pyranosyl-d-arabinose,MAPPED,unique
+beta-D-galactopyranosyl-(1->3)-2-acetamido-2-deoxy-beta-D-glucopyranosyl-(1->3)-beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,cas:14116-68-8,Lacto-N-tetraose,CHEBI:30248,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-2-acetamido-2-deoxy-beta-D-glucopyranosyl-(1->3)-beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:60239,Lacto-N-neotetraose,CHEBI:60239,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-alpha-D-glucopyranose,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-beta-D-glucopyranose,synonym,CHEBI:36218,Beta-Lactose,CHEBI:36218,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-D-galactopyranose,ontology_label,cas:2152-98-9,"1,4-B-D-Galactobiose",CHEBI:36226,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Beta-D-galactoside,preferred_term,CHEBI:28034,Beta-D-galactoside,CHEBI:28034,MAPPED,unique
+beta-D-Galp-(1->4)-beta-D-Glcp,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+beta-D-Galp-(1->4)-D-Glcp,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+beta-D-Glcp-(1->6)-beta-D-Glcp,ontology_label,CHEBI:71422,Beta-gentiobiose,CHEBI:71422,MAPPED,unique
+beta-D-glucan,ontology_label,CHEBI:28793,b-Glucan from Oat,CHEBI:28793,MAPPED,unique
+beta-D-glucopyranosyl-(1->3)-D-glucopyranose,synonym,CHEBI:18411,Laminaribiose,CHEBI:18411,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-beta-D-glucoopyranosyl-(1->4)-beta-D-glucoopyranosyl-(1->4)-D-glucoopyranose,synonym,CHEBI:62974,Cellotetraose,CHEBI:62974,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranose,synonym,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:62976,Cellopentaose,CHEBI:62976,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:3528,Cellotriose,CHEBI:3528,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:3528,Cellotriose,CHEBI:3528,MAPPED,unique
+beta-D-glucopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+beta-D-glucopyranosyl-(1->6)-D-glucopyranose,synonym,CHEBI:28066,Gentibiose,CHEBI:28066,MAPPED,unique
+beta-D-glucopyranuronamide,synonym,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,unique
+Beta-d-glucose,preferred_term,CHEBI:15903,Beta-d-glucose,CHEBI:15903,MAPPED,unique
+beta-D-glucuronamide,ontology_label,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,unique
+Beta-D-glucuronic Acid,preferred_term,CHEBI:28860,Beta-D-glucuronic Acid,CHEBI:28860,MAPPED,unique
+beta-D-mannopyranosyl-(1->4)-D-mannopyranose,synonym,CHEBI:25164,Mannobiose,CHEBI:25164,MAPPED,unique
+beta-D-mannopyranosyl-(1->4)-D-mannose,synonym,CHEBI:25164,Mannobiose,CHEBI:25164,MAPPED,unique
+beta-D-xylopyranosyl-(1->4)-beta-D-xylopyranosyl-(1->4)-beta-D-xylopyranosyl-(1->4)-D-xylopyranose,synonym,CHEBI:62972,Xylotetraose,CHEBI:62972,MAPPED,unique
+beta-D-xylopyranosyl-(1->4)-D-xylopyranose,synonym,CHEBI:28309,Xylobiose,CHEBI:28309,MAPPED,unique
+Beta-D-xylose,preferred_term,CHEBI:28161,Beta-D-xylose,CHEBI:28161,MAPPED,unique
+beta-Fruit sugar,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+Beta-gentiobiose,preferred_term,CHEBI:71422,Beta-gentiobiose,CHEBI:71422,MAPPED,unique
+Beta-Glycerophosphate disodium salt hydrate,preferred_term,cas:154804-51-0,Beta-Glycerophosphate disodium salt hydrate,CHEBI:17270,MAPPED,unique
+beta-Hydroxy-L-alanine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+beta-Hydroxyalanine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+Beta-hydroxybutyrate,synonym,CHEBI:37054,3-hydroxybutyrate,CHEBI:37054,MAPPED,unique
+beta-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+Beta-Lactose,preferred_term,CHEBI:36218,Beta-Lactose,CHEBI:36218,MAPPED,unique
+Beta-Lapachone,preferred_term,CHEBI:10429,Beta-Lapachone,CHEBI:10429,MAPPED,unique
+beta-Levulose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+beta-Lipomycin,preferred_term,mesh:C000601869,beta-Lipomycin,mesh:C000601869,MAPPED,unique
+beta-mercaptoethanesulfonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+BETA-MERCAPTOETHANOL,synonym,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
+beta-methacrylate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+beta-methylacrylate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+beta-methylbutyric acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+beta-NAD,preferred_term,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+beta-phenyl-L-alanine,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+Beta-phenylethylamine,synonym,CHEBI:18397,2-phenylethylamine,CHEBI:18397,MAPPED,unique
+beta-pyridinecarboxamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+beta-pyridinecarboxylic acid,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+beta-Rhodomycin,ontology_label,CHEBI:81879,Rhodomycin B,CHEBI:81879,MAPPED,unique
+beta-T,synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+beta-trichloroethane,synonym,CHEBI:36018,"1,1,2-Trichloroethane",CHEBI:36018,MAPPED,unique
+beta-Uridine,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+betadex,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+Betaine,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Betaine hydrochloride,preferred_term,cas:590-46-5,Betaine hydrochloride,CHEBI:17750,MAPPED,unique
+Betaine x H2O,preferred_term,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Betanin,preferred_term,CHEBI:3080,Betanin,CHEBI:3080,MAPPED,unique
+BG-11 Medium,preferred_term,UNMAPPED_0061,BG-11 Medium,,UNMAPPED,unique
+BG-11 Trace Metals Solution,preferred_term,kgmicrobe.ingredient:bg-11_trace_metals_solution,BG-11 Trace Metals Solution,kgmicrobe.ingredient:bg-11_trace_metals_solution,MAPPED,unique
+BH(OH)2,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
+BHC,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+BHI,preferred_term,kgmicrobe.ingredient:bhi,BHI,kgmicrobe.ingredient:bhi,MAPPED,unique
+bicarbonate of soda,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Bicine,preferred_term,CHEBI:40957,Bicine,CHEBI:40957,REJECTED,unique
+Bicine,synonym,CHEBI:40957,BICINE buffer,CHEBI:40957,MAPPED,unique
+BICINE buffer,preferred_term,CHEBI:40957,BICINE buffer,CHEBI:40957,MAPPED,unique
+bicozamycin,ontology_label,CHEBI:60584,Bicyclomycin,CHEBI:60584,MAPPED,unique
+Bicyclomycin,preferred_term,CHEBI:60584,Bicyclomycin,CHEBI:60584,MAPPED,unique
+Bile Acid,preferred_term,CHEBI:3098,Bile Acid,CHEBI:3098,MAPPED,unique
+bile salt,ontology_label,CHEBI:22868,Bile salts,CHEBI:22868,MAPPED,unique
+Bile salts,preferred_term,CHEBI:22868,Bile salts,CHEBI:22868,MAPPED,unique
+Biletan,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Bilineurin chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Bilineurine,synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+bilorin,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Bimuno,preferred_term,NCIT:C187267,Bimuno,NCIT:C187267,MAPPED,unique
+Biochanin a diacetate,preferred_term,cas:54443-59-3,Biochanin a diacetate,cas:54443-59-3,MAPPED,unique
+Biocolina,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Biocoline,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Bioecolians,preferred_term,UNMAPPED_0207,Bioecolians,,UNMAPPED,unique
+Bios I,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+Biotin,preferred_term,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Biotin (Vitamin B7),synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Biotin Vitamin Solution,preferred_term,kgmicrobe.ingredient:biotin_vitamin_solution,Biotin Vitamin Solution,MICRO:0000460,MAPPED,unique
+biotina,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Biotine,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+biotinum,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Biphenyl,preferred_term,CHEBI:17097,Biphenyl,CHEBI:17097,MAPPED,unique
+"biphenyl-4,4'-diol",ontology_label,CHEBI:34367,"4,4'-dihydroxybiphenyl",CHEBI:34367,MAPPED,unique
+Bipotassium chromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+bis(2-cyanoethan-1-aminium) (2E)-but-2-enedioate,synonym,CHEBI:91084,3-Aminopropionitrile Fumarate,CHEBI:91084,MAPPED,unique
+bis(2-ethylhexyl) phthalate,ontology_label,CHEBI:17747,Bis(2-ethylhexyl)phthalate,CHEBI:17747,MAPPED,unique
+Bis(2-ethylhexyl)phthalate,preferred_term,CHEBI:17747,Bis(2-ethylhexyl)phthalate,CHEBI:17747,MAPPED,unique
+Bis(3-aminopropyl)amine,preferred_term,CHEBI:16841,Bis(3-aminopropyl)amine,CHEBI:16841,MAPPED,unique
+bis(beta-amino-beta-carboxyethyl) disulfide,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+bis(dioxidosulfate)(S--S)(2-),synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+bis(hydridooxygen)(O--O),synonym,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
+bis(oxido)manganese,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+BIS-2-HYDROXY-IMINO-TRIS-HYDROXYMETHYL-METHANE,synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+Bis-4-nitrophenyl Phosphate,preferred_term,CHEBI:3122,Bis-4-nitrophenyl Phosphate,CHEBI:3122,MAPPED,unique
+Bis-4-nitrophenyl-phenyl Phosphonate,preferred_term,kgmicrobe.compound:bis-4-nitrophenyl-phenyl_phosphonate,Bis-4-nitrophenyl-phenyl Phosphonate,kgmicrobe.compound:bis-4-nitrophenyl-phenyl_phosphonate,MAPPED,unique
+Bis-4-nitrophenyl-phosphorylcholine,preferred_term,kgmicrobe.compound:bis-4-nitrophenyl-phosphorylcholine,Bis-4-nitrophenyl-phosphorylcholine,kgmicrobe.compound:bis-4-nitrophenyl-phosphorylcholine,MAPPED,unique
+Bis-Tris,preferred_term,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+bis[pyridine-2-thiolato-kappaS 1(oxide-kappaO)]zinc,synonym,CHEBI:32076,Zinc Pyrithione,CHEBI:32076,MAPPED,unique
+Bisabolene,preferred_term,CHEBI:49235,Bisabolene,CHEBI:49235,MAPPED,unique
+Bisabolol,synonym,CHEBI:125,(-)-alpha-bisabolol,CHEBI:125,MAPPED,unique
+bisammonium dioxido(dioxo)molybdenum,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,conflict:different_substances
+bisammonium dioxido(dioxo)molybdenum,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,conflict:different_substances
+bisammonium ethanedioate,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+bismuth(III) chloride,preferred_term,cas:7787-60-2,bismuth(III) chloride,cas:7787-60-2,MAPPED,unique
+Bisodium tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+bistris,synonym,CHEBI:41250,Bis-Tris,CHEBI:41250,MAPPED,unique
+Bisulase,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+bitter salt,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+BL Agar,preferred_term,UNMAPPED_0114,BL Agar,,UNMAPPED,unique
+black manganese oxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Blasticidin A,preferred_term,CHEBI:218571,Blasticidin A,CHEBI:218571,MAPPED,unique
+Blasticidin S,preferred_term,CHEBI:15353,Blasticidin S,CHEBI:15353,MAPPED,unique
+Bleomycin,preferred_term,CHEBI:22907,Bleomycin,CHEBI:22907,MAPPED,unique
+Bleomycin sulfate,preferred_term,CHEBI:34582,Bleomycin sulfate,CHEBI:34582,MAPPED,unique
+bleu de methylene,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Blood Agar Base,preferred_term,UNMAPPED_0339,Blood Agar Base,,UNMAPPED,unique
+Blood agar No 2,preferred_term,UNMAPPED_0340,Blood agar No 2,,UNMAPPED,unique
+blood serum,ontology_label,UBERON:0001977,Serum,UBERON:0001977,MAPPED,unique
+Bluensomycin,preferred_term,CHEBI:81193,Bluensomycin,CHEBI:81193,MAPPED,resolved:owned
+Bluensomycin,ontology_label,NCIT:C90636,Glebomycin,NCIT:C90636,MAPPED,resolved:owned
+boiled in 10% ethanol,synonym,UNMAPPED_0247,b-glucan from Barley,,UNMAPPED,unique
+Bold 1NV Medium,preferred_term,UNMAPPED_0051,Bold 1NV Medium,,UNMAPPED,unique
+Bold Trace Stock,preferred_term,kgmicrobe.ingredient:bold_trace_stock,Bold Trace Stock,kgmicrobe.ingredient:bold_trace_stock,MAPPED,unique
+Boldine,preferred_term,CHEBI:3148,Boldine,CHEBI:3148,MAPPED,unique
+borax,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Bordet-Gengou-Agar-Base,preferred_term,UNMAPPED_0341,Bordet-Gengou-Agar-Base,,UNMAPPED,unique
+Boric acid,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+Borneol,preferred_term,CHEBI:28093,Borneol,CHEBI:28093,MAPPED,unique
+Boron Stock,preferred_term,kgmicrobe.ingredient:boron_stock,Boron Stock,kgmicrobe.ingredient:boron_stock,MAPPED,unique
+boron trihydroxide,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+boronic acid,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
+Borrelidin,preferred_term,CHEBI:78661,Borrelidin,CHEBI:78661,MAPPED,unique
+Bottromycin,preferred_term,mesh:C024712,Bottromycin,mesh:C024712,MAPPED,unique
+Bovine albumin,preferred_term,MICRO:0000307,Bovine albumin,MICRO:0000307,MAPPED,unique
+Bovine calf serum,preferred_term,MICRO:0001709,Bovine calf serum,MICRO:0001709,MAPPED,unique
+Bovine horn meal,preferred_term,UNMAPPED_0344,Bovine horn meal,,UNMAPPED,unique
+Bovine serum,preferred_term,UNMAPPED_0345,Bovine serum,,UNMAPPED,unique
+bovine serum albumin,preferred_term,cas:9048-46-8,bovine serum albumin,NCIT:C85253,MAPPED,unique
+brain,ontology_label,UNMAPPED_0170,Calf brains,UBERON:0000955,UNMAPPED,unique
+Brain heart infusion,preferred_term,MICRO:0000193,Brain heart infusion,MICRO:0000193,MAPPED,unique
+brain heart infusion,ontology_label,MICRO:0000193,Bacto brain heart infusion,MICRO:0000193,MAPPED,unique
+brain heart infusion,ontology_label,MICRO:0000193,Brain heart infusion broth,MICRO:0000193,MAPPED,unique
+Brain heart infusion broth,preferred_term,MICRO:0000193,Brain heart infusion broth,MICRO:0000193,MAPPED,unique
+Brazilein,preferred_term,CHEBI:69196,Brazilein,CHEBI:69196,MAPPED,unique
+Brenzcatechin,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+Brenztraubensaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+Brewer anaerobic agar,preferred_term,UNMAPPED_0116,Brewer anaerobic agar,,UNMAPPED,unique
+Bristol Medium,preferred_term,UNMAPPED_0023,Bristol Medium,,UNMAPPED,unique
+Bromide salt of sodium,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
+Bromnatrium,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
+Bromocresol purple,preferred_term,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+"bromocresol purple""",synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+Bromosuccinate,preferred_term,CHEBI:73706,Bromosuccinate,CHEBI:73706,MAPPED,unique
+Bromothymol blue,preferred_term,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
+bromothymol sulfone phthalein,synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
+Bromthymol blue,synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
+Bronopol,ontology_label,CHEBI:31306,"2-bromo-2-nitro-1,3-propanediol",CHEBI:31306,MAPPED,unique
+Brucella agar,preferred_term,MICRO:0000595,Brucella agar,MICRO:0000595,MAPPED,unique
+Brucella Broth,preferred_term,UNMAPPED_0348,Brucella Broth,,UNMAPPED,unique
+Brucine,preferred_term,CHEBI:3193,Brucine,CHEBI:3193,MAPPED,unique
+Bryamycin,synonym,CHEBI:29693,Thiostrepton,CHEBI:29693,MAPPED,unique
+BTS,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+Burnt potassium alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Butamine,preferred_term,kgmicrobe.compound:butamine,Butamine,kgmicrobe.compound:butamine,MAPPED,unique
+Butan-1-amine,preferred_term,CHEBI:43799,Butan-1-amine,CHEBI:43799,MAPPED,unique
+butan-1-ol,ontology_label,CHEBI:28885,Butanol,CHEBI:28885,MAPPED,unique
+Butandisaeure,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Butane-1,synonym,CHEBI:41189,"1,4-Butanediol",CHEBI:41189,MAPPED,unique
+Butane-1,synonym,CHEBI:41189,"Butane-1,4-diol",CHEBI:41189,REJECTED,unique
+"butane-1,3-diol",ontology_label,CHEBI:52683,"1,3-Butanediol",CHEBI:52683,MAPPED,unique
+"Butane-1,4-diamine",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+"butane-1,4-diamine;dihydrochloride",synonym,cas:333-93-7,Putrescine Dihydrochloride,CHEBI:201718,MAPPED,unique
+"Butane-1,4-diol",preferred_term,CHEBI:41189,"Butane-1,4-diol",CHEBI:41189,REJECTED,unique
+"Butane-1,4-diol",synonym,CHEBI:41189,"1,4-Butanediol",CHEBI:41189,MAPPED,unique
+"butane-2,3-diol",synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"butane-2,3-dione",ontology_label,CHEBI:16583,Diacetyl,CHEBI:16583,MAPPED,unique
+butane-2-carboxylic acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+butanedioic acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Butanedionic acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+butanic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+BUTANOIC ACID,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+"Butanoic acid, sodium salt",synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+"Butanoic acid, sodium salt (1:1)",synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Butanol,preferred_term,CHEBI:28885,Butanol,CHEBI:28885,MAPPED,unique
+butoic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+butter of zinc,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+Buttersaeure,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+butyl octadecanoate,ontology_label,CHEBI:85983,Butyl stearate,CHEBI:85983,MAPPED,unique
+Butyl stearate,preferred_term,CHEBI:85983,Butyl stearate,CHEBI:85983,MAPPED,unique
+Butyl vinyl ether,preferred_term,mesh:C521980,Butyl vinyl ether,mesh:C521980,MAPPED,unique
+butylacetic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+butylenediamine,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+Butyrate,preferred_term,CHEBI:17968,Butyrate,CHEBI:17968,MAPPED,unique
+Butyrate (sodium salt),synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Butyrate sodium,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Butyric acid,preferred_term,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+Butyric acid sodium salt,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+"Butyric acid, sodium salt",synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Butyricin 7423,preferred_term,mesh:C010427,Butyricin 7423,mesh:C010427,MAPPED,unique
+Butyrolactam,preferred_term,CHEBI:36592,Butyrolactam,CHEBI:36592,MAPPED,unique
+C.I. 42000,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+C.I. 52015,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+C.I. 73015,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+C.I. 75781,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+C.I. Acid Blue 74,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+C.I. Basic Green 4,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+C.I. Food Blue 1,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"C.I. Food Blue 1, disodium salt",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+C.I. Natural Blue 2,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+C18:1 n-9,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+C2H5OH,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Ca,preferred_term,UNMAPPED_0049,Ca,,UNMAPPED,unique
+Ca pantotenate,synonym,CHEBI:31345,Ca-pantothenate,CHEBI:31345,REJECTED,unique
+Ca(NO3)2,preferred_term,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+Ca(NO3)2 x 4 H2O,preferred_term,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2 x 4 H2O (0.1% w/v),synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2 · 4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2.4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2x4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2·4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2•4H2O(CAS: 13477-34-4),synonym,UNMAPPED_0049,Ca,,UNMAPPED,unique
+Ca(NO3)2・4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca-folinate,preferred_term,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
+Ca-pantothenate,preferred_term,CHEBI:31345,Ca-pantothenate,CHEBI:31345,REJECTED,unique
+Ca-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+CaCl .6H O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
+CaCl 2 X 2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2,preferred_term,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
+CaCl2  x 2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 . 2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 . 7H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2 . 7H2O,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2 x  2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2 H2O,preferred_term,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2 H2O (0.1% w/v),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2 H2O (50 g/l stock solution),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2 H2O (5M),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2 H2O solution (7%),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 x 6 H2O,preferred_term,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+CaCl2 x 7 H2O,preferred_term,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,resolved:owned
+CaCl2 x 7 H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,resolved:owned
+CaCl2 x H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2 x H2O,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2 x2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 · 2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2 × 2 H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2 × 2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,conflict:different_substances
+CaCl2 × 2 H2O,synonym,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,conflict:different_substances
+CaCl2 × 2 H2O,synonym,CHEBI:86158,CaCl22H2O,CHEBI:86158,REJECTED,conflict:different_substances
+CaCl2*2H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2*2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,conflict:different_substances
+CaCl2*2H2O,synonym,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,conflict:different_substances
+CaCl2*2H2O,synonym,CHEBI:86158,CaCl22H2O,CHEBI:86158,REJECTED,conflict:different_substances
+CaCl2. 2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2.2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2.6H2O,synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+CaCl22H2O,preferred_term,CHEBI:86158,CaCl22H2O,CHEBI:86158,REJECTED,resolved:owned
+CaCl22H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,resolved:owned
+CaCl22H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,resolved:owned
+CaCl22H2O,synonym,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,resolved:owned
+CaCl2x 2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2x2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2x6H2O,synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+CaCl2·2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2·6H2O,synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+CaCl2·H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2·H2O,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2•2H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2•2H2O (Sigma C-3881),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2•2H2O(CAS: 10035-04-8),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2•2H2O(Sigma C-3881),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+CaCl2⋅7H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2⋅7H2O,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2・6 H2O,synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+CaCl2・H2O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+CaCl2・H2O,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+CaCO3,preferred_term,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+CaCO3(Fisher C 64),synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+CaCO3(optional) (Fisher C 64),synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+CaCO3(optional)(Fisher C 64),synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Cadaverine,preferred_term,CHEBI:18127,Cadaverine,CHEBI:18127,MAPPED,unique
+cadmium acetate,ontology_label,cas:5743-04-4,Cadmium acetate dihydrate,CHEBI:232796,MAPPED,unique
+Cadmium acetate dihydrate,preferred_term,cas:5743-04-4,Cadmium acetate dihydrate,CHEBI:232796,MAPPED,unique
+Cadmium chloride hemipentahydrate,preferred_term,CHEBI:63938,Cadmium chloride hemipentahydrate,CHEBI:63938,MAPPED,unique
+cadmium dichloride hemipentahydrate,ontology_label,CHEBI:63938,Cadmium chloride hemipentahydrate,CHEBI:63938,MAPPED,unique
+cadmium dinitrate,synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,conflict:different_substances
+cadmium dinitrate,synonym,CHEBI:77732,cadmium nitrate,CHEBI:77732,MAPPED,conflict:different_substances
+Cadmium dinitrate tetrahydrate,synonym,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+cadmium nitrate,preferred_term,CHEBI:77732,cadmium nitrate,CHEBI:77732,MAPPED,resolved:owned
+cadmium nitrate,synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,resolved:owned
+cadmium nitrate tetrahydrate,synonym,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+cadmium nitrate--water (1/4),synonym,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+cadmium(2+);diacetate,synonym,cas:5743-04-4,Cadmium acetate dihydrate,CHEBI:232796,MAPPED,unique
+Cadmium(II) nitrate,synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+Cadmium(II) nitrate tetrahydrate (1:2:4),synonym,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+Cadmium-NTA,preferred_term,UNMAPPED_0156,Cadmium-NTA,,UNMAPPED,unique
+caesium chloride,ontology_label,CHEBI:63039,Cesium chloride,CHEBI:63039,MAPPED,unique
+caffeic acid,preferred_term,CHEBI:36281,caffeic acid,CHEBI:36281,MAPPED,unique
+Caffeine,preferred_term,CHEBI:27732,Caffeine,CHEBI:27732,MAPPED,unique
+Caffeine Hydrobromide,preferred_term,cas:5743-18-0,Caffeine Hydrobromide,cas:5743-18-0,MAPPED,unique
+CaHPO4,preferred_term,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+"calcium bis[(3R,5S,6E)-7-{4-(4-fluorophenyl)-6-isopropyl-2-[methyl(methylsulfonyl)amino]pyrimidin-5-yl}-3,5-dihydroxyhept-6-enoate]",synonym,CHEBI:77249,Rosuvastatin calcium,CHEBI:77249,MAPPED,unique
+"calcium bis{(3R,5R)-7-[3-(anilinocarbonyl)-5-(4-fluorophenyl)-2-isopropyl-4-phenyl-1H-pyrrol-1-yl]-3,5-dihydroxyheptanoate} trihydrate",synonym,CHEBI:2911,Atorvastatin calcium salt trihydrate,CHEBI:2911,MAPPED,unique
+Calcium Carbonate,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+calcium carbonate (1:1),synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Calcium Chloride,preferred_term,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,resolved:owned
+Calcium chloride,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,resolved:owned
+calcium chloride,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,resolved:owned
+calcium chloride,synonym,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,resolved:owned
+Calcium chloride anhydrous,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+Calcium chloride anhydrous,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+Calcium chloride dihydrate,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+calcium chloride dihydrate,ontology_label,CHEBI:86158,CaCl22H2O,CHEBI:86158,REJECTED,unique
+calcium chloride hexahydrate,synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+calcium chloride--water (1/2),synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
+calcium chloride--water (1/2),synonym,CHEBI:86158,CaCl22H2O,CHEBI:86158,REJECTED,unique
+calcium chloride--water (1/6),synonym,CHEBI:91243,CaCl2 x 6 H2O,CHEBI:91243,MAPPED,unique
+"calcium D,L-pantothenate",synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Calcium D-(+)-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Calcium D-Pantothenate,preferred_term,CHEBI:31345,Calcium D-Pantothenate,CHEBI:31345,REJECTED,unique
+Calcium D-Pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+calcium dichloride,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
+calcium dichloride,ontology_label,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
+calcium dichloride,ontology_label,CHEBI:3312,Calcium Chloride,CHEBI:3312,REJECTED,conflict:different_substances
+calcium dinitrate,synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+Calcium dinitrate tetrahydrate,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Calcium folinate,synonym,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
+calcium hydrogen phosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+calcium hydrogenphosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+calcium nitrate,ontology_label,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+Calcium nitrate tetrahydrate,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+calcium nitrate--water (1/4),synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Calcium panthothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Calcium pantothenate,preferred_term,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Calcium pantothenate,ontology_label,CHEBI:31345,Ca-pantothenate,CHEBI:31345,REJECTED,unique
+Calcium pantothenate,ontology_label,CHEBI:31345,Calcium D-Pantothenate,CHEBI:31345,REJECTED,unique
+Calcium sulfate,synonym,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
+calcium sulfate,ontology_label,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+calcium sulfate dihydrate,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+"calcium sulfate, anhydrous",synonym,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+calcium sulfate--water (1/2),synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+calcium sulphate,synonym,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
+calcium trioxidocarbonate,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Calcium(2+),preferred_term,CHEBI:29108,Calcium(2+),CHEBI:29108,MAPPED,unique
+"calcium(II) sulfate, dihydrate (1:1:2)",synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+Calciumcarbonat,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Calcium pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Calf brains,preferred_term,UNMAPPED_0170,Calf brains,UBERON:0000955,UNMAPPED,unique
+calf serum,ontology_label,MICRO:0001709,Bovine calf serum,MICRO:0001709,MAPPED,unique
+Calprotectin,preferred_term,NCIT:C105971,Calprotectin,NCIT:C105971,MAPPED,unique
+Calprotectin S1,preferred_term,UNMAPPED_0229,Calprotectin S1,,UNMAPPED,unique
+Calprotectin S1S2,preferred_term,UNMAPPED_0230,Calprotectin S1S2,,UNMAPPED,unique
+Camphomycin,preferred_term,kgmicrobe.compound:camphomycin,Camphomycin,kgmicrobe.compound:camphomycin,MAPPED,unique
+Camptothecin,preferred_term,CHEBI:27656,Camptothecin,CHEBI:27656,MAPPED,unique
+Canarius,preferred_term,kgmicrobe.compound:canarius,Canarius,kgmicrobe.compound:canarius,MAPPED,unique
+Canavanine,preferred_term,CHEBI:609827,Canavanine,CHEBI:609827,MAPPED,unique
+Candicidin,ontology_label,mesh:D002174,Levorin,mesh:D002174,MAPPED,unique
+Candimycin,preferred_term,kgmicrobe.compound:candimycin,Candimycin,kgmicrobe.compound:candimycin,MAPPED,unique
+Candiplanecin,preferred_term,mesh:C033379,Candiplanecin,mesh:C033379,MAPPED,unique
+Cane sugar,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Cantharidin,preferred_term,CHEBI:64213,Cantharidin,CHEBI:64213,MAPPED,unique
+Capecitabine,preferred_term,CHEBI:31348,Capecitabine,CHEBI:31348,MAPPED,unique
+Capreomycin,preferred_term,CHEBI:3371,Capreomycin,CHEBI:3371,MAPPED,unique
+Caproic acid,preferred_term,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+Caprolactam,preferred_term,CHEBI:28579,Caprolactam,CHEBI:28579,MAPPED,unique
+Capronic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+Caprylic acid,synonym,CHEBI:28837,Octanoic acid,CHEBI:28837,MAPPED,unique
+Caprylic acid sodium salt,synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+CAPS,synonym,CHEBI:191088,CAPS buffer,CHEBI:191088,MAPPED,unique
+CAPS buffer,preferred_term,CHEBI:191088,CAPS buffer,CHEBI:191088,MAPPED,unique
+capsaicin,preferred_term,CHEBI:3374,capsaicin,CHEBI:3374,MAPPED,unique
+CAPSO,preferred_term,CHEBI:183882,CAPSO,CHEBI:183882,MAPPED,unique
+Carbamide,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Carbenicillin,preferred_term,CHEBI:3393,Carbenicillin,CHEBI:3393,MAPPED,unique
+carbenicillin disodium,ontology_label,CHEBI:34609,Carbenicillin disodium salt,CHEBI:34609,MAPPED,unique
+Carbenicillin disodium salt,preferred_term,CHEBI:34609,Carbenicillin disodium salt,CHEBI:34609,MAPPED,unique
+carbinol,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+carbocerate,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+carbohydrate,ontology_label,kgmicrobe.compound:sugars,Sugars,CHEBI:16646,MAPPED,unique
+carbolic acid,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Carbolsaeure,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Carbomycin,preferred_term,NCIT:C166659,Carbomycin,NCIT:C166659,MAPPED,unique
+Carbon dioxide,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+carbon dioxide,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+Carbon dioxide gas,preferred_term,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+Carbon Monoxide,preferred_term,CHEBI:17245,Carbon Monoxide,CHEBI:17245,MAPPED,unique
+Carbon source solution,preferred_term,kgmicrobe.ingredient:carbon_source_solution,Carbon source solution,kgmicrobe.ingredient:carbon_source_solution,MAPPED,unique
+carbonate de calcium,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Carbonate of potash,synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+carbonato de calcio,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+carbonic acid calcium salt (1:1),synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+carbonic acid monosodium salt,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+"Carbonic acid, dipotassium salt",synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+carbonic anhydride,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+carbonyl cyanide p-trifluoromethoxyphenylhydrazone,ontology_label,CHEBI:75458,FCCP,CHEBI:75458,MAPPED,unique
+carbonyldiamide,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Carboximethylcellulosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+carboxyethane,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Carboxymethyl cellulose,preferred_term,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carboxymethyl cellulose (sodium salt),synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carboxymethylcellulose,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carboxymethylcellulose sodium,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+carboxymethylcellulose sodium salt,ontology_label,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carboxymethylcellulosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carcinomycin,preferred_term,kgmicrobe.compound:carcinomycin,Carcinomycin,kgmicrobe.compound:carcinomycin,MAPPED,unique
+carmellosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+carmelosa,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Carminate,preferred_term,CHEBI:149531,Carminate,CHEBI:149531,MAPPED,unique
+carminate(2-),ontology_label,CHEBI:149531,Carminate,CHEBI:149531,MAPPED,unique
+Carminomycin,preferred_term,CHEBI:31359,Carminomycin,CHEBI:31359,MAPPED,unique
+carnitine,ontology_label,CHEBI:17126,DL-carnitine,CHEBI:17126,MAPPED,unresolved:partial_chemistry
+carnitine,ontology_label,cas:461-06-3,Carnitine (Dl) Hydrochloride,CHEBI:17126,MAPPED,unresolved:partial_chemistry
+carnitine,ontology_label,kgmicrobe.compound:carnitine_hydrochloride,Carnitine Hydrochloride,CHEBI:17126,MAPPED,unresolved:partial_chemistry
+Carnitine (Dl) Hydrochloride,preferred_term,cas:461-06-3,Carnitine (Dl) Hydrochloride,CHEBI:17126,MAPPED,unique
+Carnitine Hydrochloride,preferred_term,kgmicrobe.compound:carnitine_hydrochloride,Carnitine Hydrochloride,CHEBI:17126,MAPPED,unique
+Carnosic Acid,preferred_term,CHEBI:65585,Carnosic Acid,CHEBI:65585,MAPPED,unique
+Carotenoid,preferred_term,CHEBI:23044,Carotenoid,CHEBI:23044,MAPPED,unique
+Carrageenan,preferred_term,CHEBI:3435,Carrageenan,CHEBI:3435,MAPPED,unique
+Carrot,preferred_term,NCIT:C72000,Carrot,NCIT:C72000,MAPPED,unique
+Caryomycin,preferred_term,kgmicrobe.compound:caryomycin,Caryomycin,kgmicrobe.compound:caryomycin,MAPPED,unique
+Caryophyllene [T(-)],preferred_term,CHEBI:10357,Caryophyllene [T(-)],CHEBI:10357,MAPPED,unique
+Casamino Acid,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+Casamino acids,preferred_term,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,resolved:owned
+casamino acids,ontology_label,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,resolved:owned
+Casamino Acids (0.01 %,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+Casamino acids (vit. assay),synonym,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
+Casamino acids (vitamin assay),preferred_term,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
+Casaminoacids,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+Casein,preferred_term,FOODON:03420180,Casein,FOODON:03420180,MAPPED,unique
+Casein Enzymic Hydrolysate,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Casein enzymic hydrolysate,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Casein hydrolysate,preferred_term,MICRO:0001366,Casein hydrolysate,MICRO:0001366,MAPPED,resolved:owned
+Casein hydrolysate,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,resolved:owned
+casein hydrolysate,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,resolved:owned
+"Casein hydrolysate (NZ Case TT, Quest International)",synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+casein hydrolyzate acid,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Casein peptone,preferred_term,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+"Casein peptone, tryptic digest",synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+"Casein peptone, tryptic digested",synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Caseine peptone,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Casitone,preferred_term,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
+Casitone (BD--Difco),synonym,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
+Casitone (BD-BBL),synonym,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
+Casitone (BD-Difco),synonym,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
+Casitone + Yeast Extract + Rumen Fluid,preferred_term,kgmicrobe.ingredient:casitone_yeast_extract_rumen_fluid,Casitone + Yeast Extract + Rumen Fluid,kgmicrobe.ingredient:casitone_yeast_extract_rumen_fluid,MAPPED,unique
+Casman-Agar-Base,preferred_term,UNMAPPED_0353,Casman-Agar-Base,,UNMAPPED,unique
+Casmino Acid,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+Casmino acids,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+CaSO4,preferred_term,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
+CaSO4 . 2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4 x 2 H2O,preferred_term,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4 x 2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4 x 7 H2O,preferred_term,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+CaSO4 x2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4 · 2 H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4 · 2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4.2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4·2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4•2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4•2H2O(Mallinckroft 4300),synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4•2H2Osaturated solution,preferred_term,kgmicrobe.ingredient:caso42h2osaturated_solution,CaSO4•2H2Osaturated solution,kgmicrobe.ingredient:caso42h2osaturated_solution,MAPPED,unique
+CaSO4•2H2Osaturated solution (Mallinckroft 4300),synonym,kgmicrobe.ingredient:caso42h2osaturated_solution,CaSO4•2H2Osaturated solution,kgmicrobe.ingredient:caso42h2osaturated_solution,MAPPED,unique
+CaSO4・2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4・7H2O,synonym,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+Catalase,preferred_term,NCIT:C61062,Catalase,NCIT:C61062,MAPPED,unique
+catechol,ontology_label,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+catechol-3-carboxylic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+catena-poly[(oxidoarsenate-mu-oxido)]sodium,synonym,CHEBI:29678,Sodium m-arsenite,CHEBI:29678,MAPPED,unique
+caustic potash,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+caustic soda,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+Cbl,synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+CCCP,preferred_term,CHEBI:3259,CCCP,CHEBI:3259,MAPPED,unique
+CCRIS 3494,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+Cd(NO3)2,synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+Cd(NO3)2 x 4 H2O,preferred_term,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+Cd(NO3)2.4H2O,synonym,CHEBI:86156,Cd(NO3)2 x 4 H2O,CHEBI:86156,MAPPED,unique
+CeCl3,preferred_term,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
+CeCl3 x 7 H2O,preferred_term,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:35458,MAPPED,unique
+Cecropin A,preferred_term,CHEBI:201428,Cecropin A,CHEBI:201428,MAPPED,unique
+Cecropin B,preferred_term,CHEBI:201469,Cecropin B,CHEBI:201469,MAPPED,unique
+Cedrelone,preferred_term,CHEBI:197237,Cedrelone,CHEBI:197237,MAPPED,unique
+Cefaclor,preferred_term,CHEBI:3478,Cefaclor,CHEBI:3478,MAPPED,unique
+Cefadroxil,preferred_term,CHEBI:3479,Cefadroxil,CHEBI:3479,MAPPED,unique
+Cefaloridine,preferred_term,CHEBI:3537,Cefaloridine,CHEBI:3537,MAPPED,unique
+Cefalotin,preferred_term,CHEBI:124991,Cefalotin,CHEBI:124991,MAPPED,unique
+Cefamandole,preferred_term,CHEBI:3480,Cefamandole,CHEBI:3480,MAPPED,unique
+Cefazolin,preferred_term,CHEBI:474053,Cefazolin,CHEBI:474053,MAPPED,unique
+cefazolin sodium,ontology_label,CHEBI:3483,Cefazolin sodium salt,CHEBI:3483,MAPPED,unique
+Cefazolin sodium salt,preferred_term,CHEBI:3483,Cefazolin sodium salt,CHEBI:3483,MAPPED,unique
+Cefepime,preferred_term,CHEBI:478164,Cefepime,CHEBI:478164,MAPPED,unique
+Cefixime,preferred_term,CHEBI:472657,Cefixime,CHEBI:472657,MAPPED,unique
+Cefmetazole,preferred_term,CHEBI:3489,Cefmetazole,CHEBI:3489,MAPPED,unique
+Cefminox,preferred_term,CHEBI:135817,Cefminox,CHEBI:135817,MAPPED,unique
+Cefoperazone,preferred_term,CHEBI:3493,Cefoperazone,CHEBI:3493,MAPPED,unique
+Cefotaxime,preferred_term,CHEBI:204928,Cefotaxime,CHEBI:204928,MAPPED,unique
+cefotaxime sodium,ontology_label,CHEBI:3498,Cefotaxime sodium salt,CHEBI:3498,MAPPED,unique
+Cefotaxime sodium salt,preferred_term,CHEBI:3498,Cefotaxime sodium salt,CHEBI:3498,MAPPED,unique
+Cefotetan,preferred_term,CHEBI:3499,Cefotetan,CHEBI:3499,MAPPED,unique
+Cefotiam,preferred_term,CHEBI:355510,Cefotiam,CHEBI:355510,MAPPED,unique
+Cefoxitin,preferred_term,CHEBI:209807,Cefoxitin,CHEBI:209807,MAPPED,unique
+Cefoxitin sodium,ontology_label,CHEBI:3501,Cefoxitin sodium salt,CHEBI:3501,MAPPED,unique
+Cefoxitin sodium salt,preferred_term,CHEBI:3501,Cefoxitin sodium salt,CHEBI:3501,MAPPED,unique
+Cefpodoxime,preferred_term,CHEBI:3504,Cefpodoxime,CHEBI:3504,MAPPED,unique
+Cefprozil,preferred_term,CHEBI:3506,Cefprozil,CHEBI:3506,MAPPED,unique
+Cefsulodin sodium,ontology_label,kgmicrobe.compound:cefsulodin_sodium_salt_hydrate,Cefsulodin sodium salt hydrate,CHEBI:31380,MAPPED,unique
+Cefsulodin sodium salt hydrate,preferred_term,kgmicrobe.compound:cefsulodin_sodium_salt_hydrate,Cefsulodin sodium salt hydrate,CHEBI:31380,MAPPED,unique
+Ceftazidime,preferred_term,CHEBI:3508,Ceftazidime,CHEBI:3508,MAPPED,resolved:owned
+ceftazidime,ontology_label,cas:120618-65-7,Ceftazidime hydrate,CHEBI:3508,MAPPED,resolved:owned
+Ceftazidime hydrate,preferred_term,cas:120618-65-7,Ceftazidime hydrate,CHEBI:3508,MAPPED,unique
+Ceftriaxone,preferred_term,CHEBI:29007,Ceftriaxone,CHEBI:29007,MAPPED,unique
+Ceftriaxone disodium salt hemi(heptahydrate),preferred_term,CHEBI:3514,Ceftriaxone disodium salt hemi(heptahydrate),CHEBI:3514,MAPPED,unique
+Ceftriaxone disodium salt hemiheptahydrate,ontology_label,CHEBI:3514,Ceftriaxone disodium salt hemi(heptahydrate),CHEBI:3514,MAPPED,unique
+Cefuroxime,preferred_term,CHEBI:3515,Cefuroxime,CHEBI:3515,MAPPED,unique
+Cefuroxime Sodium,preferred_term,CHEBI:3517,Cefuroxime Sodium,CHEBI:3517,MAPPED,unique
+Celesticetin,preferred_term,CHEBI:156421,Celesticetin,CHEBI:156421,MAPPED,unique
+Cell lysate,preferred_term,BTO:0004304,Cell lysate,BTO:0004304,MAPPED,unique
+Cellobiose,preferred_term,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+Cellohexaose,preferred_term,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
+Cellopentaose,preferred_term,CHEBI:62976,Cellopentaose,CHEBI:62976,MAPPED,unique
+cellose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+Cellostatin,preferred_term,kgmicrobe.compound:cellostatin,Cellostatin,kgmicrobe.compound:cellostatin,MAPPED,unique
+Cellotetraose,preferred_term,CHEBI:62974,Cellotetraose,CHEBI:62974,MAPPED,unique
+Cellotriose,preferred_term,CHEBI:3528,Cellotriose,CHEBI:3528,MAPPED,unique
+Cellulose,preferred_term,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+Cellulose MN 300,preferred_term,UNMAPPED_0354,Cellulose MN 300,,UNMAPPED,unique
+Celluloseglycolic acid,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+CeNO33 x 6 H2O,preferred_term,UNMAPPED_0355,CeNO33 x 6 H2O,,UNMAPPED,unique
+Cephalexin,preferred_term,CHEBI:3534,Cephalexin,CHEBI:3534,MAPPED,unique
+Cephalosporin,preferred_term,CHEBI:23066,Cephalosporin,CHEBI:23066,MAPPED,unique
+Cephalothin,preferred_term,NCIT:C62021,Cephalothin,NCIT:C62021,MAPPED,unique
+cephalothin sodium,ontology_label,CHEBI:3542,Cephalothin sodium salt,CHEBI:3542,MAPPED,unique
+Cephalothin sodium salt,preferred_term,CHEBI:3542,Cephalothin sodium salt,CHEBI:3542,MAPPED,unique
+cephamycin,ontology_label,kgmicrobe.compound:cephamycin_a,Cephamycin A,CHEBI:55429,MAPPED,unique
+Cephamycin A,preferred_term,kgmicrobe.compound:cephamycin_a,Cephamycin A,CHEBI:55429,MAPPED,unique
+Cephradine,preferred_term,CHEBI:3547,Cephradine,CHEBI:3547,MAPPED,unique
+Cereal leaves,preferred_term,UNMAPPED_0356,Cereal leaves,,UNMAPPED,unique
+cerium chloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
+cerium trichloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,conflict:different_substances
+cerium trichloride,ontology_label,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:35458,MAPPED,conflict:different_substances
+cerium(3+) chloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,conflict:different_substances
+cerium(3+) chloride,synonym,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:35458,MAPPED,conflict:different_substances
+cerium(III) chloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,conflict:different_substances
+cerium(III) chloride,synonym,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:35458,MAPPED,conflict:different_substances
+Cerophyll,preferred_term,UNMAPPED_0357,Cerophyll,,UNMAPPED,unique
+cerous chloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
+cerous(III) chloride,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
+Cerulenin,preferred_term,CHEBI:171741,Cerulenin,CHEBI:171741,MAPPED,unique
+Cesium chloride,preferred_term,CHEBI:63039,Cesium chloride,CHEBI:63039,MAPPED,unique
+Cetan,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+cetane,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+Cetocycline,preferred_term,NCIT:C98044,Cetocycline,NCIT:C98044,MAPPED,unique
+Cetomacrogol,ontology_label,cas:9004-95-9,Cetomacrogol 1000,mesh:D002592,MAPPED,unique
+Cetomacrogol 1000,preferred_term,cas:9004-95-9,Cetomacrogol 1000,mesh:D002592,MAPPED,unique
+Cetrimonium bromide,preferred_term,CHEBI:3567,Cetrimonium bromide,CHEBI:3567,MAPPED,unique
+cetyltrimethylammonium bromide,ontology_label,CHEBI:3567,Cetrimonium bromide,CHEBI:3567,MAPPED,unique
+Cextromaltose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+CH3-[CH2]14-CH3,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+CH3-[CH2]15-CH3,synonym,CHEBI:16148,Heptadecane,CHEBI:16148,MAPPED,unique
+CH3-[CH2]16-COOH,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+CH3-[CH2]2-COOH,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+CH3-[CH2]3-COOH,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+CH3-[CH2]4-COOH,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+CH3-[CH2]8-CH3,synonym,CHEBI:41808,n-Decane,CHEBI:41808,MAPPED,unique
+CH3-CH2-COOH,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+CH3-COOH,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+CH3-NH2,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+CH3CO2H,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+CH3CO2K,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+CH3CO2NH4,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+CH3COCOOH,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+CH3COONH4,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+CH3OH,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Chalcopyrite,preferred_term,CHEBI:86202,Chalcopyrite,CHEBI:86202,MAPPED,unique
+Champamycin B,preferred_term,kgmicrobe.compound:champamycin_b,Champamycin B,kgmicrobe.compound:champamycin_b,MAPPED,unique
+Chaninin,preferred_term,kgmicrobe.compound:chaninin,Chaninin,kgmicrobe.compound:chaninin,MAPPED,unique
+Charcoal,preferred_term,CHEBI:91090,Charcoal,CHEBI:91090,MAPPED,unique
+Chartreusin,preferred_term,CHEBI:3580,Chartreusin,CHEBI:3580,MAPPED,unique
+Chaulmoogric acid,preferred_term,CHEBI:27939,Chaulmoogric acid,CHEBI:27939,MAPPED,unique
+Chelated Iron Solution,preferred_term,kgmicrobe.ingredient:chelated_iron_solution,Chelated Iron Solution,kgmicrobe.ingredient:chelated_iron_solution,MAPPED,unique
+Chelating Agent,ontology_label,NCIT:C360,EDTA (chelating agent),NCIT:C360,MAPPED,unique
+Chenodeoxycholic acid,preferred_term,CHEBI:16755,Chenodeoxycholic acid,CHEBI:16755,MAPPED,unique
+chicken egg yolk food product,ontology_label,FOODON:03315772,Egg yolk,FOODON:03315772,MAPPED,unique
+Chile saltpeter,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+CHIR-090,preferred_term,CHEBI:134107,CHIR-090,CHEBI:134107,MAPPED,unique
+Chitin,preferred_term,CHEBI:17029,Chitin,CHEBI:17029,MAPPED,resolved:owned
+chitin,ontology_label,UNMAPPED_0248,Chitin from shrimp shells,CHEBI:17029,UNMAPPED,resolved:owned
+Chitin from shrimp shells,preferred_term,UNMAPPED_0248,Chitin from shrimp shells,CHEBI:17029,UNMAPPED,unique
+Chitosan,preferred_term,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+Chloramphenicol,preferred_term,CHEBI:17698,Chloramphenicol,CHEBI:17698,MAPPED,unique
+chlorane,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Chlorate de sodium,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+Chlorate salt of sodium,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+chlorhexidine acetate,ontology_label,kgmicrobe.compound:chlorhexidine_diacetate_salt_hydrate,Chlorhexidine diacetate salt hydrate,CHEBI:81711,MAPPED,unique
+Chlorhexidine diacetate salt hydrate,preferred_term,kgmicrobe.compound:chlorhexidine_diacetate_salt_hydrate,Chlorhexidine diacetate salt hydrate,CHEBI:81711,MAPPED,unique
+"Chloric acid, sodium salt",synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+Chloridazon,preferred_term,CHEBI:81838,Chloridazon,CHEBI:81838,MAPPED,unique
+Chloride de choline,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+chlorido(protoporphyrinato)iron(III),synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+chloridohydrogen,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+chloro(protoporphyrinato)iron(III),synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+"chloro[3,7,12,17-tetramethyl-8,13-divinylporphyrin-2,18-dipropanoato(2-)]iron(III)",synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Chlorogenic acid,preferred_term,CHEBI:16112,Chlorogenic acid,CHEBI:16112,MAPPED,unique
+chlorohemin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+chloroprotoferrihem,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Chlororaphin,preferred_term,kgmicrobe.compound:chlororaphin,Chlororaphin,kgmicrobe.compound:chlororaphin,MAPPED,unique
+Chlorpromazine hydrochloride,preferred_term,CHEBI:3649,Chlorpromazine hydrochloride,CHEBI:3649,MAPPED,unique
+Chlortetracyclin,synonym,CHEBI:27644,Chlortetracycline,CHEBI:27644,MAPPED,unique
+Chlortetracycline,preferred_term,CHEBI:27644,Chlortetracycline,CHEBI:27644,MAPPED,unique
+chlorure d'hydrogene,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Chlorure de choline,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+chlorure de lithium,synonym,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+Chlorure de magnesium hydrate,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+chlorure de methylthioninium,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+chlorure de sodium,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+chlorure de zinc,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+Chlorwasserstoff,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Cholest-5-en-3beta-ol,synonym,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,unique
+Cholesterin,synonym,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,unique
+cholesterol,preferred_term,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,resolved:owned
+cholesterol,ontology_label,kgmicrobe.ingredient:cholesterol_lipid_concentrate,cholesterol lipid concentrate,CHEBI:16113,MAPPED,resolved:owned
+cholesterol lipid concentrate,preferred_term,kgmicrobe.ingredient:cholesterol_lipid_concentrate,cholesterol lipid concentrate,CHEBI:16113,MAPPED,unique
+Cholic acid,preferred_term,CHEBI:16359,Cholic acid,CHEBI:16359,MAPPED,unique
+Cholin acetate,preferred_term,cas:14586-35-7,Cholin acetate,cas:14586-35-7,MAPPED,unique
+Choline,preferred_term,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+choline alfoscerate,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Choline alphoscerate,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Choline chlorhydrate,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Choline chloride,preferred_term,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Choline glycerophosphate,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Choline hydrochloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+CHOLINE ION,synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+Choline Lysine,synonym,mesh:C000655964,Cholinium lysinate,mesh:C000655964,MAPPED,unique
+cholini alfosceras,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Cholini chloridum,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Cholini glycerophosphas,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Cholinium alpha ketoglutarate,preferred_term,UNMAPPED_0164,Cholinium alpha ketoglutarate,,UNMAPPED,unique
+Cholinium aspartate,preferred_term,UNMAPPED_0163,Cholinium aspartate,,UNMAPPED,unique
+Cholinium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Cholinium dihydrogen phosphate,preferred_term,cas:83846-92-8,Cholinium dihydrogen phosphate,cas:83846-92-8,MAPPED,unique
+Cholinium glutamate,preferred_term,UNMAPPED_0161,Cholinium glutamate,,UNMAPPED,unique
+Cholinium hydrogen phosphate,preferred_term,UNMAPPED_0162,Cholinium hydrogen phosphate,,UNMAPPED,unique
+Cholinium lysinate,preferred_term,mesh:C000655964,Cholinium lysinate,mesh:C000655964,MAPPED,unique
+Cholinium phosphate,preferred_term,UNMAPPED_0160,Cholinium phosphate,,UNMAPPED,unique
+chondroitin sulfate,ontology_label,cas:39455-18-0,Chondroitin sulfate A sodium salt from bovine trachea,CHEBI:37397,MAPPED,unique
+Chondroitin sulfate A sodium salt from bovine trachea,preferred_term,cas:39455-18-0,Chondroitin sulfate A sodium salt from bovine trachea,CHEBI:37397,MAPPED,unique
+"Chromic acid, dipotassium salt",synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+chromic nitrate heptahydrate,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+Chromic sulfate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Chromic sulphate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+chromium (3+) nitrate heptahydrate,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+chromium (3+) trinitrate heptahydrate,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+Chromium sulfate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Chromium sulphate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+chromium trinitrate heptahydrate,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+chromium(3+) nitrate--water (1/7),synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+chromium(3+) trichloride hexahydrate,ontology_label,CHEBI:53442,Chromium(III) Chloride Hexahydrate,CHEBI:53442,MAPPED,unique
+Chromium(III) Chloride Hexahydrate,preferred_term,CHEBI:53442,Chromium(III) Chloride Hexahydrate,CHEBI:53442,MAPPED,unique
+chromium(III) nitrate heptahydrate,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+Chromium(III) sulfate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unresolved:partial_chemistry
+chromium(III) sulfate,ontology_label,cas:7788-99-0,CrKSO42 x 12 H2O,CHEBI:53471,MAPPED,unresolved:partial_chemistry
+Chromium-NTA,preferred_term,UNMAPPED_0153,Chromium-NTA,,UNMAPPED,unique
+"Chrysanthemic Acid, Ethyl Ester",preferred_term,cas:97-41-6,"Chrysanthemic Acid, Ethyl Ester",CHEBI:228794,MAPPED,unique
+Chrysarobin,preferred_term,CHEBI:3686,Chrysarobin,CHEBI:3686,MAPPED,unique
+Chrysin,preferred_term,CHEBI:75095,Chrysin,CHEBI:75095,MAPPED,unique
+Chrysophanol,preferred_term,CHEBI:3687,Chrysophanol,CHEBI:3687,MAPPED,unique
+chrysophanol-9-anthrone,ontology_label,CHEBI:3686,Chrysarobin,CHEBI:3686,MAPPED,unique
+Chu Stock Solution,preferred_term,kgmicrobe.ingredient:chu_stock_solution,Chu Stock Solution,kgmicrobe.ingredient:chu_stock_solution,MAPPED,unique
+CI 42000,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+CI Basic Green 4,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+cicloheximida,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+cicloheximide,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+cicloheximidum,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Cimicifugoside H1,preferred_term,cas:163046-73-9,Cimicifugoside H1,cas:163046-73-9,MAPPED,unique
+cinchocaine,ontology_label,CHEBI:247956,Dibucaine,CHEBI:247956,MAPPED,unique
+Cinerubin A,preferred_term,kgmicrobe.compound:cinerubin_a,Cinerubin A,kgmicrobe.compound:cinerubin_a,MAPPED,unique
+Cinerubin R,preferred_term,CHEBI:214436,Cinerubin R,CHEBI:214436,MAPPED,unique
+Cinnamic acid,preferred_term,CHEBI:27386,Cinnamic acid,CHEBI:27386,MAPPED,unique
+Cinnamycin,preferred_term,CHEBI:141991,Cinnamycin,CHEBI:141991,MAPPED,unique
+Cinoxacin,preferred_term,CHEBI:3716,Cinoxacin,CHEBI:3716,MAPPED,unique
+Ciprofloxacin,preferred_term,CHEBI:100241,Ciprofloxacin,CHEBI:100241,MAPPED,unique
+Ciprofloxacin Hydrochloride,preferred_term,CHEBI:59936,Ciprofloxacin Hydrochloride,CHEBI:59936,MAPPED,unique
+ciprofloxacin hydrochloride hydrate,ontology_label,CHEBI:59936,Ciprofloxacin Hydrochloride,CHEBI:59936,MAPPED,unique
+"cis-(+)-Tetrahydro-2-oxothieno[3,4]imidazoline-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+"cis-1,2,3,5-trans-4,6-cyclohexanehexol",synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+cis-9-octadecenoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+Cis-aconitate,preferred_term,CHEBI:16383,Cis-aconitate,CHEBI:16383,MAPPED,unique
+cis-aconitate(3-),ontology_label,CHEBI:16383,Cis-aconitate,CHEBI:16383,MAPPED,unique
+"cis-Butenedioic acid, Toxilic acid",synonym,CHEBI:18300,Maleic acid,CHEBI:18300,MAPPED,unique
+cis-Delta(9)-octadecenoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+cis-diamminedichloridoplatinum(II),synonym,CHEBI:27899,Cisplatin,CHEBI:27899,MAPPED,unique
+cis-diamminedichloroplatinum(II),synonym,CHEBI:27899,Cisplatin,CHEBI:27899,MAPPED,unique
+"cis-Hexahydro-2-oxo-1H-thieno(3,4)imidazole-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+cis-oleic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+"cis-Tetrahydro-2-oxothieno(3,4-d)imidazoline-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Cisplatin,preferred_term,CHEBI:27899,Cisplatin,CHEBI:27899,MAPPED,unique
+cisteina,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+Citraconate,preferred_term,CHEBI:30719,Citraconate,CHEBI:30719,MAPPED,unique
+citraconate(2-),ontology_label,CHEBI:30719,Citraconate,CHEBI:30719,MAPPED,unique
+Citraconic acid,preferred_term,CHEBI:17626,Citraconic acid,CHEBI:17626,MAPPED,unique
+Citramalate,preferred_term,CHEBI:13997,Citramalate,CHEBI:13997,MAPPED,unique
+citramalate(2-),ontology_label,CHEBI:13997,Citramalate,CHEBI:13997,MAPPED,unique
+citramalic acid,ontology_label,cas:1030365-02-6,potassium citramalate monohydrate,CHEBI:15584,MAPPED,unique
+Citrate,preferred_term,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,resolved:owned
+Citrate,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,resolved:owned
+citrate(3-),ontology_label,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,unique
+Citric acid,preferred_term,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,resolved:owned
+Citric Acid,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,resolved:owned
+citric acid,ontology_label,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,resolved:owned
+Citric acid . H2O,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
+citric acid diammonium salt,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Citric acid monohydrate,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
+citric acid triammonium salt,synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+citric acid trisodium salt,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,unique
+Citric acid x H2O,preferred_term,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
+Citric acid·H2O,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
+Citric Acid•H2O,preferred_term,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,unique
+Citric Acid•H2O(Fisher A 104),synonym,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,unique
+Citronensaeure,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+"Citronensaeure,Trinatrium-Salz-Dihydrat",synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+CITRULLINE,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+Cladomycin,preferred_term,kgmicrobe.compound:cladomycin,Cladomycin,kgmicrobe.compound:cladomycin,MAPPED,unique
+Clarithromycin,preferred_term,CHEBI:3732,Clarithromycin,CHEBI:3732,MAPPED,unique
+Clavulanic Acid,preferred_term,CHEBI:48947,Clavulanic Acid,CHEBI:48947,MAPPED,unique
+Cleland's reagent,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+Clindamycin,preferred_term,CHEBI:3745,Clindamycin,CHEBI:3745,MAPPED,unique
+Clofazimine,preferred_term,CHEBI:3749,Clofazimine,CHEBI:3749,MAPPED,unique
+Cloruro de colina,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+cloruro de hidrogeno,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+cloruro de litio,synonym,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+cloruro de metiltioninio,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+cloruro sodico,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Clotrimazole,preferred_term,CHEBI:3764,Clotrimazole,CHEBI:3764,MAPPED,unique
+Clovis xylem sap,preferred_term,UNMAPPED_0177,Clovis xylem sap,,UNMAPPED,unique
+Cloxacillin,preferred_term,CHEBI:49566,Cloxacillin,CHEBI:49566,MAPPED,unique
+cloxacillin sodium monohydrate,ontology_label,CHEBI:34978,Cloxacillin sodium salt monohydrate,CHEBI:34978,MAPPED,unique
+Cloxacillin sodium salt monohydrate,preferred_term,CHEBI:34978,Cloxacillin sodium salt monohydrate,CHEBI:34978,MAPPED,unique
+CMC,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+CMC + PY + Horse Serum,preferred_term,kgmicrobe.ingredient:cmc_py_horse_serum,CMC + PY + Horse Serum,kgmicrobe.ingredient:cmc_py_horse_serum,MAPPED,unique
+CMC-Na,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+CMRL 1066,preferred_term,UNMAPPED_0359,CMRL 1066,,UNMAPPED,unique
+CN-Cbl,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+CN-Cbl,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Co Carboxylase,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+CO(2),synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+Co(NO3)2,preferred_term,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Co(NO3)2 . 6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2 x 6 H2O,preferred_term,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2 x 6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2 · 6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2.6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2·6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co(NO3)2・6H2O,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Co-carboxylase,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Co-cyano-(2-methyladenin-7-yl)cobamide,synonym,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
+CO-CYANOCOBALAMIN,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+CO-CYANOCOBALAMIN,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Co-trimoxazole,preferred_term,CHEBI:3770,Co-trimoxazole,CHEBI:3770,MAPPED,unique
+CO2,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+CoA-SH,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+"Coalpha-[alpha-(5,6-dimethylbenzimidazolyl)]-cobamide",synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+"Coalpha-[alpha-(5,6-dimethylbenzimidazolyl)]-Cobeta-cyanocobamide",synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+"Coalpha-[alpha-(5,6-dimethylbenzimidazolyl)]-Cobeta-cyanocobamide",synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+CoASH,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+Cob(III)alamin,synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+COBALAMIN,synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+Cobalamin (B12),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+Cobalamin (III),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+cobalamin(III),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+Cobalamine,preferred_term,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+Cobalt (2+) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cobalt (II) chloride hexahydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+cobalt (III)-EDTA,preferred_term,UNMAPPED_0143,cobalt (III)-EDTA,,UNMAPPED,unique
+Cobalt bis(nitrate),synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobalt Brown,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+Cobalt chloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+Cobalt chloride hexahydrate,preferred_term,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+cobalt chloride hexahydrate,ontology_label,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,unique
+cobalt chloride hydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+cobalt dichloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt dichloride,ontology_label,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt dichloride,ontology_label,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+Cobalt dichloride hexahydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+cobalt dinitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+cobalt dinitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Cobalt monosulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+Cobalt nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobalt nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Cobalt sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cobalt(2+) chloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(2+) chloride,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(2+) chloride,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(2+) chloride,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+cobalt(2+) dichloride hexahydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+cobalt(2+) dinitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobalt(2+) nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobalt(2+) nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+cobalt(2+) nitrate--water (1/6),synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+cobalt(2+) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cobalt(2+) sulfate heptahydrate,ontology_label,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+cobalt(II) chloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(II) chloride,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(II) chloride,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+cobalt(II) chloride,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+Cobalt(II) chloride hexahydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+Cobalt(II) chloride--water (1/7),synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,unique
+Cobalt(II) nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobalt(II) nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Cobalt(II) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+Cobalt-NTA,preferred_term,UNMAPPED_0154,Cobalt-NTA,,UNMAPPED,unique
+Cobaltous nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
+Cobaltous nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
+Cobaltous sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cocarboxilasa,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+cocarboxylase,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+cocarboxylase chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+cocarboxylasum,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+CoCl .6H O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+CoCl 2,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+CoCl2,preferred_term,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+CoCl2 . 6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 . 6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 . 6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2 x 2 H2O,preferred_term,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 2 H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 2 H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,resolved:owned
+CoCl2 x 4 H2O,preferred_term,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 4 H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 4 H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,resolved:owned
+CoCl2 x 6 H2O,preferred_term,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,resolved:owned
+CoCl2 x 6 H2O,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CHEBI:53503,MAPPED,resolved:owned
+CoCl2 x 6 H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 6 H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,resolved:owned
+CoCl2 x 6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 x 6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 x 6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2 · 6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 · 6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 · 6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2 × 6H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 × 6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2 ∙ 6 H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2 ∙ 6 H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2·6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2·6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2·6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2∙6H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2∙6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2⋅6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2⋅6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2⋅6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2・6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2・6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
+CoCl2・6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+Coclor,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Cocositol,synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+codecarboxylase,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+coenzima M,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+Coenzym A,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+Coenzym M,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+Coenzymate,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Coenzyme A,preferred_term,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+Coenzyme M,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+Coenzyme R,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Coixol,ontology_label,CHEBI:173101,6-methoxy-2(3H)-benzoxazolone,CHEBI:173101,MAPPED,unique
+Colchiceine,preferred_term,CHEBI:183909,Colchiceine,CHEBI:183909,MAPPED,unique
+colistin,ontology_label,CHEBI:37943,Colistin sulfate salt,CHEBI:37943,MAPPED,unique
+Colistin Sulfate,preferred_term,NCIT:C386,Colistin Sulfate,NCIT:C386,MAPPED,unique
+Colistin sulfate salt,preferred_term,CHEBI:37943,Colistin sulfate salt,CHEBI:37943,MAPPED,unique
+Collagen,preferred_term,CHEBI:3815,Collagen,CHEBI:3815,MAPPED,unique
+Collinomycin,preferred_term,kgmicrobe.compound:collinomycin,Collinomycin,kgmicrobe.compound:collinomycin,MAPPED,unique
+Colloidal chitin,preferred_term,UNMAPPED_0361,Colloidal chitin,,UNMAPPED,unique
+Columbia agar base,preferred_term,MICRO:0000536,Columbia agar base,MICRO:0000536,MAPPED,unique
+Columbia blood agar base,preferred_term,UNMAPPED_0118,Columbia blood agar base,,UNMAPPED,unique
+CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+common salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Complan,preferred_term,UNMAPPED_0363,Complan,,UNMAPPED,unique
+Complexon I,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Conessine,preferred_term,CHEBI:27965,Conessine,CHEBI:27965,MAPPED,unique
+Congo red,preferred_term,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+Congocidin,preferred_term,kgmicrobe.compound:congocidin,Congocidin,kgmicrobe.compound:congocidin,MAPPED,unique
+coniferol,ontology_label,CHEBI:17745,coniferyl alcohol,CHEBI:17745,MAPPED,unique
+coniferyl alcohol,preferred_term,CHEBI:17745,coniferyl alcohol,CHEBI:17745,MAPPED,unique
+coniferyl aldehyde,preferred_term,CHEBI:16547,coniferyl aldehyde,CHEBI:16547,MAPPED,unique
+Cooked meat medium,preferred_term,FOODON:03305103,Cooked meat medium,FOODON:03305103,MAPPED,unique
+copper (II) chloride dihydrate,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+Copper (II) sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+Copper bichloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Copper chloride (CuCl),synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Copper chloride (CuCl2),synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+copper chloride pentahydrate,synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+Copper dichloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+copper dichloride,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+copper dichloride--water (1/2),synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+copper dichloride--water (1/5),synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+Copper monochloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Copper sulfate,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+copper sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+copper sulphate(5.H2O),synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+Copper(1+) chloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Copper(2+) chloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+copper(2+) chloride pentahydrate,synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+copper(2+) dichloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+copper(2+) dichloride,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+copper(2+) dichloride --water (1/2),synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+copper(2+) dichloride --water (1/5),synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+copper(2+) dinitrate,synonym,kgmicrobe.compound:cu_no32_x_3_h2o,Cu(NO3)2 x 3 H2O,CHEBI:78036,MAPPED,unique
+copper(2+) sulfate,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+copper(2+) sulfate,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+copper(2+) sulfate,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+copper(2+) sulfate (1:1) pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+copper(2+) sulfate hexahydrate,synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+copper(2+) sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+copper(2+) sulfate--water (1/5),synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+copper(2+) sulfate--water (1/6),synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+Copper(2+)chloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Copper(I) chloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Copper(II) chloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+copper(II) chloride,ontology_label,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+Copper(II) chloride (1:2),synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Copper(II) chloride dihydrate,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+copper(II) chloride pentahydrate,synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+copper(II) chloride--water (1/2),synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+copper(II) chloride--water (1/5),synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+copper(II) chloride.2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+copper(II) nitrate,ontology_label,kgmicrobe.compound:cu_no32_x_3_h2o,Cu(NO3)2 x 3 H2O,CHEBI:78036,MAPPED,unique
+copper(II) nitrate (anhydrous),synonym,kgmicrobe.compound:cu_no32_x_3_h2o,Cu(NO3)2 x 3 H2O,CHEBI:78036,MAPPED,unique
+Copper(II) sulfate,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+copper(II) sulfate,ontology_label,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+copper(II) sulfate,ontology_label,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+copper(II) sulfate hexahydrate,synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+copper(II) sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+"copper(II) sulfate, pentahydrate",synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+Copper-NTA,preferred_term,UNMAPPED_0151,Copper-NTA,,UNMAPPED,unique
+Coppertrace,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+Corn meal,preferred_term,FOODON:03310257,Corn meal,FOODON:03310257,MAPPED,unique
+Corn meal agar,preferred_term,UNMAPPED_0130,Corn meal agar,,UNMAPPED,unique
+Corn Oil,preferred_term,CHEBI:195250,Corn Oil,CHEBI:195250,MAPPED,unique
+Corn Starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Corn Steep Liquor + Glucose + Fumarate,preferred_term,kgmicrobe.ingredient:corn_steep_liquor_glucose_fumarate,Corn Steep Liquor + Glucose + Fumarate,kgmicrobe.ingredient:corn_steep_liquor_glucose_fumarate,MAPPED,unique
+Corn steep powder,preferred_term,UNMAPPED_0366,Corn steep powder,,UNMAPPED,unique
+cornmeal,ontology_label,FOODON:03310257,Corn meal,FOODON:03310257,MAPPED,unique
+CoSO4,preferred_term,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+CoSO4 . 7H2O,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+CoSO4 x 7 H2O,preferred_term,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+CoSO4 ⋅ 7H2O,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+CoSO4.7H2O,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+CoSO4·7H2O,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+CoSO4・7H2O,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+Cotarnine Chloride,preferred_term,cas:10018-19-6,Cotarnine Chloride,NCIT:C79997,MAPPED,unique
+Coumarate,preferred_term,CHEBI:23399,Coumarate,CHEBI:23399,MAPPED,unique
+Cow manure,synonym,kgmicrobe.ingredient:dry_cow-manure,Dry cow-manure,ENVO:00003031,MAPPED,unique
+cow milk,ontology_label,FOODON:02020891,Cow's milk,FOODON:02020891,MAPPED,unique
+Cow's milk,preferred_term,FOODON:02020891,Cow's milk,FOODON:02020891,MAPPED,unique
+Cr(NO3)3 x 7 H2O,preferred_term,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+Cr(NO3)3.7H2O,synonym,CHEBI:86206,Cr(NO3)3 x 7 H2O,CHEBI:86206,MAPPED,unique
+CR1 Soil,preferred_term,ENVO:00001998,CR1 Soil,ENVO:00001998,MAPPED,unique
+Cr2(SO4)3 x n H2O,preferred_term,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Cravingzgone,preferred_term,UNMAPPED_0213,Cravingzgone,,UNMAPPED,unique
+Creatin,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+Creatine,preferred_term,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+Creatine anhydride,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+creatinina,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+Creatinine,preferred_term,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+Cresol red,preferred_term,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+Cresolsulfophthalein,synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+Crinamine,preferred_term,CHEBI:3914,Crinamine,CHEBI:3914,MAPPED,unique
+CrKSO42 x 12 H2O,preferred_term,cas:7788-99-0,CrKSO42 x 12 H2O,CHEBI:53471,MAPPED,unique
+croscarmellose,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+croscarmellosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+croscarmelosa,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+Crotonic acid,preferred_term,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+Crude Oil,preferred_term,ENVO:00002984,Crude Oil,ENVO:00002984,MAPPED,unique
+Cryptotanshinone,preferred_term,CHEBI:149838,Cryptotanshinone,CHEBI:149838,MAPPED,unique
+Crystal Violet,preferred_term,CHEBI:41688,Crystal Violet,CHEBI:41688,MAPPED,unique
+Crystalline Cellulose,preferred_term,CHEBI:62968,Crystalline Cellulose,CHEBI:62968,MAPPED,unique
+Cu(NO3)2 x 3 H2O,preferred_term,kgmicrobe.compound:cu_no32_x_3_h2o,Cu(NO3)2 x 3 H2O,CHEBI:78036,MAPPED,unique
+Cu-lyt,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Cubic niter,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+CuCl,preferred_term,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+CuCl 2,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl 2 x 2 H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2,preferred_term,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+CuCl2 . 2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2 .2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2 x 2 H2O,preferred_term,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2 x 2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2 x 5 H2O,preferred_term,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+CuCl2 x 6 H2O,preferred_term,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,resolved:owned
+CuCl2 x 6 H2O,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,resolved:owned
+CuCl2 x H2O,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2 x H2O,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2 · 2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2 · H2O,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2 · H2O,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2 × 6H2O,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2 × 6H2O,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+CuCl2*2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2-2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2.2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2.5H2O,synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+CuCl2·2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2⋅2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuCl2・2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+CuFeS2,synonym,CHEBI:86202,Chalcopyrite,CHEBI:86202,MAPPED,unique
+Cumene hydroperoxide,preferred_term,CHEBI:78673,Cumene hydroperoxide,CHEBI:78673,MAPPED,unique
+Cupric chloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Cupric chloride anhydrous,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,conflict:different_substances
+Cupric chloride anhydrous,synonym,kgmicrobe.compound:cucl2_x_6_h2o,CuCl2 x 6 H2O,CHEBI:49553,MAPPED,conflict:different_substances
+Cupric chloride dihydrate,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+cupric chloride pentahydrate,synonym,CHEBI:91245,CuCl2 x 5 H2O,CHEBI:91245,MAPPED,unique
+cupric chloride.2H2O,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
+Cupric dichloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
+Cupric ferrous sulfide,synonym,CHEBI:86202,Chalcopyrite,CHEBI:86202,MAPPED,unique
+Cupric sulfate,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+cupric sulfate anhydrous,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+cupric sulfate anhydrous,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+cupric sulfate anhydrous,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+cupric sulfate hexahydrate,synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+cupric sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+Cuproid,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Cuprous chloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+Curamycin A,preferred_term,CHEBI:71987,Curamycin A,CHEBI:71987,MAPPED,unique
+Curcumin,preferred_term,CHEBI:3962,Curcumin,CHEBI:3962,MAPPED,unique
+Curdlan,preferred_term,cas:54724-00-4,Curdlan,mesh:C038459,MAPPED,unique
+CuSO4,preferred_term,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+CuSO4 . 2H2O,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+CuSO4 . 2H2O,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 . 2H2O,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 . 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4 .5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4 x 2 H2O,preferred_term,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 x 2 H2O,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+CuSO4 x 2 H2O,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 x 4 H2O,preferred_term,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 x 4 H2O,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+CuSO4 x 4 H2O,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 x 5 H2O,preferred_term,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4 x 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4 x 6 H2O,preferred_term,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+CuSO4 x H2O,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
+CuSO4 x H2O,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 x H2O,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
+CuSO4 · 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4 ⋅ 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4.5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4.6H2O,synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
+CuSO4·5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4・5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+Cyanocob(III)alamin,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Cyanocob(III)alamin,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin,preferred_term,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,resolved:owned
+Cyanocobalamin,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,resolved:owned
+Cyanocobalamin (B ),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin (B ),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin (Vitamin B ),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin (Vitamin B ),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyanocobalamine,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Cyanocobalamine,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin in,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Cyanocobalamin in,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyclodextrin,preferred_term,CHEBI:23456,Cyclodextrin,CHEBI:23456,MAPPED,unique
+cycloheptaamylose,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+cycloheptaglucan,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+cycloheptaglucosan,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+Cyclohexemid,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Cycloheximid,preferred_term,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Cycloheximide,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Cyclohexitol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+Cyclohexylaminopropanesulfonic acid,synonym,CHEBI:191088,CAPS buffer,CHEBI:191088,MAPPED,unique
+Cyclomaltoheptaose,preferred_term,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+cyclomaltoheptaose,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
+cyclomaltohexaose,synonym,CHEBI:40585,a-Cyclodextrin,CHEBI:40585,MAPPED,unique
+Cyclopamine,preferred_term,CHEBI:4021,Cyclopamine,CHEBI:4021,MAPPED,unique
+Cyclopentanol+CO2,preferred_term,kgmicrobe.ingredient:cyclopentanol_co2,Cyclopentanol+CO2,kgmicrobe.ingredient:cyclopentanol_co2,MAPPED,unique
+cyclopentyl 3-[2-methoxy-4-(2-methylphenylsulfonylcarbamoyl)benzyl]-1-methyl-1H-indol-5-ylcarbamate,synonym,CHEBI:10100,Zafirlukast,CHEBI:10100,MAPPED,unique
+Cycloviracin B1,preferred_term,CHEBI:200226,Cycloviracin B1,CHEBI:200226,MAPPED,unique
+Cycloviracin B2,preferred_term,CHEBI:202116,Cycloviracin B2,CHEBI:202116,MAPPED,unique
+Cyd,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+Cystargin,preferred_term,mesh:C058276,Cystargin,mesh:C058276,MAPPED,unique
+Cystein,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+Cystein-HCl x 2 H2O (5% (w/v)),synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cystein-HCl x 2 H2O (5% (w/v)),synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+Cysteine,preferred_term,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,resolved:owned
+CYSTEINE,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,resolved:owned
+Cysteine hydrochloride,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cysteine monohydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+Cysteine-HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+Cysteine-HCl x H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cysteine-HCl·H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cysteine-HCl∙H2O,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+Cysteine-HCl⋅H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cystine,preferred_term,CHEBI:17376,Cystine,CHEBI:17376,MAPPED,unique
+Cyt,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+Cytidin,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+Cytidine,preferred_term,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+Cytidine 5'-Monophosphate,preferred_term,CHEBI:17361,Cytidine 5'-Monophosphate,CHEBI:17361,MAPPED,unique
+Cytisine,preferred_term,CHEBI:4055,Cytisine,CHEBI:4055,MAPPED,unique
+Cytochrome,preferred_term,CHEBI:4056,Cytochrome,CHEBI:4056,MAPPED,unique
+Cytosin,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+Cytosine,preferred_term,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+Cytosine riboside,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+cytosine-1beta-D-Ribofuranoside,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+Cytovirin,preferred_term,kgmicrobe.compound:cytovirin,Cytovirin,kgmicrobe.compound:cytovirin,MAPPED,unique
+Czapek Dox agar,preferred_term,UNMAPPED_0119,Czapek Dox agar,,UNMAPPED,unique
+Czapek-Dox liquid medium,preferred_term,UNMAPPED_0370,Czapek-Dox liquid medium,,UNMAPPED,unique
+D,preferred_term,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+D Calcium Panthothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+D(+)-Biotin,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+D(+)-Carvone,preferred_term,CHEBI:15399,D(+)-Carvone,CHEBI:15399,MAPPED,unique
+D(+)-Glucose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
+D(+)-Trehalose,synonym,CHEBI:27082,Trehalose,CHEBI:27082,MAPPED,unique
+D(-)-alpha-aminobenzylpenicillin sodium salt,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+"D,L-6,8-Thioctic Acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+"D,L-carnitine",synonym,CHEBI:17126,DL-carnitine,CHEBI:17126,MAPPED,unique
+"D,L-lactic acid, sodium salt",synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+"D,L-Malic Acid",synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+D-(+)-biotin,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+D-(+)-cellobiose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+D-(+)-Galactosamine hydrochloride,preferred_term,CHEBI:181432,D-(+)-Galactosamine hydrochloride,CHEBI:181432,MAPPED,unique
+D-(+)-Gluconic acid gamma-lactone,preferred_term,CHEBI:16217,D-(+)-Gluconic acid gamma-lactone,CHEBI:16217,MAPPED,unique
+D-(+)-glucose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
+D-(+)-maltose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+D-(+)-Melezitose hydrate,preferred_term,cas:207511-10-2,D-(+)-Melezitose hydrate,CHEBI:6731,MAPPED,unique
+D-(+)-melezitose monohydrate,preferred_term,cas:10030-67-8,D-(+)-melezitose monohydrate,CHEBI:6731,MAPPED,unique
+D-(+)-Turanose,preferred_term,CHEBI:32528,D-(+)-Turanose,CHEBI:32528,MAPPED,unique
+D-(-)-6-(alpha-aminophenylacetamido)penicillanic acid,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+D-(-)-ampicillin,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+D-(-)-lyxose,preferred_term,CHEBI:62318,D-(-)-lyxose,CHEBI:16789,REJECTED,unique
+D-(-)-lyxose,synonym,CHEBI:62318,D-lyxose,CHEBI:62318,MAPPED,unique
+D-(-)-Mannitol,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+D-(-)-Pantolactone,preferred_term,CHEBI:16719,D-(-)-Pantolactone,CHEBI:16719,MAPPED,unique
+D-(-)-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+D-(-)-tagatose,preferred_term,CHEBI:4249,D-(-)-tagatose,CHEBI:4249,MAPPED,unique
+D-2-Aminobutyric acid,preferred_term,CHEBI:28797,D-2-Aminobutyric acid,CHEBI:28797,MAPPED,unique
+D-Alanine,preferred_term,CHEBI:15570,D-Alanine,CHEBI:15570,MAPPED,unique
+D-alpha-aminobutyric acid,ontology_label,CHEBI:28797,D-2-Aminobutyric acid,CHEBI:28797,MAPPED,unique
+D-apiose,preferred_term,CHEBI:16689,D-apiose,CHEBI:16689,MAPPED,unique
+D-Ara,synonym,CHEBI:17108,D-Arabinose,CHEBI:17108,MAPPED,unique
+D-arabinitol,ontology_label,CHEBI:18333,D-arabitol,CHEBI:18333,MAPPED,unique
+D-arabino-hex-2-ulose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+D-arabino-pentose,synonym,CHEBI:17108,D-Arabinose,CHEBI:17108,MAPPED,unique
+D-Arabinose,preferred_term,CHEBI:17108,D-Arabinose,CHEBI:17108,MAPPED,unique
+D-arabitol,preferred_term,CHEBI:18333,D-arabitol,CHEBI:18333,MAPPED,unique
+D-aspartate,preferred_term,CHEBI:29994,D-aspartate,CHEBI:29994,MAPPED,unique
+D-aspartate(2-),ontology_label,CHEBI:29994,D-aspartate,CHEBI:29994,MAPPED,unique
+D-Aspartic Acid,preferred_term,CHEBI:17364,D-Aspartic Acid,CHEBI:17364,MAPPED,unique
+D-Biotin,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+D-Ca-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+D-Calcium pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+D-celiobiose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+D-Cellobiose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+D-cellobiose (cellobiose),synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+D-Cycloserine,preferred_term,CHEBI:40009,D-Cycloserine,CHEBI:40009,MAPPED,unique
+D-erythro-tetrose,synonym,CHEBI:27904,D-erythrose,CHEBI:27904,MAPPED,unique
+D-erythrose,preferred_term,CHEBI:27904,D-erythrose,CHEBI:27904,MAPPED,unique
+D-Fru,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+D-Fructose,preferred_term,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+D-fructose 6-(dihydrogen phosphate),synonym,CHEBI:15946,Fructose-6-phosphate,CHEBI:15946,MAPPED,unique
+D-Fructose 6-phosphate,synonym,CHEBI:15946,Fructose-6-phosphate,CHEBI:15946,MAPPED,unique
+D-Fructose 6-phosphate disodium salt hydrate,preferred_term,cas:26177-86-6,D-Fructose 6-phosphate disodium salt hydrate,CHEBI:190546,MAPPED,unique
+D-Fructose 6-Phosphate-Disodium Salt,ontology_label,cas:26177-86-6,D-Fructose 6-phosphate disodium salt hydrate,CHEBI:190546,MAPPED,unique
+D-fucopyranose,ontology_label,CHEBI:2179,6-deoxy-d-galactose,CHEBI:2179,MAPPED,unique
+D-fucose,preferred_term,CHEBI:28847,D-fucose,CHEBI:28847,MAPPED,unique
+D-Gal,synonym,CHEBI:12936,D-Galactose,CHEBI:12936,MAPPED,unique
+D-galacto-hexose,synonym,CHEBI:12936,D-Galactose,CHEBI:12936,MAPPED,unique
+D-galactonate,preferred_term,CHEBI:12931,D-galactonate,CHEBI:12931,MAPPED,unique
+D-galactonic Acid Lactone,preferred_term,CHEBI:15895,D-galactonic Acid Lactone,CHEBI:15895,MAPPED,unique
+"D-galactono-1,4-lactone",ontology_label,CHEBI:15895,D-galactonic Acid Lactone,CHEBI:15895,MAPPED,unique
+D-Galactose,preferred_term,CHEBI:12936,D-Galactose,CHEBI:12936,MAPPED,unique
+D-galacturonate,synonym,CHEBI:18024,D-galacturonic acid,CHEBI:18024,MAPPED,conflict:different_substances
+D-galacturonate,synonym,cas:91510-62-2,D-Galacturonic Acid monohydrate,CHEBI:18024,MAPPED,conflict:different_substances
+D-galacturonic acid,preferred_term,CHEBI:18024,D-galacturonic acid,CHEBI:18024,MAPPED,resolved:owned
+D-galacturonic acid,ontology_label,cas:91510-62-2,D-Galacturonic Acid monohydrate,CHEBI:18024,MAPPED,resolved:owned
+D-Galacturonic Acid monohydrate,preferred_term,cas:91510-62-2,D-Galacturonic Acid monohydrate,CHEBI:18024,MAPPED,unique
+D-galacturonic acids,synonym,CHEBI:18024,D-galacturonic acid,CHEBI:18024,MAPPED,unique
+D-Glc,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+D-Glcp,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+D-glucarate,preferred_term,CHEBI:30612,D-glucarate,CHEBI:30612,MAPPED,unique
+D-glucarate(2-),ontology_label,CHEBI:30612,D-glucarate,CHEBI:30612,MAPPED,unique
+D-Glucaric acid,preferred_term,CHEBI:16002,D-Glucaric acid,CHEBI:16002,MAPPED,resolved:owned
+D-glucaric acid,ontology_label,cas:576-42-1,D-Saccharic acid potassium salt,CHEBI:16002,MAPPED,resolved:owned
+D-Glucitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+D-gluco-hexose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
+D-gluconate,preferred_term,CHEBI:18391,D-gluconate,CHEBI:18391,MAPPED,unique
+"D-Gluconic acid, monosodium salt",synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+"D-glucono-1,5-lactone",ontology_label,CHEBI:16217,D-(+)-Gluconic acid gamma-lactone,CHEBI:16217,MAPPED,unique
+D-glucopyranose,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+D-glucopyranose 1-phosphate,ontology_label,CHEBI:16077,Glucose 1-phosphate,CHEBI:16077,MAPPED,unique
+D-glucosamine,preferred_term,CHEBI:17315,D-glucosamine,CHEBI:17315,MAPPED,unique
+D-Glucosamine 6-phosphate,preferred_term,CHEBI:12962,D-Glucosamine 6-phosphate,CHEBI:12962,MAPPED,unique
+D-Glucosamine Hydrochloride,preferred_term,cas:66-84-2,D-Glucosamine Hydrochloride,NCIT:C83732,MAPPED,unique
+D-glucosaminic Acid,preferred_term,CHEBI:17784,D-glucosaminic Acid,CHEBI:17784,MAPPED,unique
+D-Glucose,preferred_term,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,resolved:owned
+D-glucose,synonym,CHEBI:17234,glucose,CHEBI:17234,REJECTED,resolved:owned
+D-glucose,ontology_label,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,resolved:owned
+D-glucose 6-phosphate,preferred_term,CHEBI:14314,D-glucose 6-phosphate,CHEBI:14314,MAPPED,resolved:owned
+D-glucose 6-phosphate,ontology_label,cas:54010-71-8,D-Glucose-6-Phosphate sodium salt,CHEBI:14314,MAPPED,resolved:owned
+D-GLUCOSE IN LINEAR FORM,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+D-Glucose-6-Phosphate sodium salt,preferred_term,cas:54010-71-8,D-Glucose-6-Phosphate sodium salt,CHEBI:14314,MAPPED,unique
+D-glucosyl-beta-(1-4)-D-glucose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
+D-Glucuronamide,synonym,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,unique
+D-glucuronate,preferred_term,CHEBI:15748,D-glucuronate,CHEBI:15748,MAPPED,unique
+D-glucuronic acid,preferred_term,CHEBI:4178,D-glucuronic acid,CHEBI:4178,MAPPED,resolved:owned
+D-glucuronic acid,ontology_label,cas:207300-70-7,D-Glucuronic acid sodium salt monohydrate,CHEBI:4178,MAPPED,resolved:owned
+D-Glucuronic acid gamma lactone,preferred_term,CHEBI:18268,D-Glucuronic acid gamma lactone,CHEBI:18268,MAPPED,unique
+D-Glucuronic acid sodium salt monohydrate,preferred_term,cas:207300-70-7,D-Glucuronic acid sodium salt monohydrate,CHEBI:4178,MAPPED,unique
+"D-glucurono-6,3-lactone",ontology_label,CHEBI:18268,D-Glucuronic acid gamma lactone,CHEBI:18268,MAPPED,unique
+D-Glucuronsaeure,synonym,CHEBI:4178,D-glucuronic acid,CHEBI:4178,MAPPED,unique
+D-Glukuronsaeure,synonym,CHEBI:4178,D-glucuronic acid,CHEBI:4178,MAPPED,unique
+D-Glutamic Acid,preferred_term,CHEBI:15966,D-Glutamic Acid,CHEBI:15966,MAPPED,unique
+D-glutamine,preferred_term,CHEBI:17061,D-glutamine,CHEBI:17061,MAPPED,unique
+D-glycerate,preferred_term,CHEBI:16659,D-glycerate,CHEBI:16659,MAPPED,unique
+D-histidine,preferred_term,CHEBI:27947,D-histidine,CHEBI:27947,MAPPED,unique
+D-lactate,synonym,CHEBI:16004,(R)-lactate,CHEBI:16004,MAPPED,unique
+D-lactic Acid Methyl Ester,synonym,CHEBI:74611,Methyl (R)-lactate,CHEBI:74611,MAPPED,unique
+D-lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+D-lactose (lactose),synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+D-laevulose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+D-Leucine,preferred_term,CHEBI:28225,D-Leucine,CHEBI:28225,MAPPED,unique
+D-Leucrose,preferred_term,cas:7158-70-5,D-Leucrose,cas:7158-70-5,MAPPED,unique
+d-limonene,preferred_term,cas:138-86-7,d-limonene,cas:138-86-7,MAPPED,unique
+D-Lysine,preferred_term,CHEBI:16855,D-Lysine,CHEBI:16855,MAPPED,unique
+D-lyxo-pentose,synonym,CHEBI:62318,D-lyxose,CHEBI:62318,MAPPED,unique
+D-lyxo-pentose,synonym,CHEBI:62318,D-(-)-lyxose,CHEBI:16789,REJECTED,unique
+D-lyxose,preferred_term,CHEBI:62318,D-lyxose,CHEBI:62318,MAPPED,unique
+D-Lyxose,synonym,CHEBI:62318,D-(-)-lyxose,CHEBI:16789,REJECTED,unique
+D-malate,preferred_term,CHEBI:15588,D-malate,CHEBI:15588,MAPPED,unique
+D-Maltose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+D-maltose (maltose),synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+D-Maltose monohydrate,preferred_term,cas:6363-53-7,D-Maltose monohydrate,CHEBI:17306,MAPPED,unique
+D-Mannitol,preferred_term,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+D-manno-hexose,synonym,CHEBI:16024,D-Mannose,CHEBI:16024,MAPPED,unique
+D-Mannose,preferred_term,CHEBI:16024,D-Mannose,CHEBI:16024,MAPPED,unique
+D-mannose 6-(dihydrogen phosphate),synonym,CHEBI:17369,Mannose-6-Phosphate,CHEBI:17369,MAPPED,conflict:different_substances
+D-mannose 6-(dihydrogen phosphate),synonym,cas:70442-25-0,D-Mannose 6-phosphate sodium salt,CHEBI:17369,MAPPED,conflict:different_substances
+D-mannose 6-phosphate,ontology_label,CHEBI:17369,Mannose-6-Phosphate,CHEBI:17369,MAPPED,conflict:different_substances
+D-mannose 6-phosphate,ontology_label,cas:70442-25-0,D-Mannose 6-phosphate sodium salt,CHEBI:17369,MAPPED,conflict:different_substances
+D-Mannose 6-phosphate sodium salt,preferred_term,cas:70442-25-0,D-Mannose 6-phosphate sodium salt,CHEBI:17369,MAPPED,unique
+D-Melibiose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+D-melibiose (melibiose),synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+D-mellibiose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+D-Methionine,preferred_term,CHEBI:16867,D-Methionine,CHEBI:16867,MAPPED,unique
+D-myo-Inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+D-ornithine,preferred_term,CHEBI:16176,D-ornithine,CHEBI:16176,MAPPED,unique
+D-Proline,preferred_term,CHEBI:16313,D-Proline,CHEBI:16313,MAPPED,unique
+D-psicose,preferred_term,CHEBI:27605,D-psicose,CHEBI:27605,MAPPED,unique
+D-raffinose (raffinose),synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+D-Raffinose pentahydrate,preferred_term,cas:17629-30-0,D-Raffinose pentahydrate,CHEBI:189430,MAPPED,unique
+D-rhamnose,preferred_term,CHEBI:63150,D-rhamnose,CHEBI:63150,MAPPED,unique
+D-ribo-pentose,synonym,CHEBI:16988,D-Ribose,CHEBI:16988,MAPPED,unique
+D-Ribose,preferred_term,CHEBI:16988,D-Ribose,CHEBI:16988,MAPPED,unique
+D-saccharate,synonym,CHEBI:30612,D-glucarate,CHEBI:30612,MAPPED,unique
+D-Saccharic acid potassium salt,preferred_term,cas:576-42-1,D-Saccharic acid potassium salt,CHEBI:16002,MAPPED,unique
+D-saccharose (sucrose),synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+d-salicin,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+D-Serine,preferred_term,CHEBI:16523,D-Serine,CHEBI:16523,MAPPED,unique
+D-Sorbit,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+D-Sorbitol,preferred_term,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+D-sorbitol (D-glucitol),synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+D-sorbose,preferred_term,CHEBI:17317,D-sorbose,CHEBI:17317,MAPPED,unique
+D-Sucrose,preferred_term,CHEBI:17992,D-Sucrose,CHEBI:17992,REJECTED,unique
+D-Sucrose,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+D-tagatopyranose,ontology_label,CHEBI:4249,D-(-)-tagatose,CHEBI:4249,MAPPED,unique
+D-tagatose,preferred_term,CHEBI:16443,D-tagatose,CHEBI:16443,MAPPED,unique
+D-threonine,preferred_term,CHEBI:16398,D-threonine,CHEBI:16398,MAPPED,unique
+D-Trehalose,synonym,CHEBI:27082,Trehalose,CHEBI:27082,MAPPED,unique
+D-Trehalose dihydrate,preferred_term,CHEBI:232797,D-Trehalose dihydrate,CHEBI:232797,MAPPED,unique
+D-tryptophan,preferred_term,CHEBI:16296,D-tryptophan,CHEBI:16296,MAPPED,unique
+D-valine,preferred_term,CHEBI:27477,D-valine,CHEBI:27477,MAPPED,unique
+D-XYLITOL,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+D-Xylose,preferred_term,CHEBI:65327,D-Xylose,CHEBI:65327,MAPPED,unique
+D-xylose 5-(dihydrogen phosphate),synonym,cas:66768-39-6,D-xylose 5-phosphate lithium salt,CHEBI:37492,MAPPED,unique
+D-xylose 5-phosphate,ontology_label,cas:66768-39-6,D-xylose 5-phosphate lithium salt,CHEBI:37492,MAPPED,unique
+D-xylose 5-phosphate lithium salt,preferred_term,cas:66768-39-6,D-xylose 5-phosphate lithium salt,CHEBI:37492,MAPPED,unique
+D2O,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+Dactimicin,preferred_term,CHEBI:81430,Dactimicin,CHEBI:81430,MAPPED,unique
+Daidzein,preferred_term,CHEBI:28197,Daidzein,CHEBI:28197,MAPPED,unique
+Dambose,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+DAMPA,preferred_term,cas:19741-14-1,DAMPA,cas:19741-14-1,MAPPED,unique
+Danomycin,preferred_term,kgmicrobe.compound:danomycin,Danomycin,kgmicrobe.compound:danomycin,MAPPED,unique
+Danubomycin,preferred_term,kgmicrobe.compound:danubomycin,Danubomycin,kgmicrobe.compound:danubomycin,MAPPED,unique
+DANVA,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+Daptomycin,preferred_term,CHEBI:600103,Daptomycin,CHEBI:600103,MAPPED,unique
+DAS Macro Solution,preferred_term,kgmicrobe.ingredient:das_macro_solution,DAS Macro Solution,kgmicrobe.ingredient:das_macro_solution,MAPPED,unique
+DAS Vitamin Cocktail,preferred_term,kgmicrobe.ingredient:das_vitamin_cocktail,DAS Vitamin Cocktail,kgmicrobe.ingredient:das_vitamin_cocktail,MAPPED,unique
+Daunorubicin,preferred_term,CHEBI:41977,Daunorubicin,CHEBI:41977,MAPPED,unique
+Day_AminoAcid20,preferred_term,kgmicrobe.ingredient:day_aminoacid20,Day_AminoAcid20,kgmicrobe.ingredient:day_aminoacid20,MAPPED,unique
+DBF,synonym,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
+DCMU,preferred_term,CHEBI:116509,DCMU,CHEBI:116509,MAPPED,unique
+Deacetylchitin,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+DEANONOate,preferred_term,cas:372965-00-9,DEANONOate,CHEBI:77707,MAPPED,unique
+decan-1-ol,ontology_label,CHEBI:28903,decyl alcohol,CHEBI:28903,MAPPED,unique
+DECANE,synonym,CHEBI:41808,n-Decane,CHEBI:41808,MAPPED,unique
+Decanedioic acid,synonym,CHEBI:41865,Sebacic acid,CHEBI:41865,MAPPED,unique
+Decanoate,preferred_term,CHEBI:27689,Decanoate,CHEBI:27689,MAPPED,unique
+Decanoic acid,preferred_term,CHEBI:30813,Decanoic acid,CHEBI:30813,MAPPED,unique
+Decaplanin,preferred_term,mesh:C076135,Decaplanin,mesh:C076135,MAPPED,unique
+Decoyinine,preferred_term,CHEBI:191094,Decoyinine,CHEBI:191094,MAPPED,unique
+decyl alcohol,preferred_term,CHEBI:28903,decyl alcohol,CHEBI:28903,MAPPED,unique
+Defibrinated horse blood,preferred_term,MICRO:0001572,Defibrinated horse blood,MICRO:0001572,MAPPED,unique
+Defibrinated rabbit blood,synonym,MICRO:0001229,Rabbit blood,MICRO:0001229,MAPPED,unique
+Defibrinated sheep blood,preferred_term,MICRO:0001570,Defibrinated sheep blood,MICRO:0001570,MAPPED,unique
+degradation: starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Dehydrated ethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+dehydrated RCM medium,preferred_term,UNMAPPED_0372,dehydrated RCM medium,,UNMAPPED,unique
+dehydrated Wilkins-Chalgren medium,preferred_term,UNMAPPED_0373,dehydrated Wilkins-Chalgren medium,,UNMAPPED,unique
+Dekan,synonym,CHEBI:41808,n-Decane,CHEBI:41808,MAPPED,unique
+Delamanid,preferred_term,CHEBI:134742,Delamanid,CHEBI:134742,MAPPED,unique
+delphinic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+delta-Amino-n-valeric acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+delta-aminovaleric acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+Delta-Decalactone,preferred_term,CHEBI:87327,Delta-Decalactone,CHEBI:87327,MAPPED,unique
+Delta-Dodecalactone,preferred_term,CHEBI:171817,Delta-Dodecalactone,CHEBI:171817,MAPPED,unique
+delta-hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+Delta-Nonalactone,preferred_term,CHEBI:171747,Delta-Nonalactone,CHEBI:171747,MAPPED,unique
+Delta-Undecalactone,preferred_term,CHEBI:171846,Delta-Undecalactone,CHEBI:171846,MAPPED,unique
+delta-ureidonorvaline,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+Deoxycholic acid,preferred_term,CHEBI:28834,Deoxycholic acid,CHEBI:28834,MAPPED,unique
+Deoxyinosine,synonym,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
+deoxyribonucleic acid,ontology_label,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+deoxyribonucleic acid,ontology_label,kgmicrobe.ingredient:fish-sperm_dna,Deoxyribonucleic acid from herring sperm,CHEBI:16991,REJECTED,unique
+Deoxyribonucleic acid from herring sperm,preferred_term,kgmicrobe.ingredient:fish-sperm_dna,Deoxyribonucleic acid from herring sperm,CHEBI:16991,REJECTED,unique
+Deoxyribonucleic acid from herring sperm,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+deoxyribonucleic acids,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+deoxyribonucleic acids,synonym,kgmicrobe.ingredient:fish-sperm_dna,Deoxyribonucleic acid from herring sperm,CHEBI:16991,REJECTED,unique
+"Deoxysappanone B 7,3'-Dimethyl Ether",preferred_term,UNMAPPED_0200,"Deoxysappanone B 7,3'-Dimethyl Ether",,UNMAPPED,unique
+Deoxythymidine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+Deoxyuridine,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
+Dermadram,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Dermcidin,preferred_term,mesh:C442243,Dermcidin,mesh:C442243,MAPPED,unique
+Desacetoxymatricarin,ontology_label,CHEBI:4441,Leucodin,CHEBI:4441,MAPPED,unique
+Desferrioxamine,preferred_term,CHEBI:50453,Desferrioxamine,CHEBI:50453,MAPPED,unique
+Desicatted Ox-bile,preferred_term,UNMAPPED_0374,Desicatted Ox-bile,,UNMAPPED,unique
+Desoxyribonukleinsaeure,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+desoxyribose nucleic acid,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+Destomycin,preferred_term,kgmicrobe.compound:destomycin,Destomycin,kgmicrobe.compound:destomycin,MAPPED,unique
+Desulfovibrio trace elements,preferred_term,mesh:D014131,Desulfovibrio trace elements,mesh:D014131,MAPPED,unique
+DETA/NO,preferred_term,CHEBI:50154,DETA/NO,CHEBI:50154,MAPPED,unique
+deuterated glucose,preferred_term,cas:201417-01-8,deuterated glucose,NCIT:C200498,MAPPED,unique
+deuterated water,preferred_term,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+deuterium oxide,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+Deuteriumoxid,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+Dextran,preferred_term,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+Dextran 40,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+Dextran 70,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+Dextran 75,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+"dextran, Mw ~1,270",preferred_term,UNMAPPED_0167,"dextran, Mw ~1,270",,UNMAPPED,unique
+"dextran, Mw ~200,000",preferred_term,UNMAPPED_0168,"dextran, Mw ~200,000",,UNMAPPED,unique
+dextrane,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+dextrano,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+dextrans,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+dextranum,synonym,CHEBI:52071,Dextran,CHEBI:52071,MAPPED,unique
+Dextrin,preferred_term,CHEBI:28675,Dextrin,CHEBI:28675,MAPPED,unique
+dextrine,synonym,CHEBI:28675,Dextrin,CHEBI:28675,MAPPED,unique
+dextrines,synonym,CHEBI:28675,Dextrin,CHEBI:28675,MAPPED,unique
+dextrins,synonym,CHEBI:28675,Dextrin,CHEBI:28675,MAPPED,unique
+Dextrose,preferred_term,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+Dextrose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
+dH2O,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Diacetyl,preferred_term,CHEBI:16583,Diacetyl,CHEBI:16583,MAPPED,unique
+Diallyl sulfide,preferred_term,CHEBI:4489,Diallyl sulfide,CHEBI:4489,MAPPED,unique
+Diaminopimelic acid,preferred_term,CHEBI:23673,Diaminopimelic acid,CHEBI:23673,MAPPED,unique
+diammonium 3-carboxy-3-hydroxypentanedioate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+diammonium [(sulfonatoperoxy)sulfonyl]oxidanide,synonym,CHEBI:156543,ammonium persulfate,CHEBI:156543,MAPPED,unique
+Diammonium Citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Diammonium hydrogen citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+diammonium hydrogen phosphate,ontology_label,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+Diammonium molybdate,preferred_term,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+Diammonium nickel disulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+Diammonium oxalate,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+diammonium sulfate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+diammonium tetraoxomolybdate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+diamond green B,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+diazanium hydrogen phosphate,synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+diazanium sulfate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+Dibasic ammonium citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Dibasic potassium phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Dibasic sodium arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+Dibasic sodium phosphate,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+"dibenzo[b,d]furan",synonym,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
+"dibenzo[b,d]thiophene",synonym,CHEBI:23681,Dibenzothiophene,CHEBI:23681,MAPPED,unique
+Dibenzofuran,preferred_term,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
+dibenzofuran,synonym,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
+Dibenzothiophene,preferred_term,CHEBI:23681,Dibenzothiophene,CHEBI:23681,MAPPED,unique
+Dibucaine,preferred_term,CHEBI:247956,Dibucaine,CHEBI:247956,MAPPED,unique
+Diced potato,preferred_term,UNMAPPED_0375,Diced potato,,UNMAPPED,unique
+Dichloran-Glycerol-agar base,preferred_term,UNMAPPED_0376,Dichloran-Glycerol-agar base,,UNMAPPED,unique
+dichloro-lambda(2)-plumbane,synonym,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPPED,unique
+dichlorocadmium--water (2/5),synonym,CHEBI:63938,Cadmium chloride hemipentahydrate,CHEBI:63938,MAPPED,unique
+dichloroiron--water (1/4),synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+dichloromanganese--water (1/2),synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+dichloromanganese--water (1/4),synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+dichloromethane,ontology_label,CHEBI:15767,methylene chloride,CHEBI:15767,MAPPED,unique
+dichlorozinc,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+dichlorure de manganese,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+Dichromium sulfate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Dichromium sulphate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Dichromium trisulfate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+Dichromium trisulphate,synonym,CHEBI:53471,Cr2(SO4)3 x n H2O,CHEBI:53471,MAPPED,unique
+dicloxacillin sodium monohydrate,ontology_label,CHEBI:52019,Dicloxacillin sodium salt monohydrate,CHEBI:52019,MAPPED,unique
+Dicloxacillin sodium salt monohydrate,preferred_term,CHEBI:52019,Dicloxacillin sodium salt monohydrate,CHEBI:52019,MAPPED,unique
+Dicopac,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Dicopac,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Dicopper dichloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
+dideuterium oxide,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+diethyl ether,preferred_term,CHEBI:35702,diethyl ether,CHEBI:35702,MAPPED,unique
+diethylamine NONOate,ontology_label,cas:372965-00-9,DEANONOate,CHEBI:77707,MAPPED,unique
+Difco 0001,preferred_term,UNMAPPED_0377,Difco 0001,,UNMAPPED,unique
+Difco Bacto- Tryptone,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Difco Bacto-yeast extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Difco marine broth,preferred_term,UNMAPPED_0378,Difco marine broth,,UNMAPPED,unique
+Difucosyllactose,preferred_term,CHEBI:89917,Difucosyllactose,CHEBI:89917,MAPPED,unique
+Digested serum,preferred_term,MICRO:0001362,Digested serum,MICRO:0001362,MAPPED,unique
+Digitonin,preferred_term,CHEBI:27729,Digitonin,CHEBI:27729,MAPPED,unique
+Digoxigenin,preferred_term,CHEBI:42098,Digoxigenin,CHEBI:42098,MAPPED,unique
+dihydridooxygen,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+dihydridosulfur,synonym,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,unique
+Dihydro Azathymidine,preferred_term,kgmicrobe.compound:dihydro_azathymidine,Dihydro Azathymidine,kgmicrobe.compound:dihydro_azathymidine,MAPPED,unique
+Dihydrocelastrol,preferred_term,CHEBI:132340,Dihydrocelastrol,CHEBI:132340,MAPPED,unique
+Dihydrodehydroerosone,preferred_term,UNMAPPED_0192,Dihydrodehydroerosone,,UNMAPPED,unique
+Dihydrofumaric acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+dihydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+Dihydrogen ammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+dihydrogen arsenite,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+dihydrogen oxide,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+dihydrogen peroxide,synonym,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
+dihydrogen tetraoxosulfate,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+dihydrogen wolframate,synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+dihydrogen(peroxide),synonym,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
+dihydrogen(sulfide),synonym,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,unique
+"dihydrojasmonic acid, methyl ester",preferred_term,CHEBI:89741,"dihydrojasmonic acid, methyl ester",CHEBI:89741,MAPPED,unique
+Dihydrostreptomycin,preferred_term,CHEBI:38291,Dihydrostreptomycin,CHEBI:38291,MAPPED,unique
+dihydroxidodioxidosulfur,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+dihydroxidodioxidotungsten,synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+dihydroxidooxidoselenium,synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+Dihydroxyacetone,preferred_term,CHEBI:16016,Dihydroxyacetone,CHEBI:16016,MAPPED,unique
+dihydroxyborane,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
+diiron trioxide,synonym,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+Diiron tris(sulphate),synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Diiron trisulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Dimethyl Disulfide,preferred_term,CHEBI:4608,Dimethyl Disulfide,CHEBI:4608,MAPPED,unique
+dimethyl ether,ontology_label,cas:5728-44-9,Apigenin Dimethyl Ether,CHEBI:28887,MAPPED,unique
+Dimethyl sulfide,preferred_term,CHEBI:17437,Dimethyl sulfide,CHEBI:17437,MAPPED,unique
+dimethyl sulfone,preferred_term,CHEBI:9349,dimethyl sulfone,CHEBI:9349,MAPPED,unique
+Dimethyl sulfoxide,preferred_term,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+dimethyl sulfur oxide,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+dimethyl sulphoxide,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+Dimethylacetic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+Dimethylamine,preferred_term,CHEBI:17170,Dimethylamine,CHEBI:17170,MAPPED,unique
+Dimethylene glycol,synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+Dimethylethylene glycol,synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+Dimethylfraxetin,preferred_term,cas:6035-49-0,Dimethylfraxetin,CHEBI:93172,MAPPED,unique
+dimethyli sulfoxidum,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+Dimethylsulfide,synonym,CHEBI:17437,Dimethyl sulfide,CHEBI:17437,MAPPED,unique
+Dimethylsulfoniopropionate hydrochloride,preferred_term,CHEBI:16457,Dimethylsulfoniopropionate hydrochloride,CHEBI:16457,MAPPED,unique
+Dimethylsulfoxid,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+dimethylsulfoxyde,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+dimetil sulfoxido,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+Dimetridazole,preferred_term,CHEBI:141155,Dimetridazole,CHEBI:141155,MAPPED,unique
+dinitrogen,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+dinitrogen oxide,ontology_label,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
+Diosgenin,preferred_term,CHEBI:4629,Diosgenin,CHEBI:4629,MAPPED,unique
+dioxidane,synonym,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
+dioxidocarbon,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+Dioxy-creatinine,synonym,CHEBI:16354,N-methylhydantoin,CHEBI:16354,MAPPED,unique
+Dioxygen,preferred_term,CHEBI:15379,Dioxygen,CHEBI:15379,MAPPED,unique
+Diphenylene oxide,synonym,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
+"Diphosphoric acid, tetrasodium salt",synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+Dipicolinic Acid,preferred_term,CHEBI:46837,Dipicolinic Acid,CHEBI:46837,MAPPED,unique
+dipotassium carbonate,synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+Dipotassium chromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+dipotassium dichromate,synonym,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
+dipotassium dioxido(dioxo)chromium,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+Dipotassium hydrogen phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,conflict:different_substances
+dipotassium hydrogen phosphate,ontology_label,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,conflict:different_substances
+Dipotassium hydrogenorthophosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Dipotassium monochromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+Dipotassium monohydrogen phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Dipotassium monophosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Dipotassium orthophosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Dipotassium phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+dipotassium sulfate,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
+dipotassium tellurite,synonym,CHEBI:75248,potassium tellurate,CHEBI:75248,MAPPED,agree:same_substance
+dipotassium tellurite,synonym,cas:123333-66-4,Potassium tellurite hydrate,CHEBI:75248,MAPPED,agree:same_substance
+Dipotassium tetrathionate,synonym,CHEBI:86466,K2S4O6,CHEBI:86466,MAPPED,unique
+Direct red 28,synonym,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+disodium (-)-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+"disodium (2E)-3-oxo-2-(3-oxo-5-sulfonato-1,3-dihydro-2H-indol-2-ylidene)-2,3-dihydro-1H-indole-5-sulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+disodium (2E)-but-2-enedioate,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+"disodium (2R,3R)-2,3-dihydroxybutanedioate",synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+disodium (2S)-2-hydroxybutanedioate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+disodium (2Z)-but-2-enedioate,synonym,CHEBI:91263,Sodium maleate,CHEBI:91263,MAPPED,unique
+disodium (ethylenedinitrilo)tetraacetate dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+"disodium (R-(R*,R*))-2,3-dihydroxybutanedioate",synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+disodium (S)-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+"disodium 1,3-dihydroxypropan-2-yl phosphate",synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+"disodium 2,2',2'',2'''-(ethane-1,2-diyldiammonio)tetraacetate",synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,conflict:different_substances
+"disodium 2,2',2'',2'''-(ethane-1,2-diyldiammonio)tetraacetate",synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,conflict:different_substances
+"disodium 2,2',2'',2'''-(ethane-1,2-diyldiammonio)tetraacetate--water (1/2)",synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+"disodium 3,3'-((1,1'-biphenyl)-4,4'-diylbis(azo))bis(4-aminonaphthalene-1-sulphonate)",synonym,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+"disodium 3,3'-(biphenyl-4,4'-diyldidiazene-2,1-diyl)bis(4-aminonaphthalene-1-sulfonate)",synonym,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+"Disodium 3,3'-dioxo-(delta2,2'-biindoline)-5,5'-disulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"disodium 4,4'-(1,10-phenanthroline-4,7-diyl)dibenzenesulfonate",synonym,kgmicrobe.compound:bathophenanthrolinedisulfonic_acid_disodium_salt_hydrate,Bathophenanthrolinedisulfonic acid disodium salt hydrate,CHEBI:78157,MAPPED,unique
+"disodium 4,7-diphenyl-1,10-phenanthroline 4',4''-disulfonate",ontology_label,kgmicrobe.compound:bathophenanthrolinedisulfonic_acid_disodium_salt_hydrate,Bathophenanthrolinedisulfonic acid disodium salt hydrate,CHEBI:78157,MAPPED,unique
+"Disodium 5,5'-disulfoindigo",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"Disodium 5,5'-indigotin disulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"disodium 6beta-(2-carboxylato-2-phenylacetamido)-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:34609,Carbenicillin disodium salt,CHEBI:34609,MAPPED,unique
+"disodium 6beta-{[(2R)-2-carboxylato-2-thiophen-3-ylacetyl]amino}-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:35017,Ticarcillin disodium salt,CHEBI:35017,MAPPED,unique
+Disodium acid arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+disodium arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+Disodium beta-glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+disodium butanedioate,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+disodium butanedioate hexahydrate,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+disodium butanedioate--water(1/6),synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+disodium butanedioate.6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+disodium carbonate,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+disodium dioxido(dioxo)chromium,synonym,CHEBI:78671,Sodium Chromate,CHEBI:78671,MAPPED,unique
+Disodium disulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Disodium disulphite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+disodium dithionite,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+disodium edetate dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+disodium EDTA dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+disodium ethanedioate,synonym,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+Disodium fumarate,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+Disodium Glutarate,preferred_term,cas:13521-83-0,Disodium Glutarate,mesh:C000730144,MAPPED,unique
+Disodium glycerol 2-phosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Disodium glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+disodium hydrogen arsorate--water (1/7),synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+Disodium hydrogen phosphate,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+disodium hydrogen phosphate heptahydrate,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
+disodium hydrogenarsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+disodium hydrogenphosphate,ontology_label,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+disodium hydrogenphosphate,ontology_label,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,conflict:different_substances
+disodium hydrogenphosphate dihydrate,ontology_label,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
+disodium hydrogenphosphate dodecahydrate,ontology_label,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
+"Disodium indigo-5,5-disulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Disodium L-(+)-tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+Disodium L-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+disodium L-tyrosinate,synonym,CHEBI:53696,L-tyrosine disodium salt,CHEBI:53696,MAPPED,unique
+Disodium Malate,preferred_term,CHEBI:91260,Disodium Malate,CHEBI:91260,MAPPED,unique
+disodium maleate,synonym,CHEBI:91263,Sodium maleate,CHEBI:91263,MAPPED,unique
+Disodium metabisulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Disodium molybdate,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Disodium molybdate dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Disodium monohydrogen arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+disodium monosulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Disodium oxalate,preferred_term,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+disodium oxido(oxo)-kappa(4)-sulfanesulfonate,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+disodium oxosilanediolate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Disodium Phosphate,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Disodium phosphate heptahydrate (0.02 M stock),preferred_term,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
+disodium phosphorofluoridate,synonym,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
+Disodium pyrosulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Disodium salt of L-(+)-tartaric acid,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+disodium selenate,synonym,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+disodium selenite,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+disodium selenite hydrate,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+disodium selenite pentahydrate,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+disodium selenite pentahydrate,ontology_label,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
+disodium selenium trioxide,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Disodium succinate,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+disodium succinate (anh.),synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+disodium succinate hexahydrate,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+disodium succinate.6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+disodium sulfate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+disodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+disodium sulfide--water (1/9),synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+disodium sulfite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+disodium sulfite,synonym,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,unique
+disodium sulfurothioate,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+disodium sulphate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+disodium tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+disodium tetraborate,synonym,CHEBI:38892,Na2B4O7,CHEBI:38892,MAPPED,unique
+disodium tetraborate decahydrate,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Disodium thiosulfate,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+disodium thiosulfate pentahydrate,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+disodium thiosulphate pentahydrate,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+disodium trioxidocarbonate,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,conflict:different_substances
+disodium trioxidocarbonate,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,conflict:different_substances
+disodium trioxidocarbonate,synonym,cas:5968-11-6,sodium carbonate monohydrate,CHEBI:29377,MAPPED,conflict:different_substances
+disodium tungstate,synonym,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
+disodium;6-hydroxy-5-[(2-methoxy-5-methyl-4-sulonatophenyl)diazenyl]naphthalene-2-sulonate,synonym,CHEBI:172687,Allura Red AC,CHEBI:172687,MAPPED,unique
+"disodium;[(2R,3R,4S)-2,3,4,6-tetrahydroxy-5-oxohexyl] phosphate",synonym,cas:26177-86-6,D-Fructose 6-phosphate disodium salt hydrate,CHEBI:190546,MAPPED,unique
+DISTAMYCIN A,ontology_label,CHEBI:41958,Stallimycin,CHEBI:41958,MAPPED,unique
+Distiled water,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Distilled water,preferred_term,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+"Disulfurous acid, disodium salt",synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Dithionit,synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+Dithionite,preferred_term,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+DITHIONITE,synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+dithionite(2-),ontology_label,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
+Dithiothreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+Dithiotreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+diuron,ontology_label,CHEBI:116509,DCMU,CHEBI:116509,MAPPED,unique
+Diydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+DL vitamins,preferred_term,kgmicrobe.ingredient:dl_vitamins,DL vitamins,kgmicrobe.ingredient:dl_vitamins,MAPPED,unique
+DL-2-Aminoadipic acid,preferred_term,CHEBI:37023,DL-2-Aminoadipic acid,CHEBI:37023,MAPPED,unique
+DL-2-Aminobutyric acid,preferred_term,CHEBI:35621,DL-2-Aminobutyric acid,CHEBI:35621,MAPPED,unique
+DL-2-gamma-aminobutyrate,preferred_term,UNMAPPED_0710,DL-2-gamma-aminobutyrate,,REJECTED,unique
+DL-2-Methyl butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+DL-2-Methylbutyric acid,preferred_term,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+DL-3-Aminoisobutyric acid,preferred_term,CHEBI:27389,DL-3-Aminoisobutyric acid,CHEBI:27389,MAPPED,unique
+DL-3-Hydroxyisobutyric acid sodium salt,preferred_term,cas:1219589-99-7,DL-3-Hydroxyisobutyric acid sodium salt,CHEBI:18064,MAPPED,unique
+"DL-6,8-thioctic acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Dl-alanine,preferred_term,NCIT:C61731,Dl-alanine,NCIT:C61731,MAPPED,unique
+DL-alpha-lipoic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+DL-alpha-Methyl butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+DL-Aminosuccinic acid,synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+DL-Asparagic acid,synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+DL-Asparagine,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+DL-Asparagine x H2O,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+DL-aspartic acid,preferred_term,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+DL-Calcium pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+DL-carnitine,preferred_term,CHEBI:17126,DL-carnitine,CHEBI:17126,MAPPED,unique
+DL-Dithiothreitol,preferred_term,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+DL-glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+DL-Glutamic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+DL-Glutaminic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+DL-glyceraldehyde,preferred_term,CHEBI:5445,DL-glyceraldehyde,CHEBI:5445,MAPPED,unique
+DL-Glyceraldehyde 3-phosphate,preferred_term,CHEBI:17138,DL-Glyceraldehyde 3-phosphate,CHEBI:17138,MAPPED,unique
+DL-Glycerol 1-phosphate sodium salt hydrate,preferred_term,cas:17603-42-8,DL-Glycerol 1-phosphate sodium salt hydrate,CHEBI:14336,MAPPED,unique
+DL-Histidine,preferred_term,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
+DL-Histidine monohydrochloride monohydrate,preferred_term,cas:123333-71-1,DL-Histidine monohydrochloride monohydrate,NCIT:C87334,MAPPED,unique
+DL-Isocitric acid trisodium salt hydrate,preferred_term,kgmicrobe.compound:dl-isocitric_acid_trisodium_salt_hydrate,DL-Isocitric acid trisodium salt hydrate,CHEBI:172950,MAPPED,unique
+DL-kavain,ontology_label,CHEBI:156288,Kawain,CHEBI:156288,MAPPED,unique
+DL-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+DL-Malate,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+DL-Malic acid,preferred_term,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+DL-methionine,preferred_term,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+DL-mevalonic acid,preferred_term,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
+DL-Na-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+DL-Na-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+DL-Pantothenic acid,synonym,CHEBI:7916,Pantothenic acid,CHEBI:7916,MAPPED,unique
+DL-Proline,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
+DL-Sodium malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+DL-threonine,synonym,CHEBI:26986,Threonine,CHEBI:26986,MAPPED,unique
+DL-Tryptophan,preferred_term,CHEBI:57912,DL-Tryptophan,CHEBI:57912,MAPPED,unique
+DL-Tyrosine,preferred_term,CHEBI:18186,DL-Tyrosine,CHEBI:18186,MAPPED,unique
+DL-xylose,synonym,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
+DL-α-Methyl butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+DMSO,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+DNA,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+DNA from Salmon,preferred_term,cas:438545-06-3,DNA from Salmon,cas:438545-06-3,MAPPED,unique
+DNAn,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+DNAn+1,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+DOBK,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+Docosane,preferred_term,CHEBI:46050,Docosane,CHEBI:46050,MAPPED,unique
+Docosanol,preferred_term,CHEBI:197511,Docosanol,CHEBI:197511,MAPPED,unique
+Dodecandioic acid,preferred_term,CHEBI:4676,Dodecandioic acid,CHEBI:4676,MAPPED,unique
+dodecane,preferred_term,CHEBI:28817,dodecane,CHEBI:28817,MAPPED,unique
+dodecanedioic acid,ontology_label,CHEBI:4676,Dodecandioic acid,CHEBI:4676,MAPPED,unique
+Dodecanoate,preferred_term,CHEBI:18262,Dodecanoate,CHEBI:18262,MAPPED,unique
+dodecanoic acid,ontology_label,CHEBI:30805,Lauric acid,CHEBI:30805,MAPPED,unique
+"Dodecanoic acid, sodium salt",synonym,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
+Dodecanol,preferred_term,CHEBI:23866,Dodecanol,CHEBI:23866,MAPPED,unique
+Dopamine hydrochloride,preferred_term,CHEBI:4698,Dopamine hydrochloride,CHEBI:4698,MAPPED,unique
+Dopsisamine,preferred_term,mesh:C048266,Dopsisamine,mesh:C048266,MAPPED,unique
+Doripenem,preferred_term,CHEBI:135928,Doripenem,CHEBI:135928,MAPPED,unique
+Dotriacontane,preferred_term,CHEBI:36020,Dotriacontane,CHEBI:36020,MAPPED,unique
+Doxorubicin,preferred_term,CHEBI:28748,Doxorubicin,CHEBI:28748,MAPPED,unique
+Doxorubicin hydrochloride,preferred_term,CHEBI:31522,Doxorubicin hydrochloride,CHEBI:31522,MAPPED,unique
+Doxycycline,preferred_term,CHEBI:50845,Doxycycline,CHEBI:50845,MAPPED,unique
+Doxycycline hyclate,preferred_term,CHEBI:34730,Doxycycline hyclate,CHEBI:34730,MAPPED,unique
+Dried sodium sulfite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+Dried yeast extract S (Wako),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Dry cow-manure,preferred_term,kgmicrobe.ingredient:dry_cow-manure,Dry cow-manure,ENVO:00003031,MAPPED,unique
+dThd,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+DTL,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+DTT,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+dU,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
+duartin,ontology_label,cas:52305-04-1,Duartin (-),mesh:C087989,MAPPED,unique
+Duartin (-),preferred_term,cas:52305-04-1,Duartin (-),mesh:C087989,MAPPED,unique
+Dulbecco's Phosphate-Buffered Saline,ontology_label,kgmicrobe.ingredient:pbs,PBS,NCIT:C178908,MAPPED,unique
+dulcite,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+Durhamycin,preferred_term,kgmicrobe.compound:durhamycin,Durhamycin,kgmicrobe.compound:durhamycin,MAPPED,unique
+Dv_base_medium,preferred_term,UNMAPPED_0305,Dv_base_medium,,UNMAPPED,unique
+Dv_base_Y_medium,preferred_term,UNMAPPED_0278,Dv_base_Y_medium,,UNMAPPED,unique
+DYIII Medium,preferred_term,UNMAPPED_0083,DYIII Medium,,UNMAPPED,unique
+Dynemicin,preferred_term,NCIT:C1928,Dynemicin,NCIT:C1928,MAPPED,unique
+DYV Metal Solution,preferred_term,kgmicrobe.ingredient:dyv_metal_solution,DYV Metal Solution,kgmicrobe.ingredient:dyv_metal_solution,MAPPED,unique
+D­glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+E 132,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+E 170,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+E 222,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+E 260,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+E 264,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+E 290,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+E 300,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+E 4 Aminostyryl Acetate,preferred_term,kgmicrobe.compound:e_4_aminostyryl_acetate,E 4 Aminostyryl Acetate,kgmicrobe.compound:e_4_aminostyryl_acetate,MAPPED,unique
+E 420,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+E 421,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+E 500,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+E 920,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+E 949,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+E-260,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+E-264,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+E-290,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+E-300,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+E-420,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+E-421,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+E-500,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+E-920,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+E-949,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+e-Amino-N-Caproic Acid,preferred_term,CHEBI:16586,e-Amino-N-Caproic Acid,CHEBI:16586,MAPPED,unique
+E101,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+E211,synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+E222,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+E223,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+E260,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+E261,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+E264,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+E281,synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+E290,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+E296,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+E297,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+E300,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+E325,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+E330,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+E345,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+E363,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+E365,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+E381,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+E420,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+E421,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+E500,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+E501,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+E920,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+E921,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+E927b,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+E949,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+eau,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+EBIOS,preferred_term,UNMAPPED_0380,EBIOS,,UNMAPPED,unique
+Ebselen,preferred_term,CHEBI:77543,Ebselen,CHEBI:77543,MAPPED,unique
+econazole nitrate,ontology_label,CHEBI:4755,Econazole nitrate salt,CHEBI:4755,MAPPED,unique
+Econazole nitrate salt,preferred_term,CHEBI:4755,Econazole nitrate salt,CHEBI:4755,MAPPED,unique
+Ectoine,preferred_term,CHEBI:27592,Ectoine,CHEBI:27592,MAPPED,unique
+EDDS,synonym,cas:20846-91-7,"Ethylenediamine-N,N'-disuccinic acid",cas:20846-91-7,MAPPED,unique
+Edetate disodium anhydrous,synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+edetate trisodium,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+edetic acid,synonym,CHEBI:4735,EDTA (acid form),CHEBI:4735,REJECTED,unique
+"edit(1S,3R,4R,5R)-3-{[(2E)-3-(3,4-dihydroxyphenyl)prop-2-enoyl]oxy}-1,4,5-trihydroxycyclohexane-1-carboxylic acid",synonym,CHEBI:16112,Chlorogenic acid,CHEBI:16112,MAPPED,unique
+EDTA,preferred_term,CHEBI:4735,EDTA,CHEBI:4735,MAPPED,unique
+EDTA (acid form),preferred_term,CHEBI:4735,EDTA (acid form),CHEBI:4735,REJECTED,unique
+EDTA (acid form),synonym,CHEBI:4735,EDTA,CHEBI:4735,MAPPED,unique
+EDTA (chelating agent),preferred_term,NCIT:C360,EDTA (chelating agent),NCIT:C360,MAPPED,unique
+EDTA (disodium salt),synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA 2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA 3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA di sodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA disodium,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA disodium (anh.),synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA disodium (anhydrous),synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+EDTA disodium dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+EDTA disodium salt (anh.),synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA disodium salt (anhydrous),ontology_label,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,conflict:different_substances
+EDTA disodium salt (anhydrous),synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,conflict:different_substances
+EDTA disodium salt dihydrate,ontology_label,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+EDTA disodium salt dihydrate,ontology_label,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+EDTA Stock,preferred_term,kgmicrobe.ingredient:edta_stock,EDTA Stock,kgmicrobe.ingredient:edta_stock,MAPPED,unique
+EDTA tetrasodium tetrahydrate salt,preferred_term,cas:13235-36-4,EDTA tetrasodium tetrahydrate salt,CHEBI:4735,MAPPED,unique
+EDTA trisodium,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA trisodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA-2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA-3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA.Na .2H O,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTANa,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA·2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA·3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA・2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+EDTA・3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+Egg yolk,preferred_term,FOODON:03315772,Egg yolk,FOODON:03315772,MAPPED,unique
+Eisen,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+Eisencitrat,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Elastin,preferred_term,CHEBI:4767,Elastin,CHEBI:4767,MAPPED,unique
+electron acceptor: amorphous fe(iii) oxyhydroxid,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+electron acceptor: amorphous iron (iii) oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+electron acceptor: ethylenediaminetetraacetatoferrate,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+elemental sulfur,ontology_label,kgmicrobe.compound:sulfur_powder,Sulfur (powder),CHEBI:33403,MAPPED,unique
+Elemental sulphur,synonym,kgmicrobe.compound:sulfur_powder,Sulfur (powder),CHEBI:33403,MAPPED,unique
+Emodin,preferred_term,CHEBI:42223,Emodin,CHEBI:42223,MAPPED,unique
+Enoxacin,preferred_term,CHEBI:157175,Enoxacin,CHEBI:157175,MAPPED,unique
+Enriched Seawater Medium,preferred_term,UNMAPPED_0062,Enriched Seawater Medium,,UNMAPPED,unique
+Enrichment Solution for Seawater Medium,preferred_term,kgmicrobe.ingredient:enrichment_solution_for_seawater_medium,Enrichment Solution for Seawater Medium,kgmicrobe.ingredient:enrichment_solution_for_seawater_medium,MAPPED,unique
+Enrofloxacin,preferred_term,CHEBI:35720,Enrofloxacin,CHEBI:35720,MAPPED,unique
+Enterobactin,preferred_term,CHEBI:28855,Enterobactin,CHEBI:28855,MAPPED,unique
+enterocin,ontology_label,mesh:C012306,Vulgamycin,mesh:C012306,MAPPED,unique
+Enzymatic digest of casein,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Epiandrosterone,preferred_term,CHEBI:541975,Epiandrosterone,CHEBI:541975,MAPPED,unique
+Epigallocatechin,preferred_term,CHEBI:42255,Epigallocatechin,CHEBI:42255,MAPPED,unique
+Epitheaflavic Acid,preferred_term,UNMAPPED_0188,Epitheaflavic Acid,,UNMAPPED,unique
+epsilon-caprolactam,ontology_label,CHEBI:28579,Caprolactam,CHEBI:28579,MAPPED,unique
+epsom salt,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+epsomite,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+Erdschreiber's Medium,preferred_term,UNMAPPED_0024,Erdschreiber's Medium,,UNMAPPED,unique
+ergothioneine,ontology_label,CHEBI:4828,L-(+)-Ergothioneine,CHEBI:4828,MAPPED,unique
+Ertapenem,preferred_term,CHEBI:404903,Ertapenem,CHEBI:404903,MAPPED,unique
+erythritol,ontology_label,CHEBI:17113,meso-Erythritol,CHEBI:17113,MAPPED,unique
+erythromycin,preferred_term,CHEBI:48923,erythromycin,CHEBI:48923,MAPPED,unique
+Erythromycin A,preferred_term,CHEBI:42355,Erythromycin A,CHEBI:42355,MAPPED,unique
+Erythromycin B,preferred_term,CHEBI:28196,Erythromycin B,CHEBI:28196,MAPPED,unique
+Erythrose,preferred_term,CHEBI:33946,Erythrose,CHEBI:33946,MAPPED,unique
+erythrulose,ontology_label,CHEBI:23958,L-(+)-Erythrulose,CHEBI:23958,MAPPED,unique
+Escin,preferred_term,CHEBI:2500,Escin,CHEBI:2500,MAPPED,unique
+esculin,ontology_label,CHEBI:4853,Esculin Monohydrate,CHEBI:4853,MAPPED,unique
+Esculin Ferric Citrate,preferred_term,kgmicrobe.ingredient:esculin_ferric_citrate,Esculin Ferric Citrate,kgmicrobe.ingredient:esculin_ferric_citrate,MAPPED,unique
+Esculin Hydrolysate,preferred_term,UNMAPPED_0688,Esculin Hydrolysate,,REJECTED,unique
+Esculin Monohydrate,preferred_term,CHEBI:4853,Esculin Monohydrate,CHEBI:4853,MAPPED,unique
+Essigsaeure,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+ester of thiosulfuric acid,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+esters of thiosulfuric acid,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+Estragole,preferred_term,CHEBI:4867,Estragole,CHEBI:4867,MAPPED,unique
+Etabetacin,preferred_term,kgmicrobe.compound:etabetacin,Etabetacin,kgmicrobe.compound:etabetacin,MAPPED,unique
+Etamycin,preferred_term,mesh:C004910,Etamycin,mesh:C004910,MAPPED,unique
+etanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Ethambutol,preferred_term,CHEBI:4877,Ethambutol,CHEBI:4877,MAPPED,unique
+Ethambutol dihydrochloride,preferred_term,CHEBI:4878,Ethambutol dihydrochloride,CHEBI:4878,MAPPED,unique
+"ethane-1,2-diol",synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+ethanecarboxylic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Ethanedioic acid diammonium salt,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+"Ethanedioic acid, disodium salt",synonym,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+Ethanediol,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+Ethanoat,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+ethanoate,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+Ethanoic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+Ethanol,preferred_term,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Ethanol absolute,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Ethanolamine,preferred_term,CHEBI:16000,Ethanolamine,CHEBI:16000,MAPPED,unique
+Ethanolamine acetate,preferred_term,UNMAPPED_0159,Ethanolamine acetate,,UNMAPPED,unique
+Ether,synonym,CHEBI:35702,diethyl ether,CHEBI:35702,MAPPED,unique
+Ethidium Bromide,preferred_term,CHEBI:4883,Ethidium Bromide,CHEBI:4883,MAPPED,unique
+ethinyl trichloride,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Ethionamide,preferred_term,CHEBI:4885,Ethionamide,CHEBI:4885,MAPPED,unique
+ethoic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+"ethyl 2,2-dimethyl-3-(2-methylprop-1-enyl)cyclopropane-1-carboxylate",synonym,cas:97-41-6,"Chrysanthemic Acid, Ethyl Ester",CHEBI:228794,MAPPED,unique
+ethyl 2-hexenoate,synonym,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
+"ethyl 4-(8-chloro-5,6-dihydro-11H-benzo[5,6]cyclohepta[1,2-b]pyridin-11-ylidene)piperidine-1-carboxylate",synonym,CHEBI:6538,Loratadine,CHEBI:6538,MAPPED,unique
+ethyl acetate,preferred_term,CHEBI:27750,ethyl acetate,CHEBI:27750,MAPPED,unique
+Ethyl alcohol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Ethyl benzoate,preferred_term,CHEBI:156074,Ethyl benzoate,CHEBI:156074,MAPPED,unique
+Ethyl chrysanthemumate,ontology_label,cas:97-41-6,"Chrysanthemic Acid, Ethyl Ester",CHEBI:228794,MAPPED,unique
+Ethyl decanoate,preferred_term,CHEBI:87430,Ethyl decanoate,CHEBI:87430,MAPPED,unique
+ethyl hex-2-enoate,synonym,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
+ethyl methyl sulfide,preferred_term,CHEBI:231886,ethyl methyl sulfide,CHEBI:231886,MAPPED,unique
+ethylacetic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+Ethylene glycol,preferred_term,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+ethylene tetrachloride,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+ethylene trichloride,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Ethylenediamine N N Prime Disuccinic Acid,preferred_term,kgmicrobe.compound:ethylenediamine_n_n_prime_disuccinic_acid,Ethylenediamine N N Prime Disuccinic Acid,kgmicrobe.compound:ethylenediamine_n_n_prime_disuccinic_acid,MAPPED,unique
+Ethylenediamine-N,synonym,kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,"Ethylenediamine-N,N'-disuccinic acid (EDDS)",kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,MAPPED,unique
+"Ethylenediamine-N,N'-disuccinic acid",preferred_term,cas:20846-91-7,"Ethylenediamine-N,N'-disuccinic acid",cas:20846-91-7,MAPPED,unique
+"Ethylenediamine-N,N'-disuccinic acid (EDDS)",preferred_term,kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,"Ethylenediamine-N,N'-disuccinic acid (EDDS)",kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,MAPPED,unique
+ethylenediaminetetraacetatoferrate,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+ethylenediaminetetraacetatoferrate(1-),ontology_label,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+ethylenediaminetetraacetic acid,ontology_label,CHEBI:4735,EDTA,CHEBI:4735,MAPPED,conflict:different_substances
+ethylenediaminetetraacetic acid,ontology_label,cas:13235-36-4,EDTA tetrasodium tetrahydrate salt,CHEBI:4735,MAPPED,conflict:different_substances
+ethylenediaminetetraacetic acid,ontology_label,CHEBI:4735,EDTA (acid form),CHEBI:4735,REJECTED,conflict:different_substances
+ethylenediaminetetraacetic acid disodium salt dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+ethylenediaminetetraacetic acid trisodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+Ethylenesuccinic acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+ethylformic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Ethylic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+Ethylmalonic acid,preferred_term,CHEBI:741548,Ethylmalonic acid,CHEBI:741548,MAPPED,unique
+ethylmethylacetic acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+ethylpropanedioic acid,synonym,CHEBI:741548,Ethylmalonic acid,CHEBI:741548,MAPPED,unique
+EtOH,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Eudesmic Acid,preferred_term,CHEBI:454991,Eudesmic Acid,CHEBI:454991,MAPPED,unique
+Eugenol,preferred_term,CHEBI:4917,Eugenol,CHEBI:4917,MAPPED,unique
+Euglena Medium,preferred_term,UNMAPPED_0064,Euglena Medium,,UNMAPPED,unique
+Euphol,preferred_term,CHEBI:4940,Euphol,CHEBI:4940,MAPPED,unique
+Eurocidin,preferred_term,kgmicrobe.compound:eurocidin,Eurocidin,kgmicrobe.compound:eurocidin,MAPPED,unique
+europium chloride,synonym,cas:10025-76-0,Europium(III) chloride,cas:10025-76-0,MAPPED,unique
+Europium(III) chloride,preferred_term,cas:10025-76-0,Europium(III) chloride,cas:10025-76-0,MAPPED,unique
+Exfoliatin,preferred_term,kgmicrobe.compound:exfoliatin,Exfoliatin,kgmicrobe.compound:exfoliatin,MAPPED,unique
+Exopolysaccharide,preferred_term,CHEBI:72813,Exopolysaccharide,CHEBI:72813,MAPPED,unique
+F/2 Medium,preferred_term,UNMAPPED_0033,F/2 Medium,,UNMAPPED,unique
+FA 18:1,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+Factor A,synonym,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
+Factor IIIm,synonym,UNMAPPED_0180,5-methoxybenzimidazolyl cobamide,,UNMAPPED,unique
+FAD,preferred_term,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+farnesol,ontology_label,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
+Fastidious Anaerobe Agar,preferred_term,UNMAPPED_0120,Fastidious Anaerobe Agar,,UNMAPPED,unique
+Fastidious Anaerobe Basal Broth,preferred_term,UNMAPPED_0381,Fastidious Anaerobe Basal Broth,,UNMAPPED,unique
+Fastidious Anaerobe Broth With Meat Granules,preferred_term,kgmicrobe.ingredient:fastidious_anaerobe_broth_with_meat_granules,Fastidious Anaerobe Broth With Meat Granules,kgmicrobe.ingredient:fastidious_anaerobe_broth_with_meat_granules,MAPPED,unique
+Fatty acid,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fatty acid mixture (see Medium No. 266),preferred_term,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+fatty acids,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+FBS,synonym,NCIT:C113696,Fetal bovine serum,NCIT:C113696,MAPPED,unique
+FCCP,preferred_term,CHEBI:75458,FCCP,CHEBI:75458,MAPPED,unique
+FD and C Blue No. 2,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+FD&C Blue No. 2,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+FE EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Fe SO4 x 7 H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+Fe(0),synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+Fe(3+)-citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Fe(II)SO4,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+Fe(III) citrate,preferred_term,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Fe(III)-EDTA,preferred_term,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Fe(III)-oxyhydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+Fe(III)PO4 x 4 H2O,preferred_term,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+Fe(III)·EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Fe(NH3)citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Fe(NH4)2(SO4)2 . 6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 . 7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2 x 6 H2O,preferred_term,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 x 6 H2O (0.01% w/v),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 x 6 H2O (0.1% w/v),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 x 6 H2O (2% v/v),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 x 6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2 x 7 H2O,preferred_term,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2 x 7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2x7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2·6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)2(SO4)2·7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2・6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Fe(NH4)citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+Fe2(SO4)3 x n H2O,preferred_term,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,resolved:owned
+Fe2(SO4)3 x n H2O,synonym,UNMAPPED_0385,FeSO43 x n H2O,,UNMAPPED,resolved:owned
+Fe4(PO4)2,preferred_term,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+FeCl 2 x 4 H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2,preferred_term,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,unique
+FeCl2 . 4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 tetrahydrate,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 x 4 H2O,preferred_term,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 x 4 H2O (0.1% w/v in 0.2 N HCl),synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 x 4 H2O (0.2% w/v in 0.02 N HCl),synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2 x 6 H2O,preferred_term,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,resolved:owned
+FeCl2 x 6 H2O,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,resolved:owned
+FeCl2 x 7 H2O,preferred_term,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,resolved:owned
+FeCl2 x 7 H2O,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,resolved:owned
+FeCl2 ∙ 4 H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2. 4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2.4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2·4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl2·6H2O,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+FeCl2·6H2O,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+FeCl2⋅6H2O,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+FeCl2⋅6H2O,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+FeCl2・4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+FeCl3,preferred_term,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
+FeCl3 x 4 H2O,preferred_term,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,unique
+FeCl3 x 6 H2O,preferred_term,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3.6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3·4H2O,synonym,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,unique
+FeCl3·6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+Fen,synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+FeNa-EDTA,synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+fenazona,synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+FePO4,preferred_term,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+FePO4.4H2O,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+fer,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+fermentation: glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+Fermented Rumen Extract,preferred_term,kgmicrobe.ingredient:fermented_rumen_extract,Fermented Rumen Extract,kgmicrobe.ingredient:fermented_rumen_extract,MAPPED,unique
+Feromax,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Feroritard,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Ferric ammonium citrate,preferred_term,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+ferric chloride,synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
+Ferric chloride hexahydrate,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+Ferric citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Ferric citrate monohydrate,preferred_term,CHEBI:144434,Ferric citrate monohydrate,CHEBI:144434,MAPPED,unique
+ferric diphosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Ferric EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+ferric hydroxide oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+Ferric Iron,preferred_term,CHEBI:29034,Ferric Iron,CHEBI:29034,MAPPED,unique
+Ferric iron citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+ferric malate solution,preferred_term,kgmicrobe.ingredient:ferric_malate_solution,ferric malate solution,kgmicrobe.ingredient:ferric_malate_solution,MAPPED,unique
+Ferric orthophosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+ferric orthophosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+ferric oxide,ontology_label,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+ferric oxy-hydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+ferric oxyhydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+Ferric persulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+ferric phosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+ferric phosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+Ferric pyrophosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Ferric sesquisulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Ferric sulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Ferric tersulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Ferric-NTA,preferred_term,UNMAPPED_0149,Ferric-NTA,,UNMAPPED,unique
+Ferrihydrite,preferred_term,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+ferriprotoporphyrin IX chloride,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+FerriSeltz,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+Ferro-Gradumet,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+ferrous ammonium sulfate heptahydrate,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+ferrous ammonium sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+Ferrous chloride,synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,unique
+"Ferrous chloride, tetrahydrate",synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+Ferrous citrate,preferred_term,mesh:C016600,Ferrous citrate,mesh:C016600,MAPPED,unique
+Ferrous Ion,preferred_term,CHEBI:29033,Ferrous Ion,CHEBI:29033,MAPPED,unique
+Ferrous sulfate,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+ferrous sulfate (anh.),synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+ferrous sulfate (anhydrous),synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+ferrous sulfate (anhydrous),synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+ferrous sulfate (anhydrous),synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+ferrous sulfate anhydrous,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+ferrous sulfate anhydrous,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+ferrous sulfate anhydrous,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+ferrous sulfate heptahydrate,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+ferrous sulfate monohydrate,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+ferrous sulfate.7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+ferroverdin,preferred_term,CHEBI:219729,ferroverdin,CHEBI:219729,MAPPED,unique
+ferrum,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+Ferulate,preferred_term,CHEBI:17620,Ferulate,CHEBI:17620,MAPPED,unique
+Ferulic Acid,preferred_term,CHEBI:193350,Ferulic Acid,CHEBI:193350,MAPPED,unique
+FeSO .7H O,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+FeSO4,preferred_term,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+FeSO4 . 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4 x 5 H2O,preferred_term,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 5 H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 5 H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,resolved:owned
+FeSO4 x 6 H2O,preferred_term,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 6 H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 6 H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,resolved:owned
+FeSO4 x 6H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4 x 6H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4 x 6H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+FeSO4 x 7 H2O,preferred_term,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4 x 7H2O,preferred_term,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,resolved:owned
+FeSO4 x 7H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 7H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,resolved:owned
+FeSO4 x 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,resolved:owned
+FeSO4 x H2O,preferred_term,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+FeSO4 x7 H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4 x7 H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4 x7 H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+FeSO4 x7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4 · 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4 ⋅ 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4.7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4.H2O,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+FeSO43 x n H2O,preferred_term,UNMAPPED_0385,FeSO43 x n H2O,,UNMAPPED,unique
+FeSO4·6H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4·6H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4·6H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+FeSO4·7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4⋅7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4・6H2O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4・6H2O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+FeSO4・6H2O,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+FeSO4・7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+FeSO4・H2O,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Fespan,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Fetal bovine serum,preferred_term,NCIT:C113696,Fetal bovine serum,NCIT:C113696,MAPPED,unique
+Fettsaeure,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fettsaeuren,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fibersol-2-AG,preferred_term,UNMAPPED_0211,Fibersol-2-AG,,UNMAPPED,unique
+Fiboflavin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Fibrin,preferred_term,CHEBI:5054,Fibrin,CHEBI:5054,MAPPED,unique
+Fidaxomicin,preferred_term,CHEBI:68590,Fidaxomicin,CHEBI:68590,MAPPED,unique
+Fig,preferred_term,NCIT:C71971,Fig,NCIT:C71971,MAPPED,unique
+Fildes Enrichment,preferred_term,MICRO:0001597,Fildes Enrichment,MICRO:0001597,MAPPED,unique
+Filipin,preferred_term,mesh:D005372,Filipin,mesh:D005372,MAPPED,unique
+Filter paper (cellulose substrate),synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+filtered,synonym,UNMAPPED_0166,Red Arabinan from sugar-beet,,UNMAPPED,unresolved:no_chemistry
+filtered,synonym,UNMAPPED_0237,"b-Glucan from Beet (1,2-b-Glucan)",,UNMAPPED,unresolved:no_chemistry
+filtered,synonym,UNMAPPED_0238,Galactan from Potato,,UNMAPPED,unresolved:no_chemistry
+Filtered Seawater,preferred_term,MICRO:0001773,Filtered Seawater,MICRO:0001773,MAPPED,unique
+"filtered, dextran, Mw ~200,000",synonym,UNMAPPED_0168,"dextran, Mw ~200,000",,UNMAPPED,unique
+"filtered, Mannan from Saccharomyces cerevisiae",synonym,cas:9036-88-8,Mannan from Saccharomyces cerevisiae,NCIT:C14271,MAPPED,unique
+"filtered, Pectic galactan from potato",synonym,UNMAPPED_0231,Pectic galactan from potato,,UNMAPPED,unique
+"filtered, polygalacturonic acid (ultrapure)",synonym,CHEBI:62969,polygalacturonic acid,CHEBI:62969,MAPPED,unique
+Fish peptone,preferred_term,MICRO:0000462,Fish peptone,MICRO:0000462,MAPPED,resolved:owned
+Fish peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,resolved:owned
+Fish peptone (Fluka),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Fish-Sperm DNA,preferred_term,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+fitomenadiona,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+fitomenadione,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Flavaxin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Flavensomycin,preferred_term,kgmicrobe.compound:flavensomycin,Flavensomycin,kgmicrobe.compound:flavensomycin,MAPPED,unique
+Flavin adenine dinucleotide,preferred_term,CHEBI:24040,Flavin adenine dinucleotide,CHEBI:24040,MAPPED,unique
+Flavin Bb,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+FLAVIN-ADENINE DINUCLEOTIDE,synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+Flavofungin,preferred_term,mesh:C001897,Flavofungin,mesh:C001897,MAPPED,unique
+Flavomycin,preferred_term,CHEBI:28908,Flavomycin,CHEBI:28908,MAPPED,unique
+Flavone,preferred_term,CHEBI:42491,Flavone,CHEBI:42491,MAPPED,unique
+Flaxain,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Fleroxacin,preferred_term,CHEBI:31810,Fleroxacin,CHEBI:31810,MAPPED,unique
+Fluoranthene,preferred_term,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
+fluoranthene,synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
+Fluorene,preferred_term,CHEBI:28266,Fluorene,CHEBI:28266,MAPPED,unique
+Fluorescein,preferred_term,NCIT:C61766,Fluorescein,NCIT:C61766,MAPPED,unique
+Folate,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Folic acid,preferred_term,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Folicet,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Folinic acid,preferred_term,CHEBI:15640,Folinic acid,CHEBI:15640,MAPPED,unique
+Folinic acid (citrovorum),synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Folsaeure,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Formaldehyde,preferred_term,CHEBI:16842,Formaldehyde,CHEBI:16842,MAPPED,unique
+Formamicin,preferred_term,CHEBI:203275,Formamicin,CHEBI:203275,MAPPED,unique
+Formamide,preferred_term,CHEBI:16397,Formamide,CHEBI:16397,MAPPED,unique
+Formate,preferred_term,CHEBI:15740,Formate,CHEBI:15740,MAPPED,unique
+Formate+3-methyl Mercaptopropionate,preferred_term,kgmicrobe.ingredient:formate_3_methyl_mercaptopropionate,Formate+3-methyl Mercaptopropionate,kgmicrobe.ingredient:formate_3_methyl_mercaptopropionate,MAPPED,unique
+Formate+dimethylsulfide,preferred_term,kgmicrobe.ingredient:formate_dimethylsulfide,Formate+dimethylsulfide,kgmicrobe.ingredient:formate_dimethylsulfide,MAPPED,unique
+Formate+methanol,preferred_term,kgmicrobe.ingredient:formate_methanol,Formate+methanol,kgmicrobe.ingredient:formate_methanol,MAPPED,unique
+Formate+tetramethylammonium,preferred_term,kgmicrobe.ingredient:formate_tetramethylammonium,Formate+tetramethylammonium,kgmicrobe.ingredient:formate_tetramethylammonium,MAPPED,unique
+Formate+trimethylamine,preferred_term,kgmicrobe.ingredient:formate_trimethylamine,Formate+trimethylamine,kgmicrobe.ingredient:formate_trimethylamine,MAPPED,unique
+Formic acid,preferred_term,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+"FORMIC ACID, NA SALT",synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+"formic acid, sodium salt",synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+"Formic acid, sodium salt (1:1)",synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Formimidoyl-fortimicin A,ontology_label,CHEBI:81430,Dactimicin,CHEBI:81430,MAPPED,unique
+formylic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Fortimicin B,preferred_term,CHEBI:81284,Fortimicin B,CHEBI:81284,MAPPED,unique
+Fosfomycin,preferred_term,CHEBI:28915,Fosfomycin,CHEBI:28915,MAPPED,unique
+Fosmidomycin sodium salt,ontology_label,cas:66508-37-0,Fosmidomycin sodium salt hydrate,CHEBI:201600,MAPPED,unique
+Fosmidomycin sodium salt hydrate,preferred_term,cas:66508-37-0,Fosmidomycin sodium salt hydrate,CHEBI:201600,MAPPED,unique
+Fradicin,preferred_term,mesh:C033989,Fradicin,mesh:C033989,MAPPED,unique
+Framycetin,preferred_term,CHEBI:7508,Framycetin,CHEBI:7508,MAPPED,unique
+Fraxetin,preferred_term,CHEBI:5169,Fraxetin,CHEBI:5169,MAPPED,unique
+FREE CYSTEINE,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+Fresh Baker's Yeast Extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Fresh egg mixture,preferred_term,UNMAPPED_0387,Fresh egg mixture,,UNMAPPED,unique
+Fru,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+Fruchtzucker,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+Fructooligosaccharides (FOS),preferred_term,cas:308066-66-2,Fructooligosaccharides (FOS),CHEBI:28645,MAPPED,unique
+Fructooligosaccharides from chicory,preferred_term,UNMAPPED_0209,Fructooligosaccharides from chicory,,UNMAPPED,unique
+Fructose,preferred_term,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,resolved:owned
+FRUCTOSE,synonym,cas:308066-66-2,Fructooligosaccharides (FOS),CHEBI:28645,MAPPED,resolved:owned
+Fructose-6-phosphate,preferred_term,CHEBI:15946,Fructose-6-phosphate,CHEBI:15946,MAPPED,unique
+Fructose-asparagine,preferred_term,cas:34393-27-6,Fructose-asparagine,cas:34393-27-6,MAPPED,unique
+Fruktose,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
+FSL,preferred_term,cas:322455-70-9,FSL,cas:322455-70-9,MAPPED,unique
+Fuc,synonym,CHEBI:33984,Fucose,CHEBI:33984,MAPPED,unique
+Fuc(a1-3)[Gal(b1-4)]Glc,synonym,cas:41312-47-4,3'-fucosyllactose,CHEBI:90065,MAPPED,unique
+Fuc(a1-3)[Glc(a1-4)]Gal,synonym,cas:150-90-3,Sodium succinate dibasic,CHEBI:63675,MAPPED,unique
+Fucoidan,preferred_term,CHEBI:5181,Fucoidan,CHEBI:5181,MAPPED,unique
+Fucose,preferred_term,CHEBI:33984,Fucose,CHEBI:33984,MAPPED,unique
+Full composition available at source database,preferred_term,UNMAPPED_0001,Full composition available at source database,,UNMAPPED,unique
+Fumarate,preferred_term,CHEBI:29806,Fumarate,CHEBI:29806,MAPPED,unique
+fumarate(2-),ontology_label,CHEBI:29806,Fumarate,CHEBI:29806,MAPPED,unique
+Fumaric acid,preferred_term,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+"Fumaric acid, disodium salt",synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+Fumarprotocetraric Acid,preferred_term,CHEBI:144157,Fumarprotocetraric Acid,CHEBI:144157,MAPPED,unique
+Fumarsaeure,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+Fungichromin,preferred_term,CHEBI:31639,Fungichromin,CHEBI:31639,MAPPED,unique
+Furaltadone hydrochloride,preferred_term,cas:3759-92-1,Furaltadone hydrochloride,NCIT:C217928,MAPPED,unique
+furan-2-carbaldehyde,synonym,CHEBI:34768,2-Furfuraldehyde,CHEBI:34768,MAPPED,unique
+Furan-2-carbonsaeure,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+furan-2-carboxylic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+furan-2-ylmethanol,synonym,CHEBI:207496,Furfuryl Alcohol,CHEBI:207496,MAPPED,unique
+Furaxone,preferred_term,kgmicrobe.compound:furaxone,Furaxone,kgmicrobe.compound:furaxone,MAPPED,unique
+Furazolidone,preferred_term,CHEBI:5195,Furazolidone,CHEBI:5195,MAPPED,unique
+furfural,ontology_label,CHEBI:34768,2-Furfuraldehyde,CHEBI:34768,MAPPED,unique
+Furfuryl Alcohol,preferred_term,CHEBI:207496,Furfuryl Alcohol,CHEBI:207496,MAPPED,unique
+Fusaric acid,preferred_term,CHEBI:5199,Fusaric acid,CHEBI:5199,MAPPED,unique
+Fusidate,preferred_term,CHEBI:71321,Fusidate,CHEBI:71321,MAPPED,unique
+Fusidic acid,synonym,cas:751-94-0,Fusidic acid sodium salt,CHEBI:29013,MAPPED,unique
+Fusidic acid sodium salt,preferred_term,cas:751-94-0,Fusidic acid sodium salt,CHEBI:29013,MAPPED,unique
+G Glycerol,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+G Glycerol,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+G Starch,synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+G-ol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+G418,synonym,cas:108321-42-2,G418 disulfate salt solution,cas:108321-42-2,MAPPED,unique
+G418 disulfate salt solution,preferred_term,cas:108321-42-2,G418 disulfate salt solution,cas:108321-42-2,MAPPED,unique
+G9 Trace Metals for J medium,preferred_term,kgmicrobe.ingredient:g9_trace_metals_for_j_medium,G9 Trace Metals for J medium,kgmicrobe.ingredient:g9_trace_metals_for_j_medium,MAPPED,unique
+GABA,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+Gal,synonym,CHEBI:28260,Galactose,CHEBI:28260,MAPPED,unique
+"Gal-alpha(1,6)Glc",synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+Galactan from Potato,preferred_term,UNMAPPED_0238,Galactan from Potato,,UNMAPPED,unique
+Galactarate,preferred_term,CHEBI:16537,Galactarate,CHEBI:16537,MAPPED,unique
+galactarate(2-),ontology_label,CHEBI:16537,Galactarate,CHEBI:16537,MAPPED,unique
+galactaric acid,ontology_label,CHEBI:30852,Mucic acid,CHEBI:30852,MAPPED,unique
+Galactitol,preferred_term,CHEBI:16813,Galactitol,CHEBI:16813,MAPPED,unique
+galacto-hexose,synonym,CHEBI:28260,Galactose,CHEBI:28260,MAPPED,unique
+Galacto-oligosaccharide Prebiotic Supplement,ontology_label,NCIT:C187267,Bimuno,NCIT:C187267,MAPPED,unique
+galactomannan,ontology_label,cas:11078-30-1,Galactomannan from guar,CHEBI:27680,MAPPED,unique
+Galactomannan from guar,preferred_term,cas:11078-30-1,Galactomannan from guar,CHEBI:27680,MAPPED,unique
+Galactonate,preferred_term,CHEBI:24148,Galactonate,CHEBI:24148,MAPPED,unique
+Galactose,preferred_term,CHEBI:28260,Galactose,CHEBI:28260,MAPPED,unique
+Galactose 1-phosphate dipotassium salt pentahydrate,preferred_term,cas:19046-60-7,Galactose 1-phosphate dipotassium salt pentahydrate,CHEBI:17973,MAPPED,unique
+Galacturonate,preferred_term,CHEBI:24175,Galacturonate,CHEBI:24175,MAPPED,unique
+Galaktose,synonym,CHEBI:28260,Galactose,CHEBI:28260,MAPPED,unique
+Galb1-4Glcb,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Galbeta1-4Glc,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Galbeta1-4Glcbeta,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Gallate + Formate,preferred_term,kgmicrobe.ingredient:gallate_formate,Gallate + Formate,kgmicrobe.ingredient:gallate_formate,MAPPED,unique
+Gallic Acid,preferred_term,CHEBI:30778,Gallic Acid,CHEBI:30778,MAPPED,unique
+Gallium(III)chloride,preferred_term,cas:13450-90-3,Gallium(III)chloride,cas:13450-90-3,MAPPED,unique
+GAM agar,preferred_term,UNMAPPED_0121,GAM agar,,UNMAPPED,unique
+GAM broth,preferred_term,UNMAPPED_0388,GAM broth,,UNMAPPED,unique
+GAM Broth mod. powder,preferred_term,UNMAPPED_0389,GAM Broth mod. powder,,UNMAPPED,unique
+GAM Broth powder,preferred_term,UNMAPPED_0390,GAM Broth powder,,UNMAPPED,unique
+Gambogic Acid,preferred_term,CHEBI:67521,Gambogic Acid,CHEBI:67521,MAPPED,unique
+Gamborg B5 Medium incl. Vitamins,preferred_term,UNMAPPED_0391,Gamborg B5 Medium incl. Vitamins,,UNMAPPED,unique
+GAMMA-AMINO-BUTANOIC ACID,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+gamma-amino-n-butyric acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+gamma-Aminobenzoic acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+gamma-aminobutanoic acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+gamma-Aminobuttersaeure,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+gamma-aminobutyrate,ontology_label,CHEBI:30566,4-aminobutyrate,CHEBI:30566,MAPPED,unique
+gamma-Aminobutyric acid,preferred_term,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+Gamma-Aminobutyric Acid Hydrochloride,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+Gamma-cyclodextrin,preferred_term,CHEBI:495056,Gamma-cyclodextrin,CHEBI:495056,MAPPED,unique
+gamma-Guanidinobutyrate,synonym,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+gamma-Guanidinobutyric acid,synonym,CHEBI:15728,4-Guanidinobutyric acid,CHEBI:15728,MAPPED,unique
+gamma-L-Glutamyl-L-cysteinyl-glycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+garciniaxanthone F,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+Garden soil,preferred_term,ENVO:00002263,Garden soil,ENVO:00002263,MAPPED,unique
+garden soil,ontology_label,ENVO:00002263,air-dried garden soil,ENVO:00002263,MAPPED,unique
+Gardimycin,preferred_term,mesh:C012993,Gardimycin,mesh:C012993,MAPPED,unique
+Gelatin,synonym,CHEBI:5291,Gelatine,CHEBI:5291,MAPPED,unique
+Gelatin Hydrolyzed,preferred_term,UNMAPPED_0731,Gelatin Hydrolyzed,,REJECTED,unique
+Gelatin peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Gelatine,preferred_term,CHEBI:5291,Gelatine,CHEBI:5291,MAPPED,unique
+Gellan Gum,synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+Gelrite,preferred_term,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+geneticin,ontology_label,CHEBI:42768,Geneticin G418,CHEBI:42768,MAPPED,unique
+Geneticin G418,preferred_term,CHEBI:42768,Geneticin G418,CHEBI:42768,MAPPED,unique
+Gentamicin,preferred_term,CHEBI:17833,Gentamicin,CHEBI:17833,MAPPED,unique
+Gentamicin C2b,preferred_term,CHEBI:81283,Gentamicin C2b,CHEBI:81283,MAPPED,unique
+gentamicin sulfate,ontology_label,CHEBI:5312,Gentamicin sulfate salt,CHEBI:5312,MAPPED,unique
+Gentamicin sulfate salt,preferred_term,CHEBI:5312,Gentamicin sulfate salt,CHEBI:5312,MAPPED,unique
+gentamycin,ontology_label,CHEBI:17833,Gentamicin,CHEBI:17833,MAPPED,unique
+Gentibiose,preferred_term,CHEBI:28066,Gentibiose,CHEBI:28066,MAPPED,unique
+gentiobiose,ontology_label,CHEBI:28066,Gentibiose,CHEBI:28066,MAPPED,unique
+Gentisate,synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+Gentisic acid,preferred_term,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+Geomycin,preferred_term,mesh:D010118,Geomycin,mesh:D010118,MAPPED,unique
+Gepotidacin,preferred_term,CHEBI:747127,Gepotidacin,CHEBI:747127,MAPPED,unique
+Geraniol,preferred_term,CHEBI:17447,Geraniol,CHEBI:17447,MAPPED,unique
+Ginger,preferred_term,NCIT:C66725,Ginger,NCIT:C66725,MAPPED,unique
+Ginkgolide A,preferred_term,CHEBI:5355,Ginkgolide A,CHEBI:5355,MAPPED,unique
+Ginkgotoxin,preferred_term,CHEBI:166575,Ginkgotoxin,CHEBI:166575,MAPPED,unique
+Gjerstad humics,preferred_term,UNMAPPED_0145,Gjerstad humics,,UNMAPPED,unique
+Glc,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+Glc(b1-4)Glc(b1-4)Glc(b1-4)Glc(b1-4)Glc(b1-4)b-Glc,synonym,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
+Glc-OH,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
+Glc-ol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+Glca1-4Glca,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+Glcalpha1-4Glca,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+Glcalpha1-4Glcalpha,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+Glebomycin,preferred_term,NCIT:C90636,Glebomycin,NCIT:C90636,MAPPED,unique
+Glicerofosfato de colina,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Glu-Glu,ontology_label,CHEBI:5390,Glutamyl-glutamic Acid,CHEBI:5390,MAPPED,unique
+Glucarolactone,synonym,CHEBI:16217,D-(+)-Gluconic acid gamma-lactone,CHEBI:16217,MAPPED,unique
+glucitol,synonym,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
+gluco-hexose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+glucomannan,ontology_label,cas:11078-31-2,Glucomannan (konjac),CHEBI:17020,MAPPED,unique
+Glucomannan (konjac),preferred_term,cas:11078-31-2,Glucomannan (konjac),CHEBI:17020,MAPPED,unique
+Gluconate,preferred_term,CHEBI:24265,Gluconate,CHEBI:24265,MAPPED,unique
+Gluconic acid,preferred_term,CHEBI:24266,Gluconic acid,CHEBI:24266,MAPPED,unique
+Gluconic acid sodium salt,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Glucosamine,preferred_term,CHEBI:5417,Glucosamine,CHEBI:5417,MAPPED,unique
+Glucosamine Hydrochloride,ontology_label,cas:66-84-2,D-Glucosamine Hydrochloride,NCIT:C83732,MAPPED,unique
+Glucose,preferred_term,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+glucose,preferred_term,CHEBI:17234,glucose,CHEBI:17234,REJECTED,unique
+glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+Glucose + Acetate,preferred_term,kgmicrobe.ingredient:glucose_acetate,Glucose + Acetate,kgmicrobe.ingredient:glucose_acetate,MAPPED,unique
+Glucose + Cellobiose + Starch + Trypticase + Yeast Extract,preferred_term,kgmicrobe.ingredient:glucose_cellobiose_starch_trypticase_yeast_extract,Glucose + Cellobiose + Starch + Trypticase + Yeast Extract,kgmicrobe.ingredient:glucose_cellobiose_starch_trypticase_yeast_extract,MAPPED,unique
+Glucose + Formate,preferred_term,kgmicrobe.ingredient:glucose_formate,Glucose + Formate,kgmicrobe.ingredient:glucose_formate,MAPPED,unique
+Glucose + Lactate,preferred_term,kgmicrobe.ingredient:glucose_lactate,Glucose + Lactate,kgmicrobe.ingredient:glucose_lactate,MAPPED,unique
+Glucose + Maltose + Cellobiose + Starch + Glycerol,preferred_term,kgmicrobe.ingredient:glucose_maltose_cellobiose_starch_glycerol,Glucose + Maltose + Cellobiose + Starch + Glycerol,kgmicrobe.ingredient:glucose_maltose_cellobiose_starch_glycerol,MAPPED,unique
+Glucose + Xylose,preferred_term,kgmicrobe.ingredient:glucose_xylose,Glucose + Xylose,kgmicrobe.ingredient:glucose_xylose,MAPPED,unique
+Glucose + Yeast Extract,preferred_term,kgmicrobe.ingredient:glucose_yeast_extract,Glucose + Yeast Extract,kgmicrobe.ingredient:glucose_yeast_extract,MAPPED,unique
+Glucose 1-phosphate,preferred_term,CHEBI:16077,Glucose 1-phosphate,CHEBI:16077,MAPPED,unique
+Glucose Peptone-yeast Extract,preferred_term,kgmicrobe.ingredient:glucose_peptone_yeast_extract,Glucose Peptone-yeast Extract,kgmicrobe.ingredient:glucose_peptone_yeast_extract,MAPPED,unique
+Glucuronamide,preferred_term,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,unique
+Glucuronate,preferred_term,CHEBI:24297,Glucuronate,CHEBI:24297,MAPPED,unique
+Glukose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+Glutamate,preferred_term,CHEBI:29987,Glutamate,CHEBI:29987,MAPPED,unique
+glutamate(2-),ontology_label,CHEBI:29987,Glutamate,CHEBI:29987,MAPPED,unique
+Glutamic acid,preferred_term,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,resolved:owned
+GLUTAMIC ACID,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,resolved:owned
+GLUTAMIC ACID,synonym,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydrate,CHEBI:16015,MAPPED,resolved:owned
+Glutamic Acid,ontology_label,kgmicrobe.compound:hydro_methylpteroylglutamylglutamic_acid,Hydro Methylpteroylglutamylglutamic Acid,NCIT:C1115,MAPPED,resolved:owned
+Glutamic acid 5-amide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+Glutamic acid amide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+GLUTAMINE,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+Glutaminic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+Glutaminsaeure,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+Glutamyl-glutamic Acid,preferred_term,CHEBI:5390,Glutamyl-glutamic Acid,CHEBI:5390,MAPPED,unique
+Glutaraldehyde,preferred_term,CHEBI:64276,Glutaraldehyde,CHEBI:64276,MAPPED,unique
+Glutarate,preferred_term,CHEBI:24329,Glutarate,CHEBI:24329,MAPPED,unique
+Glutaric acid,preferred_term,CHEBI:17859,Glutaric acid,CHEBI:17859,MAPPED,unique
+Glutathione,preferred_term,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+glutathione,ontology_label,CHEBI:16856,L-Glutathione,CHEBI:16856,REJECTED,unique
+glutathione disulfide,ontology_label,CHEBI:17858,Glutathione oxidized,CHEBI:17858,MAPPED,unique
+Glutathione oxidized,preferred_term,CHEBI:17858,Glutathione oxidized,CHEBI:17858,MAPPED,unique
+Glutathione-SH,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+Gly,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Gly-Asp,ontology_label,CHEBI:73804,Glycyl L-aspartic Acid,CHEBI:73804,MAPPED,unique
+Gly-DL-Asp,preferred_term,cas:79731-35-4,Gly-DL-Asp,CHEBI:193741,MAPPED,unique
+Gly-Gln,ontology_label,cas:172669-64-6,Gly-Gln monohydrate,CHEBI:73898,MAPPED,unique
+Gly-Gln monohydrate,preferred_term,cas:172669-64-6,Gly-Gln monohydrate,CHEBI:73898,MAPPED,unique
+Gly-Glu,preferred_term,CHEBI:73801,Gly-Glu,CHEBI:73801,MAPPED,unique
+Gly-Gly,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+Gly-Pro,ontology_label,CHEBI:70744,Glycyl-L-proline,CHEBI:70744,MAPPED,unique
+Gly2,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+glyceraldehyde,ontology_label,CHEBI:5445,DL-glyceraldehyde,CHEBI:5445,MAPPED,unique
+glyceraldehyde 3-phosphate,ontology_label,CHEBI:17138,DL-Glyceraldehyde 3-phosphate,CHEBI:17138,MAPPED,unique
+Glycerate,preferred_term,CHEBI:33871,Glycerate,CHEBI:33871,MAPPED,unique
+glycerin,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+glycerine,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+glycerine,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+glycerine monostearate,synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+Glyceritol,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Glyceritol,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+glycero-tetrulose,synonym,CHEBI:23958,L-(+)-Erythrulose,CHEBI:23958,MAPPED,unique
+Glycerol,preferred_term,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+glycerol,preferred_term,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+glycerol,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+glycerol 1-(dihydrogen phosphate),synonym,cas:17603-42-8,DL-Glycerol 1-phosphate sodium salt hydrate,CHEBI:14336,MAPPED,unique
+glycerol 1-phosphate,ontology_label,cas:17603-42-8,DL-Glycerol 1-phosphate sodium salt hydrate,CHEBI:14336,MAPPED,unique
+glycerol 2-phosphate,ontology_label,cas:154804-51-0,Beta-Glycerophosphate disodium salt hydrate,CHEBI:17270,MAPPED,unique
+Glycerol 3-phosphate,preferred_term,CHEBI:15978,Glycerol 3-phosphate,CHEBI:15978,MAPPED,unique
+Glycerol anhydrous,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Glycerol mono-oleate,preferred_term,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+Glycerol monostearate,preferred_term,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+glycerol phosphate,ontology_label,cas:55073-41-1,Glycerol phosphate disodium salt hydrate,CHEBI:26707,MAPPED,unique
+Glycerol phosphate disodium salt hydrate,preferred_term,cas:55073-41-1,Glycerol phosphate disodium salt hydrate,CHEBI:26707,MAPPED,unique
+"Glycerol, 2-(dihydrogen phosphate), disodium salt",synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Glycerol-3-phosphatidylcholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+glycerol-3-phosphocholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Glycerol-asparagine agar,preferred_term,UNMAPPED_0122,Glycerol-asparagine agar,,UNMAPPED,unique
+Glycerophosphate de choline,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Glycine,preferred_term,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Glycine 1%,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Glycine betaine,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,conflict:different_substances
+glycine betaine,ontology_label,cas:590-46-5,Betaine hydrochloride,CHEBI:17750,MAPPED,conflict:different_substances
+glycine dipeptide,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+Glycine-NaOH buffer,preferred_term,kgmicrobe.ingredient:glycine-naoh_buffer,Glycine-NaOH buffer,kgmicrobe.ingredient:glycine-naoh_buffer,MAPPED,unique
+Glycine-proline,synonym,CHEBI:70744,Glycyl-L-proline,CHEBI:70744,MAPPED,unique
+Glycocholic acid hydrate,preferred_term,CHEBI:182320,Glycocholic acid hydrate,CHEBI:182320,MAPPED,unique
+Glycocoll,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Glycocyamine,preferred_term,CHEBI:16344,Glycocyamine,CHEBI:16344,MAPPED,unique
+Glycogen,preferred_term,CHEBI:28087,Glycogen,CHEBI:28087,MAPPED,resolved:owned
+glycogen,ontology_label,cas:9005-79-2,Glycogen from bovine liver,CHEBI:28087,MAPPED,resolved:owned
+Glycogen from bovine liver,preferred_term,cas:9005-79-2,Glycogen from bovine liver,CHEBI:28087,MAPPED,unique
+Glycol,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+Glycol (polysorbate 80),synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+glycolaldehyde,preferred_term,CHEBI:17071,glycolaldehyde,CHEBI:17071,MAPPED,unique
+Glycolate,preferred_term,CHEBI:29805,Glycolate,CHEBI:29805,MAPPED,unique
+Glycolic Acid,preferred_term,CHEBI:17497,Glycolic Acid,CHEBI:17497,MAPPED,unique
+Glycolic acid cellulose ether,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+Glycyl L-aspartic Acid,preferred_term,CHEBI:73804,Glycyl L-aspartic Acid,CHEBI:73804,MAPPED,unique
+Glycyl-Aspartate,ontology_label,cas:79731-35-4,Gly-DL-Asp,CHEBI:193741,MAPPED,unique
+Glycyl-glycine,preferred_term,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+glycyl-glycyl-glycine,ontology_label,CHEBI:63961,Glycylglycylglycine,CHEBI:63961,MAPPED,unique
+Glycyl-L-bromosuccinic Glutamic Acid,preferred_term,UNMAPPED_0817,Glycyl-L-bromosuccinic Glutamic Acid,,REJECTED,unique
+Glycyl-l-glutamate,synonym,CHEBI:73801,Gly-Glu,CHEBI:73801,MAPPED,unique
+glycyl-L-glutamic acid,synonym,CHEBI:73801,Gly-Glu,CHEBI:73801,MAPPED,unique
+glycyl-L-glutamine,synonym,cas:172669-64-6,Gly-Gln monohydrate,CHEBI:73898,MAPPED,unique
+Glycyl-L-proline,preferred_term,CHEBI:70744,Glycyl-L-proline,CHEBI:70744,MAPPED,unique
+Glycylglycine,preferred_term,CHEBI:17201,Glycylglycine,CHEBI:17201,REJECTED,unique
+Glycylglycine,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+Glycylglycine(CAS: 556-50-3),synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+Glycylglycine(CAS: 556-50-3),synonym,CHEBI:17201,Glycylglycine,CHEBI:17201,REJECTED,unique
+Glycylglycylglycine,preferred_term,CHEBI:63961,Glycylglycylglycine,CHEBI:63961,MAPPED,unique
+"Glycyrrhizic Acid, Ammonium Salt",preferred_term,CHEBI:15939,"Glycyrrhizic Acid, Ammonium Salt",CHEBI:15939,MAPPED,unique
+glycyrrhizinic acid,ontology_label,CHEBI:15939,"Glycyrrhizic Acid, Ammonium Salt",CHEBI:15939,MAPPED,unique
+Glykokoll,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Glyoxylate,preferred_term,CHEBI:36655,Glyoxylate,CHEBI:36655,MAPPED,unique
+Glyoxyldiureide,synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+"Glyoxylic acid, sodium salt",synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
+Glyzerin,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Glyzerin,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+Glyzin,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+gold (III) chloride hydrate,preferred_term,cas:27988-77-8,gold (III) chloride hydrate,CHEBI:30076,MAPPED,unique
+gold trichloride,ontology_label,cas:27988-77-8,gold (III) chloride hydrate,CHEBI:30076,MAPPED,unique
+Gossypetin,preferred_term,CHEBI:16400,Gossypetin,CHEBI:16400,MAPPED,unique
+Gossypol,preferred_term,CHEBI:28584,Gossypol,CHEBI:28584,MAPPED,unique
+Gossypol-Acetic Acid Complex,preferred_term,UNMAPPED_0193,Gossypol-Acetic Acid Complex,,UNMAPPED,unique
+Gossypose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+GPCho,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+Grace's Insect Medium,preferred_term,UNMAPPED_0395,Grace's Insect Medium,,UNMAPPED,unique
+Gramicidin,preferred_term,cas:1405-97-6,Gramicidin,NCIT:C65816,MAPPED,unique
+Gramicidin S,preferred_term,CHEBI:5530,Gramicidin S,CHEBI:5530,MAPPED,unique
+Gramine,preferred_term,CHEBI:28948,Gramine,CHEBI:28948,MAPPED,unique
+Granaticin,preferred_term,CHEBI:5533,Granaticin,CHEBI:5533,MAPPED,unique
+Grasseriomycin,preferred_term,kgmicrobe.compound:grasseriomycin,Grasseriomycin,kgmicrobe.compound:grasseriomycin,MAPPED,unique
+Green House Soil,preferred_term,kgmicrobe.ingredient:green_house_soil,Green House Soil,ENVO:00001998,MAPPED,unique
+Grisamine,preferred_term,kgmicrobe.compound:grisamine,Grisamine,kgmicrobe.compound:grisamine,MAPPED,unique
+Griseolutein A,preferred_term,mesh:C018306,Griseolutein A,mesh:C018306,MAPPED,unique
+Griseolutein B,preferred_term,mesh:C018307,Griseolutein B,mesh:C018307,MAPPED,unique
+Ground beef,preferred_term,FOODON:00001282,Ground beef,FOODON:00001282,MAPPED,unique
+GSH,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+Gua,synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
+Guaiacol,preferred_term,CHEBI:28591,Guaiacol,CHEBI:28591,MAPPED,unique
+Guaiazulene,preferred_term,CHEBI:5550,Guaiazulene,CHEBI:5550,MAPPED,unique
+Guanidine Hydrochloride,preferred_term,cas:50-01-1,Guanidine Hydrochloride,NCIT:C47551,MAPPED,unique
+Guanidinium Chloride,preferred_term,CHEBI:32735,Guanidinium Chloride,CHEBI:32735,MAPPED,unique
+guanidinoacetic acid,ontology_label,CHEBI:16344,Glycocyamine,CHEBI:16344,MAPPED,unique
+Guanine,preferred_term,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
+Guanine riboside,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+Guanine-9-beta-D-ribofuranoside,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+Guanosin,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+Guanosine,preferred_term,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+gulitol,synonym,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
+gum arabic,ontology_label,cas:9000-01-5,Gum arabic from acacia tree,FOODON:03412975,MAPPED,unique
+Gum arabic from acacia tree,preferred_term,cas:9000-01-5,Gum arabic from acacia tree,FOODON:03412975,MAPPED,unique
+Guo,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
+GYP-sodium acetate-mineral salts broth,preferred_term,UNMAPPED_0397,GYP-sodium acetate-mineral salts broth,,UNMAPPED,unique
+GYPS,preferred_term,kgmicrobe.ingredient:gyps,GYPS,kgmicrobe.ingredient:gyps,MAPPED,unique
+H(2),synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+H(2)O,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+H-COOH,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+H2,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+H2 + CO2,preferred_term,kgmicrobe.ingredient:h2_co2,H2 + CO2,kgmicrobe.ingredient:h2_co2,MAPPED,unique
+H2+3-methyl Mercaptopropionate,preferred_term,kgmicrobe.ingredient:h2_3_methyl_mercaptopropionate,H2+3-methyl Mercaptopropionate,kgmicrobe.ingredient:h2_3_methyl_mercaptopropionate,MAPPED,unique
+H2+dimethylsulfide,preferred_term,kgmicrobe.ingredient:h2_dimethylsulfide,H2+dimethylsulfide,kgmicrobe.ingredient:h2_dimethylsulfide,MAPPED,unique
+H2+methanol,preferred_term,kgmicrobe.ingredient:h2_methanol,H2+methanol,kgmicrobe.ingredient:h2_methanol,MAPPED,unique
+H2+tetramethylammonium,preferred_term,kgmicrobe.ingredient:h2_tetramethylammonium,H2+tetramethylammonium,kgmicrobe.ingredient:h2_tetramethylammonium,MAPPED,unique
+H2+trimethylamine,preferred_term,kgmicrobe.ingredient:h2_trimethylamine,H2+trimethylamine,kgmicrobe.ingredient:h2_trimethylamine,MAPPED,unique
+H2_CO2,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+H2_methanol,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+H2mal,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+H2N(CH2)4NH2,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+H2N-CH2-COOH,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+H2NC(O)NH2,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+H2O,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+H2SeO3,preferred_term,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+H2SO4,preferred_term,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+H2WO4,preferred_term,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+H3BO,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+H3BO2,preferred_term,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
+H3BO3,preferred_term,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+H3BO3(Baker 0084),synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+H3cit,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
+H3nta,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+H3tea,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+Haemin,preferred_term,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Halomicin,preferred_term,kgmicrobe.compound:halomicin,Halomicin,kgmicrobe.compound:halomicin,MAPPED,unique
+Hans 1000x minerals,preferred_term,kgmicrobe.ingredient:hans_1000x_minerals,Hans 1000x minerals,kgmicrobe.ingredient:hans_1000x_minerals,MAPPED,unique
+Hans 100x vitamins,preferred_term,kgmicrobe.ingredient:hans_100x_vitamins,Hans 100x vitamins,kgmicrobe.ingredient:hans_100x_vitamins,MAPPED,unique
+Harg,synonym,CHEBI:29016,Arginine,CHEBI:29016,MAPPED,unique
+Harmaline,preferred_term,CHEBI:28172,Harmaline,CHEBI:28172,MAPPED,unique
+Harmalol,preferred_term,CHEBI:27943,Harmalol,CHEBI:27943,MAPPED,unique
+harman,ontology_label,CHEBI:5623,Harmane,CHEBI:5623,MAPPED,unique
+Harmane,preferred_term,CHEBI:5623,Harmane,CHEBI:5623,MAPPED,unique
+Harmine,preferred_term,CHEBI:28121,Harmine,CHEBI:28121,MAPPED,unique
+Harmol,preferred_term,CHEBI:192558,Harmol,CHEBI:192558,MAPPED,unique
+Harmol Hydrochloride,preferred_term,cas:40580-83-4,Harmol Hydrochloride,cas:40580-83-4,MAPPED,unique
+Harnstoff,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Hasp,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
+HBO3,preferred_term,UNMAPPED_0398,HBO3,,UNMAPPED,unique
+HCH,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+HCl,preferred_term,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl.,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCO2H,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+HCOOH,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Hcys,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+Heart Infusion Broth,preferred_term,UNMAPPED_0399,Heart Infusion Broth,,UNMAPPED,unique
+heavy water,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+Hecogenin,preferred_term,CHEBI:5633,Hecogenin,CHEBI:5633,MAPPED,unique
+Helenine,preferred_term,CHEBI:2540,Helenine,CHEBI:2540,MAPPED,unique
+Hemicalcium D-(+)- pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Hemicalcium D-+-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Hemin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Hemin chloride,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+hemin IX,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Hemine,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Hemodal,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Henicosane,preferred_term,CHEBI:32931,Henicosane,CHEBI:32931,MAPPED,unique
+Hepacholine,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+heparin sodium,ontology_label,kgmicrobe.ingredient:heparin_sodium_salt_from_porcine_intestinal_mucosa,Heparin sodium salt from porcine intestinal mucosa,CHEBI:230519,MAPPED,unique
+Heparin sodium salt from porcine intestinal mucosa,preferred_term,kgmicrobe.ingredient:heparin_sodium_salt_from_porcine_intestinal_mucosa,Heparin sodium salt from porcine intestinal mucosa,CHEBI:230519,MAPPED,unique
+HEPES,preferred_term,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+HEPES buffer,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+HEPES buffer(CAS: 7365-45-9),synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+HEPES buffer(Sigma H-3375),synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+"heptadec-16-ene-1,2,4-triol",synonym,CHEBI:172520,Avocadene,CHEBI:172520,MAPPED,unique
+"heptadec-16-yne-1,2,4-triol",synonym,CHEBI:168507,Avocadyne,CHEBI:168507,MAPPED,unique
+Heptadecane,preferred_term,CHEBI:16148,Heptadecane,CHEBI:16148,MAPPED,unique
+heptadecanoic acid,preferred_term,CHEBI:32365,heptadecanoic acid,CHEBI:32365,MAPPED,unique
+Heptadekan,synonym,CHEBI:16148,Heptadecane,CHEBI:16148,MAPPED,unique
+heptamethylnonane,synonym,CHEBI:131383,"2,2,4,4,6,8,8-Heptamethylnonane",CHEBI:131383,MAPPED,unique
+heptanedioic acid,synonym,CHEBI:30531,Pimelic acid,CHEBI:30531,MAPPED,unique
+Heptanoic acid,preferred_term,CHEBI:45571,Heptanoic acid,CHEBI:45571,MAPPED,unique
+heptanol,preferred_term,CHEBI:195607,heptanol,CHEBI:195607,MAPPED,unique
+Hesperidin,preferred_term,CHEBI:28775,Hesperidin,CHEBI:28775,MAPPED,unique
+Hexachlorcyclohexan,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+Hexachlorocyclo-hexane,preferred_term,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+hexachlorocyclohexane,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+hexachlorocyclohexanes,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+Hexachlorzyklohexan,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
+Hexadecane,preferred_term,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+Hexadecanoate,preferred_term,CHEBI:7896,Hexadecanoate,CHEBI:7896,MAPPED,unique
+hexadecanoic acid,ontology_label,CHEBI:15756,Palmitic acid,CHEBI:15756,MAPPED,unique
+Hexadekan,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+Hexane,preferred_term,CHEBI:29021,Hexane,CHEBI:29021,MAPPED,unique
+hexanedioic acid,synonym,CHEBI:30832,Adipic acid,CHEBI:30832,MAPPED,unique
+Hexanoate,preferred_term,CHEBI:17120,Hexanoate,CHEBI:17120,MAPPED,unique
+HEXANOIC ACID,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+"Hexanoic acid, sodium salt",synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+hexanol,preferred_term,CHEBI:143552,hexanol,CHEBI:143552,MAPPED,unique
+hexoic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+Hexylic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+Hgly,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+hierro,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+Hipolypepton,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Hipolypepton (Nihon seiyaku),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Hippurate,synonym,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
+Hippuric acid,preferred_term,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
+Histamine,preferred_term,CHEBI:18295,Histamine,CHEBI:18295,MAPPED,unique
+Histidin,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
+histidina,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
+Histidine,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,agree:same_substance
+histidine,ontology_label,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,agree:same_substance
+Histidine Monohydrochloride Monohydrate,ontology_label,cas:123333-71-1,DL-Histidine monohydrochloride monohydrate,NCIT:C87334,MAPPED,agree:same_substance
+Histidine Monohydrochloride Monohydrate,ontology_label,cas:5934-29-2,L-Histidine monohydrochloride monohydrate,NCIT:C87334,MAPPED,agree:same_substance
+Hitachimycin,preferred_term,mesh:C031780,Hitachimycin,mesh:C031780,MAPPED,unique
+Hmet,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+HO-CH2-CH2-OH,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+HOAc,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+HOH,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Homo-PIPES,preferred_term,UNMAPPED_0401,Homo-PIPES,,UNMAPPED,unique
+"homopiperazine-1,4-bis(2-ethanesulfonic acid), HOMO-PIPES",synonym,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
+HOMOPIPES,preferred_term,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
+homovanillic acid,preferred_term,CHEBI:545959,homovanillic acid,CHEBI:545959,MAPPED,unique
+homovanillyl alcohol,preferred_term,CHEBI:173769,homovanillyl alcohol,CHEBI:173769,MAPPED,unique
+HOOC-CH2-CH2-COOH,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+Hopanoid,preferred_term,CHEBI:51963,Hopanoid,CHEBI:51963,MAPPED,unique
+Horikoshi-I medium,preferred_term,UNMAPPED_0402,Horikoshi-I medium,,UNMAPPED,unique
+Horse serum,preferred_term,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Hortesin,preferred_term,kgmicrobe.compound:hortesin,Hortesin,kgmicrobe.compound:hortesin,MAPPED,unique
+Hpro,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
+HS-CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+HSCoA,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+HSDB 7729,synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+Htrp,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+Hunter's Trace Stock Solution,preferred_term,kgmicrobe.ingredient:hunters_trace_stock_solution,Hunter's Trace Stock Solution,kgmicrobe.ingredient:hunters_trace_stock_solution,MAPPED,unique
+Huperzine A,preferred_term,CHEBI:78330,Huperzine A,CHEBI:78330,MAPPED,unique
+Hy-Case Amino,preferred_term,UNMAPPED_0404,Hy-Case Amino,,UNMAPPED,unique
+Hyaluronic acid sodium,ontology_label,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
+Hyaluronic acid sodium salt from Streptococcus equi,preferred_term,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
+Hydantoin,preferred_term,CHEBI:27612,Hydantoin,CHEBI:27612,MAPPED,unique
+Hydrastine,ontology_label,CHEBI:69919,"Hydrastine (1R, 9S)",CHEBI:69919,MAPPED,unique
+"Hydrastine (1R, 9S)",preferred_term,CHEBI:69919,"Hydrastine (1R, 9S)",CHEBI:69919,MAPPED,unique
+hydridodihydroxidoboron,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
+Hydro Methylpteroylglutamylglutamic Acid,preferred_term,kgmicrobe.compound:hydro_methylpteroylglutamylglutamic_acid,Hydro Methylpteroylglutamylglutamic Acid,NCIT:C1115,MAPPED,unique
+Hydrocarbon,preferred_term,CHEBI:24632,Hydrocarbon,CHEBI:24632,MAPPED,unique
+hydrocarbons,synonym,CHEBI:24632,Hydrocarbon,CHEBI:24632,MAPPED,unique
+hydrochloric acid,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Hydrochloride,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Hydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+Hydrogen (gas),synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+hydrogen carboxylic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Hydrogen chloride,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+Hydrogen dipotassium phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Hydrogen disodium arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+Hydrogen gas,preferred_term,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+hydrogen hydroxide,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Hydrogen peroxide,preferred_term,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
+Hydrogen sulfide,preferred_term,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,unique
+hydrogen sulfite sodium,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+hydrogen tetraoxosulfate(2-),synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+hydrogen tetraoxosulfate(VI),synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+Hydrogenchlorid,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+hydrolysis: cationic chitosan,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+hydrolysis: urea,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Hydroquinone,preferred_term,CHEBI:17594,Hydroquinone,CHEBI:17594,MAPPED,unique
+Hydroquinonecarboxylic acid,synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
+hydrous ferric oxide,preferred_term,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+hydroxy(4-hydroxyphenyl)acetic acid,synonym,cas:184901-84-6,4-Hydroxymandelic acid monohydrate,CHEBI:16388,MAPPED,unique
+hydroxy(phenyl)acetic acid,synonym,CHEBI:35825,Mandelic acid,CHEBI:35825,MAPPED,unique
+Hydroxy-L-Proline,preferred_term,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+Hydroxyacetaldehyde,synonym,CHEBI:17071,glycolaldehyde,CHEBI:17071,MAPPED,unique
+Hydroxyacetic acid,synonym,CHEBI:17497,Glycolic Acid,CHEBI:17497,MAPPED,unique
+Hydroxyacetophenone,preferred_term,CHEBI:24668,Hydroxyacetophenone,CHEBI:24668,MAPPED,unique
+Hydroxybenzene,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+hydroxybutanedioic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+hydroxyde de potassium,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+hydroxyde de sodium,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+hydroxyethane,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Hydroxyethylcellulose,preferred_term,CHEBI:85249,Hydroxyethylcellulose,CHEBI:85249,MAPPED,unique
+hydroxyflavone,ontology_label,kgmicrobe.compound:36-dihydroxyflavone,"3',6-Dihydroxyflavone",CHEBI:24698,MAPPED,unique
+hydroxylamine hcl,synonym,CHEBI:5807,Hydroxylamine hydrochloride,CHEBI:5807,MAPPED,unique
+Hydroxylamine hydrochloride,preferred_term,CHEBI:5807,Hydroxylamine hydrochloride,CHEBI:5807,MAPPED,unique
+Hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+Hydroxystreptomycin,preferred_term,CHEBI:24750,Hydroxystreptomycin,CHEBI:24750,MAPPED,unique
+hydroxysuccinic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+Hydroxyurea,preferred_term,CHEBI:44423,Hydroxyurea,CHEBI:44423,MAPPED,unique
+Hyflavin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Hygromycin,preferred_term,CHEBI:24753,Hygromycin,CHEBI:24753,MAPPED,unique
+Hygromycin A,preferred_term,CHEBI:69414,Hygromycin A,CHEBI:69414,MAPPED,unique
+Hygromycin B,preferred_term,CHEBI:16976,Hygromycin B,CHEBI:16976,MAPPED,unique
+Hymecromone Methyl Ether,preferred_term,cas:2555-28-4,Hymecromone Methyl Ether,CHEBI:107662,MAPPED,unique
+Hypotaurine,preferred_term,CHEBI:16668,Hypotaurine,CHEBI:16668,MAPPED,unique
+Hypoxanthine,preferred_term,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+hypoxanthine D-riboside,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+hypoxanthosine,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+Hypro,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+i-inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+i-propanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+i-Propylalkohol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+Icosane,preferred_term,CHEBI:43619,Icosane,CHEBI:43619,MAPPED,unique
+IMDM-Medium,preferred_term,UNMAPPED_0405,IMDM-Medium,,UNMAPPED,unique
+Imidazole,preferred_term,CHEBI:14434,Imidazole,CHEBI:14434,MAPPED,unique
+"imidazolidine-2,4,5-trione",synonym,CHEBI:74661,Parabanic Acid,CHEBI:74661,MAPPED,unique
+"imidazolidine-2,4-dione",synonym,CHEBI:27612,Hydantoin,CHEBI:27612,MAPPED,unique
+Imipenem,preferred_term,CHEBI:471744,Imipenem,CHEBI:471744,MAPPED,unique
+imipenem hydrate,ontology_label,CHEBI:51799,Impenum monohydrate,CHEBI:51799,MAPPED,unique
+Impenum monohydrate,preferred_term,CHEBI:51799,Impenum monohydrate,CHEBI:51799,MAPPED,unique
+Indigo carmine,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Indigocarmine,preferred_term,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"Indigotin-5,5'-disulfonic acid disodium salt",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Indigotindisulfonate sodium,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Indochrome,preferred_term,kgmicrobe.compound:indochrome,Indochrome,kgmicrobe.compound:indochrome,MAPPED,unique
+Indole,preferred_term,CHEBI:16881,Indole,CHEBI:16881,MAPPED,unique
+INDOLE,synonym,CHEBI:16881,Indole,CHEBI:16881,MAPPED,unique
+indole 3-acetic acid sodium salt,preferred_term,cas:6505-45-9,indole 3-acetic acid sodium salt,CHEBI:230840,MAPPED,unique
+Indole-3-acetate,preferred_term,CHEBI:30854,Indole-3-acetate,CHEBI:30854,MAPPED,unique
+indole-3-acetic acid,ontology_label,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
+Indole-3-acetic acid sodium salt,ontology_label,cas:6505-45-9,indole 3-acetic acid sodium salt,CHEBI:230840,MAPPED,unique
+Indole-3-butyric acid,preferred_term,CHEBI:33070,Indole-3-butyric acid,CHEBI:33070,MAPPED,unique
+Indole-3-propionic acid,preferred_term,CHEBI:43580,Indole-3-propionic acid,CHEBI:43580,MAPPED,unique
+Indole-3-pyruvic acid,preferred_term,cas:392-12-1,Indole-3-pyruvic acid,cas:392-12-1,MAPPED,unique
+Indolicidin,preferred_term,CHEBI:80180,Indolicidin,CHEBI:80180,MAPPED,unique
+Indolmycin,preferred_term,CHEBI:79394,Indolmycin,CHEBI:79394,MAPPED,unique
+Indoxyl Acetate,preferred_term,CHEBI:169991,Indoxyl Acetate,CHEBI:169991,MAPPED,unique
+Infusion Broth,preferred_term,UNMAPPED_0406,Infusion Broth,,UNMAPPED,unique
+Infusion from Potatoes,preferred_term,UNMAPPED_0251,Infusion from Potatoes,,UNMAPPED,unique
+inorganic salt,ontology_label,UNMAPPED_0123,Inorganic salts-starch agar,CHEBI:24839,UNMAPPED,unique
+Inorganic salts-starch agar,preferred_term,UNMAPPED_0123,Inorganic salts-starch agar,CHEBI:24839,UNMAPPED,unique
+Inosin,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+inosina,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+Inosine,preferred_term,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+inosinum,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
+inosite,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+Inositol,preferred_term,CHEBI:24848,Inositol,CHEBI:24848,MAPPED,unique
+Inositol (myo-inositol),synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+inositols,synonym,CHEBI:24848,Inositol,CHEBI:24848,MAPPED,unique
+Ins,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+INS No. 260,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+INS No. 264,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+Inulin,preferred_term,CHEBI:15443,Inulin,CHEBI:15443,MAPPED,unique
+Iodide,preferred_term,CHEBI:16382,Iodide,CHEBI:16382,MAPPED,unique
+Iodonitrotetrazolium chloride,preferred_term,CHEBI:75421,Iodonitrotetrazolium chloride,CHEBI:75421,MAPPED,unique
+Irgasan,preferred_term,CHEBI:164200,Irgasan,CHEBI:164200,MAPPED,unique
+Irigenin,preferred_term,CHEBI:81409,Irigenin,CHEBI:81409,MAPPED,unique
+Iron,preferred_term,CHEBI:18248,Iron,CHEBI:18248,MAPPED,resolved:owned
+Iron,ontology_label,UNMAPPED_0604,Iron (as FeCl3 in EDTA),NCIT:C598,UNMAPPED,resolved:owned
+Iron (as FeCl3 in EDTA),preferred_term,UNMAPPED_0604,Iron (as FeCl3 in EDTA),NCIT:C598,UNMAPPED,unique
+Iron (II) chloride tetrahydrate,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+"Iron (II) chloride, tetrahydrate",synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+Iron (II) sulfate heptahydrate,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+Iron (III) chloride hexahydrate,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+Iron ammonium sulfate hydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
+iron atom,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
+Iron chloride tetrahydrate,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+iron dichloride,synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,conflict:different_substances
+iron dichloride,ontology_label,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+iron dichloride,ontology_label,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+iron dichloride tetrahydrate,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+iron dust,synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+iron hydroxide oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+Iron metal,synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+Iron orthophosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+Iron persulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Iron phosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+Iron powder,preferred_term,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+Iron pyrophosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Iron sesquisulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Iron Stock,preferred_term,kgmicrobe.ingredient:iron_stock,Iron Stock,kgmicrobe.ingredient:iron_stock,MAPPED,unique
+iron sulfate (1:1),synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+Iron tersulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+iron trichloride,synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,conflict:different_substances
+iron trichloride,ontology_label,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,conflict:different_substances
+iron trichloride hexahydrate,ontology_label,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+iron(0),synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
+iron(2+),ontology_label,CHEBI:29033,Ferrous Ion,CHEBI:29033,MAPPED,unique
+iron(2+) chloride,synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,conflict:different_substances
+iron(2+) chloride,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+iron(2+) chloride,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+"Iron(2+) chloride, tetrahydrate",synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
+iron(2+) disulfide,synonym,CHEBI:86471,Pyrite,CHEBI:86471,MAPPED,unique
+iron(2+) sulfate,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,conflict:different_substances
+iron(2+) sulfate,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+iron(2+) sulfate,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,conflict:different_substances
+iron(2+) sulfate,synonym,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,conflict:different_substances
+iron(2+) sulfate (anh.),synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+iron(2+) sulfate (anhydrous),synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,unique
+iron(2+) sulfate (anhydrous),synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,unique
+iron(2+) sulfate (anhydrous),ontology_label,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+iron(2+) sulfate heptahydrate,ontology_label,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+iron(2+) sulfate heptahydrate,ontology_label,CHEBI:75836,FeSO4 x 7H2O,CHEBI:75836,REJECTED,unique
+iron(2+) sulfate monohydrate,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+iron(2+) sulfate--water (1/1),synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+iron(2+) sulfate--water (1/7),synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+iron(3+),ontology_label,CHEBI:29034,Ferric Iron,CHEBI:29034,MAPPED,unique
+"iron(3+) 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+"iron(3+) 2-hydroxypropane-1,2,3-tricarboxylate hydrate",synonym,CHEBI:144434,Ferric citrate monohydrate,CHEBI:144434,MAPPED,unique
+iron(3+) chloride,synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,conflict:different_substances
+iron(3+) chloride,synonym,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,conflict:different_substances
+iron(3+) diphosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+iron(3+) diphosphate (4/3),synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+iron(3+) orthophosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+iron(3+) oxide,synonym,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+iron(3+) phosphate,ontology_label,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+iron(3+) phosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+iron(3+) phosphate--water (1/4),synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+Iron(3+) pyrophosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+"iron(3+) sodium 2,2',2'',2'''-(ethane-1,2-diyldinitrilo)tetraacetate",synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+iron(3+) sulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Iron(II) chloride,synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,conflict:different_substances
+iron(II) chloride,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+iron(II) chloride,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
+Iron(II) sulfate,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+iron(II) sulfate (1:1),synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+Iron(II) sulfate heptahydrate,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
+iron(II) sulfate monohydrate,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+iron(III) chloride,synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,conflict:different_substances
+iron(III) chloride,synonym,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,conflict:different_substances
+Iron(III) citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+iron(III) citrate monohydrate,ontology_label,CHEBI:144434,Ferric citrate monohydrate,CHEBI:144434,MAPPED,unique
+Iron(III) diphosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+iron(III) orthophosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+iron(III) oxide,synonym,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+iron(III) oxyhydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+iron(III) phosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
+iron(III) phosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
+Iron(III) pyrophosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Iron(III) sulfate,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+iron(III) sulfate hydrate,synonym,UNMAPPED_0385,FeSO43 x n H2O,,UNMAPPED,unique
+iron(III) sulfate(VI),synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
+Iron(III)-edta,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Iron-EDTA,preferred_term,UNMAPPED_0606,Iron-EDTA,,UNMAPPED,unique
+Isepamicin,preferred_term,CHEBI:37951,Isepamicin,CHEBI:37951,MAPPED,unique
+ISK-1 bacteriocin,synonym,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
+Iso-butanol,synonym,CHEBI:46645,Isobutyl alcohol,CHEBI:46645,MAPPED,unique
+iso-Butyric acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+iso-C3H7COOH,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+iso-Valeric acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+isoamylol,ontology_label,CHEBI:15837,3-methyl-1-butanol,CHEBI:15837,MAPPED,unique
+isobutanoic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+isobutanol,ontology_label,CHEBI:46645,Isobutyl alcohol,CHEBI:46645,MAPPED,unique
+Isobuttersaeure,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+Isobutyl alcohol,preferred_term,CHEBI:46645,Isobutyl alcohol,CHEBI:46645,MAPPED,unique
+isobutylformic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+Isobutyramide,preferred_term,CHEBI:193555,Isobutyramide,CHEBI:193555,MAPPED,unique
+Isobutyrate,preferred_term,CHEBI:48944,Isobutyrate,CHEBI:48944,MAPPED,unique
+Isobutyric acid,preferred_term,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+Isocaproate,preferred_term,CHEBI:74904,Isocaproate,CHEBI:74904,MAPPED,unique
+isocetane,synonym,CHEBI:131383,"2,2,4,4,6,8,8-Heptamethylnonane",CHEBI:131383,MAPPED,unique
+Isocitrate,preferred_term,CHEBI:16087,Isocitrate,CHEBI:16087,MAPPED,unique
+isocitrate(3-),ontology_label,CHEBI:16087,Isocitrate,CHEBI:16087,MAPPED,unique
+"Isocitric acid, DL-",ontology_label,kgmicrobe.compound:dl-isocitric_acid_trisodium_salt_hydrate,DL-Isocitric acid trisodium salt hydrate,CHEBI:172950,MAPPED,unique
+Isocorydine,ontology_label,CHEBI:6000,S-Isocorydine (),CHEBI:6000,MAPPED,unique
+Isoleucine,synonym,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
+Isoliquiritigenin,preferred_term,CHEBI:310312,Isoliquiritigenin,CHEBI:310312,MAPPED,unique
+Isomaltose,preferred_term,CHEBI:28189,Isomaltose,CHEBI:28189,MAPPED,unique
+Isoniazid,preferred_term,CHEBI:6030,Isoniazid,CHEBI:6030,MAPPED,unique
+isoniazide,ontology_label,CHEBI:6030,Isoniazid,CHEBI:6030,MAPPED,unique
+Isoorientin,preferred_term,CHEBI:17965,Isoorientin,CHEBI:17965,MAPPED,unique
+isopentanoic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+isopentenyl alcohol,ontology_label,CHEBI:62898,3-methyl-3-butenol,CHEBI:62898,MAPPED,unique
+Isophthalate,preferred_term,CHEBI:30803,Isophthalate,CHEBI:30803,MAPPED,unique
+isophthalate(2-),ontology_label,CHEBI:30803,Isophthalate,CHEBI:30803,MAPPED,unique
+Isopropanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+Isopropionate,preferred_term,kgmicrobe.compound:isopropionate,Isopropionate,kgmicrobe.compound:isopropionate,MAPPED,unique
+isopropyl 3-keto-N-acetyl-a-D-glucosamine,preferred_term,UNMAPPED_0234,isopropyl 3-keto-N-acetyl-a-D-glucosamine,,UNMAPPED,unique
+Isopropyl alcohol,preferred_term,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+isopropylacetic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+Isopropylalkohol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+isopropylformic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
+Isosafrole,preferred_term,CHEBI:6054,Isosafrole,CHEBI:6054,MAPPED,unique
+ISOT,preferred_term,UNMAPPED_0220,ISOT,,UNMAPPED,unique
+ISOT LC742-071714,preferred_term,UNMAPPED_0218,ISOT LC742-071714,,UNMAPPED,unique
+ISOT Lot160120,preferred_term,UNMAPPED_0219,ISOT Lot160120,,UNMAPPED,unique
+ISOT Umich-01,preferred_term,UNMAPPED_0205,ISOT Umich-01,,UNMAPPED,unique
+ISOT Umich-02.b,preferred_term,UNMAPPED_0206,ISOT Umich-02.b,,UNMAPPED,unique
+Isovalerate,preferred_term,CHEBI:48942,Isovalerate,CHEBI:48942,MAPPED,unique
+isovalerianic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+Isovaleriansaeure,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+Isovaleric acid,preferred_term,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
+Isovanillin,preferred_term,CHEBI:193161,Isovanillin,CHEBI:193161,MAPPED,unique
+Isovitalex,preferred_term,kgmicrobe.ingredient:isovitalex,Isovitalex,kgmicrobe.ingredient:isovitalex,MAPPED,unique
+Isovitexin,preferred_term,CHEBI:18330,Isovitexin,CHEBI:18330,MAPPED,unique
+ISP 7 Medium,preferred_term,UNMAPPED_0408,ISP 7 Medium,,UNMAPPED,unique
+Itaconate,preferred_term,CHEBI:17240,Itaconate,CHEBI:17240,MAPPED,unique
+itaconate(2-),ontology_label,CHEBI:17240,Itaconate,CHEBI:17240,MAPPED,unique
+Itaconic Acid,preferred_term,CHEBI:30838,Itaconic Acid,CHEBI:30838,MAPPED,unique
+Izalpinin,preferred_term,cas:480-14-4,Izalpinin,cas:480-14-4,MAPPED,unique
+Jasmonic acid,preferred_term,CHEBI:18292,Jasmonic acid,CHEBI:18292,MAPPED,unique
+Juglone,preferred_term,CHEBI:15794,Juglone,CHEBI:15794,MAPPED,unique
+K 2HPO4,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+K HPO,synonym,CHEBI:32030,KBr,CHEBI:32030,MAPPED,unique
+K-acetate,preferred_term,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+K-F,synonym,CHEBI:66872,potassium fluoride,CHEBI:66872,MAPPED,unique
+K-F,synonym,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+K-phosphate buffer,preferred_term,kgmicrobe.ingredient:k-phosphate_buffer,K-phosphate buffer,kgmicrobe.ingredient:k-phosphate_buffer,MAPPED,unique
+K2CO3,preferred_term,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+K2CrO4,preferred_term,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+K2HPO,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+K2HPO4,preferred_term,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+K2HPO4 x 3 H2O,preferred_term,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4 x 3H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4 · 3 H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4(Sigma P 3786),synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+K2HPO4.3H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4x 3 H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4·3H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2HPO4・3H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131527,MAPPED,unique
+K2S4O6,preferred_term,CHEBI:86466,K2S4O6,CHEBI:86466,MAPPED,unique
+K2SO4,preferred_term,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
+K2SO4 x 7 H2O,preferred_term,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
+K2SO4·7H2O,synonym,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
+K2SO4・7H2O,synonym,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
+KAl(SO4)2,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+KAl(SO4)2 . 12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+KAl(SO4)2 x 12 H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+KAl(SO4)2·12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+KAl(SO4)2・12H2O,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Kalinite,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Kaliumazetat,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+Kaliumbromid,synonym,CHEBI:32030,KBr,CHEBI:32030,MAPPED,unique
+Kaliumcarbonat,synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+Kaliumchlorid,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Kaliumhydroxid,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+Kaliumiodid,synonym,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+Kaliumjodid,synonym,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+Kaliumnitrat,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Kaliumsulfat,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
+Kalziumkarbonat,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Kalziumsulfat,synonym,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
+Kanamycin,preferred_term,CHEBI:6104,Kanamycin,CHEBI:6104,MAPPED,unique
+Kanamycin A sulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
+Kanamycin acid sulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
+Kanamycin monosulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
+Kanamycin sulfate,preferred_term,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
+Kanchanomycin,preferred_term,mesh:C001493,Kanchanomycin,mesh:C001493,MAPPED,unique
+Kao and Michayluk vitamin solution,preferred_term,kgmicrobe.ingredient:kao_and_michayluk_vitamin_solution,Kao and Michayluk vitamin solution,MICRO:0000460,MAPPED,unique
+Kaon-Cl 10,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Kappaxin,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Karanjin,preferred_term,CHEBI:166631,Karanjin,CHEBI:166631,MAPPED,unique
+Karbamid,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Karbolsaeure,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Kasugamycin,preferred_term,CHEBI:81419,Kasugamycin,CHEBI:81419,MAPPED,unique
+Kawain,preferred_term,CHEBI:156288,Kawain,CHEBI:156288,MAPPED,unique
+KBr,preferred_term,CHEBI:32030,KBr,CHEBI:32030,MAPPED,unique
+KCl,preferred_term,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+KCl (Fisher P 217),synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+KCl(CAS: 7447-40-7),synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+KCl(CAS:7447-40-7),synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+KCl(Fisher P 217),synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Keratin,preferred_term,mesh:D007633,Keratin,mesh:D007633,MAPPED,unique
+Keratins,ontology_label,mesh:D007633,Keratin,mesh:D007633,MAPPED,unique
+keto-D-fructose 6-phosphate,ontology_label,CHEBI:15946,Fructose-6-phosphate,CHEBI:15946,MAPPED,unique
+Ketomycin,preferred_term,mesh:C008231,Ketomycin,mesh:C008231,MAPPED,unique
+KF,preferred_term,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+KF,synonym,CHEBI:66872,potassium fluoride,CHEBI:66872,MAPPED,unique
+KH PO,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+KH2HPO4,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+KH2PO3,preferred_term,cas:13977-65-6,KH2PO3,CHEBI:44976,MAPPED,unique
+KH2PO4,preferred_term,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+KH2PO4(Sigma P 0662),synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+KHAYASIN,ontology_label,UNMAPPED_0191,Khayasin C,CHEBI:185858,UNMAPPED,unique
+Khayasin C,preferred_term,UNMAPPED_0191,Khayasin C,CHEBI:185858,UNMAPPED,unique
+KHCO3,preferred_term,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+KI,preferred_term,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+Kieselsaeureanhydrid,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+kijanimicin,preferred_term,CHEBI:220048,kijanimicin,CHEBI:220048,MAPPED,unique
+KJ,synonym,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+Klor-con,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Klotrix,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+KNO,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+KNO2,preferred_term,CHEBI:232610,KNO2,CHEBI:232610,MAPPED,unique
+KNO3,preferred_term,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+KOAc,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+Kobalt chlorid,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+Kobalt(II)-chlorid,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+Kobaltdichlorid,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
+Kochsalz,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Koenzym A,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
+KOH,preferred_term,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+kohlensaurer Kalk,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+Komplexon I,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Kongorot,synonym,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+Kreatin,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+Kreatinin,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+KRX-0502,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+KSCN,preferred_term,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+L(+)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+L(+)-Tartaric acid,preferred_term,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+L-(+)-alpha-Aminoisovaleric acid,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+L-(+)-arginine,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+L-(+)-ascorbic acid,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+L-(+)-Cysteine hydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+L-(+)-Ergothioneine,preferred_term,CHEBI:4828,L-(+)-Ergothioneine,CHEBI:4828,MAPPED,unique
+L-(+)-Erythrulose,preferred_term,CHEBI:23958,L-(+)-Erythrulose,CHEBI:23958,MAPPED,unique
+L-(+)-glutamine,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-(+)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+L-(-)-fucose,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+L-(-)-histidine,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+L-(-)-methionine,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+L-(-)-proline,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+L-(-)-serine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-(-)-sorbose,preferred_term,CHEBI:17266,L-(-)-sorbose,CHEBI:17266,MAPPED,unique
+L-(-)-Threonine,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+L-(-)-tryptophan,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+L--Cysteine HCl H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L--Cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L--cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L--Cysteine・HCL・H2O,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+"L-1,2-dithiolane 3-valeric acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+L-15 medium,preferred_term,UNMAPPED_0414,L-15 medium,,UNMAPPED,unique
+L-15 powder,preferred_term,UNMAPPED_0415,L-15 powder,,UNMAPPED,unique
+"L-2,6-Diaminocaproic acid",synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+L-2-Amino-3-hydroxybutyric acid,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+L-2-Amino-3-hydroxypropionic acid,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-2-Amino-3-mercaptopropionic acid,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-2-Amino-5-ureidovaleric acid,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+L-2-aminoadipic acid,ontology_label,CHEBI:37023,DL-2-Aminoadipic acid,CHEBI:37023,MAPPED,unique
+L-2-Aminobutyric acid,preferred_term,CHEBI:35619,L-2-Aminobutyric acid,CHEBI:35619,MAPPED,unique
+L-2-Aminoglutaramic acid,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-2-Aminopropionic acid,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+L-2-aminosuccinamic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+L-3-Hydroxy-2-aminopropionic acid,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-3-Hydroxy-alanine,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-4-Hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"L-6,8-thioctic acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+L-6-thioctic acid,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+L-Alanin,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+L-alaninamide,preferred_term,CHEBI:21217,L-alaninamide,CHEBI:21217,MAPPED,unique
+L-Alanine,preferred_term,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+L-alanine 4-nitroanilide,preferred_term,kgmicrobe.compound:l-alanine_4-nitroanilide,L-alanine 4-nitroanilide,kgmicrobe.compound:l-alanine_4-nitroanilide,MAPPED,unique
+L-alanosine,ontology_label,CHEBI:221124,alanosine,CHEBI:221124,MAPPED,unique
+L-alanylglycine,preferred_term,CHEBI:73757,L-alanylglycine,CHEBI:73757,MAPPED,unique
+L-alliin,preferred_term,CHEBI:2596,L-alliin,CHEBI:2596,MAPPED,unique
+"L-alpha,epsilondiaminocaproic acid monohydrochloride",synonym,CHEBI:53633,L-Lysine HCl,CHEBI:53633,MAPPED,unique
+L-alpha-Alanine,synonym,CHEBI:16977,L-Alanine,CHEBI:16977,MAPPED,unique
+L-alpha-amino-beta-hydroxybutyric acid,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+L-alpha-Amino-beta-methylbutyric acid,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+L-alpha-amino-gamma-methylmercaptobutyric acid,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+L-alpha-aminobutyric acid,ontology_label,CHEBI:35619,L-2-Aminobutyric acid,CHEBI:35619,MAPPED,unique
+L-alpha-Diamino-beta-dithiolactic acid,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+L-alpha-Glycerophosphocholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+L-alpha-Glycerophosphorylcholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+L-alpha-Phosphatidylcholine,preferred_term,CHEBI:86658,L-alpha-Phosphatidylcholine,CHEBI:86658,MAPPED,unique
+L-alpha-pyrrolidinecarboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+l-Apfelsaure als natrium salz,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+L-Arabinitol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+L-arabino-pentose,synonym,CHEBI:30849,L-Arabinose,CHEBI:30849,MAPPED,unique
+L-Arabinol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+L-Arabinose,preferred_term,CHEBI:30849,L-Arabinose,CHEBI:30849,MAPPED,unique
+L-Arabitol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+L-arabitol (L-arabinitol),synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+L-Arg,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+L-Arginin,synonym,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+L-Arginine,preferred_term,CHEBI:16467,L-Arginine,CHEBI:16467,MAPPED,unique
+L-Arginine x HCI,synonym,CHEBI:31235,L-Arginine x HCl,CHEBI:31235,MAPPED,unique
+L-Arginine x HCl,preferred_term,CHEBI:31235,L-Arginine x HCl,CHEBI:31235,MAPPED,unique
+L-Ascorbic acid,preferred_term,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+L-ascorbic acid sodium salt,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+"L-ascorbic acid, monosodium salt",synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+L-Asparagin,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+L-Asparagine,preferred_term,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+L-Asparagine monohydrate,preferred_term,cas:5794-13-8,L-Asparagine monohydrate,NCIT:C87433,MAPPED,unique
+L-Asparaginsaeure,synonym,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,unique
+L-aspartate,preferred_term,CHEBI:29991,L-aspartate,CHEBI:29991,MAPPED,unique
+L-aspartate(1-),ontology_label,CHEBI:29991,L-aspartate,CHEBI:29991,MAPPED,unique
+L-Aspartic acid,preferred_term,CHEBI:17053,L-Aspartic acid,CHEBI:17053,MAPPED,resolved:owned
+L-aspartic acid,ontology_label,cas:1115-63-5,L-Aspartic acid potassium salt,CHEBI:17053,MAPPED,resolved:owned
+L-aspartic acid,ontology_label,cas:323194-76-9,L-Aspartic acid sodium salt monohydrate,CHEBI:17053,MAPPED,resolved:owned
+L-aspartic acid beta-amide,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
+L-Aspartic acid potassium salt,preferred_term,cas:1115-63-5,L-Aspartic acid potassium salt,CHEBI:17053,MAPPED,unique
+L-aspartic acid residue,synonym,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+L-Aspartic acid sodium salt monohydrate,preferred_term,cas:323194-76-9,L-Aspartic acid sodium salt monohydrate,CHEBI:17053,MAPPED,unique
+L-aspartic residue,synonym,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+L-aspartyl,synonym,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+L-beta-3-indolylalanine,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+L-canavanine,ontology_label,CHEBI:609827,Canavanine,CHEBI:609827,MAPPED,unique
+L-Carnitine,preferred_term,CHEBI:16347,L-Carnitine,CHEBI:16347,MAPPED,unique
+L-Carnitine hydrochloride,preferred_term,CHEBI:233463,L-Carnitine hydrochloride,CHEBI:233463,MAPPED,unique
+"L-Choline hydroxide 2,3-dihydroxypropyl hydrogen phosphate inner salt",synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+L-Citrulline,preferred_term,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+L-cysteic acid,ontology_label,cas:23537-25-9,L-Cysteic acid monohydrate,CHEBI:17285,MAPPED,unique
+L-Cysteic acid monohydrate,preferred_term,cas:23537-25-9,L-Cysteic acid monohydrate,CHEBI:17285,MAPPED,unique
+L-Cystein,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-Cysteine,preferred_term,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-Cysteine HCl,preferred_term,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+L-Cysteine HCl monohydrate,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine HCl x H2O,preferred_term,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine HCl x H2O,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-cysteine HCl.H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-cysteine HCl.H2O,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-cysteine hydrochloride,ontology_label,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unresolved:partial_chemistry
+L-cysteine hydrochloride,ontology_label,kgmicrobe.ingredient:l-cysteine_x_hcl_x_h2o_solution,L-Cysteine x HCl x H2O solution,CHEBI:91247,MAPPED,unresolved:partial_chemistry
+L-cysteine hydrochloride hydrate,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-cysteine hydrochloride hydrate,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-Cysteine hydrochloride monohydrate,preferred_term,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-Cysteine hydrochloride monohydrate,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-cysteine hydrochloride--water (1/1),synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-cysteine hydrochloride--water (1/1),synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-Cysteine monohydrate monochloride,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine monohydrate monochloride,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-Cysteine monohydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+L-Cysteine x HCl x H2O solution,preferred_term,kgmicrobe.ingredient:l-cysteine_x_hcl_x_h2o_solution,L-Cysteine x HCl x H2O solution,CHEBI:91247,MAPPED,unique
+L-cysteine zwitterion,preferred_term,CHEBI:35235,L-cysteine zwitterion,CHEBI:35235,MAPPED,resolved:owned
+L-cysteine zwitterion,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,resolved:owned
+L-Cysteine-HCl x H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine-HCl·H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L-Cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
+L-cysteinium chloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+L-Cysteiniumchloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+L-Cystine,preferred_term,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+L-Deoxyalliin,preferred_term,CHEBI:74077,L-Deoxyalliin,CHEBI:74077,MAPPED,unique
+L-Dicysteine,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+L-dopa,ontology_label,CHEBI:15765,Levodopa,CHEBI:15765,MAPPED,unique
+L-fructose,preferred_term,CHEBI:28120,L-fructose,CHEBI:28120,MAPPED,unique
+L-Fuc,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+L-Fucose,preferred_term,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+L-galacto-hexose,synonym,CHEBI:37618,L-Galactose,CHEBI:37618,MAPPED,unique
+L-galactomethylose,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
+L-galactonate,preferred_term,CHEBI:53071,L-galactonate,CHEBI:53071,MAPPED,unique
+L-galactonic Acid Gamma-lactone,preferred_term,CHEBI:17464,L-galactonic Acid Gamma-lactone,CHEBI:17464,MAPPED,unique
+"L-galactono-1,4-lactone",ontology_label,CHEBI:17464,L-galactonic Acid Gamma-lactone,CHEBI:17464,MAPPED,unique
+L-Galactose,preferred_term,CHEBI:37618,L-Galactose,CHEBI:37618,MAPPED,unique
+L-gamma-glutamyl-L-cysteinylglycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+L-gamma-glutamyl-L-cysteinylglycine,synonym,CHEBI:16856,L-Glutathione,CHEBI:16856,REJECTED,unique
+L-Glu,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+L-Glutamate,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,conflict:different_substances
+L-glutamate,synonym,CHEBI:64243,Na-glutamate,CHEBI:64243,REJECTED,conflict:different_substances
+L-glutamate-gamma-3-carboxy-4-nitroanilide,preferred_term,kgmicrobe.compound:l-glutamate-gamma-3-carboxy-4-nitroanilide,L-glutamate-gamma-3-carboxy-4-nitroanilide,kgmicrobe.compound:l-glutamate-gamma-3-carboxy-4-nitroanilide,MAPPED,unique
+L-Glutamic acid,preferred_term,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,resolved:owned
+L-glutamic acid,ontology_label,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydrate,CHEBI:16015,MAPPED,resolved:owned
+L-glutamic acid dianion,synonym,CHEBI:64243,Na-glutamate,CHEBI:64243,REJECTED,unique
+L-glutamic acid gamma-amide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-Glutamic acid monopotassium salt monohydrate,preferred_term,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydrate,CHEBI:16015,MAPPED,unique
+"L-Glutamic acid potassium salt monohydrate, L-Glutamic acid potassium salt",synonym,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydrate,CHEBI:16015,MAPPED,unique
+L-Glutamin,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-Glutamine,preferred_term,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-Glutaminic acid,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+L-Glutaminsaeure,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,unique
+L-Glutaminsaeure-5-amid,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+L-Glutathione,preferred_term,CHEBI:16856,L-Glutathione,CHEBI:16856,REJECTED,unique
+L-Glutathione,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+L-glutathione reduced,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+L-Gulitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+L-Histidin,synonym,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+L-Histidine,preferred_term,CHEBI:15971,L-Histidine,CHEBI:15971,MAPPED,unique
+L-histidine 2-naphthylamide,preferred_term,CHEBI:90447,L-histidine 2-naphthylamide,CHEBI:90447,MAPPED,unique
+L-Histidine monohydrochloride monohydrate,preferred_term,cas:5934-29-2,L-Histidine monohydrochloride monohydrate,NCIT:C87334,MAPPED,unique
+L-Homoserine,preferred_term,CHEBI:15699,L-Homoserine,CHEBI:15699,MAPPED,unique
+L-inositol,preferred_term,CHEBI:27374,L-inositol,CHEBI:27374,MAPPED,unique
+L-Isoleucine,preferred_term,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
+L-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+L-Leucin,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+L-Leucine,preferred_term,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+L-leucylglycine 2-naphthylamide,preferred_term,CHEBI:90741,L-leucylglycine 2-naphthylamide,CHEBI:90741,MAPPED,unique
+L-Leuzin,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+L-Lys-L-Phe,synonym,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+L-Lysin,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+L-Lysine,preferred_term,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+L-Lysine HCl,preferred_term,CHEBI:53633,L-Lysine HCl,CHEBI:53633,MAPPED,unique
+L-lysine hydrochloride,synonym,CHEBI:53633,L-Lysine HCl,CHEBI:53633,MAPPED,unique
+L-lysyl-L-phenylalanine,synonym,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+L-Lyxitol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+L-lyxose,preferred_term,CHEBI:62320,L-lyxose,CHEBI:62320,MAPPED,unique
+L-m-tyrosine,ontology_label,cas:587-33-7,L-Meta-tyrosine,CHEBI:44303,MAPPED,unique
+L-malate,preferred_term,CHEBI:15589,L-malate,CHEBI:15589,MAPPED,unique
+L-Malic acid,preferred_term,CHEBI:30797,L-Malic acid,CHEBI:30797,MAPPED,unique
+L-Malic acid disodium salt monohydrate,preferred_term,cas:207511-06-6,L-Malic acid disodium salt monohydrate,NCIT:C80654,MAPPED,unique
+"l-Malic acid, sodium salt",synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+L-Meta-tyrosine,preferred_term,cas:587-33-7,L-Meta-tyrosine,CHEBI:44303,MAPPED,unique
+L-Methionin,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+L-Methionine,preferred_term,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,unique
+L-myo-Inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+L-norleucine,preferred_term,CHEBI:18347,L-norleucine,CHEBI:18347,MAPPED,unique
+L-Ornithine,preferred_term,CHEBI:15729,L-Ornithine,CHEBI:15729,MAPPED,unique
+L-Ornithine monochlorohydrate/ornithine,synonym,CHEBI:195690,L-ornithine monohydrochloride,CHEBI:195690,MAPPED,unique
+L-ornithine monohydrochloride,preferred_term,CHEBI:195690,L-ornithine monohydrochloride,CHEBI:195690,MAPPED,unique
+L-Phenylalanine,preferred_term,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+L-Pipecolic Acid,preferred_term,CHEBI:30913,L-Pipecolic Acid,CHEBI:30913,MAPPED,unique
+L-Prolin,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+L-Proline,preferred_term,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+L-proline 2-naphthylamide,preferred_term,CHEBI:90600,L-proline 2-naphthylamide,CHEBI:90600,MAPPED,unique
+L-proline-4-nitroanilide,preferred_term,kgmicrobe.compound:l-proline-4-nitroanilide,L-proline-4-nitroanilide,kgmicrobe.compound:l-proline-4-nitroanilide,MAPPED,unique
+L-Pyroglutamic acid,preferred_term,CHEBI:18183,L-Pyroglutamic acid,CHEBI:18183,MAPPED,unique
+L-pyroglutamic Acid 2-naphthylamide,preferred_term,CHEBI:90601,L-pyroglutamic Acid 2-naphthylamide,CHEBI:90601,MAPPED,unique
+L-pyrrolidine-2-carboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+L-Rhamnose,preferred_term,CHEBI:62345,L-Rhamnose,CHEBI:62345,MAPPED,resolved:owned
+L-rhamnose,ontology_label,cas:10030-85-0,L-Rhamnose monohydrate,CHEBI:62345,MAPPED,resolved:owned
+L-Rhamnose monohydrate,preferred_term,cas:10030-85-0,L-Rhamnose monohydrate,CHEBI:62345,MAPPED,unique
+L-rhamnoses,synonym,CHEBI:62345,L-Rhamnose,CHEBI:62345,MAPPED,unique
+L-Ser,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-Serin,synonym,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-Serine,preferred_term,CHEBI:17115,L-Serine,CHEBI:17115,MAPPED,unique
+L-serine 2-naphthylamide,preferred_term,CHEBI:90603,L-serine 2-naphthylamide,CHEBI:90603,MAPPED,unique
+L-shikimic acid,synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+L-Sodium lactate,synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+L-Sodium lactate,synonym,CHEBI:232798,Sodium L-lactate,CHEBI:232798,REJECTED,unique
+L-sorbose,ontology_label,CHEBI:17266,L-(-)-sorbose,CHEBI:17266,MAPPED,unique
+L-Tartaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+L-tartrate,synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+L-threarate,synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+L-threaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+L-threo-4-hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"L-threo-hex-2-enono-1,4-lactone",synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
+L-Threonin,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+L-Threonine,preferred_term,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
+L-Tryptophan,preferred_term,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
+L-tryptophan zwitterion,ontology_label,CHEBI:57912,DL-Tryptophan,CHEBI:57912,MAPPED,unique
+L-Tyrosin,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+L-Tyrosine,preferred_term,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unique
+L-tyrosine 2-naphthylamide,preferred_term,CHEBI:90607,L-tyrosine 2-naphthylamide,CHEBI:90607,MAPPED,unique
+L-tyrosine disodium salt,preferred_term,CHEBI:53696,L-tyrosine disodium salt,CHEBI:53696,MAPPED,unique
+L-Tyrosine sodium salt (1:2),synonym,CHEBI:53696,L-tyrosine disodium salt,CHEBI:53696,MAPPED,unique
+L-Valin,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+L-Valine,preferred_term,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+L-xylitol,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+L-xylo-hex-2-ulose,synonym,CHEBI:17266,L-(-)-sorbose,CHEBI:17266,MAPPED,unique
+L-Xylose,preferred_term,CHEBI:65328,L-Xylose,CHEBI:65328,MAPPED,unique
+L-Zystein,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-α-Phosphatidylcholine,synonym,CHEBI:86658,L-alpha-Phosphatidylcholine,CHEBI:86658,MAPPED,unique
+L-α-Phosphatidylinositol from Glycine max (soybean),preferred_term,cas:97281-52-2,L-α-Phosphatidylinositol from Glycine max (soybean),CHEBI:28874,MAPPED,unique
+Lab Lemco powder,preferred_term,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
+Lab-Lemco beef extract,synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Lac,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Lacidipine,preferred_term,CHEBI:135737,Lacidipine,CHEBI:135737,MAPPED,unique
+Lactalbumin hydrolysate,preferred_term,MICRO:0001365,Lactalbumin hydrolysate,MICRO:0001365,MAPPED,unique
+Lactate,preferred_term,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+Lactate (sodium salt),synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Lactic acid sodium salt,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+"Lactic acid, monosodium salt",synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Lactitol,preferred_term,CHEBI:75323,Lactitol,CHEBI:75323,MAPPED,unique
+Lacto-N-fucopentaose I,preferred_term,cas:7578-25-8,Lacto-N-fucopentaose I,mesh:C045442,MAPPED,unique
+Lacto-N-fucopentaose II,preferred_term,CHEBI:89932,Lacto-N-fucopentaose II,CHEBI:89932,MAPPED,unique
+Lacto-N-fucopentaose III,preferred_term,cas:25541-09-7,Lacto-N-fucopentaose III,mesh:C434666,MAPPED,unique
+Lacto-N-fucopentaose-2,ontology_label,CHEBI:89932,Lacto-N-fucopentaose II,CHEBI:89932,MAPPED,unique
+Lacto-N-neotetraose,preferred_term,CHEBI:60239,Lacto-N-neotetraose,CHEBI:60239,MAPPED,unique
+Lacto-N-tetraose,preferred_term,cas:14116-68-8,Lacto-N-tetraose,CHEBI:30248,MAPPED,unique
+Lactobacilli MRS broth,preferred_term,UNMAPPED_0421,Lactobacilli MRS broth,,UNMAPPED,unique
+Lactobacillus MRS broth,preferred_term,UNMAPPED_0422,Lactobacillus MRS broth,,UNMAPPED,unique
+Lactodifucotetraose,ontology_label,CHEBI:89917,Difucosyllactose,CHEBI:89917,MAPPED,unique
+Lactone,preferred_term,CHEBI:25000,Lactone,CHEBI:25000,MAPPED,unique
+Lactose,preferred_term,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,resolved:owned
+lactose,synonym,CHEBI:36218,Beta-Lactose,CHEBI:36218,MAPPED,resolved:owned
+Lactulose,preferred_term,CHEBI:6359,Lactulose,CHEBI:6359,MAPPED,unique
+Laevulose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+Laktobiose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Laktose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+lambda(2)-tin(2+) dihydrate dichloride,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+laminarabiose,ontology_label,CHEBI:18411,Laminaribiose,CHEBI:18411,MAPPED,unique
+Laminaribiose,preferred_term,CHEBI:18411,Laminaribiose,CHEBI:18411,MAPPED,unique
+laminarin,ontology_label,CHEBI:6364,Laminarin from Laminaria digitata,CHEBI:6364,MAPPED,unique
+Laminarin from Laminaria digitata,preferred_term,CHEBI:6364,Laminarin from Laminaria digitata,CHEBI:6364,MAPPED,unique
+LaNO33 x 6 H2O,preferred_term,UNMAPPED_0423,LaNO33 x 6 H2O,,UNMAPPED,unique
+Lanthanum (III) chloride,preferred_term,cas:20211-76-1,Lanthanum (III) chloride,CHEBI:231515,MAPPED,unique
+lanthanum trichloride,ontology_label,cas:20211-76-1,Lanthanum (III) chloride,CHEBI:231515,MAPPED,unique
+Lapachol,preferred_term,CHEBI:6377,Lapachol,CHEBI:6377,MAPPED,unique
+Larchwood xylan,preferred_term,UNMAPPED_0424,Larchwood xylan,,UNMAPPED,unique
+Lauric acid,preferred_term,CHEBI:30805,Lauric acid,CHEBI:30805,MAPPED,unique
+"Lauric acid, sodium salt",synonym,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
+Lawsone,preferred_term,CHEBI:44401,Lawsone,CHEBI:44401,MAPPED,unique
+LCFM Carbon mix,preferred_term,kgmicrobe.ingredient:lcfm_carbon_mix,LCFM Carbon mix,kgmicrobe.ingredient:lcfm_carbon_mix,MAPPED,unique
+lead (II) chloride,preferred_term,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPPED,unique
+Lead (II) nitrate,preferred_term,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
+lead dinitrate,synonym,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
+lead nitrate,ontology_label,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
+lead(2+) dichloride,synonym,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPPED,unique
+lead(2+) nitrate,synonym,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
+lead(II) chloride,ontology_label,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPPED,unique
+lead(II) nitrate,synonym,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
+Lecithin,preferred_term,CHEBI:61995,Lecithin,CHEBI:61995,MAPPED,unique
+Legionella agar enrichment,preferred_term,kgmicrobe.ingredient:legionella_agar_enrichment,Legionella agar enrichment,kgmicrobe.ingredient:legionella_agar_enrichment,MAPPED,unique
+Leimzucker,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+Lemon,preferred_term,NCIT:C72005,Lemon,NCIT:C72005,MAPPED,unique
+Lentilan from mushroom,preferred_term,CHEBI:31770,Lentilan from mushroom,CHEBI:31770,MAPPED,unique
+lentinan,ontology_label,CHEBI:31770,Lentilan from mushroom,CHEBI:31770,MAPPED,unique
+Leptospira Medium Base EMJH,preferred_term,UNMAPPED_0426,Leptospira Medium Base EMJH,,UNMAPPED,unique
+Leucine,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
+Leucodin,preferred_term,CHEBI:4441,Leucodin,CHEBI:4441,MAPPED,unique
+Leucovorin calcium,synonym,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
+Leupeptin,preferred_term,CHEBI:6426,Leupeptin,CHEBI:6426,MAPPED,unique
+Levan - from Erwinia herbicola,preferred_term,CHEBI:16703,Levan - from Erwinia herbicola,CHEBI:16703,MAPPED,unique
+levocarnitine chloride,ontology_label,CHEBI:233463,L-Carnitine hydrochloride,CHEBI:233463,MAPPED,unique
+Levodopa,preferred_term,CHEBI:15765,Levodopa,CHEBI:15765,MAPPED,unique
+Levofloxacin,preferred_term,CHEBI:63598,Levofloxacin,CHEBI:63598,MAPPED,unique
+Levoglutamide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+Levomenthol,preferred_term,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+Levorin,preferred_term,mesh:D002174,Levorin,mesh:D002174,MAPPED,unique
+Levulinic Acid,preferred_term,CHEBI:45630,Levulinic Acid,CHEBI:45630,MAPPED,unique
+Lichenan (icelandic moss),preferred_term,kgmicrobe.ingredient:lichenan_icelandic_moss,Lichenan (icelandic moss),CHEBI:6452,MAPPED,unique
+lichenin,ontology_label,kgmicrobe.ingredient:lichenan_icelandic_moss,Lichenan (icelandic moss),CHEBI:6452,MAPPED,unique
+LiCl,preferred_term,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+Lignin,preferred_term,CHEBI:6457,Lignin,CHEBI:6457,MAPPED,unique
+Lignin alkali,preferred_term,cas:8068-05-1,Lignin alkali,cas:8068-05-1,MAPPED,unique
+Limocrocin,preferred_term,mesh:C079132,Limocrocin,mesh:C079132,MAPPED,unique
+Limonin,preferred_term,CHEBI:16226,Limonin,CHEBI:16226,MAPPED,unique
+Linalool,preferred_term,CHEBI:17580,Linalool,CHEBI:17580,MAPPED,unique
+Lincomycin,preferred_term,CHEBI:6472,Lincomycin,CHEBI:6472,MAPPED,unique
+Lincomycin hydrochloride,preferred_term,CHEBI:182465,Lincomycin hydrochloride,CHEBI:182465,MAPPED,unique
+Linezolid,preferred_term,CHEBI:63607,Linezolid,CHEBI:63607,MAPPED,unique
+Linsmaier & Skoog Medium including vitamins,preferred_term,UNMAPPED_0427,Linsmaier & Skoog Medium including vitamins,,UNMAPPED,unique
+Lipoate,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Lipoic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+liponic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Lipopolysaccharide,preferred_term,CHEBI:16412,Lipopolysaccharide,CHEBI:16412,MAPPED,unique
+lipoprotein concentrate,preferred_term,UNMAPPED_0428,lipoprotein concentrate,,UNMAPPED,unique
+Liposomal Amphotericin B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
+Lipotril,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Liquid yeast extract (Flow),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+lithii chloridum,synonym,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+lithium chloride,ontology_label,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,conflict:different_substances
+lithium chloride,ontology_label,cas:85144-11-2,Lithium chloride hydrate,CHEBI:48607,MAPPED,conflict:different_substances
+Lithium chloride hydrate,preferred_term,cas:85144-11-2,Lithium chloride hydrate,CHEBI:48607,MAPPED,unique
+lithium deoxyribonoate,synonym,cas:7284-15-3,2-Deoxy-D-ribonic acid lithium salt,CHEBI:86350,MAPPED,unique
+Lithiumchlorid,synonym,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+Lithocholic acid,preferred_term,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
+Liver Concentrate,preferred_term,UNMAPPED_0429,Liver Concentrate,,UNMAPPED,unique
+Liver digest,preferred_term,MICRO:0001668,Liver digest,MICRO:0001668,MAPPED,unique
+Liver extract,preferred_term,MICRO:0001363,Liver extract,MICRO:0001363,MAPPED,unique
+liver extract,ontology_label,MICRO:0001363,Liver extract concentrate,MICRO:0001363,MAPPED,unique
+liver extract,ontology_label,MICRO:0001363,Liver extract infusion,MICRO:0001363,MAPPED,unique
+Liver extract concentrate,preferred_term,MICRO:0001363,Liver extract concentrate,MICRO:0001363,MAPPED,unique
+Liver extract infusion,preferred_term,MICRO:0001363,Liver extract infusion,MICRO:0001363,MAPPED,unique
+LL-37,preferred_term,CHEBI:81664,LL-37,CHEBI:81664,MAPPED,unique
+LL17-29,preferred_term,UNMAPPED_0172,LL17-29,,UNMAPPED,unique
+Locust bean gum,preferred_term,cas:9000-40-2,Locust bean gum,FOODON:03413132,MAPPED,unique
+Lomefloxacin,preferred_term,CHEBI:116278,Lomefloxacin,CHEBI:116278,MAPPED,unique
+Lomefloxacin hydrochloride,preferred_term,CHEBI:6518,Lomefloxacin hydrochloride,CHEBI:6518,MAPPED,unique
+Lomofungin,preferred_term,CHEBI:224243,Lomofungin,CHEBI:224243,MAPPED,unique
+Loratadine,preferred_term,CHEBI:6538,Loratadine,CHEBI:6538,MAPPED,unique
+Lovastatin,preferred_term,CHEBI:40303,Lovastatin,CHEBI:40303,MAPPED,unique
+Lucimycin,preferred_term,CHEBI:135874,Lucimycin,CHEBI:135874,MAPPED,unique
+Lumazine,preferred_term,CHEBI:16489,Lumazine,CHEBI:16489,MAPPED,unique
+Lumichrome,preferred_term,CHEBI:17781,Lumichrome,CHEBI:17781,MAPPED,unique
+Lupeol,preferred_term,CHEBI:6570,Lupeol,CHEBI:6570,MAPPED,unique
+Luridin chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Lydimycin,preferred_term,NCIT:C90684,Lydimycin,NCIT:C90684,MAPPED,unique
+Lys-Phe,synonym,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+lysina,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+Lysine,preferred_term,CHEBI:25094,Lysine,CHEBI:25094,MAPPED,unique
+Lysine acid,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+lysinum,synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
+Lysocellin,preferred_term,CHEBI:212437,Lysocellin,CHEBI:212437,MAPPED,unique
+Lysostaphin,preferred_term,NCIT:C166895,Lysostaphin,NCIT:C166895,MAPPED,unique
+Lysozyme,preferred_term,cas:2650-88-3,Lysozyme,FOODON:03413135,MAPPED,unique
+Lysylphenylalanine,synonym,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+m-(aminocarbonyl)pyridine,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+m-dimethylbenzene,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+m-Hydroxybenzoic acid,synonym,CHEBI:30764,3-Hydroxybenzoic acid,CHEBI:30764,MAPPED,unique
+m-Inositol,preferred_term,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+m-Inositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+m-methyltoluene,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+m-pyridinecarboxylic acid,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+m-salicylic acid,synonym,CHEBI:30764,3-Hydroxybenzoic acid,CHEBI:30764,MAPPED,unique
+m-Xylene,preferred_term,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+m-Xylol,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+Macro Component 1 for J Medium,preferred_term,kgmicrobe.ingredient:macro_component_1_for_j_medium,Macro Component 1 for J Medium,kgmicrobe.ingredient:macro_component_1_for_j_medium,MAPPED,unique
+Macro Component 2 for J medium,preferred_term,kgmicrobe.ingredient:macro_component_2_for_j_medium,Macro Component 2 for J medium,kgmicrobe.ingredient:macro_component_2_for_j_medium,MAPPED,unique
+Macrolide Antibiotic,preferred_term,CHEBI:25105,Macrolide Antibiotic,CHEBI:25105,MAPPED,unique
+Magainin I,preferred_term,CHEBI:201898,Magainin I,CHEBI:201898,MAPPED,unique
+magnesium 3-carboxy-3-hydroxypentanedioate,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+Magnesium acetate,preferred_term,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+magnesium carbonate,ontology_label,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
+Magnesium chloride,preferred_term,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+Magnesium chloride anhydrous,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+Magnesium chloride anhydrous,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+Magnesium chloride anhydrous,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+magnesium chloride dihydrate,synonym,CHEBI:131394,MgCl2 x 2 H2O,CHEBI:131394,MAPPED,unique
+Magnesium chloride hexahydrate,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+Magnesium chloride hydrate,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+"Magnesium chloride, monohydrate",synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+Magnesium citrate dibasic,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+Magnesium di(acetate),synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+magnesium diacetate,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+magnesium dichloride,synonym,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,conflict:different_substances
+magnesium dichloride,ontology_label,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+magnesium dichloride,ontology_label,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+magnesium dichloride dihydrate,synonym,CHEBI:131394,MgCl2 x 2 H2O,CHEBI:131394,MAPPED,unique
+magnesium dichloride hexahydrate,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+magnesium dichloride hexahydrate,ontology_label,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+magnesium dichloride monohydrate,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+magnesium dichloride--water (1/1),synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+magnesium dichloride--water (1/6),synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+magnesium dichloride--water (1/6),synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+Magnesium hydrogen citrate,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+magnesium nitrate,ontology_label,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+magnesium nitrate hexahydrate,preferred_term,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+Magnesium sulfate,preferred_term,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+magnesium sulfate,ontology_label,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,unique
+Magnesium sulfate (1:1),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+magnesium sulfate (1:1) heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate (1:1) heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+Magnesium sulfate heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,unique
+magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+magnesium sulphate heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+magnesium sulphate heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+Magnesium(2+),preferred_term,CHEBI:18420,Magnesium(2+),CHEBI:18420,MAPPED,unique
+Magnesiumchlorid,synonym,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,unique
+Magnesiumsulfat,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+Malachite green,preferred_term,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+malachite green chloride,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+malachite green chloride salt,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+Malate,preferred_term,CHEBI:25115,Malate,CHEBI:25115,MAPPED,unique
+malates,synonym,CHEBI:25115,Malate,CHEBI:25115,MAPPED,unique
+Maleic acid,preferred_term,CHEBI:18300,Maleic acid,CHEBI:18300,MAPPED,unique
+"Maleic acid, disodium salt",synonym,CHEBI:91263,Sodium maleate,CHEBI:91263,MAPPED,unique
+Malic acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,conflict:different_substances
+Malic Acid,ontology_label,cas:207511-06-6,L-Malic acid disodium salt monohydrate,NCIT:C80654,MAPPED,conflict:different_substances
+malic acid anion,synonym,CHEBI:25115,Malate,CHEBI:25115,MAPPED,unique
+Malonamide,preferred_term,CHEBI:48537,Malonamide,CHEBI:48537,MAPPED,unique
+Malonate,preferred_term,CHEBI:15792,Malonate,CHEBI:15792,MAPPED,unique
+malonate(2-),ontology_label,CHEBI:15792,Malonate,CHEBI:15792,MAPPED,unique
+Malondialdehyde tetrabutylammonium salt,preferred_term,cas:100683-54-3,Malondialdehyde tetrabutylammonium salt,CHEBI:51992,MAPPED,unique
+Malonic acid,preferred_term,CHEBI:30794,Malonic acid,CHEBI:30794,MAPPED,unique
+Malt extract,preferred_term,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,resolved:owned
+malt extract,ontology_label,kgmicrobe.ingredient:malt_extract_agar,Malt extract agar,FOODON:03301056,MAPPED,resolved:owned
+malt extract,ontology_label,kgmicrobe.ingredient:malt_extract_agar_~28nissui~29,Malt Extract Agar (Nissui),FOODON:03301056,MAPPED,resolved:owned
+malt extract,ontology_label,kgmicrobe.ingredient:malt_extract_agar_~28oxoid~29,Malt extract agar (Oxoid),FOODON:03301056,MAPPED,resolved:owned
+malt extract,ontology_label,kgmicrobe.ingredient:malt_extract_broth,Malt extract broth,FOODON:03301056,MAPPED,resolved:owned
+malt extract,ontology_label,kgmicrobe.ingredient:yeast_extract_malt_extract_agar,Yeast extract-malt extract agar,FOODON:03301056,MAPPED,resolved:owned
+Malt extract (BD--Difco),synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
+Malt extract (BD-Difco),synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
+Malt extract agar,preferred_term,kgmicrobe.ingredient:malt_extract_agar,Malt extract agar,FOODON:03301056,MAPPED,unique
+Malt Extract Agar (Nissui),preferred_term,kgmicrobe.ingredient:malt_extract_agar_~28nissui~29,Malt Extract Agar (Nissui),FOODON:03301056,MAPPED,unique
+Malt extract agar (Oxoid),preferred_term,kgmicrobe.ingredient:malt_extract_agar_~28oxoid~29,Malt extract agar (Oxoid),FOODON:03301056,MAPPED,unique
+Malt extract broth,preferred_term,kgmicrobe.ingredient:malt_extract_broth,Malt extract broth,FOODON:03301056,MAPPED,unique
+Malt extract powder,synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
+Malt extract(Sigma M-0383),synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
+Malt sugar,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+Maltitol,preferred_term,CHEBI:68428,Maltitol,CHEBI:68428,MAPPED,unique
+Maltodextrin,preferred_term,CHEBI:25140,Maltodextrin,CHEBI:25140,MAPPED,unique
+Maltohexaose,preferred_term,CHEBI:27445,Maltohexaose,CHEBI:27445,MAPPED,unique
+Maltose,preferred_term,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,resolved:owned
+maltose,preferred_term,CHEBI:17306,maltose,CHEBI:17306,REJECTED,resolved:owned
+maltose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,resolved:owned
+maltose,ontology_label,cas:6363-53-7,D-Maltose monohydrate,CHEBI:17306,MAPPED,resolved:owned
+maltose,ontology_label,kgmicrobe.compound:maltose_hydrate,Maltose Hydrate,CHEBI:17306,MAPPED,resolved:owned
+Maltose Hydrate,preferred_term,kgmicrobe.compound:maltose_hydrate,Maltose Hydrate,CHEBI:17306,MAPPED,unique
+Maltose monohydrate,synonym,cas:6363-53-7,D-Maltose monohydrate,CHEBI:17306,MAPPED,unique
+Maltose x H2O,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+Maltotetraose,preferred_term,CHEBI:28460,Maltotetraose,CHEBI:28460,MAPPED,unique
+Maltotriose,preferred_term,CHEBI:61993,Maltotriose,CHEBI:61993,MAPPED,resolved:owned
+maltotriose,ontology_label,cas:312693-63-3,Maltotriose hydrate,CHEBI:61993,MAPPED,resolved:owned
+Maltotriose hydrate,preferred_term,cas:312693-63-3,Maltotriose hydrate,CHEBI:61993,MAPPED,unique
+Malzzucker,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+mammalian milk protein (hydrolyzed),ontology_label,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
+mammalian milk protein (hydrolyzed),ontology_label,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Man Rogosa Sharp broth,preferred_term,UNMAPPED_0432,Man Rogosa Sharp broth,,UNMAPPED,unique
+Mandelic acid,preferred_term,CHEBI:35825,Mandelic acid,CHEBI:35825,MAPPED,unique
+Mangandichlorid,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+Mangandioxid,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Manganese,preferred_term,NCIT:C624,Manganese,NCIT:C624,MAPPED,unique
+Manganese (II) chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+Manganese bichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese binoxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Manganese chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese chloride dihydrate,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+Manganese chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganese dichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese dichloride dihydrate,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+Manganese dichloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganese dioxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Manganese monosulfate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+manganese peroxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Manganese sulfate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+Manganese sulfate anhydrous,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+Manganese sulfate anhydrous,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+Manganese sulfate hydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+Manganese sulfate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+Manganese sulfate tetrahydrate,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+Manganese sulphate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+"Manganese sulphate, tetrahydrate",synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese superoxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+manganese(2+) chloride dihydrate,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+manganese(2+) chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganese(2+) chloride--water (1/2),synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+manganese(2+) chloride--water (1/4),synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganese(2+) dichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese(2+) sulfate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,conflict:different_substances
+manganese(2+) sulfate,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+manganese(2+) sulfate,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+manganese(2+) sulfate dihydrate,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+manganese(2+) sulfate hexahydrate,synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+manganese(2+) sulfate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+manganese(2+) sulfate pentahydrate,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+manganese(2+) sulfate tetrahydrate,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese(2+) sulfate--water (1/1),synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+manganese(2+) sulfate--water (1/2),synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+manganese(2+) sulfate--water (1/4),synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese(2+) sulfate--water (1/5),synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+manganese(2+) sulfate--water (1/6),synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+manganese(2+) sulphate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+manganese(2+) sulphate dihydrate,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+manganese(2+) sulphate hexahydrate,synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+manganese(2+) sulphate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+manganese(2+) sulphate pentahydrate,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+manganese(2+) sulphate tetrahydrate,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese(II) chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unresolved:partial_chemistry
+manganese(II) chloride,synonym,UNMAPPED_0450,MnCl4 x 6 H2O,,UNMAPPED,unresolved:partial_chemistry
+Manganese(II) chloride (1:2),synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese(II) chloride dihydrate,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+manganese(II) chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganese(II) dichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+manganese(II) sulfate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+manganese(II) sulfate,ontology_label,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,unique
+manganese(II) sulfate dihydrate,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+manganese(II) sulfate hexahydrate,synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+manganese(II) sulfate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+manganese(II) sulfate monohydrate,ontology_label,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,unique
+manganese(II) sulfate pentahydrate,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+Manganese(II) sulfate tetrahydrate,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese(II) sulphate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+manganese(II) sulphate dihydrate,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+manganese(II) sulphate hexahydrate,synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+manganese(II) sulphate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+manganese(II) sulphate pentahydrate,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+manganese(II) sulphate tetrahydrate,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+manganese(IV) dioxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+manganese(IV) oxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+Manganese-NTA,preferred_term,UNMAPPED_0155,Manganese-NTA,,UNMAPPED,unique
+Manganous chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+Manganous chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+manganous dichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+Manganous sulfate,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+Manganous sulfate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+Mangiferin,preferred_term,CHEBI:6682,Mangiferin,CHEBI:6682,MAPPED,unique
+manna sugar,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+Mannan from Saccharomyces cerevisiae,preferred_term,cas:9036-88-8,Mannan from Saccharomyces cerevisiae,NCIT:C14271,MAPPED,unique
+mannite,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+Mannitol,preferred_term,CHEBI:29864,Mannitol,CHEBI:29864,MAPPED,resolved:owned
+Mannitol,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,resolved:owned
+Mannobiose,preferred_term,CHEBI:25164,Mannobiose,CHEBI:25164,MAPPED,unique
+Mannose,preferred_term,CHEBI:37684,Mannose,CHEBI:37684,MAPPED,unique
+Mannose-6-Phosphate,preferred_term,CHEBI:17369,Mannose-6-Phosphate,CHEBI:17369,MAPPED,unique
+Mannotriose,preferred_term,CHEBI:146181,Mannotriose,CHEBI:146181,MAPPED,unique
+Margaric acid,synonym,CHEBI:32365,heptadecanoic acid,CHEBI:32365,MAPPED,unique
+Marine agar 2216,preferred_term,kgmicrobe.ingredient:marine_agar_2216,Marine agar 2216,kgmicrobe.ingredient:marine_agar_2216,MAPPED,unique
+Marine Broth,preferred_term,UNMAPPED_0433,Marine Broth,,UNMAPPED,unique
+Marine broth 2216,preferred_term,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
+Marinostatin,preferred_term,CHEBI:221095,Marinostatin,CHEBI:221095,MAPPED,unique
+Marmite,preferred_term,mesh:C008328,Marmite,mesh:C008328,MAPPED,unique
+mascagnite,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+masoprocol,ontology_label,CHEBI:73468,Nordihydroguaretic Acid,CHEBI:73468,MAPPED,unique
+Matamycin,synonym,CHEBI:157683,Althiomycin,CHEBI:157683,MAPPED,unique
+Matrine,preferred_term,CHEBI:6700,Matrine,CHEBI:6700,MAPPED,unique
+Mc_general_salts,preferred_term,kgmicrobe.ingredient:mc_general_salts,Mc_general_salts,kgmicrobe.ingredient:mc_general_salts,MAPPED,unique
+Mc_general_salts_SO4free,preferred_term,kgmicrobe.ingredient:mc_general_salts_so4free,Mc_general_salts_SO4free,kgmicrobe.ingredient:mc_general_salts_so4free,MAPPED,unique
+Mc_trace_minerals,preferred_term,kgmicrobe.ingredient:mc_trace_minerals,Mc_trace_minerals,kgmicrobe.ingredient:mc_trace_minerals,MAPPED,unique
+Mc_trace_minerals_SO4free,preferred_term,kgmicrobe.ingredient:mc_trace_minerals_so4free,Mc_trace_minerals_SO4free,kgmicrobe.ingredient:mc_trace_minerals_so4free,MAPPED,unique
+Mc_vitamins,preferred_term,kgmicrobe.ingredient:mc_vitamins,Mc_vitamins,kgmicrobe.ingredient:mc_vitamins,MAPPED,unique
+Me3N.HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+meat (cooked),ontology_label,FOODON:03305103,Cooked meat medium,FOODON:03305103,MAPPED,unique
+Meat Extract,preferred_term,FOODON:03315424,Meat Extract,FOODON:03315424,MAPPED,unique
+Meat infusion,preferred_term,UNMAPPED_0436,Meat infusion,,UNMAPPED,unique
+Meat peptone,preferred_term,MICRO:0000176,Meat peptone,MICRO:0000176,MAPPED,resolved:owned
+Meat peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,resolved:owned
+Meat sugar,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+MeCH(OH)CO2 anion,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+Mecillinam,preferred_term,CHEBI:51208,Mecillinam,CHEBI:51208,MAPPED,unique
+MeCO2 anion,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+MeCO2H,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+MeCO2K,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+MeCOOH,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+Medicamycin,preferred_term,kgmicrobe.compound:medicamycin,Medicamycin,kgmicrobe.compound:medicamycin,MAPPED,unique
+Mediject L,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Melanin,preferred_term,CHEBI:89634,Melanin,CHEBI:89634,MAPPED,unique
+Melezitose,preferred_term,CHEBI:6731,Melezitose,CHEBI:6731,MAPPED,resolved:owned
+melezitose,ontology_label,cas:10030-67-8,D-(+)-melezitose monohydrate,CHEBI:6731,MAPPED,resolved:owned
+melezitose,ontology_label,cas:207511-10-2,D-(+)-Melezitose hydrate,CHEBI:6731,MAPPED,resolved:owned
+Melibiose,preferred_term,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
+Melitose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+Melitriose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+MEM alpha Modification,preferred_term,UNMAPPED_0437,MEM alpha Modification,,UNMAPPED,unique
+MEM-Medium,preferred_term,UNMAPPED_0438,MEM-Medium,,UNMAPPED,unique
+menadion,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Menadione,preferred_term,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,resolved:owned
+menadione,ontology_label,kgmicrobe.ingredient:menadione_solution,Menadione solution,CHEBI:28869,MAPPED,resolved:owned
+Menadione sodium bisulfate,preferred_term,CHEBI:63928,Menadione sodium bisulfate,CHEBI:63928,MAPPED,unique
+menadione sodium sulfonate,ontology_label,CHEBI:63928,Menadione sodium bisulfate,CHEBI:63928,MAPPED,unique
+Menadione solution,preferred_term,kgmicrobe.ingredient:menadione_solution,Menadione solution,CHEBI:28869,MAPPED,unique
+menaphthon,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+menaphthone,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Menaquinone,preferred_term,CHEBI:16374,Menaquinone,CHEBI:16374,MAPPED,unique
+menaquinone 0,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+MeNH2,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+Menthol,preferred_term,cas:1490-04-6,Menthol,CHEBI:25187,MAPPED,unique
+MeOH,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Mephyton,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+"Mercaptoacetic acid, sodium salt",synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Mercaptoethanol,synonym,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
+mercury (II) chloride,preferred_term,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
+mercury dichloride,ontology_label,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
+mercury(2+) chloride,synonym,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
+mercury(II) chloride,synonym,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
+Meropenem,preferred_term,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
+meropenem trihydrate,ontology_label,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
+MES,preferred_term,CHEBI:39010,MES,CHEBI:39010,MAPPED,resolved:owned
+MES,ontology_label,kgmicrobe.ingredient:mes_buffer,MES buffer,CHEBI:39010,MAPPED,resolved:owned
+MES (2-[N-Morpholino]ethane sulfonic acid),synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+MES (2-Morpholinoethanesulfonic acid),synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+MES [2-(N-morpholino) ethane sulfonic acid],preferred_term,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+MES acids,synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
+MES buffer,preferred_term,kgmicrobe.ingredient:mes_buffer,MES buffer,CHEBI:39010,MAPPED,unique
+MES Hydrat,preferred_term,cas:145224-94-8,MES Hydrat,CHEBI:39005,MAPPED,unique
+MES sodium salt,preferred_term,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+MES-Na,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+Mesna,ontology_label,CHEBI:31824,Sodium 2-mercaptoethanesulfonate,CHEBI:31824,MAPPED,unique
+meso-Erythritol,preferred_term,CHEBI:17113,meso-Erythritol,CHEBI:17113,MAPPED,unique
+MESO-ERYTHRITOL,synonym,CHEBI:17113,meso-Erythritol,CHEBI:17113,MAPPED,unique
+meso-galactaric acid,synonym,CHEBI:30852,Mucic acid,CHEBI:30852,MAPPED,unique
+meso-xylitol,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+meta-xylene,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
+metacetonic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Metall salt sol. 44,preferred_term,kgmicrobe.ingredient:metall_salt_sol_44,Metall salt sol. 44,kgmicrobe.ingredient:metall_salt_sol_44,MAPPED,unique
+Methacycline,preferred_term,CHEBI:6805,Methacycline,CHEBI:6805,MAPPED,unique
+Methanamine,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+"Methanamine, hydrochloride (1:1)",synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+methanaminium chloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+methane,preferred_term,CHEBI:16183,methane,CHEBI:16183,MAPPED,unique
+Methanecarboxylic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
+methanedione,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+Methanoic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Methanol,preferred_term,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Methanol-utilizing bacteria medium B,preferred_term,UNMAPPED_0443,Methanol-utilizing bacteria medium B,,UNMAPPED,unique
+Methicillin,preferred_term,CHEBI:6827,Methicillin,CHEBI:6827,MAPPED,unique
+Methionin,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+METHIONINE,synonym,CHEBI:16643,L-Methionine,CHEBI:16643,MAPPED,agree:same_substance
+methionine,ontology_label,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,agree:same_substance
+methoic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
+Methotrexate,preferred_term,CHEBI:44185,Methotrexate,CHEBI:44185,MAPPED,unique
+Methoxymethane,synonym,cas:5728-44-9,Apigenin Dimethyl Ether,CHEBI:28887,MAPPED,unique
+Methyamine,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+methyl (2E)-3-(4-hydroxy-3-methoxyphenyl)prop-2-enoate,synonym,cas:22329-76-6,methyl ferulate,CHEBI:67379,MAPPED,unique
+Methyl (R)-lactate,preferred_term,CHEBI:74611,Methyl (R)-lactate,CHEBI:74611,MAPPED,unique
+"methyl 1-methyl-3,6-dihydro-2H-pyridine-5-carboxylate;hydrobromide",synonym,CHEBI:233150,Arecoline Hydrobromide,CHEBI:233150,MAPPED,unique
+"methyl 2-[(1S,3S,7R,8R,9R,12S,13S)-13-(uran-3-yl)-6,6,8,12-tetramethyl-17-methylidene-5,15-dioxo-2,14-dioxatetracyclo[7.7.1.01,12.03,8]heptadecan-7-yl]-2-hydroxyacetate",synonym,CHEBI:181871,Methyl 6-Hydroxyangolensate,CHEBI:181871,MAPPED,unique
+"methyl 2-[3-[(3E,5E)-7-(2,4-dioxopyrrolidin-3-ylidene)-7-hydroxy-4-methylhepta-3,5-dien-2-yl]-1,4-dimethyl-6-oxospiro[2,9-dioxabicyclo[3.3.1]nonane-8,3'-oxirane]-2'-yl]propanoate",synonym,CHEBI:219652,nocamycin,CHEBI:219652,MAPPED,unique
+"methyl 2-{[(4-methoxy-6-methyl-1,3,5-triazin-2-yl)(methyl)carbamoyl]sulfamoyl}benzoate",synonym,CHEBI:9678,Tribenuron-methyl,CHEBI:9678,MAPPED,unique
+methyl 3-(4-hydroxyphenyl)prop-2-enoate,synonym,CHEBI:86904,methyl-cis-p-coumarate,CHEBI:86904,MAPPED,unique
+methyl 3-(4-hydroxyphenyl)propanoate,synonym,CHEBI:176565,Methyl 3-(4-hydroxyphenyl)propionate,CHEBI:176565,MAPPED,unique
+Methyl 3-(4-hydroxyphenyl)propionate,preferred_term,CHEBI:176565,Methyl 3-(4-hydroxyphenyl)propionate,CHEBI:176565,MAPPED,unique
+methyl 3-keto-a-D-glucopyranoside,preferred_term,UNMAPPED_0233,methyl 3-keto-a-D-glucopyranoside,,UNMAPPED,unique
+Methyl 6-Hydroxyangolensate,preferred_term,CHEBI:181871,Methyl 6-Hydroxyangolensate,CHEBI:181871,MAPPED,unique
+Methyl alcohol,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+methyl alpha-D-galactoside,ontology_label,CHEBI:55507,1-o-methyl Alpha-galactopyranoside,CHEBI:55507,MAPPED,unique
+Methyl alpha-D-glucopyranoside,preferred_term,CHEBI:320061,Methyl alpha-D-glucopyranoside,CHEBI:320061,MAPPED,unique
+Methyl Alpha-D-mannoside,preferred_term,CHEBI:43943,Methyl Alpha-D-mannoside,CHEBI:43943,MAPPED,unique
+Methyl beta-D-galactopyranoside,synonym,CHEBI:17540,Methyl-B-D-galactopyranoside,CHEBI:17540,MAPPED,unique
+methyl beta-D-galactoside,ontology_label,CHEBI:17540,Methyl-B-D-galactopyranoside,CHEBI:17540,MAPPED,unique
+Methyl beta-D-glucopyranoside,preferred_term,CHEBI:320055,Methyl beta-D-glucopyranoside,CHEBI:320055,MAPPED,unique
+Methyl Beta-D-xylopyranoside,preferred_term,CHEBI:74863,Methyl Beta-D-xylopyranoside,CHEBI:74863,MAPPED,unique
+Methyl D-glucoside,preferred_term,CHEBI:37657,Methyl D-glucoside,CHEBI:37657,MAPPED,unique
+Methyl dihydrojasmonate,ontology_label,CHEBI:89741,"dihydrojasmonic acid, methyl ester",CHEBI:89741,MAPPED,unique
+methyl ferulate,preferred_term,cas:22329-76-6,methyl ferulate,CHEBI:67379,MAPPED,unique
+methyl jasmonate,preferred_term,CHEBI:15929,methyl jasmonate,CHEBI:15929,MAPPED,unique
+Methyl methanesulfonate,preferred_term,CHEBI:25255,Methyl methanesulfonate,CHEBI:25255,MAPPED,unique
+"methyl N-[(2R,3R,4S,6R)-6-[[(1S,3R,6S,7E,9S,11E,13S,16S,17S,18S,20S,21R,22S,23E)-17-[(2R,4R,5S,6S)-4-[(2S,6S)-4-[(2S,4S,5R,6S)-4,5-dihydroxy-6-methyloxan-2-yl]oxy-5-[(2R,4R,5R,6S)-4-hydroxy-5-methoxy-6-methyloxan-2-yl]oxy-6-methyloxan-2-yl]oxy-5-hydroxy-6-methyloxan-2-yl]oxy-23-hydroxy-4-(hydroxymethyl)-3,8,12,18,20,22-hexamethyl-25,27-dioxo-26-oxapentacyclo[22.2.1.01,6.013,22.016,21]heptacosa-4,7,11,14,23-pentaen-9-yl]oxy]-2,4-dimethyl-4-nitrooxan-3-yl]carbamate",synonym,CHEBI:220048,kijanimicin,CHEBI:220048,MAPPED,unique
+Methyl Pyruvate,preferred_term,CHEBI:51850,Methyl Pyruvate,CHEBI:51850,MAPPED,unique
+"methyl {(1R,2R)-3-oxo-2-[(2Z)-pent-2-en-1-yl]cyclopentyl}acetate",synonym,CHEBI:15929,methyl jasmonate,CHEBI:15929,MAPPED,unique
+Methyl-2-Hydroxy-Phenylproprionate,preferred_term,cas:89471-28-0,Methyl-2-Hydroxy-Phenylproprionate,cas:89471-28-0,MAPPED,unique
+methyl-alpha-D-xylopyranoside,preferred_term,cas:91-09-8,methyl-alpha-D-xylopyranoside,cas:91-09-8,MAPPED,unique
+Methyl-B-D-galactopyranoside,preferred_term,CHEBI:17540,Methyl-B-D-galactopyranoside,CHEBI:17540,MAPPED,unique
+methyl-beta-D-xylopyranoside,preferred_term,cas:612-05-5,methyl-beta-D-xylopyranoside,cas:612-05-5,MAPPED,unique
+methyl-beta-L-arabinopyranoside,preferred_term,cas:1825-00-9,methyl-beta-L-arabinopyranoside,cas:1825-00-9,MAPPED,unique
+methyl-cis-p-coumarate,preferred_term,CHEBI:86904,methyl-cis-p-coumarate,CHEBI:86904,MAPPED,unique
+methyl-trans-p-coumarate,preferred_term,cas:19367-38-5,methyl-trans-p-coumarate,CHEBI:194094,MAPPED,unique
+methylacetic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Methylalkohol,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Methylamine,preferred_term,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+Methylamine hydrochloride,preferred_term,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+Methylamine-HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+Methylammonium chloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+methylbenzene,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
+Methylcarbinol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Methylenblau,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Methylene blue,preferred_term,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+methylene chloride,preferred_term,CHEBI:15767,methylene chloride,CHEBI:15767,MAPPED,unique
+methylethylacetic acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+Methylglycocyamine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+methylglyoxal,preferred_term,CHEBI:17158,methylglyoxal,CHEBI:17158,MAPPED,unique
+methylisothiazolinone,ontology_label,CHEBI:53620,2-methyl-4-isothizaolin-3-one,CHEBI:53620,MAPPED,unique
+methylsulfinylmethane,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+methylthioninii chloridum,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Methylthioninium chloride,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Methylxanthoxylin,preferred_term,cas:23121-32-6,Methylxanthoxylin,CHEBI:169463,MAPPED,unique
+metionina,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+Metronidazole,preferred_term,CHEBI:6909,Metronidazole,CHEBI:6909,MAPPED,unique
+mevalonic acid,ontology_label,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
+Mexicanolide,preferred_term,cas:1915-67-9,Mexicanolide,mesh:C554989,MAPPED,unique
+Mezlocillin,preferred_term,CHEBI:6919,Mezlocillin,CHEBI:6919,MAPPED,unique
+MG (0:0/18:0/0:0),synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
+Mg Acetate,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+Mg(II) acetate,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+Mg(NO3)2 x 6 H2O,synonym,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+Mg-citrate,preferred_term,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+Mg2SO4,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MG[18:1(omega-9)],synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+MgCl*6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+MgCl2,preferred_term,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,unique
+MgCl2  x 6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2  x 7 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2  x 7 H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2  x 7 H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2  x 76 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2  x 76 H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2  x 76 H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2 . 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2 x 2 H2O,preferred_term,CHEBI:131394,MgCl2 x 2 H2O,CHEBI:131394,MAPPED,unique
+MgCl2 x 6 H2O,preferred_term,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2 x 6 H2O (200 g/l stock solution),synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2 X 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2 X 6H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2 X 6H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2 x 7 H2O,preferred_term,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,resolved:owned
+MgCl2 x 7 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,resolved:owned
+MgCl2 x 7 H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,resolved:owned
+MgCl2 x 7H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2 x 7H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2 x 7H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2 x H2O,preferred_term,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+MgCl2 · 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2.2H2O,synonym,CHEBI:131394,MgCl2 x 2 H2O,CHEBI:131394,MAPPED,unique
+MgCl2.6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2.H2O,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+MgCl2x 6 H2O,preferred_term,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,resolved:owned
+MgCl2x 6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,resolved:owned
+MgCl2x 6 H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,resolved:owned
+MgCl2x 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2x6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2x7H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2x7H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2x7H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2 x 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
+MgCl2 x 6H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
+MgCl2 x 6H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2·6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2·6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2·H2O,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+MgCl2∙6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+MgCl2⋅6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2・6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCO,synonym,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
+MgCO3,preferred_term,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
+MgCO3(MCIB CB486),synonym,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
+MgNO32 x 6 H2O,synonym,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+MgSO,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+MgSO .7H O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MgSO 4,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+MgSO 4 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO 4 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO2,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+MgSO2 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO2 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO4,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MgSO4 . 7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 . 7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 . 7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 . H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 . H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 . H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 6 H2O,preferred_term,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,resolved:owned
+MgSO4 x 6 H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,resolved:owned
+MgSO4 x 6 H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,resolved:owned
+MgSO4 x 6H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 6H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 6H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7 H20,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+MgSO4 x 7 H2O,preferred_term,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4 x 7 H2O (0.1% w/v),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O (0.1% w/v),synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O (0.1% w/v),synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7 H2O (100 mM),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O (100 mM),synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O (100 mM),synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7 H2O solution (25%),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O solution (25%),synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O solution (25%),synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7 H2O to 15.0 g).,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O to 15.0 g).,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7 H2O to 15.0 g).,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x 7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x7 H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x7 H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x7 H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 x7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 · 7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 · 7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 · 7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 ·7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 ·7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
+MgSO4 ·7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 × 7 H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MgSO4.7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4.7H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO47H2O,preferred_term,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+MgSO47H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4x7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4x7H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO4·7H2O,preferred_term,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,unique
+MgSO4·7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4·H2O,preferred_term,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO4·H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O (Sigma 230391),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O(CAS: 10034-99-8),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O(Sigma 230391),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MHPP,synonym,CHEBI:176565,Methyl 3-(4-hydroxyphenyl)propionate,CHEBI:176565,MAPPED,unique
+micronutrient solution,preferred_term,kgmicrobe.ingredient:micronutrient_solution,micronutrient solution,kgmicrobe.ingredient:micronutrient_solution,MAPPED,unique
+Microstop,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+Middlebrook 7H10 agar,preferred_term,NCIT:C85509,Middlebrook 7H10 agar,NCIT:C85509,MAPPED,unique
+Middlebrook 7H10 Growth Medium,ontology_label,NCIT:C85509,Middlebrook 7H10 agar,NCIT:C85509,MAPPED,unique
+Midecamycin,preferred_term,CHEBI:31845,Midecamycin,CHEBI:31845,MAPPED,unique
+miharamycin A,preferred_term,CHEBI:216282,miharamycin A,CHEBI:216282,MAPPED,unique
+Milchzucker,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
+Milk,preferred_term,UBERON:0001913,Milk,UBERON:0001913,MAPPED,unique
+Mineral 3B solution,preferred_term,kgmicrobe.ingredient:mineral_3b_solution,Mineral 3B solution,kgmicrobe.ingredient:mineral_3b_solution,MAPPED,unique
+Mineral 3B solution minus Nitrogen,preferred_term,kgmicrobe.ingredient:mineral_3b_solution_minus_nitrogen,Mineral 3B solution minus Nitrogen,kgmicrobe.ingredient:mineral_3b_solution_minus_nitrogen,MAPPED,unique
+Mineral 3B solution minus phosphorus,preferred_term,kgmicrobe.ingredient:mineral_3b_solution_minus_phosphorus,Mineral 3B solution minus phosphorus,kgmicrobe.ingredient:mineral_3b_solution_minus_phosphorus,MAPPED,unique
+Mineral salts base,preferred_term,kgmicrobe.ingredient:mineral_salts_base,Mineral salts base,kgmicrobe.ingredient:mineral_salts_base,MAPPED,unique
+Mineral salts medium base,preferred_term,UNMAPPED_0609,Mineral salts medium base,,UNMAPPED,unique
+Mineral solution see Medium No. 976,preferred_term,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,Mineral solution see Medium No. 976,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,MAPPED,unique
+Mineral water,preferred_term,FOODON:03301328,Mineral water,FOODON:03301328,MAPPED,unique
+Minimycin,preferred_term,mesh:C002363,Minimycin,mesh:C002363,MAPPED,unique
+Minocycline,preferred_term,CHEBI:50694,Minocycline,CHEBI:50694,MAPPED,unique
+Minocycline hydrochloride,preferred_term,CHEBI:50697,Minocycline hydrochloride,CHEBI:50697,MAPPED,unique
+Minor Nutrients,preferred_term,kgmicrobe.ingredient:minor_nutrients,Minor Nutrients,kgmicrobe.ingredient:minor_nutrients,MAPPED,unique
+Mitomycin C,preferred_term,CHEBI:27504,Mitomycin C,CHEBI:27504,MAPPED,unique
+MKP,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+MME Trace Minerals,preferred_term,kgmicrobe.ingredient:mme_trace_minerals,MME Trace Minerals,kgmicrobe.ingredient:mme_trace_minerals,MAPPED,unique
+MnCl2,preferred_term,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
+MnCl2 . 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2 x 2 H2O,preferred_term,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+MnCl2 x 4 H2O,preferred_term,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2 · 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2 × 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2 ∙ 4 H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2.4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2·2H2O,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+MnCl2∙4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2⋅4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2・4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2．2H2O,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+MnCl2･4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl4 x 4 H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl4 x 6 H2O,preferred_term,UNMAPPED_0450,MnCl4 x 6 H2O,,UNMAPPED,unique
+MnII x EDTA,preferred_term,UNMAPPED_0451,MnII x EDTA,,UNMAPPED,unique
+MnO2,preferred_term,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
+MnSO4,preferred_term,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+MnSO4 . 2H2O,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4 . 5H2O,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+MnSO4 . 7H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4 . 7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+MnSO4 . H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4 x 1 H2O,preferred_term,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,resolved:owned
+MnSO4 x 1 H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,resolved:owned
+MnSO4 x 1 H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,resolved:owned
+MnSO4 x 2 H2O,preferred_term,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4 x 2 H2O (0.1% w/v),synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4 x 2 H2O (1% solution),synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4 x 4 H2O,preferred_term,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+MnSO4 x 5 H2O,preferred_term,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+MnSO4 x 6 H2O,preferred_term,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+MnSO4 x 7 H2O,preferred_term,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,resolved:owned
+MnSO4 x 7 H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,resolved:owned
+MnSO4 x 7H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4 x 7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+MnSO4 x H2O,preferred_term,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,resolved:owned
+MnSO4 x H2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,resolved:owned
+MnSO4 x n H2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+MnSO4 · 4 H2O,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+MnSO4 · H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4 ⋅ H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4.2H2O,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4.4H2O,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+MnSO4.5H2O,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+MnSO4.6H2O,synonym,CHEBI:131523,MnSO4 x 6 H2O,CHEBI:131523,MAPPED,unique
+MnSO4.7H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4.7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+MnSO4.H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4·2H2O,synonym,CHEBI:86356,MnSO4 x 2 H2O,CHEBI:86356,MAPPED,unique
+MnSO4·4H2O,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
+MnSO4·5H2O,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+MnSO4·7H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4·7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+MnSO4·H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4·nH2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+MnSO4⋅H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
+MnSO4・5H2O,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
+MnSO4・xH2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4・xH2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:different_substances
+MnSO4・xH2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
+Modified Bold 3N Medium,preferred_term,UNMAPPED_0089,Modified Bold 3N Medium,,UNMAPPED,unique
+Modified COMBO Medium,preferred_term,UNMAPPED_0111,Modified COMBO Medium,,UNMAPPED,unique
+Modified Cooked Meat Medium,preferred_term,kgmicrobe.ingredient:modified_cooked_meat_medium,Modified Cooked Meat Medium,kgmicrobe.ingredient:modified_cooked_meat_medium,MAPPED,unique
+Modified P-IV chelated Micronutrient Solution,preferred_term,kgmicrobe.ingredient:modified_p-iv_chelated_micronutrient_solution,Modified P-IV chelated Micronutrient Solution,kgmicrobe.ingredient:modified_p-iv_chelated_micronutrient_solution,MAPPED,unique
+Modified trace vitamins,preferred_term,kgmicrobe.ingredient:modified_trace_vitamins,Modified trace vitamins,kgmicrobe.ingredient:modified_trace_vitamins,MAPPED,unique
+Modified Wolfe's Minerals,preferred_term,kgmicrobe.ingredient:modified_wolfes_minerals,Modified Wolfe's Minerals,kgmicrobe.ingredient:modified_wolfes_minerals,MAPPED,unique
+molecular hydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+molecular nitrogen,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+MoLS4,preferred_term,UNMAPPED_0292,MoLS4,,UNMAPPED,unique
+molybdenum trioxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
+molybdenum(6+) oxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
+molybdenum(VI) oxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
+Molybdic acid ammonium salt tetrahydrate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+"Molybdic acid, diammonium salt",synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+"Molybdic acid, disodium salt",synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+"Molybdic acid, disodium salt, dihydrate",synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+monazomycin,preferred_term,CHEBI:201539,monazomycin,CHEBI:201539,MAPPED,unique
+Monensin,preferred_term,CHEBI:27617,Monensin,CHEBI:27617,MAPPED,unique
+monensin A,ontology_label,CHEBI:27617,Monensin,CHEBI:27617,MAPPED,unique
+Mono- And Disaccharides,preferred_term,kgmicrobe.ingredient:mono_and_disaccharides,Mono- And Disaccharides,kgmicrobe.ingredient:mono_and_disaccharides,MAPPED,unique
+mono-(9Z)-octadecenoylglycerol,synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+Monoammonium acid phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monoammonium dihydrogen orthophosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monoammonium dihydrogen phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monoammonium hydrogen phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monoammonium orthophosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monoammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Monobasic ammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+monocalcium acid phosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+Monoethylene glycol,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+monoferrous acid citrate,ontology_label,mesh:C016600,Ferrous citrate,mesh:C016600,MAPPED,unique
+Monomethyl Succinate,preferred_term,CHEBI:75146,Monomethyl Succinate,CHEBI:75146,MAPPED,unique
+monomethylamine,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
+Monomethylamine hydrochloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+Monomethylammonium chloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+monooleoylglycerol,synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+monopotassium carbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+Monopotassium chloride,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Monopotassium dihydrogen phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Monopotassium monophosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Monopotassium orthophosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Monopotassium phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Monosodium 2-hydroxypropanoate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+"monosodium D-(-)-6-(2-amino-2-phenylacetamido)-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo(3.2.0)heptane-2-carboxylate",synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+Monosodium D-gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Monosodium gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Monosodium glutamate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+monosodium L-ascorbate,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+monosodium L-glutamate,ontology_label,CHEBI:64243,Sodium L-glutamate,CHEBI:64243,MAPPED,unique
+monosodium L-glutamate,ontology_label,CHEBI:64243,Na-glutamate,CHEBI:64243,REJECTED,unique
+monosodium L-glutamate hydrate,ontology_label,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+Monosodium lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Monosodium orotate,synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+monosodium phosphate,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+Monosodium phosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+MoO3,preferred_term,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
+MOPS,preferred_term,CHEBI:39074,MOPS,CHEBI:39074,MAPPED,resolved:owned
+MOPS,ontology_label,kgmicrobe.ingredient:mops_2m_ph7,MOPS_2M_pH7,CHEBI:39074,MAPPED,resolved:owned
+MOPS (3-(N-morpholino) propane-sulfonic acid),synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+MOPS buffer,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+MOPS_2M_pH7,preferred_term,kgmicrobe.ingredient:mops_2m_ph7,MOPS_2M_pH7,CHEBI:39074,MAPPED,unique
+Morin,preferred_term,CHEBI:75092,Morin,CHEBI:75092,MAPPED,unique
+Morpholinopropane sulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+Moxifloxacin,preferred_term,CHEBI:63611,Moxifloxacin,CHEBI:63611,MAPPED,unique
+MoYLS4,preferred_term,UNMAPPED_0264,MoYLS4,,UNMAPPED,unique
+MreB Perturbing Compound A22,preferred_term,cas:22816-60-0,MreB Perturbing Compound A22,cas:22816-60-0,MAPPED,unique
+MRS broth,preferred_term,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS medium,preferred_term,UNMAPPED_0454,MRS medium,,UNMAPPED,unique
+Mucic acid,preferred_term,CHEBI:30852,Mucic acid,CHEBI:30852,MAPPED,unique
+Mucin,preferred_term,NCIT:C16883,Mucin,NCIT:C16883,MAPPED,unique
+Mucin from porcine stomach type III,preferred_term,cas:84082-64-4,Mucin from porcine stomach type III,cas:84082-64-4,MAPPED,unique
+"Mucin from porcine stomach type III, bound sialic acid 0.5-1.5 %, Mucin from porcine stomach type III",synonym,cas:84082-64-4,Mucin from porcine stomach type III,cas:84082-64-4,MAPPED,unique
+"Mucin from porcine stomach,Type II",preferred_term,cas:84082-64-4,"Mucin from porcine stomach,Type II",cas:84082-64-4,MAPPED,unique
+"Mucin, Bovine Submaxillary Gland, type I-S",preferred_term,cas:84195-52-8,"Mucin, Bovine Submaxillary Gland, type I-S",cas:84195-52-8,MAPPED,unique
+Mueller Hinton II agar,preferred_term,UNMAPPED_0128,Mueller Hinton II agar,,UNMAPPED,unique
+Murashige & Skoog medium,preferred_term,UNMAPPED_0455,Murashige & Skoog medium,,UNMAPPED,unique
+Murashige-Skoog basal salts,preferred_term,kgmicrobe.ingredient:murashige-skoog_basal_salts,Murashige-Skoog basal salts,kgmicrobe.ingredient:murashige-skoog_basal_salts,MAPPED,unique
+muriate of potash,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+MWC Metal Solution,preferred_term,kgmicrobe.ingredient:mwc_metal_solution,MWC Metal Solution,kgmicrobe.ingredient:mwc_metal_solution,MAPPED,unique
+Mycobacidin,preferred_term,mesh:C010250,Mycobacidin,mesh:C010250,MAPPED,unique
+Mycobactine J,preferred_term,UNMAPPED_0456,Mycobactine J,,UNMAPPED,unique
+myo-Inositol,preferred_term,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+myo-inositol,ontology_label,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+Myoinositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
+Myricetin,preferred_term,CHEBI:18152,Myricetin,CHEBI:18152,MAPPED,unique
+Myristic acid,preferred_term,CHEBI:28875,Myristic acid,CHEBI:28875,MAPPED,unique
+MYRISTIC ACID,synonym,CHEBI:28875,Myristic acid,CHEBI:28875,MAPPED,unique
+N#N,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+"N'-(3-aminopropyl)butane-1,4-diamine;trihydrochloride",synonym,CHEBI:233088,Spermidine trihydrochloride,CHEBI:233088,MAPPED,unique
+N'-(3-chlorophenyl)carbonohydrazonoyl dicyanide,synonym,CHEBI:3259,CCCP,CHEBI:3259,MAPPED,unique
+N'-disuccinic Acid (EDDS),preferred_term,kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,N'-disuccinic Acid (EDDS),,REJECTED,unique
+N'-disuccinic Acid (EDDS),synonym,kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,"Ethylenediamine-N,N'-disuccinic acid (EDDS)",kgmicrobe.compound:ethylenediamine_n_n_disuccinic_acid,MAPPED,unique
+"N(1),N(1),N(2),N(2)-tetrakis[(pyridin-2-yl)methyl]ethane-1,2-diamine",synonym,CHEBI:88217,"N,N,N′,N′-Tetrakis(2-pyridylmethyl)ethylenediamine",CHEBI:88217,MAPPED,unique
+N(2),synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+N(2)-acetyl-L-lysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+N(2)-acetylglutamine,synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+N(5)-(aminocarbonyl)-L-ornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+N(5)-carbamoyl-L-ornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+N(alpha)-acetyl-L-lysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+N(alpha)-acetyllysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+N(CH2-COOH)3,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+N(CH2CH2OH)3,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+N(CH3)3,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+N(delta)-carbamylornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+"N,5-bis(4-chlorophenyl)-3-(propan-2-ylimino)-3,5-dihydrophenazin-2-amine",synonym,CHEBI:3749,Clofazimine,CHEBI:3749,MAPPED,unique
+"N,N''''-hexane-1,6-diylbis[N'-(4-chlorophenyl)triimidodicarbonic diamide] acetate (1:2)",synonym,kgmicrobe.compound:chlorhexidine_diacetate_salt_hydrate,Chlorhexidine diacetate salt hydrate,CHEBI:81711,MAPPED,unique
+"N,N',N''-[(3S,7S,11S)-2,6,10-trioxo-1,5,9-trioxacyclododecane-3,7,11-triyl]tris(2,3-dihydroxybenzamide)",synonym,CHEBI:28855,Enterobactin,CHEBI:28855,MAPPED,unique
+"N,N'-1,2-ethanediylbis[N-(carboxymethyl)glycine] trisodium salt",synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+"N,N'-1,2-ethanediylbis[N-(carboxymethyl)glycine], disodium salt",synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+"N,N'-bis[(2S)-1-hydroxybutan-2-yl]ethane-1,2-diaminium dichloride",synonym,CHEBI:4878,Ethambutol dihydrochloride,CHEBI:4878,MAPPED,unique
+"N,N,N',N'-tetrakis(2-pyridylmethyl)ethylenediamine",ontology_label,CHEBI:88217,"N,N,N′,N′-Tetrakis(2-pyridylmethyl)ethylenediamine",CHEBI:88217,MAPPED,unique
+"N,N,N',N'-tetramethylacridine-3,6-diamine hydrochloride",synonym,CHEBI:51739,Acridine orange,CHEBI:51739,MAPPED,unique
+"N,N,N',N'-tetramethylethane-1,2-diamine",synonym,CHEBI:32850,"N,N,N′,N′-Tetramethylethylenediamine",CHEBI:32850,MAPPED,unique
+"N,N,N',N'-tetramethylethylenediamine",ontology_label,CHEBI:32850,"N,N,N′,N′-Tetramethylethylenediamine",CHEBI:32850,MAPPED,unique
+"N,N,N-trimethylamine",synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+"N,N,N-trimethylammonioacetate",synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+"N,N,N-trimethylethanol-ammonium",synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+"N,N,N-Trimethylglycine",synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+"N,N,N-trimethylhexadecan-1-aminium bromide",synonym,CHEBI:3567,Cetrimonium bromide,CHEBI:3567,MAPPED,unique
+"N,N,N-trimethylmethanaminium",synonym,CHEBI:46020,Tetramethyl ammonium,CHEBI:46020,MAPPED,unresolved:partial_chemistry
+"N,N,N-trimethylmethanaminium",synonym,kgmicrobe.compound:tetramethyl_ammonium_chloride,Tetramethyl ammonium chloride,CHEBI:46020,MAPPED,unresolved:partial_chemistry
+"N,N,N′,N′-Tetrakis(2-pyridylmethyl)ethylenediamine",preferred_term,CHEBI:88217,"N,N,N′,N′-Tetrakis(2-pyridylmethyl)ethylenediamine",CHEBI:88217,MAPPED,unique
+"N,N,N′,N′-Tetramethylethylenediamine",preferred_term,CHEBI:32850,"N,N,N′,N′-Tetramethylethylenediamine",CHEBI:32850,MAPPED,unique
+"N,N-bis(2-hydroxyethyl)glycine",synonym,CHEBI:40957,BICINE buffer,CHEBI:40957,MAPPED,unique
+"N,N-bis(2-hydroxyethyl)glycine",ontology_label,CHEBI:40957,Bicine,CHEBI:40957,REJECTED,unique
+"N,N-bis(carboxymethyl)glycine",synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,conflict:different_substances
+"N,N-bis(carboxymethyl)glycine",synonym,cas:15467-20-6,Nitrilotriacetic acid disodium salt,CHEBI:44557,MAPPED,conflict:different_substances
+"N,N-Bis(carboxymethyl)glycine, trisodium salt",synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+"N,N-dimethylcon-5-enin-3beta-amine",synonym,CHEBI:27965,Conessine,CHEBI:27965,MAPPED,unique
+"N,N-dimethylglycine",ontology_label,CHEBI:17724,N-N Dimethyl glycine,CHEBI:17724,MAPPED,unique
+"N,N-Dimethylmethanamine",synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+"N,N-dimethylmethanamine hydrochloride",synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+"N,N-dimethylmethanamine oxide",synonym,CHEBI:15724,Trimethylamine-N-oxide,CHEBI:15724,MAPPED,unique
+"N,N-dimethylmethanaminium chloride",synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+"N-(2,4-dihydroxy-3,3-dimethylbutanoyl)-beta-alaninate",synonym,CHEBI:16454,Pantothenate,CHEBI:16454,MAPPED,unique
+"N-(2,4-dihydroxy-3,3-dimethylbutanoyl)-beta-alanine",synonym,CHEBI:7916,Pantothenic acid,CHEBI:7916,MAPPED,unique
+"N-(2,5-Dioxo-4-imidazolidinyl)urea",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+"N-(2,5-dioxoimidazolidin-4-yl)urea",synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
+N-(2-acetamido)-2-aminoethanesulfonic acid,preferred_term,CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,CHEBI:39060,MAPPED,unique
+N-(2-acetamido)-2-aminoethanesulfonic acid,ontology_label,CHEBI:39060,ACES,CHEBI:39060,REJECTED,unique
+N-(2-oxooxolan-3-yl)decanamide,synonym,CHEBI:181434,N-decanoyl-DL-Homoserine lactone,CHEBI:181434,MAPPED,unique
+"N-(3-Aminopropyl)-1,4-butane-diamine",synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+"N-(3-aminopropyl)butane-1,4-diamine",synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+N-(3-oxohexanoyl)-DL-homoserine lactone,preferred_term,CHEBI:29640,N-(3-oxohexanoyl)-DL-homoserine lactone,CHEBI:29640,MAPPED,unique
+N-(3-oxohexanoyl)homoserine lactone,ontology_label,CHEBI:29640,N-(3-oxohexanoyl)-DL-homoserine lactone,CHEBI:29640,MAPPED,unique
+"N-(4-{[(2,4-diaminopteridin-6-yl)methyl](methyl)amino}benzoyl)-L-glutamic acid",synonym,CHEBI:44185,Methotrexate,CHEBI:44185,MAPPED,unique
+"N-(4-{[(2-amino-4-oxo-3,4-dihydropteridin-6-yl)methyl]amino}benzoyl)-L-glutamic acid",synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+"N-(9-{2-[(4-{[(2,5-dioxopyrrolidin-1-yl)oxy]carbonyl}piperidin-1-yl)sulfonyl]phenyl}-6-[methyl(4-sulfophenyl)amino]-3H-xanthen-3-ylidene)-N-methyl-4-sulfoanilinium",synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
+N-(aminoiminomethyl)-N-methylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+N-(carbamoylmethyl)taurine,synonym,CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,CHEBI:39060,MAPPED,unique
+N-(N-gamma-L-Glutamyl-L-cysteinyl)glycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+"N-({(5S)-3-[3-fluoro-4-(morpholin-4-yl)phenyl]-2-oxo-1,3-oxazolidin-5-yl}methyl)acetamide",synonym,CHEBI:63607,Linezolid,CHEBI:63607,MAPPED,unique
+"N-[(2S,3R)-3-hydroxy-1-(hydroxyamino)-1-oxobutan-2-yl]-4-({4-[(morpholin-4-yl)methyl]phenyl}ethynyl)benzamide",synonym,CHEBI:134107,CHIR-090,CHEBI:134107,MAPPED,unique
+"N-[(4-{[(2-amino-4-oxo-1,4-dihydropteridin-6-yl)methyl]amino}phenyl)carbonyl]-L-glutamic acid",synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+"N-[(7S)-10-hydroxy-1,2,3-trimethoxy-9-oxo-6,7-dihydro-5H-benzo[a]heptalen-7-yl]acetamide",synonym,CHEBI:183909,Colchiceine,CHEBI:183909,MAPPED,unique
+N-[(E)-AMINO(IMINO)METHYL]-N-METHYLGLYCINE,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+"N-[4-({[2-amino-5-formyl-4-oxo-3,4,5,6,7,8-hexahydropteridin-6-yl]methyl}amino)benzoyl]-L-glutamic acid",synonym,CHEBI:15640,Folinic acid,CHEBI:15640,MAPPED,unique
+N-[amino(imino)methyl]-N-methylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+N-[tris(hydroxymethyl)methyl]-3-amino-2-hydroxypropanesulfonic acid,synonym,cas:68399-81-5,TAPSO,cas:68399-81-5,MAPPED,unique
+N-[tris(hydroxymethyl)methyl]-3-aminopropanesulfonic acid,ontology_label,cas:91000-53-2,TAPS sodium salt,CHEBI:191055,MAPPED,unique
+N-acetyl-beta-D-mannosamine,preferred_term,CHEBI:63154,N-acetyl-beta-D-mannosamine,CHEBI:63154,MAPPED,unique
+N-Acetyl-D-galactosamine,preferred_term,CHEBI:28037,N-Acetyl-D-galactosamine,CHEBI:28037,MAPPED,unique
+N-Acetyl-D-glucosamine,preferred_term,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
+N-acetyl-D-glucosamine 6-phosphate,ontology_label,CHEBI:15784,N-Acetyl-D-glucosamine 6-phosphate sodium salt,CHEBI:15784,MAPPED,unique
+N-Acetyl-D-glucosamine 6-phosphate sodium salt,preferred_term,CHEBI:15784,N-Acetyl-D-glucosamine 6-phosphate sodium salt,CHEBI:15784,MAPPED,unique
+N-Acetyl-glutamic acid,preferred_term,CHEBI:172431,N-Acetyl-glutamic acid,CHEBI:172431,MAPPED,unique
+n-Acetyl-glutamine,preferred_term,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+N-Acetyl-L-aspartic acid,preferred_term,CHEBI:21547,N-Acetyl-L-aspartic acid,CHEBI:21547,MAPPED,unique
+N-Acetyl-L-Glutamic Acid,preferred_term,CHEBI:17533,N-Acetyl-L-Glutamic Acid,CHEBI:17533,MAPPED,unique
+N-Acetyl-L-glutamine,preferred_term,CHEBI:21553,N-Acetyl-L-glutamine,CHEBI:21553,MAPPED,unique
+n-Acetyl-lysine,preferred_term,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+n-Acetyl-muramic acid,preferred_term,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
+n-Acetyl-muramic acid,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+N-acetyl-neuraminic Acid,synonym,CHEBI:17012,N-acetylneuraminic acid,CHEBI:17012,MAPPED,unique
+N-acetylgalactosamine,preferred_term,CHEBI:28800,N-acetylgalactosamine,CHEBI:28800,MAPPED,unique
+N-Acetylglucosamine,preferred_term,CHEBI:59640,N-Acetylglucosamine,CHEBI:59640,MAPPED,unique
+N-acetylglucosamines,synonym,CHEBI:59640,N-Acetylglucosamine,CHEBI:59640,MAPPED,unique
+N-Acetylglutamine,synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
+N-acetylmuramic acid,preferred_term,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
+N-acetylneuraminate,preferred_term,CHEBI:35418,N-acetylneuraminate,CHEBI:35418,MAPPED,unique
+N-acetylneuraminic acid,preferred_term,CHEBI:17012,N-acetylneuraminic acid,CHEBI:17012,MAPPED,unique
+N-acetyltyramine,preferred_term,CHEBI:125610,N-acetyltyramine,CHEBI:125610,MAPPED,unique
+N-alpha-Acetyl-L-glutamate,synonym,CHEBI:17533,N-Acetyl-L-Glutamic Acid,CHEBI:17533,MAPPED,unique
+N-alpha-Acetyl-L-glutamine,synonym,CHEBI:21553,N-Acetyl-L-glutamine,CHEBI:21553,MAPPED,unique
+N-alpha-acetyl-L-lysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+N-amidinosarcosine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+N-benzoylglycine,ontology_label,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
+"N-benzyl-N,N-dimethyl-2-{2-[4-(2,4,4-trimethylpentan-2-yl)phenoxy]ethoxy}ethanaminium chloride",synonym,CHEBI:31264,Benzethonium chloride,CHEBI:31264,MAPPED,unique
+n-BuCOOH,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+n-butanoic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+n-Butyric acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+n-Caproic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+N-carbamimidoyl-N-methylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+N-carbamimidoylglycine,synonym,CHEBI:16344,Glycocyamine,CHEBI:16344,MAPPED,unique
+n-cetane,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+n-Decane,preferred_term,CHEBI:41808,n-Decane,CHEBI:41808,MAPPED,unique
+N-decanoyl-DL-Homoserine lactone,preferred_term,CHEBI:181434,N-decanoyl-DL-Homoserine lactone,CHEBI:181434,MAPPED,unique
+"N-decanoyl-L-tryptophyl-L-asparaginyl-N-[(3S,6S,9R,15S,18R,21S,24S,30S,31R)-3-[2-(2-aminophenyl)-2-oxoethyl]-24-(3-aminopropyl)-15,21-bis(carboxymethyl)-6-[(2R)-1-carboxypropan-2-yl]-9-(hydroxymethyl)-18,31-dimethyl-2,5,8,11,14,17,20,23,26,29-decaoxo-1-oxa-4,7,10,13,16,19,22,25,28-nonaazacyclohentriacontan-30-yl]-L-alpha-asparagine",synonym,CHEBI:600103,Daptomycin,CHEBI:600103,MAPPED,unique
+n-Dekan,synonym,CHEBI:41808,n-Decane,CHEBI:41808,MAPPED,unique
+"N-ethylethanaminium 1,1-diethyl-3-oxotriazan-2-olate",synonym,cas:372965-00-9,DEANONOate,CHEBI:77707,MAPPED,unique
+N-glycylglycine,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+n-heptadecane,synonym,CHEBI:16148,Heptadecane,CHEBI:16148,MAPPED,unique
+n-hexadecane,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+n-hexanoic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+n-hexoic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+n-hexylic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+N-hydroxyserinamide,synonym,CHEBI:75494,Serine hydroxamate,CHEBI:75494,MAPPED,unique
+N-HYDROXYUREA,synonym,CHEBI:44423,Hydroxyurea,CHEBI:44423,MAPPED,unique
+N-lauroylsarcosine sodium salt,preferred_term,CHEBI:183704,N-lauroylsarcosine sodium salt,CHEBI:183704,MAPPED,unique
+N-Methyl-N-guanylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+N-Methylammonium chloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
+N-methylhydantoin,preferred_term,CHEBI:16354,N-methylhydantoin,CHEBI:16354,MAPPED,unique
+"N-Methylimidazolidine-2,4-dione",synonym,CHEBI:16354,N-methylhydantoin,CHEBI:16354,MAPPED,unique
+N-N Dimethyl glycine,preferred_term,CHEBI:17724,N-N Dimethyl glycine,CHEBI:17724,MAPPED,unique
+n-octadecanoic acid,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+n-Pentanoate,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+n-pentanoic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+N-pteroyl-L-glutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+N-trimethylethanolamine,synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+n-Valeric acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+N-Z amine,preferred_term,UNMAPPED_0457,N-Z amine,,UNMAPPED,unique
+N-Z-Amine® A,preferred_term,UNMAPPED_0458,N-Z-Amine® A,,UNMAPPED,unique
+N-Z-Case,preferred_term,UNMAPPED_0459,N-Z-Case,,UNMAPPED,unique
+"N-{[(1S,4S,7S,8S,11R,14S,17R,20S)-7-{[N(2)-({(3R,9S,12S,15S,21S,22S)-21-[(N(2)-{[(6R,9S,10S,15aS)-10-({[(3R,6S,12S,15S)-12-[(2S)-butan-2-yl]-6-isobutyl-15-{[(2Z)-2-(L-isoleucylamino)but-2-enoyl]amino}-9-methylene-5,8,11,14-tetraoxo-1-thia-4,7,10,13-tetraazacyclohexadecan-3-yl]carbonyl}amino)-9-methyl-1,4,11-trioxododecahydro-1H,9H-pyrrolo[2,1-i][1,4,7,10]thiatriazacyclotridecin-6-yl]carbonyl}-L-lysyl)amino]-12-isobutyl-15,22-dimethyl-9-[2-(methylsulfanyl)ethyl]-5,8,11,14,17,20-hexaoxo-1-thia-4,7,10,13,16,19-hexaazacyclodocosan-3-yl}carbonyl)-L-asparaginyl-L-methionyl-L-lysyl]amino}-14-(1H-imidazol-5-ylmethyl)-4,8,20-trimethyl-3,6,12,15,21-pentaoxo-9,19-dithia-2,5,13,16,22-pentaazabicyclo[9.9.2]docos-17-yl]carbonyl}-L-seryl-L-isoleucyl-L-histidyl-N-(3-{[(1S)-5-amino-1-carboxypentyl]amino}-3-oxoprop-1-en-2-yl)-L-valinamide",synonym,CHEBI:71629,Nisin,CHEBI:71629,MAPPED,unique
+N2,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+N2-Acetyl-L-lysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
+N2O,synonym,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
+N5-(Aminocarbonyl)ornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+N5-carbamoylornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+Na Acetate,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Na CO,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+NA EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Na glutamate,preferred_term,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+Na HPO,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Na HPO anydrous,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Na malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Na NO3,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+Na pyruvate,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Na silicate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Na SiO .9H O,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Na Succinate,synonym,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+Na-(DL)-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Na-(L)-lactate,synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+Na-3-hydroxybutyrate,preferred_term,CHEBI:113373,Na-3-hydroxybutyrate,CHEBI:113373,MAPPED,unique
+Na-acetate,preferred_term,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Na-acetate x 3 H2O,synonym,CHEBI:32138,Sodium acetate trihydrate,CHEBI:32138,MAPPED,unique
+Na-ampicillin,preferred_term,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+Na-ascorbate,preferred_term,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Na-benzoate,preferred_term,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+Na-butyrate,preferred_term,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Na-caproate,preferred_term,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Na-crotonate,preferred_term,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+Na-DL-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Na-DL-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Na-EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na-EDTA x 2 H2O,synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+Na-formate,preferred_term,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Na-formiate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Na-fumarate,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+Na-gallate,preferred_term,CHEBI:115197,Na-gallate,CHEBI:115197,MAPPED,unique
+Na-gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Na-glutamate,preferred_term,CHEBI:64243,Na-glutamate,CHEBI:64243,REJECTED,unique
+Na-glutamate,synonym,CHEBI:64243,Sodium L-glutamate,CHEBI:64243,MAPPED,unique
+Na-L-lactate,preferred_term,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+Na-L-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Na-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Na-laurate,preferred_term,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
+Na-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Na-Nitrilotriacetat,preferred_term,UNMAPPED_0460,Na-Nitrilotriacetat,,UNMAPPED,unique
+Na-orotate,preferred_term,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+Na-oxalate,synonym,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+Na-phosphate buffer,preferred_term,kgmicrobe.ingredient:na-phosphate_buffer,Na-phosphate buffer,kgmicrobe.ingredient:na-phosphate_buffer,MAPPED,unique
+Na-phosphate buffer,ontology_label,kgmicrobe.ingredient:na-phosphate_buffer,Na-Phosphate-Buffer,kgmicrobe.ingredient:na-phosphate_buffer,REJECTED,unique
+Na-Phosphate-Buffer,preferred_term,kgmicrobe.ingredient:na-phosphate_buffer,Na-Phosphate-Buffer,kgmicrobe.ingredient:na-phosphate_buffer,REJECTED,unique
+Na-Phosphate-Buffer,synonym,kgmicrobe.ingredient:na-phosphate_buffer,Na-phosphate buffer,kgmicrobe.ingredient:na-phosphate_buffer,MAPPED,unique
+Na-propionate,preferred_term,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Na-pyruvate,preferred_term,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Na-silicate,preferred_term,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Na-stearate,preferred_term,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
+Na-succinate,synonym,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+Na-tartrate,preferred_term,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+Na-tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+Na-tetrathionate,preferred_term,UNMAPPED_0463,Na-tetrathionate,,UNMAPPED,unique
+Na-thioglycolate,preferred_term,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Na-thiosulfate,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+Na-tungstate x 2 H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na-vanillate,preferred_term,CHEBI:132748,Na-vanillate,CHEBI:132748,MAPPED,unique
+Na2 alpha-ketoglutarate,preferred_term,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+Na2 beta-glycerol PO4 x 5 H2O,preferred_term,UNMAPPED_0465,Na2 beta-glycerol PO4 x 5 H2O,,UNMAPPED,unique
+NA2 EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na2 MoO4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2 α-ketoglutarate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
+"Na2-9,10-anthraquinone-2,6-disulfonate",synonym,cas:853-68-9,AQDS,cas:853-68-9,MAPPED,unique
+Na2-citrate,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,unique
+Na2-DL-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Na2-EDTA,preferred_term,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na2-EDTA x 2 H2O,preferred_term,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+Na2-EDTA x 2 H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2-EDTA·2H2O,synonym,CHEBI:64758,Na2-EDTA x 2 H2O,CHEBI:64758,REJECTED,unique
+Na2-fumarate,preferred_term,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+Na2-glutamate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+Na2-glyoxalate,preferred_term,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
+Na2-ß-glycerolphosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Na2B4O7,preferred_term,CHEBI:38892,Na2B4O7,CHEBI:38892,MAPPED,unique
+Na2B4O7 . 10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7 x 10 H2O,preferred_term,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7 · 10 H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7·10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7⋅10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7・10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7．10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2citrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Na2citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Na2CO,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3,preferred_term,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3 anhydrous,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3(Baker 3604),synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3-CO2 buffer,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na2EDTA . 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA · 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA.2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA· 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA·2H2O,preferred_term,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA•2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2EDTA•2H2O(Sigma ED255),synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2Glycerophosphate.5H2O,preferred_term,UNMAPPED_0081,Na2Glycerophosphate.5H2O,,UNMAPPED,unique
+Na2Glycerophosphate.5H2O(CAS:  13408-09-8),synonym,UNMAPPED_0081,Na2Glycerophosphate.5H2O,,UNMAPPED,unique
+Na2glycerophosphate•5H2O,preferred_term,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,resolved:owned
+Na2Glycerophosphate•5H2O,preferred_term,UNMAPPED_0101,Na2Glycerophosphate•5H2O,,UNMAPPED,resolved:owned
+Na2glycerophosphate•5H2O(CAS: 13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unresolved:no_chemistry
+Na2Glycerophosphate•5H2O(CAS: 13408-09-8),synonym,UNMAPPED_0101,Na2Glycerophosphate•5H2O,,UNMAPPED,unresolved:no_chemistry
+Na2glycerophosphate•5H2O(CAS:  13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2H2EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
+Na2H2EDTA.2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
+Na2H2PO4,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Na2HAsO4 x 7 H2O,preferred_term,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+Na2HPO4,preferred_term,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Na2HPO4 . 12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x 12 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 2H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x 3 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
+Na2HPO4 x H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 × 12 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4 × 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4-KH2PO4 buffer,preferred_term,kgmicrobe.ingredient:na2hpo4-kh2po4_buffer,Na2HPO4-KH2PO4 buffer,kgmicrobe.ingredient:na2hpo4-kh2po4_buffer,MAPPED,unique
+Na2HPO4-NaH2PO4 buffer,preferred_term,kgmicrobe.ingredient:na2hpo4-nah2po4_buffer,Na2HPO4-NaH2PO4 buffer,kgmicrobe.ingredient:na2hpo4-nah2po4_buffer,MAPPED,unique
+Na2HPO4.12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
+Na2HPO4·2H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
+Na2HPO4·6H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,unique
+Na2HPO4•7H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,unique
+Na2Mo4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4,preferred_term,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4 . 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 . 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 . H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 . H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 x 2 H2O,preferred_term,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4 x 2 H2O (0.1% w/v),synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 x 2 H2O (0.1% w/v),synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 x 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 x 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 x 7 H2O,preferred_term,CHEBI:86473,Na2MoO4 x 7 H2O,CHEBI:86473,MAPPED,unique
+Na2MoO4 x H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4 · 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 · 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 · H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 · H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4 × H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4 ∙ 2 H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4 ⋅ 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4 ⋅ 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4*2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4*2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4-2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4. 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4. 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4.2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO4.7H2O,synonym,CHEBI:86473,Na2MoO4 x 7 H2O,CHEBI:86473,MAPPED,unique
+Na2MoO4.H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4.H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4xH2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4xH2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4·2H2O,preferred_term,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,resolved:owned
+Na2MoO4·2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,resolved:owned
+Na2MoO4·2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,resolved:owned
+Na2MoO4∙2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4⋅2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4⋅2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO4・2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+Na2MoO4・2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+Na2MoO7 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO7O4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoSO4,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoSO4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2S,preferred_term,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Na2S . 9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S x 9 H2O,preferred_term,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S x 9 H2O (3% w/v),synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S x 9 H2O(24% w/v),synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S x 9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S x H2O,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Na2S ∙ 9 H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S.9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S2O3,preferred_term,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+Na2S2O3 . 5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3 x 5 H2O,preferred_term,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3 x 5 H2O (10% solution),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3 x 5 H2O(24 % w/v),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3 x 5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3.5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3x5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3·5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3・5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O4,preferred_term,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Na2S2O4,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Na2S2O5,preferred_term,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Na2S2SO3,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+Na2Se2O3,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Na2SeO3,preferred_term,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Na2SeO3 . 5H2O,synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
+Na2SeO3 x 5 H2O,preferred_term,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+Na2SeO3 x 5 H2O (0.01% w/v),synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
+Na2SeO3·5H2O,preferred_term,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
+Na2SeO3·5H2O,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+Na2SeO3・5H2O,synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
+Na2SeO4,preferred_term,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+Na2SiO3 x 9 H2O,preferred_term,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3.9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3·9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3•9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3•9H2O(CAS: 13517-24-3),synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3•9H2O(Sigma 307815),synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3∙9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3・9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SO3,preferred_term,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+Na2SO3 x 5 H2O,preferred_term,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,unique
+Na2SO4,preferred_term,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+Na2SO4 x 10 H2O,preferred_term,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
+Na2SO4.10H2O,synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
+Na2S·9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S⋅9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S・9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2WO2 x 2 H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4,preferred_term,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
+Na2WO4 . 2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4 x 2 H2O,preferred_term,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4 x 2 H2O (0.1% w/v),synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4 × 2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4*2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4.2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4·2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4・2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na3-citrate,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,unique
+Na3-citrate x 2 H2O,preferred_term,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Na3-citrate x 2 H2O (0.6 g/l stock solution),synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Na3-EDTA,preferred_term,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+Na3-NTA x H2O,preferred_term,UNMAPPED_0475,Na3-NTA x H2O,,UNMAPPED,unique
+Na3Citrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Na3Citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Na3VO4,preferred_term,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+Na3‐citrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Na3‐citrate x 2H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Na3‐citrate x 2H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+NAA,synonym,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+NaBr,preferred_term,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
+NaCl,preferred_term,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+NaCl (Fisher S271-500),synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+NaCl(Fisher S271-500),synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+NaClO3,preferred_term,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+NaClO4,synonym,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,unique
+NaCO3,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+NAD(+),synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+NAD+,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+NaF,preferred_term,CHEBI:28741,NaF,CHEBI:28741,MAPPED,unique
+nafcillin sodium monohydrate,ontology_label,CHEBI:51919,Nafcillin sodium salt monohydrate,CHEBI:51919,MAPPED,unique
+Nafcillin sodium salt monohydrate,preferred_term,CHEBI:51919,Nafcillin sodium salt monohydrate,CHEBI:51919,MAPPED,unique
+naftaleno,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+naftalina,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+NaH PO .2H O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+NaH2PO4,preferred_term,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+NaH2PO4 x 2 H2O,preferred_term,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,resolved:owned
+NaH2PO4 x 2 H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,resolved:owned
+NaH2PO4 x 2H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4 x 2H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4 x H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4 x H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4·2H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4·2H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4·H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4·H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4•H2O,preferred_term,cas:10049-21-5,NaH2PO4•H2O,CHEBI:37585,MAPPED,unique
+NaH2PO4•H2O(MCIB 742),synonym,cas:10049-21-5,NaH2PO4•H2O,CHEBI:37585,MAPPED,unique
+NaH2PO4・2H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4・2H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4・H2O,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+NaH2PO4・H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+NaHAsO4.7H2O,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+NaHCO,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3,preferred_term,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3(Fisher S 233),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHSO3,preferred_term,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+nalidixic acid,ontology_label,cas:3374-05-8,Nalidixic acid sodium salt,CHEBI:100147,MAPPED,unique
+Nalidixic acid sodium salt,preferred_term,cas:3374-05-8,Nalidixic acid sodium salt,CHEBI:100147,MAPPED,unique
+NaMoO4,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+NaMoO4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+NaNO,preferred_term,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
+NaNO2,preferred_term,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
+NaNO3,preferred_term,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+NaNO3(autoclave before adding)(Fisher BP360-500),synonym,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
+NaNO3(CAS: 7631-99-4),synonym,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
+NaNO3(Fisher BP360-500),synonym,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
+NaOH,preferred_term,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+naphtalene,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+naphtaline,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+Naphthalen,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+naphthalen-1-ylacetic acid,synonym,CHEBI:32918,1-Naphthylacetic acid,CHEBI:32918,MAPPED,unique
+Naphthalene,preferred_term,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+Naphthalene sulfonic acid,preferred_term,CHEBI:36336,Naphthalene sulfonic acid,CHEBI:36336,MAPPED,unique
+"naphthalene-1,4-dione",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+naphthalenesulfonic acid,synonym,CHEBI:36336,Naphthalene sulfonic acid,CHEBI:36336,MAPPED,unique
+Naphthalin,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
+naphthoquinone,synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+naramycin,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+naramycin A,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Narbomycin,preferred_term,CHEBI:29649,Narbomycin,CHEBI:29649,MAPPED,unique
+Narcogen,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Naringenin,preferred_term,CHEBI:50202,Naringenin,CHEBI:50202,MAPPED,unique
+Naringin,preferred_term,CHEBI:28819,Naringin,CHEBI:28819,MAPPED,unique
+NaS2O3,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+NaS2O3 x 5 H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+NaSiO3 x 9 H2O,preferred_term,UNMAPPED_0477,NaSiO3 x 9 H2O,,UNMAPPED,unique
+NaSO4,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+Natamycin,preferred_term,CHEBI:7488,Natamycin,CHEBI:7488,MAPPED,unique
+natrii ascorbas,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+natrii chloridum,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Natrium nitrit,synonym,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
+Natrium octanoat,synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+Natrium pyrophosphat,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+Natrium sulfurosum,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+Natriumazetat,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Natriumbisulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+Natriumchlorat,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+Natriumchlorid,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Natriumhydrogenkarbonat,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Natriumhydrogensulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+Natriumhydroxid,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+Natriumkarbonat,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Natriummolybdat,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Natriumoxalat,synonym,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+Natriumperchlorat,synonym,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,unique
+Natriumpropionat,synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Natriumpyruvat,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Natriumselenit,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Natriumsulfat,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+Natriumsulfid,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+Natural blue 2,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+Natural sea water,preferred_term,kgmicrobe.ingredient:natural_sea_water,Natural sea water,ENVO:00002149,MAPPED,unique
+Natural sea-salt,preferred_term,UNMAPPED_0050,Natural sea-salt,,UNMAPPED,unique
+"Natural seawater (filtered, 95% strength)",synonym,MICRO:0001773,Filtered Seawater,MICRO:0001773,MAPPED,unique
+NaVO3,preferred_term,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
+NaVO3 x H2O,preferred_term,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+NaVO3 x n H2O,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+NaVO3.H2O,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+NaWO4·2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+NdCl3 x 6 H2O,preferred_term,UNMAPPED_0479,NdCl3 x 6 H2O,,UNMAPPED,unique
+Neoantimycin,preferred_term,CHEBI:215310,Neoantimycin,CHEBI:215310,MAPPED,unique
+Neomycin,preferred_term,CHEBI:7507,Neomycin,CHEBI:7507,MAPPED,unique
+Neomycin E,synonym,CHEBI:7934,Paromomycin,CHEBI:7934,MAPPED,unique
+Neomycin F,preferred_term,CHEBI:81287,Neomycin F,CHEBI:81287,MAPPED,unique
+neomycin sulfate,ontology_label,kgmicrobe.compound:neomycin_trisulfate_salt_hydrate,Neomycin trisulfate salt hydrate,CHEBI:31635,MAPPED,unique
+Neomycin trisulfate salt hydrate,preferred_term,kgmicrobe.compound:neomycin_trisulfate_salt_hydrate,Neomycin trisulfate salt hydrate,CHEBI:31635,MAPPED,unique
+Neopeptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Neopeptone (BD-Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+"Neopeptone (Difco Laboratories, Detroit, Ml)",synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Nerol,preferred_term,CHEBI:29452,Nerol,CHEBI:29452,MAPPED,unique
+Nerolidol,preferred_term,CHEBI:7524,Nerolidol,CHEBI:7524,MAPPED,unique
+Netilmicin,synonym,CHEBI:7528,Netilmycin,CHEBI:7528,MAPPED,unique
+Netilmycin,preferred_term,CHEBI:7528,Netilmycin,CHEBI:7528,MAPPED,unique
+Netropsin,preferred_term,mesh:D009429,Netropsin,mesh:D009429,MAPPED,unique
+Neutral red,preferred_term,CHEBI:86370,Neutral red,CHEBI:86370,MAPPED,unique
+NH4-oxalate,preferred_term,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+NH42CO3,preferred_term,CHEBI:229630,NH42CO3,CHEBI:229630,MAPPED,unique
+NH4Cl,preferred_term,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+NH4Cl(CAS: 12125-02-9),synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+NH4Cl(Fisher A 649-500),synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+NH4Cl2,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
+NH4H2PO4,preferred_term,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+NH4HCO3,preferred_term,CHEBI:184335,NH4HCO3,CHEBI:184335,MAPPED,unique
+NH4MgPO,preferred_term,CHEBI:149425,NH4MgPO,CHEBI:149425,MAPPED,unique
+NH4MgPO4(Sigma 529354),synonym,CHEBI:149425,NH4MgPO,CHEBI:149425,MAPPED,unique
+NH4NO,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+NH4NO3,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+NH4NO3(CAS: 6484-52-2),synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+NH4OAc,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+Niacin,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Niacinamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Niacor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+niamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Niaproof,preferred_term,CHEBI:75273,Niaproof,CHEBI:75273,MAPPED,unique
+Niaspan,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Nickel (II) chloride hexahydrate,preferred_term,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+Nickel (II) sulfate hexahydrate,preferred_term,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+Nickel ammonium sulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+Nickel chloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
+nickel chloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
+Nickel chloride hexahydrate,synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+nickel chloride hexahydrate,ontology_label,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,unique
+nickel chloride--water (1/6),synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+Nickel diammonium disulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+nickel dichloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+nickel dichloride,ontology_label,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+nickel dichloride,ontology_label,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+Nickel dichloride hexahydrate,synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+Nickel monosulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickel sulfate heptahydrate,ontology_label,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,unique
+Nickel sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickel sulfate hexahydrate,ontology_label,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,unique
+Nickel sulphate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickel(2+) chloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(2+) chloride,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(2+) chloride,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(2+) chloride,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+nickel(2+) sulfate,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,conflict:different_substances
+nickel(2+) sulfate,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,conflict:different_substances
+Nickel(2+) sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickel(2+) sulfate--water (1/6),synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+Nickel(II) chloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(II) chloride,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(II) chloride,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(II) chloride,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+nickel(II) chloride,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+nickel(II) chloride hexahydrate,synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+"Nickel(II) chloride, hexahydrate",synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
+Nickel(II) sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickel(II) sulphate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+Nickel-NTA,preferred_term,UNMAPPED_0152,Nickel-NTA,,UNMAPPED,unique
+Nickelous sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+nickelous sulphate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+NiCl2,preferred_term,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
+NiCl2 . 6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 . 6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 . 6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 . 6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 x 2 H2O,preferred_term,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 2 H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 2 H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 2 H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,resolved:owned
+NiCl2 x 2H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 2H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 2H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 2H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 x 5 H2O,preferred_term,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 5 H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 5 H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 5 H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,resolved:owned
+NiCl2 x 6 H2O,preferred_term,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,resolved:owned
+NiCl2 x 6 H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 6 H2O,synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,resolved:owned
+NiCl2 x 6 H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 6 H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,resolved:owned
+NiCl2 x 6 H2O (0.1% w/v),synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6 H2O (0.1% w/v),synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6 H2O (0.1% w/v),synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6 H2O (0.1% w/v),synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 x 6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x 6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 x H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 x H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 · 6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 · 6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 · 6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 · 6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2 ∙ 6 H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2 ∙ 6 H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2.6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2.6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2.6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2.6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2x6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2x6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2x6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2x6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2·2H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·2H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·2H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·2H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2·6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2·6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2∙6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2∙6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2⋅6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2⋅6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2⋅6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2⋅6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2・5H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・5H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・5H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・5H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2・6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・6H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・6H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+NiCl2・H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・H2O,synonym,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
+NiCl2・H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:different_substances
+Nicotinamid,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+nicotinamida,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinamide,preferred_term,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinamide adenine dinucleotide,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+Nicotinamide N-oxide,preferred_term,CHEBI:89640,Nicotinamide N-oxide,CHEBI:89640,MAPPED,unique
+nicotinamidum,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinate,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+nicotine acid amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotine amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinic acid,preferred_term,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Nicotinic acid (PP),synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Nicotinic acid amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+nicotinic amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinsaeureamid,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinsaure,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+nicotylamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Niddamycin,preferred_term,CHEBI:31908,Niddamycin,CHEBI:31908,MAPPED,unique
+Nigericin sodium,ontology_label,cas:28643-80-3,Nigericin sodium salt,CHEBI:201444,MAPPED,unique
+Nigericin sodium salt,preferred_term,cas:28643-80-3,Nigericin sodium salt,CHEBI:201444,MAPPED,unique
+Nikotinamid,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nikotinsaeure,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Nikotinsaeureamid,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nisin,preferred_term,CHEBI:71629,Nisin,CHEBI:71629,MAPPED,unique
+NiSO4 . 6H2O,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,conflict:different_substances
+NiSO4 . 6H2O,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,conflict:different_substances
+NiSO4 x 6 H2O,preferred_term,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,resolved:owned
+NiSO4 x 6 H2O,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,resolved:owned
+NiSO4 x 6 H2O,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,resolved:owned
+NiSO4 x 7 H2O,preferred_term,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,resolved:owned
+NiSO4 x 7 H2O,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,resolved:owned
+NiSO4·6H2O,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,conflict:different_substances
+NiSO4·6H2O,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,conflict:different_substances
+NiSO4・6H2O,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,conflict:different_substances
+NiSO4・6H2O,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,conflict:different_substances
+NiSO4・7H2O,synonym,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,conflict:different_substances
+NiSO4・7H2O,synonym,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,conflict:different_substances
+Nitrate,preferred_term,CHEBI:17632,Nitrate,CHEBI:17632,MAPPED,unique
+Nitrate d'ammonium,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Nitrate de sodium,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+Nitrate of ammonia,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Nitrate of potash,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Nitrate of soda,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+Nitrato amonico,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Nitre,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Nitric acid ammonium salt (1:1),synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+Nitric acid monosodium salt,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+Nitric acid sodium salt (1:1),synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+"Nitric acid, ammonium salt",synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
+"Nitric acid, cadmium salt",synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+"Nitric acid, cadmium salt (2:1)",synonym,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
+"Nitric acid, potassium salt",synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+"Nitric acid, sodium salt",synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+"nitrilo-2,2',2''-triacetic acid",synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+"nitrilo-2,2',2''-triethanol",synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+Nitrilotriacetate,preferred_term,CHEBI:25548,Nitrilotriacetate,CHEBI:25548,MAPPED,unique
+Nitrilotriacetate (NTA),synonym,CHEBI:25548,Nitrilotriacetate,CHEBI:25548,MAPPED,unique
+nitrilotriacetate(3-),ontology_label,CHEBI:25548,Nitrilotriacetate,CHEBI:25548,MAPPED,unique
+Nitrilotriacetic acid,preferred_term,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,resolved:owned
+nitrilotriacetic acid,ontology_label,cas:15467-20-6,Nitrilotriacetic acid disodium salt,CHEBI:44557,MAPPED,resolved:owned
+Nitrilotriacetic acid (NTA),synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Nitrilotriacetic acid disodium salt,preferred_term,cas:15467-20-6,Nitrilotriacetic acid disodium salt,CHEBI:44557,MAPPED,unique
+Nitrilotriacetic acid sodium salt,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+nitrilotriacetic acid trisodium salt,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+"Nitrilotriacetic acid, trisodium salt",synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+Nitrilotriessigsaeure,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+nitrilotriethanol,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+Nitrite,preferred_term,CHEBI:16301,Nitrite,CHEBI:16301,MAPPED,unique
+Nitrite de sodium,synonym,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
+Nitrito sodico,synonym,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
+Nitrofurantoin,preferred_term,CHEBI:71415,Nitrofurantoin,CHEBI:71415,MAPPED,unique
+Nitrofurazone,preferred_term,CHEBI:44368,Nitrofurazone,CHEBI:44368,MAPPED,unique
+Nitrogen,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+Nitrogen (gas),synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+Nitrogen gas,preferred_term,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
+nitrous oxide,preferred_term,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
+nitroxoline,ontology_label,CHEBI:67121,8-hydroxy-nitroquinoline,CHEBI:67121,MAPPED,unique
+NLDM_metabolites,preferred_term,kgmicrobe.ingredient:nldm_metabolites,NLDM_metabolites,kgmicrobe.ingredient:nldm_metabolites,MAPPED,unique
+NMe3,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+NN(2)-acetyl-L-glutamine,synonym,CHEBI:21553,N-Acetyl-L-glutamine,CHEBI:21553,MAPPED,unique
+Nobiletin,preferred_term,CHEBI:7602,Nobiletin,CHEBI:7602,MAPPED,unique
+nocamycin,preferred_term,CHEBI:219652,nocamycin,CHEBI:219652,MAPPED,unique
+Nocardimicin G,preferred_term,CHEBI:202593,Nocardimicin G,CHEBI:202593,MAPPED,unique
+Nocardimicin H,preferred_term,CHEBI:213460,Nocardimicin H,CHEBI:213460,MAPPED,unique
+Nocardimicin I,preferred_term,CHEBI:203663,Nocardimicin I,CHEBI:203663,MAPPED,unique
+Noformicin,preferred_term,mesh:C005642,Noformicin,mesh:C005642,MAPPED,unique
+Nogalamycin,preferred_term,CHEBI:44504,Nogalamycin,CHEBI:44504,MAPPED,unique
+Nojirimycin,preferred_term,CHEBI:28945,Nojirimycin,CHEBI:28945,MAPPED,unique
+nonaethylene glycol monomethyl ether,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+nonanedioic acid,ontology_label,CHEBI:48131,Azelaic acid,CHEBI:48131,MAPPED,unique
+Nonanoic acid,preferred_term,CHEBI:29019,Nonanoic acid,CHEBI:29019,MAPPED,unique
+Nordihydroguaretic Acid,preferred_term,CHEBI:73468,Nordihydroguaretic Acid,CHEBI:73468,MAPPED,unique
+Norfloxacin,preferred_term,CHEBI:100246,Norfloxacin,CHEBI:100246,MAPPED,unique
+Norharman,preferred_term,CHEBI:109895,Norharman,CHEBI:109895,MAPPED,unique
+Northen_Exometabolite_mix_1,preferred_term,kgmicrobe.ingredient:northen_exometabolite_mix_1,Northen_Exometabolite_mix_1,kgmicrobe.ingredient:northen_exometabolite_mix_1,MAPPED,unique
+not filter sterilized,synonym,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
+Novobiocin,preferred_term,CHEBI:28368,Novobiocin,CHEBI:28368,MAPPED,unique
+Novobiocin sodium,ontology_label,CHEBI:31924,Novobiocin sodium salt,CHEBI:31924,MAPPED,unique
+Novobiocin sodium salt,preferred_term,CHEBI:31924,Novobiocin sodium salt,CHEBI:31924,MAPPED,unique
+NSC 7224,synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+NTA,preferred_term,CHEBI:39054,NTA,CHEBI:39054,MAPPED,unique
+NTA Trisodium salt,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+Nucleocidin,preferred_term,CHEBI:166872,Nucleocidin,CHEBI:166872,MAPPED,unique
+nukacin ISK-1,synonym,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
+Nutriacholic Acid,preferred_term,CHEBI:82679,Nutriacholic Acid,CHEBI:82679,MAPPED,unique
+Nutrient agar,preferred_term,UNMAPPED_0481,Nutrient agar,,UNMAPPED,unique
+nutrient broth,ontology_label,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient broth No. 2,preferred_term,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nystatin,preferred_term,CHEBI:7660,Nystatin,CHEBI:7660,MAPPED,unique
+O Carbamyl D Serine,preferred_term,mesh:C000366,O Carbamyl D Serine,mesh:C000366,MAPPED,unique
+O(6)-methylerythromycin,synonym,CHEBI:3732,Clarithromycin,CHEBI:3732,MAPPED,unique
+O-acetylferulic acid,ontology_label,CHEBI:86582,4-Acetoxy-3-methoxycinnamic acid,CHEBI:86582,MAPPED,unique
+o-Benzenediol,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+O-carbamimidamido-L-homoserine,synonym,CHEBI:609827,Canavanine,CHEBI:609827,MAPPED,unique
+O-carbamyl-D-serine,synonym,mesh:C000366,O Carbamyl D Serine,mesh:C000366,MAPPED,unique
+O-carbamylserine,ontology_label,mesh:C000366,O Carbamyl D Serine,mesh:C000366,MAPPED,unique
+o-Cresol Red,synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+o-Cresolsulfonephthalein,synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
+o-hydroxyphenol,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+O-methyl-D-glucuronoxylan,preferred_term,UNMAPPED_0227,O-methyl-D-glucuronoxylan,,UNMAPPED,unique
+O-methyl-nonaethyleneglycol,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+O-nitrophenyl-beta-D-galactopyranosid,preferred_term,CHEBI:90144,O-nitrophenyl-beta-D-galactopyranosid,CHEBI:90144,MAPPED,unique
+O-phosphoethanolamine,ontology_label,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
+O-Phosphoryl-Ethanolamine,preferred_term,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
+o-pyrocatechuic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+OADC Enrichment,preferred_term,kgmicrobe.ingredient:oadc_enrichment,OADC Enrichment,kgmicrobe.ingredient:oadc_enrichment,MAPPED,unique
+oat flour,ontology_label,FOODON:03301312,Oat flour B-glucan,FOODON:03301312,MAPPED,unique
+Oat flour B-glucan,preferred_term,FOODON:03301312,Oat flour B-glucan,FOODON:03301312,MAPPED,unique
+Oatmeal,preferred_term,NCIT:C29298,Oatmeal,NCIT:C29298,MAPPED,unique
+Oatmeal agar,preferred_term,UNMAPPED_0129,Oatmeal agar,,UNMAPPED,unique
+Oatmeal Powder,ontology_label,NCIT:C29298,Oatmeal,NCIT:C29298,MAPPED,unique
+oct-1-en-3-ol,ontology_label,CHEBI:34118,1-octen-3-ol,CHEBI:34118,MAPPED,unique
+Octadec-9-enoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+Octadecanoic acid,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+"Octadecanoic acid, sodium salt",synonym,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
+Octadecansaeure,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+octadecoic acid,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+octan-3-one,synonym,CHEBI:80946,3-octanone,CHEBI:80946,MAPPED,unique
+octane,preferred_term,CHEBI:17590,octane,CHEBI:17590,MAPPED,unique
+octanedioic acid,synonym,CHEBI:9300,Suberic acid,CHEBI:9300,MAPPED,unique
+Octanoic acid,preferred_term,CHEBI:28837,Octanoic acid,CHEBI:28837,MAPPED,unique
+"Octanoic acid, sodium salt",synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+octanol,preferred_term,CHEBI:37868,octanol,CHEBI:37868,MAPPED,unique
+Oelsaeure,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+Oelsuess,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Oelsuess,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+Ofloxacin,preferred_term,CHEBI:7731,Ofloxacin,CHEBI:7731,MAPPED,unique
+Oktadekansaeure,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+olean-12-en-3beta-ol,synonym,CHEBI:10352,Beta-Amyrin,CHEBI:10352,MAPPED,unique
+Oleandomycin,preferred_term,CHEBI:16869,Oleandomycin,CHEBI:16869,MAPPED,unique
+Oleic acid,preferred_term,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
+oleoylglycerol,synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+omega-aminobutyric acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+Optional ingredient,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,conflict:different_substances
+Optional ingredient,synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,conflict:different_substances
+Optional ingredient,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,conflict:different_substances
+Optional ingredient,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,conflict:different_substances
+Optional ingredient (Avicel SIGMA),synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+Optional ingredient (Lens tissue or MN 301),synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+Optional ingredient (MN 301),synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+Optochin,preferred_term,CHEBI:86455,Optochin,CHEBI:86455,MAPPED,unique
+Organic Peat,preferred_term,UNMAPPED_0099,Organic Peat,,UNMAPPED,unique
+Original amount: (NH4)2HPO4(Fisher A686),synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+Original amount: (NH4)2SO4(Fisher A 702),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+Ornithine,preferred_term,CHEBI:18257,Ornithine,CHEBI:18257,MAPPED,unique
+Orotic acid,preferred_term,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
+"Orotic acid, sodium salt",synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+Orotsaeure,synonym,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
+orthoboric acid,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+"Orthophosphoric acid, monopotassium salt",synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Osmitrol,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+Ossamycin,preferred_term,CHEBI:77735,Ossamycin,CHEBI:77735,MAPPED,unique
+Ox-bile,preferred_term,UNMAPPED_0485,Ox-bile,,UNMAPPED,unique
+Oxacillin,preferred_term,CHEBI:7809,Oxacillin,CHEBI:7809,MAPPED,unique
+oxacillin sodium,ontology_label,CHEBI:52134,Oxacillin sodium salt,CHEBI:52134,MAPPED,unique
+Oxacillin sodium salt,preferred_term,CHEBI:52134,Oxacillin sodium salt,CHEBI:52134,MAPPED,unique
+Oxalate,preferred_term,CHEBI:132952,Oxalate,CHEBI:132952,MAPPED,unique
+Oxalic Acid,preferred_term,CHEBI:16995,Oxalic Acid,CHEBI:16995,MAPPED,unique
+"Oxalic acid, diammonium salt",synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
+"Oxalic acid, disodium salt",synonym,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+oxaloacetate,synonym,CHEBI:30744,Oxaloacetic acid,CHEBI:30744,MAPPED,unique
+Oxaloacetic acid,preferred_term,CHEBI:30744,Oxaloacetic acid,CHEBI:30744,MAPPED,unique
+Oxamicetin,preferred_term,CHEBI:220394,Oxamicetin,CHEBI:220394,MAPPED,unique
+Oxedrine,preferred_term,CHEBI:29081,Oxedrine,CHEBI:29081,MAPPED,unique
+Oxgall,preferred_term,UNMAPPED_0486,Oxgall,,UNMAPPED,unique
+oxidane,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+oxidized L-cysteine,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+oxidodinitrogen(N--N),synonym,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
+oxidoperoxidonitrate(1-),synonym,CHEBI:25941,peroxynitrite,CHEBI:25941,MAPPED,unique
+Oxoglutaric acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+OXOID Legionella CYE-Agar base,preferred_term,UNMAPPED_0487,OXOID Legionella CYE-Agar base,,UNMAPPED,unique
+Oxoid peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Oxolinate,preferred_term,CHEBI:59066,Oxolinate,CHEBI:59066,MAPPED,unique
+Oxonitine,preferred_term,CHEBI:132646,Oxonitine,CHEBI:132646,MAPPED,unique
+Oxosulfatovanadium pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+oxovanadium(2+) sulfate--water (1/2),synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+oxovanadium(2+) sulfate--water (1/5),synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+Oxybenzene,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Oxymatrine,preferred_term,CHEBI:2672,Oxymatrine,CHEBI:2672,MAPPED,unique
+Oxytetracycline,preferred_term,CHEBI:27701,Oxytetracycline,CHEBI:27701,MAPPED,resolved:owned
+Oxytetracycline,ontology_label,mesh:D010118,Geomycin,mesh:D010118,MAPPED,resolved:owned
+Oxytetracycline hydrochloride,preferred_term,CHEBI:31953,Oxytetracycline hydrochloride,CHEBI:31953,MAPPED,unique
+p--Aminobenzoic acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-Amino Benzoic Acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-Aminobenzoate,synonym,CHEBI:17836,4-Aminobenzoate,CHEBI:17836,MAPPED,unique
+p-Aminobenzoesaeure,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-Aminobenzoic acid,preferred_term,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-carboxyaniline,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-carboxyphenylamine,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-Coumaric acid,preferred_term,CHEBI:32374,p-Coumaric acid,CHEBI:32374,MAPPED,unique
+p-Hydroxybenzoate,preferred_term,CHEBI:17879,p-Hydroxybenzoate,CHEBI:17879,MAPPED,unique
+P-HYDROXYBENZOIC ACID,synonym,CHEBI:30763,4-Hydroxybenzoic acid,CHEBI:30763,MAPPED,unique
+P-II Metal Solution,preferred_term,kgmicrobe.ingredient:p-ii_metal_solution,P-II Metal Solution,kgmicrobe.ingredient:p-ii_metal_solution,MAPPED,unique
+P-IV Metal Solution,preferred_term,kgmicrobe.ingredient:p-iv_metal_solution,P-IV Metal Solution,kgmicrobe.ingredient:p-iv_metal_solution,MAPPED,unique
+p-lacto-N-neo-hexaose,preferred_term,cas:64309-00-8,p-lacto-N-neo-hexaose,cas:64309-00-8,MAPPED,unique
+p-menthan-3-ol,ontology_label,cas:1490-04-6,Menthol,CHEBI:25187,MAPPED,unique
+p-methoxybenzaldehyde,ontology_label,CHEBI:28235,4-Anisaldehyde,CHEBI:28235,MAPPED,unique
+p-naphthoquinone,synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
+p-salicylic acid,synonym,CHEBI:30763,4-Hydroxybenzoic acid,CHEBI:30763,MAPPED,unique
+P.P. factor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+P3HB,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+PABA,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+Paclitaxel,preferred_term,CHEBI:45863,Paclitaxel,CHEBI:45863,MAPPED,unique
+Pactamycin,preferred_term,mesh:D010142,Pactamycin,mesh:D010142,MAPPED,unique
+Paeonol,preferred_term,CHEBI:69581,Paeonol,CHEBI:69581,MAPPED,unique
+Palatinose,preferred_term,CHEBI:18394,Palatinose,CHEBI:18394,MAPPED,unique
+palatinose hydrate,preferred_term,cas:343336-76-5,palatinose hydrate,CHEBI:18394,MAPPED,unique
+Palladium chloride,synonym,CHEBI:53434,Palladium(II) chloride,CHEBI:53434,MAPPED,unique
+Palladium(II) chloride,preferred_term,CHEBI:53434,Palladium(II) chloride,CHEBI:53434,MAPPED,unique
+Palmatine,preferred_term,CHEBI:16096,Palmatine,CHEBI:16096,MAPPED,unique
+Palmatine chloride,preferred_term,cas:10605-02-4,Palmatine chloride,cas:10605-02-4,MAPPED,unique
+Palmitic acid,preferred_term,CHEBI:15756,Palmitic acid,CHEBI:15756,MAPPED,unique
+Pamamycin,preferred_term,mesh:C024500,Pamamycin,mesh:C024500,MAPPED,unique
+Pancreatic Digest of Casein,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unresolved:no_chemistry
+Pancreatic digest of casein,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unresolved:no_chemistry
+Pancreatic Digest of Casein (Hardy C6530),synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Panhematin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Pantothenate,preferred_term,CHEBI:16454,Pantothenate,CHEBI:16454,MAPPED,unique
+Pantothenic acid,preferred_term,CHEBI:7916,Pantothenic acid,CHEBI:7916,MAPPED,unique
+Para-aminobenzoic acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+para-aminosalicylic acid,preferred_term,CHEBI:27565,para-aminosalicylic acid,CHEBI:27565,MAPPED,unique
+Parabanic Acid,preferred_term,CHEBI:74661,Parabanic Acid,CHEBI:74661,MAPPED,unique
+Parachlorophenylalanine,preferred_term,cas:7424-00-2,Parachlorophenylalanine,CHEBI:110187,MAPPED,unique
+Paraquat,synonym,CHEBI:28786,Paraquat dichloride,CHEBI:28786,MAPPED,unique
+Paraquat dichloride,preferred_term,CHEBI:28786,Paraquat dichloride,CHEBI:28786,MAPPED,unique
+Paresan,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Paromomycin,preferred_term,CHEBI:7934,Paromomycin,CHEBI:7934,MAPPED,unique
+Paromomycin II,ontology_label,CHEBI:81287,Neomycin F,CHEBI:81287,MAPPED,unique
+paromomycin sulfate,ontology_label,CHEBI:7935,Paromomycin sulfate salt,CHEBI:7935,MAPPED,unique
+Paromomycin sulfate salt,preferred_term,CHEBI:7935,Paromomycin sulfate salt,CHEBI:7935,MAPPED,unique
+Parthenolide,preferred_term,CHEBI:7939,Parthenolide,CHEBI:7939,MAPPED,unique
+Pasteurized Seawater,preferred_term,kgmicrobe.ingredient:pasteurized_seawater,Pasteurized Seawater,ENVO:00002149,MAPPED,unique
+PBS,preferred_term,kgmicrobe.ingredient:pbs,PBS,NCIT:C178908,MAPPED,unique
+PCA,synonym,CHEBI:62412,Phenazine-1-carboxylic acid,CHEBI:62412,MAPPED,unique
+PCE,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+Pea,preferred_term,NCIT:C72056,Pea,NCIT:C72056,MAPPED,unique
+Pea(add after dH2O),synonym,NCIT:C72056,Pea,NCIT:C72056,MAPPED,unique
+Pectic galactan from potato,preferred_term,UNMAPPED_0231,Pectic galactan from potato,,UNMAPPED,unique
+pectic substance,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+Pectin,preferred_term,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+pectina,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+pectinas,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+pectine,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+pectines,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+pectins,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+Pediocin,preferred_term,cas:133108-87-9,Pediocin,cas:133108-87-9,MAPPED,unique
+Pediocin from Pediococcus acidilactici,synonym,cas:133108-87-9,Pediocin,cas:133108-87-9,MAPPED,unique
+Pefloxacin,preferred_term,CHEBI:50199,Pefloxacin,CHEBI:50199,MAPPED,unique
+PEG-60 Sorbitan stearate,synonym,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
+Pektin,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+Pektine,synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+Pelargonic acid,synonym,CHEBI:29019,Nonanoic acid,CHEBI:29019,MAPPED,unique
+pellagra preventive factor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+Penicillin,preferred_term,CHEBI:17334,Penicillin,CHEBI:17334,MAPPED,unique
+Penicillin g,preferred_term,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
+penicillins,synonym,CHEBI:17334,Penicillin,CHEBI:17334,MAPPED,unique
+Pentachlorophenol,preferred_term,CHEBI:17642,Pentachlorophenol,CHEBI:17642,MAPPED,unique
+pentan-1-ol,ontology_label,CHEBI:44884,1-Pentanol,CHEBI:44884,MAPPED,unique
+"PENTANE-1,5-DIAMINE",synonym,CHEBI:18127,Cadaverine,CHEBI:18127,MAPPED,unique
+"Pentane-1,5-diol",ontology_label,CHEBI:185431,"1,5-Pentanediol",CHEBI:185431,MAPPED,unique
+Pentanecarboxylic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+PENTANEDIAL,synonym,CHEBI:64276,Glutaraldehyde,CHEBI:64276,MAPPED,unique
+Pentanedioic acid,synonym,CHEBI:17859,Glutaric acid,CHEBI:17859,MAPPED,unique
+Pentanoate,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+PENTANOIC ACID,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+Pentasodium tripolyphosphate hexahydrate,preferred_term,cas:15091-98-2,Pentasodium tripolyphosphate hexahydrate,FOODON:03530244,MAPPED,unique
+pentiformic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+pentoic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+pentylformic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
+Peptic digest of animal tissue,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Peptic digest of soybean meal,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Peptideglycan(N-acetyl-D-glucosamine),synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
+Peptidoglycan(N-acetyl-D-glucosamine),ontology_label,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
+Peptone,preferred_term,MICRO:0000178,Peptone,MICRO:0000178,MAPPED,unique
+Peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (0.01 %,synonym,MICRO:0000178,Peptone,MICRO:0000178,MAPPED,unique
+Peptone (BBL 11910),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (BD BACTO),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (BD Bacto),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (BD--Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (BD-Difco),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (meat),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone (Oxoid),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone + Beef Extract + Yeast Extract,preferred_term,kgmicrobe.ingredient:peptone_beef_extract_yeast_extract,Peptone + Beef Extract + Yeast Extract,kgmicrobe.ingredient:peptone_beef_extract_yeast_extract,MAPPED,unique
+Peptone + Yeast Extract,preferred_term,kgmicrobe.ingredient:peptone_yeast_extract,Peptone + Yeast Extract,kgmicrobe.ingredient:peptone_yeast_extract,MAPPED,unique
+Peptone from casein,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+Peptone from meat,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone from meat (pepsin-digested),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone from soymeal,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Peptone mixture,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+"Peptone, Bacto (BD 211677)",synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Peptone-yeast Extract-glucose,preferred_term,kgmicrobe.ingredient:peptone_yeast_extract_glucose,Peptone-yeast Extract-glucose,kgmicrobe.ingredient:peptone_yeast_extract_glucose,MAPPED,unique
+Peptones,synonym,MICRO:0000178,Peptone,MICRO:0000178,MAPPED,unique
+PERC,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+Perchlorate de sodium,synonym,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,unique
+"Perchloric acid, sodium salt",synonym,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,unique
+Perchloroethylene,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+perillic acid,ontology_label,CHEBI:36999,Perillic Acid (-),CHEBI:36999,MAPPED,unique
+Perillic Acid (-),preferred_term,CHEBI:36999,Perillic Acid (-),CHEBI:36999,MAPPED,unique
+Perillyl Alcohol,preferred_term,CHEBI:15420,Perillyl Alcohol,CHEBI:15420,MAPPED,unique
+PERK,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+peroxynitrite,preferred_term,CHEBI:25941,peroxynitrite,CHEBI:25941,MAPPED,unique
+petroleum,ontology_label,ENVO:00002984,Crude Oil,ENVO:00002984,MAPPED,unique
+Peucenin,preferred_term,cas:578-72-3,Peucenin,cas:578-72-3,MAPPED,unique
+PGA,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Phenanthrene,preferred_term,CHEBI:28851,Phenanthrene,CHEBI:28851,MAPPED,unique
+Phenazine ethosulfate,preferred_term,cas:10510-77-7,Phenazine ethosulfate,cas:10510-77-7,MAPPED,unique
+Phenazine methosulfate,preferred_term,CHEBI:8055,Phenazine methosulfate,CHEBI:8055,MAPPED,unique
+phenazine-1-carboxamide,ontology_label,CHEBI:62240,1-phenazinecarboxamide,CHEBI:62240,MAPPED,unique
+Phenazine-1-carboxylic acid,preferred_term,CHEBI:62412,Phenazine-1-carboxylic acid,CHEBI:62412,MAPPED,unique
+Phenazone,synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+phenazonum,synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
+Phenethylamine Hydrochloride,synonym,CHEBI:18397,2-phenylethylamine,CHEBI:18397,MAPPED,unique
+Phenic acid,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Phenol,preferred_term,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Phenol red,preferred_term,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+Phenolsulfonphthalein,synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+Phenoxyacetic acid,preferred_term,CHEBI:8075,Phenoxyacetic acid,CHEBI:8075,MAPPED,unique
+Phenoxymethylpenicillin,preferred_term,CHEBI:27446,Phenoxymethylpenicillin,CHEBI:27446,MAPPED,unique
+Phenyl acetic acid,preferred_term,CHEBI:30745,Phenyl acetic acid,CHEBI:30745,MAPPED,unique
+Phenyl propionic acid,preferred_term,CHEBI:28631,Phenyl propionic acid,CHEBI:28631,MAPPED,unique
+Phenylacetate,preferred_term,CHEBI:18401,Phenylacetate,CHEBI:18401,MAPPED,unique
+phenylacetic acid,ontology_label,CHEBI:30745,Phenyl acetic acid,CHEBI:30745,MAPPED,unique
+phenylacetonitrile,synonym,CHEBI:25979,Benzylcyanide,CHEBI:25979,MAPPED,unique
+Phenylalanine,synonym,CHEBI:17295,L-Phenylalanine,CHEBI:17295,MAPPED,unique
+Phenylenediamine,preferred_term,CHEBI:51402,Phenylenediamine,CHEBI:51402,MAPPED,unique
+Phenylethylamine,preferred_term,CHEBI:50048,Phenylethylamine,CHEBI:50048,MAPPED,unique
+PHENYLETHYLENECARBOXYLIC ACID,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+Phenylic acid,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Phenylic alcohol,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+phenylmethane,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
+Phleomycin,preferred_term,CHEBI:75044,Phleomycin,CHEBI:75044,MAPPED,unique
+phloretic acid,ontology_label,CHEBI:32980,4-Hydroxyphenylpropionic acid,CHEBI:32980,MAPPED,unique
+Phloretin,preferred_term,CHEBI:17276,Phloretin,CHEBI:17276,MAPPED,unique
+Phloridzin,preferred_term,CHEBI:8113,Phloridzin,CHEBI:8113,MAPPED,unique
+phlorizin,ontology_label,CHEBI:8113,Phloridzin,CHEBI:8113,MAPPED,unique
+PhOH,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
+Phoslactomycin,preferred_term,kgmicrobe.compound:phoslactomycin,Phoslactomycin,kgmicrobe.compound:phoslactomycin,MAPPED,unique
+Phosphate buffer,preferred_term,NCIT:C29321,Phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
+Phosphate Buffer,ontology_label,kgmicrobe.ingredient:phosphate_buffer_stock_solution,Phosphate Buffer Stock Solution,NCIT:C29321,MAPPED,resolved:owned
+Phosphate Buffer,ontology_label,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
+Phosphate Buffer,ontology_label,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
+Phosphate Buffer,ontology_label,kgmicrobe.ingredient:sodium_potassium_phosphate_buffer,Sodium Potassium phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
+Phosphate Buffer Stock Solution,preferred_term,kgmicrobe.ingredient:phosphate_buffer_stock_solution,Phosphate Buffer Stock Solution,NCIT:C29321,MAPPED,unique
+Phosphate-buffered saline,synonym,kgmicrobe.ingredient:pbs,PBS,NCIT:C178908,MAPPED,unique
+phosphatidylinositol,ontology_label,cas:97281-52-2,L-α-Phosphatidylinositol from Glycine max (soybean),CHEBI:28874,MAPPED,unique
+Phosphocholine,preferred_term,CHEBI:18132,Phosphocholine,CHEBI:18132,MAPPED,unique
+Phosphomycin disodium salt,preferred_term,cas:26016-99-9,Phosphomycin disodium salt,cas:26016-99-9,MAPPED,unique
+phosphonic acid,ontology_label,cas:13977-65-6,KH2PO3,CHEBI:44976,MAPPED,unique
+Phosphoric acid mono-(4-formyl-5-hydroxy-6-methyl-pyridin-3-ylmethyl) ester,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+"phosphoric acid, calcium salt (1:1)",synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+"Phosphoric acid, dipotassium salt",synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+"Phosphoric acid, monoammonium salt",synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+"Phosphoric acid, monopotassium salt",synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+"phosphoric acid, monosodium salt",synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+"Phosphoric acid, potassium salt (1:1)",synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+phosphorothioic acid,ontology_label,cas:10489-48-2,Sodium thiophosphate tribasic hydrate,CHEBI:46612,MAPPED,unique
+phosphorous acid,preferred_term,CHEBI:36361,phosphorous acid,CHEBI:36361,MAPPED,resolved:owned
+phosphorous acid,ontology_label,cas:13517-23-2,Sodium phosphite dibasic pentahydrate,CHEBI:36361,MAPPED,resolved:owned
+Phyllochinon,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Phyllochinonum,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Phyllomycin,preferred_term,kgmicrobe.compound:phyllomycin,Phyllomycin,kgmicrobe.compound:phyllomycin,MAPPED,unique
+PHYLLOQUINONE,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Physcion,preferred_term,CHEBI:38167,Physcion,CHEBI:38167,MAPPED,unique
+Phytagel,synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+phytomenadione,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+phytomenadionum,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+phytonadione,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Phytonadionum,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Phytone,preferred_term,FOODON:03315720,Phytone,FOODON:03315720,MAPPED,unique
+Phytone peptone,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Phytone peptone (BD-BBL),synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Phytylmenadione,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Picolinic acid,preferred_term,CHEBI:28747,Picolinic acid,CHEBI:28747,MAPPED,unique
+Picropodophyllin,preferred_term,CHEBI:75251,Picropodophyllin,CHEBI:75251,MAPPED,unique
+picropodophyllotoxin,ontology_label,CHEBI:75251,Picropodophyllin,CHEBI:75251,MAPPED,unique
+Picrotoxinin,preferred_term,CHEBI:8206,Picrotoxinin,CHEBI:8206,MAPPED,unique
+Piericidin,preferred_term,kgmicrobe.compound:piericidin,Piericidin,kgmicrobe.compound:piericidin,MAPPED,unique
+Pimelic acid,preferred_term,CHEBI:30531,Pimelic acid,CHEBI:30531,MAPPED,unique
+Pimpinellin,preferred_term,CHEBI:8213,Pimpinellin,CHEBI:8213,MAPPED,unique
+pinene,preferred_term,CHEBI:17187,pinene,CHEBI:17187,MAPPED,unique
+Piperacillin,preferred_term,CHEBI:8232,Piperacillin,CHEBI:8232,MAPPED,unique
+piperacillin sodium,ontology_label,CHEBI:8233,Piperacillin sodium salt,CHEBI:8233,MAPPED,unique
+Piperacillin sodium salt,preferred_term,CHEBI:8233,Piperacillin sodium salt,CHEBI:8233,MAPPED,unique
+pipercolic acid,synonym,CHEBI:30913,L-Pipecolic Acid,CHEBI:30913,MAPPED,unique
+Piperic acid,preferred_term,cas:5285-18-7,Piperic acid,mesh:C017637,MAPPED,unique
+piperidic acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+piperidin-2-one,ontology_label,CHEBI:77761,2-Piperidinone,CHEBI:77761,MAPPED,unique
+piperidinic acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
+Piperine,preferred_term,CHEBI:28821,Piperine,CHEBI:28821,MAPPED,unique
+PIPES,preferred_term,CHEBI:39033,PIPES,CHEBI:39033,MAPPED,resolved:owned
+PIPES,ontology_label,kgmicrobe.ingredient:pipes_buffer,PIPES buffer,CHEBI:39033,MAPPED,resolved:owned
+PIPES buffer,preferred_term,kgmicrobe.ingredient:pipes_buffer,PIPES buffer,CHEBI:39033,MAPPED,unique
+PIPES sesquisodium salt,preferred_term,cas:100037-69-2,PIPES sesquisodium salt,cas:100037-69-2,MAPPED,unique
+Piplartine,preferred_term,CHEBI:8241,Piplartine,CHEBI:8241,MAPPED,unique
+piridossina,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Plain flour,preferred_term,UNMAPPED_0490,Plain flour,,UNMAPPED,unique
+Planctomyces_artificial_seawater,preferred_term,UNMAPPED_0291,Planctomyces_artificial_seawater,,UNMAPPED,unique
+Planctomyces_mineral_salts,preferred_term,kgmicrobe.ingredient:planctomyces_mineral_salts,Planctomyces_mineral_salts,kgmicrobe.ingredient:planctomyces_mineral_salts,MAPPED,unique
+Planctomyces_trace_element_solution,preferred_term,kgmicrobe.ingredient:planctomyces_trace_element_solution,Planctomyces_trace_element_solution,kgmicrobe.ingredient:planctomyces_trace_element_solution,MAPPED,unique
+Planctomyces_vitamin_mix,preferred_term,kgmicrobe.ingredient:planctomyces_vitamin_mix,Planctomyces_vitamin_mix,kgmicrobe.ingredient:planctomyces_vitamin_mix,MAPPED,unique
+Plastic,preferred_term,ENVO:06105101,Plastic,ENVO:06105101,MAPPED,unique
+platinum (IV) chloride,preferred_term,cas:13454-96-1,platinum (IV) chloride,cas:13454-96-1,MAPPED,unique
+Plicacetin,preferred_term,mesh:C000633628,Plicacetin,mesh:C000633628,MAPPED,unique
+PLP,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+Plumbagin,preferred_term,CHEBI:8273,Plumbagin,CHEBI:8273,MAPPED,unique
+Plumbemycin A,preferred_term,mesh:C096638,Plumbemycin A,mesh:C096638,MAPPED,unique
+Plumbemycin B,preferred_term,mesh:C096639,Plumbemycin B,mesh:C096639,MAPPED,unique
+pluramycin,ontology_label,kgmicrobe.compound:pluramycin_a,Pluramycin A,mesh:C003169,MAPPED,unique
+Pluramycin A,preferred_term,kgmicrobe.compound:pluramycin_a,Pluramycin A,mesh:C003169,MAPPED,unique
+Polar lipid fraction,preferred_term,UNMAPPED_0491,Polar lipid fraction,,UNMAPPED,unique
+poliglusam,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+Poly hexamethylene carbonate,preferred_term,UNMAPPED_0492,Poly hexamethylene carbonate,,UNMAPPED,unique
+Poly L Lysine Polymer,preferred_term,CHEBI:61490,Poly L Lysine Polymer,CHEBI:61490,REJECTED,unique
+Poly L Lysine Polymer,synonym,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,unique
+"Poly(1,4-alpha-D-galacturonide)",synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+poly(3-hydroxy butyrate),synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+Poly(3-hydroxybutyrate),preferred_term,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+Poly(3-hydroxybutyric acid),preferred_term,cas:29435-48-1,Poly(3-hydroxybutyric acid),CHEBI:20067,MAPPED,unique
+poly(ethylene glycol),ontology_label,CHEBI:46793,Polyethylene glycol,CHEBI:46793,MAPPED,unique
+Poly(ethylene Terephthalate),preferred_term,CHEBI:53259,Poly(ethylene Terephthalate),CHEBI:53259,MAPPED,unique
+poly(ethylene terephthalate) macromolecule,ontology_label,CHEBI:53259,Poly(ethylene Terephthalate),CHEBI:53259,MAPPED,unique
+poly(L-lysine),synonym,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,unique
+poly(L-lysine),synonym,CHEBI:61490,Poly L Lysine Polymer,CHEBI:61490,REJECTED,unique
+poly(L-lysine) polymer,preferred_term,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,unique
+poly(L-lysine) polymer,synonym,CHEBI:61490,Poly L Lysine Polymer,CHEBI:61490,REJECTED,unique
+poly-3-hydroxy butyrate,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+poly-3-hydroxybutyrate,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+Poly-beta-hydroxyalkanoate,preferred_term,CHEBI:78037,Poly-beta-hydroxyalkanoate,CHEBI:78037,MAPPED,unique
+poly-ß-hydroxybutyric acid,preferred_term,UNMAPPED_0493,poly-ß-hydroxybutyric acid,,UNMAPPED,unique
+poly[(1->4)-alpha-D-GalpA],synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+"poly[oxy(1-methyl-3-oxopropane-1,3-diyl)]",synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+Poly[R-3-hydroxybutyric acid],preferred_term,UNMAPPED_0494,Poly[R-3-hydroxybutyric acid],,UNMAPPED,unique
+Polychlorobiphenyl,preferred_term,CHEBI:53156,Polychlorobiphenyl,CHEBI:53156,MAPPED,unique
+Polyethylene glycol,preferred_term,CHEBI:46793,Polyethylene glycol,CHEBI:46793,MAPPED,unique
+Polyethylene glycol hexadecyl ether,synonym,cas:9004-95-9,Cetomacrogol 1000,mesh:D002592,MAPPED,unique
+Polyethylene oxide sorbitan mono-oleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+polygalacturonic acid,preferred_term,CHEBI:62969,polygalacturonic acid,CHEBI:62969,MAPPED,resolved:owned
+polygalacturonic acid,ontology_label,cas:9049-37-0,Polygalacturonic acid sodium salt,CHEBI:62969,MAPPED,resolved:owned
+polygalacturonic acid (ultrapure),synonym,CHEBI:62969,polygalacturonic acid,CHEBI:62969,MAPPED,unique
+Polygalacturonic acid sodium salt,preferred_term,cas:9049-37-0,Polygalacturonic acid sodium salt,CHEBI:62969,MAPPED,unique
+polyhydroxyalkanoate,ontology_label,CHEBI:78037,Poly-beta-hydroxyalkanoate,CHEBI:78037,MAPPED,unique
+polyhydroxybutyrate,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
+Polymyxin,preferred_term,CHEBI:59062,Polymyxin,CHEBI:59062,MAPPED,unique
+Polymyxin B,preferred_term,NCIT:C61894,Polymyxin B,NCIT:C61894,MAPPED,unique
+Polymyxin B sulfate,preferred_term,CHEBI:8310,Polymyxin B sulfate,CHEBI:8310,MAPPED,unique
+Polyoxyethylene (20) sorbitan monooleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Polyoxyethylene (20) sorbitan monopalmitate,synonym,CHEBI:53423,Tween 40,CHEBI:53423,MAPPED,unique
+polyoxyethylene (20) sorbitan monostearate,synonym,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
+Polyoxyethylene sorbitan monooleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Polyoxyethylene sorbitan monostearate,synonym,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
+Polyoxyethylene sorbitan oleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Polypepton,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypepton (Nihon Pharm. Co.),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypeptone,preferred_term,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+polypeptone,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypeptone Peptone (BD 211910),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypeptone peptone (BD-BBL),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+polysaccharide,ontology_label,CHEBI:18154,Polysaccharides,CHEBI:18154,MAPPED,unique
+Polysaccharides,preferred_term,CHEBI:18154,Polysaccharides,CHEBI:18154,MAPPED,unique
+polysorbate 20,ontology_label,CHEBI:53424,Tween 20,CHEBI:53424,MAPPED,unique
+Polysorbate 40,synonym,CHEBI:53423,Tween 40,CHEBI:53423,MAPPED,unique
+polysorbate 60,ontology_label,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
+Polysorbate 80,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Polysorbates,ontology_label,mesh:D011136,Tween,mesh:D011136,MAPPED,unique
+polysulfur,synonym,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
+Porcine serum,preferred_term,MICRO:0001238,Porcine serum,MICRO:0001238,MAPPED,unique
+Porfiromycin,preferred_term,CHEBI:208611,Porfiromycin,CHEBI:208611,MAPPED,unique
+Porphyran,preferred_term,mesh:C038549,Porphyran,mesh:C038549,MAPPED,unique
+Porphyrin,preferred_term,CHEBI:8337,Porphyrin,CHEBI:8337,MAPPED,unique
+Potash alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Potash alum dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+potash lye,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+potasse caustique,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+Potassium,preferred_term,NCIT:C765,Potassium,NCIT:C765,MAPPED,unique
+potassium (poly)sulfide,preferred_term,cas:37199-66-9,potassium (poly)sulfide,cas:37199-66-9,MAPPED,unique
+Potassium 2-dehydro-D-gluconate,preferred_term,kgmicrobe.compound:potassium_2-dehydro-d-gluconate,Potassium 2-dehydro-D-gluconate,CHEBI:16808,MAPPED,unique
+Potassium 2-ketogluconate,preferred_term,kgmicrobe.compound:potassium_2-ketogluconate,Potassium 2-ketogluconate,CHEBI:16808,MAPPED,unique
+Potassium 4-aminobenzoate,preferred_term,cas:138-84-1,Potassium 4-aminobenzoate,cas:138-84-1,MAPPED,unique
+Potassium 5-dehydro-D-gluconate,preferred_term,kgmicrobe.compound:potassium_5-dehydro-d-gluconate,Potassium 5-dehydro-D-gluconate,CHEBI:58143,MAPPED,unique
+Potassium 5-ketogluconate,preferred_term,kgmicrobe.compound:potassium_5-ketogluconate,Potassium 5-ketogluconate,CHEBI:58143,MAPPED,unique
+Potassium acetate,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+potassium acid carbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+Potassium acid phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+potassium alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Potassium alum dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+potassium aluminium sulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+potassium aluminium sulfate dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Potassium aluminum alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Potassium aluminum chloride,preferred_term,cas:74978-20-4,Potassium aluminum chloride,NCIT:C83530,MAPPED,unique
+potassium aluminum disulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+Potassium aluminum disulfate dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+potassium bicarbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+Potassium Bromide,synonym,CHEBI:32030,KBr,CHEBI:32030,MAPPED,unique
+potassium carbonate,synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
+Potassium Chloride,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Potassium chromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+Potassium chromate(VI),synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
+potassium citramalate monohydrate,preferred_term,cas:1030365-02-6,potassium citramalate monohydrate,CHEBI:15584,MAPPED,unique
+Potassium dibasic phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Potassium dichromate,preferred_term,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
+potassium dichromate(2-),synonym,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
+potassium dichromate(VI),synonym,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
+Potassium dihydrogen orthophosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Potassium dihydrogen phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+potassium fluoride,preferred_term,CHEBI:66872,potassium fluoride,CHEBI:66872,MAPPED,unique
+potassium fluoride,ontology_label,CHEBI:66872,KF,CHEBI:66872,REJECTED,unique
+Potassium Gluconate,preferred_term,CHEBI:32032,Potassium Gluconate,CHEBI:32032,MAPPED,unique
+potassium hexahydroxoantimonate,preferred_term,cas:12208-13-8,potassium hexahydroxoantimonate,cas:12208-13-8,MAPPED,unique
+potassium hydrogen carbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+potassium hydrogencarbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
+potassium hydroxide,ontology_label,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
+potassium iodide,ontology_label,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+Potassium monohydrogen phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Potassium monophosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+potassium nitrate,ontology_label,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+potassium nitrite,ontology_label,CHEBI:232610,KNO2,CHEBI:232610,MAPPED,unique
+Potassium Oxalate,ontology_label,cas:6487-48-5,Potassium oxalate monohydrate,NCIT:C87592,MAPPED,unique
+Potassium oxalate monohydrate,preferred_term,cas:6487-48-5,Potassium oxalate monohydrate,NCIT:C87592,MAPPED,unique
+Potassium Phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,conflict:different_substances
+potassium phosphate,ontology_label,cas:16788-57-1,Potassium phosphate dibasic trihydrate,mesh:C013216,MAPPED,conflict:different_substances
+Potassium phosphate (dibasic),synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Potassium phosphate buffer,preferred_term,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+Potassium phosphate dibasic,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Potassium phosphate dibasic trihydrate,preferred_term,cas:16788-57-1,Potassium phosphate dibasic trihydrate,mesh:C013216,MAPPED,unique
+Potassium phosphate monobasic,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+potassium rhodanate,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+potassium rhodanide,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+Potassium sulfate,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
+potassium sulfate,ontology_label,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
+potassium sulfocyanate,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+potassium sulphate,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
+potassium tellurate,preferred_term,CHEBI:75248,potassium tellurate,CHEBI:75248,MAPPED,unique
+potassium tellurate hydrate,preferred_term,cas:314041-10-6,potassium tellurate hydrate,CHEBI:30463,MAPPED,unique
+potassium tellurite,ontology_label,CHEBI:75248,potassium tellurate,CHEBI:75248,MAPPED,agree:same_substance
+potassium tellurite,ontology_label,cas:123333-66-4,Potassium tellurite hydrate,CHEBI:75248,MAPPED,agree:same_substance
+Potassium tellurite hydrate,preferred_term,cas:123333-66-4,Potassium tellurite hydrate,CHEBI:75248,MAPPED,unique
+Potassium tetrathionate,synonym,CHEBI:86466,K2S4O6,CHEBI:86466,MAPPED,unique
+potassium thiocyanate,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+Potato flour,preferred_term,FOODON:03302378,Potato flour,FOODON:03302378,MAPPED,unique
+PP factor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+PPLO broth,preferred_term,UNMAPPED_0497,PPLO broth,,UNMAPPED,unique
+Pradimicin,preferred_term,CHEBI:83230,Pradimicin,CHEBI:83230,MAPPED,unique
+Pravastatin,preferred_term,CHEBI:63618,Pravastatin,CHEBI:63618,MAPPED,unique
+Pravastatin lactone,preferred_term,CHEBI:145933,Pravastatin lactone,CHEBI:145933,MAPPED,unique
+PrCl3 x H2O,preferred_term,UNMAPPED_0498,PrCl3 x H2O,,UNMAPPED,unique
+Prebiotin,preferred_term,UNMAPPED_0210,Prebiotin,,UNMAPPED,unique
+Precipitated calcium carbonate,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
+prenol,ontology_label,CHEBI:16019,3-methyl-2-butenol,CHEBI:16019,MAPPED,unique
+Prenyletin,preferred_term,cas:15870-91-4,Prenyletin,cas:15870-91-4,MAPPED,unique
+PreticX,preferred_term,UNMAPPED_0216,PreticX,,UNMAPPED,unique
+Pretomanid,preferred_term,cas:187235-37-6,Pretomanid,NCIT:C166606,MAPPED,unique
+primaeres Natriumsulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+Primary ammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
+Primocarcin,preferred_term,kgmicrobe.compound:primocarcin,Primocarcin,kgmicrobe.compound:primocarcin,MAPPED,unique
+Pristinamycin,preferred_term,CHEBI:85274,Pristinamycin,CHEBI:85274,MAPPED,unique
+Probumin Universal Grade,preferred_term,UNMAPPED_0499,Probumin Universal Grade,,UNMAPPED,unique
+Procaine hydrochloride,preferred_term,CHEBI:8431,Procaine hydrochloride,CHEBI:8431,MAPPED,unique
+produces: DL-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
+produces: ethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Prolin,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
+Proline,preferred_term,CHEBI:26271,Proline,CHEBI:26271,MAPPED,resolved:owned
+PROLINE,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,resolved:owned
+prolinum,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
+Promitor,preferred_term,UNMAPPED_0212,Promitor,,UNMAPPED,unique
+Propan-1-ol,preferred_term,CHEBI:28831,Propan-1-ol,CHEBI:28831,MAPPED,unique
+Propan-2-ol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+propan-2-one,synonym,CHEBI:15347,acetone,CHEBI:15347,MAPPED,unique
+Propandiamine,preferred_term,CHEBI:15725,Propandiamine,CHEBI:15725,MAPPED,unique
+"propane-1,2,3-triol",synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+"propane-1,2-diol",ontology_label,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
+"Propane-1,3-diamine",synonym,CHEBI:15725,Propandiamine,CHEBI:15725,MAPPED,unique
+"propane-1,3-diol",ontology_label,CHEBI:16109,"1,3-Propanediol",CHEBI:16109,MAPPED,unique
+propanecarboxylic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+Propanedioic acid,synonym,CHEBI:30794,Malonic acid,CHEBI:30794,MAPPED,unique
+Propanetriol,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Propanetriol,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+PROPANOIC ACID,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+"Propanoic acid, sodium salt",synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Propanol,synonym,CHEBI:28831,Propan-1-ol,CHEBI:28831,MAPPED,unique
+Propidium iodide,preferred_term,CHEBI:51240,Propidium iodide,CHEBI:51240,MAPPED,unique
+propioic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Propionamide,preferred_term,CHEBI:45422,Propionamide,CHEBI:45422,MAPPED,unique
+Propionate,preferred_term,CHEBI:17272,Propionate,CHEBI:17272,MAPPED,unique
+Propionate (sodium salt),synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Propionic acid,preferred_term,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Propionic acid sodium salt,synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Propionsaeure,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+propoic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+propylacetic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+propylformic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+protein hydrolyzates,ontology_label,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Proteose,preferred_term,kgmicrobe.compound:proteose,Proteose,kgmicrobe.compound:proteose,MAPPED,unique
+Proteose Peptone,preferred_term,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone (BD Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone (BD--Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone (BD-Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose Peptone (Difco no. 3),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone (Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone No 2 (DIFCO 0121-01-3),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone no. 2,preferred_term,MICRO:0002393,Proteose peptone no. 2,MICRO:0002393,MAPPED,resolved:owned
+Proteose peptone no. 2,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,resolved:owned
+Proteose Peptone No. 3,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone no. 3,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone No. 3 (BD--Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone No. 3 (BD-Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone no.3 (Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose Peptone(BD 211684),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose tryptone (DIFCO 0123-01),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Proteose yeastolate,preferred_term,UNMAPPED_0500,Proteose yeastolate,,UNMAPPED,unique
+Protocatechualdehyde,preferred_term,CHEBI:50205,Protocatechualdehyde,CHEBI:50205,MAPPED,unique
+Protocatechuate,preferred_term,CHEBI:36241,Protocatechuate,CHEBI:36241,MAPPED,unique
+Protocatechuic Acid,preferred_term,CHEBI:36062,Protocatechuic Acid,CHEBI:36062,MAPPED,unique
+protohemin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+protohemin IX,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Protoporphyrin,preferred_term,CHEBI:15430,Protoporphyrin,CHEBI:15430,MAPPED,unique
+Protoporphyrin IX,synonym,CHEBI:15430,Protoporphyrin,CHEBI:15430,MAPPED,unique
+pseudoacetic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
+Pseudobutylene glycol,synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+pseudocobalamin,synonym,UNMAPPED_0181,adeninyl cobamide,,UNMAPPED,unique
+psicofuranin,ontology_label,CHEBI:8612,Angustmycin,CHEBI:8612,MAPPED,unique
+Psicofuranine,synonym,CHEBI:8612,Angustmycin,CHEBI:8612,MAPPED,unique
+PSP,synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+PteGlu,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+"pteridine-2,4-diol",synonym,CHEBI:16489,Lumazine,CHEBI:16489,MAPPED,unique
+Pterin-6-Carboxylic Acid,preferred_term,CHEBI:88937,Pterin-6-Carboxylic Acid,CHEBI:88937,MAPPED,unique
+Pterostilbene,preferred_term,CHEBI:8630,Pterostilbene,CHEBI:8630,MAPPED,unique
+pteroyl-L-glutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+pteroyl-L-monoglutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+pteroylglutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+pteroylmonoglutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Pullulan,preferred_term,CHEBI:27941,Pullulan,CHEBI:27941,MAPPED,unique
+Pulp of sour stone cherries,preferred_term,UNMAPPED_0501,Pulp of sour stone cherries,,UNMAPPED,unique
+purin-6(1H)-one,synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+"purine-2(3H),6(1H)-dione",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+Purine-6-ol,synonym,CHEBI:17368,Hypoxanthine,CHEBI:17368,MAPPED,unique
+Purines,preferred_term,CHEBI:26401,Purines,CHEBI:26401,MAPPED,unique
+Puromycin,preferred_term,CHEBI:17939,Puromycin,CHEBI:17939,MAPPED,unique
+Puromycin dihydrochloride,preferred_term,CHEBI:8642,Puromycin dihydrochloride,CHEBI:8642,MAPPED,unique
+pustulan,ontology_label,cas:37331-28-5,Pustulan (b-1-6 glucan),mesh:C002076,MAPPED,unique
+Pustulan (b-1-6 glucan),preferred_term,cas:37331-28-5,Pustulan (b-1-6 glucan),mesh:C002076,MAPPED,unique
+Putrescin,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+putrescina,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+Putrescine,preferred_term,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,resolved:owned
+Putrescine,synonym,cas:333-93-7,Putrescine Dihydrochloride,CHEBI:201718,MAPPED,resolved:owned
+Putrescine 2 HCl,synonym,cas:333-93-7,Putrescine Dihydrochloride,CHEBI:201718,MAPPED,unique
+Putrescine Dihydrochloride,preferred_term,cas:333-93-7,Putrescine Dihydrochloride,CHEBI:201718,MAPPED,unique
+Putreszin,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+PY-cellobiose,preferred_term,kgmicrobe.ingredient:py_cellobiose,PY-cellobiose,kgmicrobe.ingredient:py_cellobiose,MAPPED,unique
+PY-fructose,preferred_term,kgmicrobe.ingredient:py_fructose,PY-fructose,kgmicrobe.ingredient:py_fructose,MAPPED,unique
+PY-glucose-rumen Fluid,preferred_term,kgmicrobe.ingredient:py_glucose_rumen_fluid,PY-glucose-rumen Fluid,kgmicrobe.ingredient:py_glucose_rumen_fluid,MAPPED,unique
+PY-maltose,preferred_term,kgmicrobe.ingredient:py_maltose,PY-maltose,kgmicrobe.ingredient:py_maltose,MAPPED,unique
+PY-pectin,preferred_term,kgmicrobe.ingredient:py_pectin,PY-pectin,kgmicrobe.ingredient:py_pectin,MAPPED,unique
+PYEG,preferred_term,kgmicrobe.ingredient:pyeg,PYEG,kgmicrobe.ingredient:pyeg,MAPPED,unique
+PYG,preferred_term,kgmicrobe.ingredient:pyg,PYG,kgmicrobe.ingredient:pyg,MAPPED,unique
+PYG + Rumen Fluid,preferred_term,kgmicrobe.ingredient:pyg_rumen_fluid,PYG + Rumen Fluid,kgmicrobe.ingredient:pyg_rumen_fluid,MAPPED,unique
+PYG-0.02% Tween 80,preferred_term,kgmicrobe.ingredient:pyg_0_02_tween_80,PYG-0.02% Tween 80,kgmicrobe.ingredient:pyg_0_02_tween_80,MAPPED,unique
+PYGS,preferred_term,kgmicrobe.ingredient:pygs,PYGS,kgmicrobe.ingredient:pygs,MAPPED,unique
+Pyocyanin,preferred_term,CHEBI:8653,Pyocyanin,CHEBI:8653,MAPPED,unique
+pyocyanine,ontology_label,CHEBI:8653,Pyocyanin,CHEBI:8653,MAPPED,unique
+Pyrazinamide,preferred_term,CHEBI:45285,Pyrazinamide,CHEBI:45285,MAPPED,unique
+PYRAZINE-2-CARBOXAMIDE,synonym,CHEBI:45285,Pyrazinamide,CHEBI:45285,MAPPED,unique
+pyrazinecarboxamide,ontology_label,CHEBI:45285,Pyrazinamide,CHEBI:45285,MAPPED,unique
+Pyrene,preferred_term,CHEBI:39106,Pyrene,CHEBI:39106,MAPPED,unique
+pyridin-2-ol,ontology_label,CHEBI:16540,2-Hydroxypyridine,CHEBI:16540,MAPPED,unique
+"PYRIDINE-2,6-DICARBOXYLIC ACID",synonym,CHEBI:46837,Dipicolinic Acid,CHEBI:46837,MAPPED,unique
+PYRIDINE-2-CARBOXYLIC ACID,synonym,CHEBI:28747,Picolinic acid,CHEBI:28747,MAPPED,unique
+pyridine-3-carboxamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+pyridine-3-carboxylic acid,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+pyridine-3-carboxylic acid amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+pyridine-4-carbohydrazide,synonym,CHEBI:6030,Isoniazid,CHEBI:6030,MAPPED,unique
+Pyridomycin,preferred_term,CHEBI:221765,Pyridomycin,CHEBI:221765,MAPPED,unique
+pyridoxal 5'-(dihydrogen phosphate),synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+pyridoxal 5'-phosphate,ontology_label,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+pyridoxal 5-monophosphoric acid ester,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+Pyridoxal 5-phosphate,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+Pyridoxal HCl,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+Pyridoxal hydrochloride,preferred_term,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+Pyridoxal phosphate,preferred_term,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+PYRIDOXAL-5'-PHOSPHATE,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+Pyridoxal·HCl,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+Pyridoxamine,preferred_term,CHEBI:16410,Pyridoxamine,CHEBI:16410,MAPPED,unique
+pyridoxamine 2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyridoxamine dichlorohydrate,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyridoxamine Dihydrochloride,preferred_term,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyridoxamine HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxamine hydrochloride,preferred_term,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+pyridoxamine monohydrochloride,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxamine-HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxamine·2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyridoxamine·HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxin,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+pyridoxina,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Pyridoxine,preferred_term,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Pyridoxine dihydrochloride,preferred_term,CHEBI:189426,Pyridoxine dihydrochloride,CHEBI:189426,MAPPED,unique
+Pyridoxine HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine hydrochloride,preferred_term,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine-HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine·HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine・HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+pyridoxinum,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Pyridoxol,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+pyridoxol hydrochloride,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+pyridoxolum,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Pyridoxylamine dihydrochloride,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyrimethamine,preferred_term,CHEBI:8673,Pyrimethamine,CHEBI:8673,MAPPED,unique
+"pyrimidine-2,4(1H,3H)-dione",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+Pyrite,preferred_term,CHEBI:86471,Pyrite,CHEBI:86471,MAPPED,unique
+pyrithiamine diphosphate,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+pyrithiamine pyrophosphate,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+pyrocatechin,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+Pyrocatechol,preferred_term,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
+pyrocatechuic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
+Pyrogallol,preferred_term,CHEBI:16164,Pyrogallol,CHEBI:16164,MAPPED,unique
+Pyromelitic acid,preferred_term,CHEBI:45165,Pyromelitic acid,CHEBI:45165,MAPPED,unique
+pyromellitic acid,ontology_label,CHEBI:45165,Pyromelitic acid,CHEBI:45165,MAPPED,unique
+Pyromucic acid,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
+Pyrophosphoric acid tetrasodium salt,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+Pyroracemic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+"Pyrosulfurous acid, disodium salt",synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Pyrrole-2-carboxylic acid,preferred_term,CHEBI:36751,Pyrrole-2-carboxylic acid,CHEBI:36751,MAPPED,unique
+pyrrolidin-2-one,ontology_label,CHEBI:36592,Butyrolactam,CHEBI:36592,MAPPED,unique
+pyrrolidine-2-carboxylic acid,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
+Pyrrolomycin A,preferred_term,CHEBI:156550,Pyrrolomycin A,CHEBI:156550,MAPPED,unique
+Pyrrolomycin B,preferred_term,CHEBI:220052,Pyrrolomycin B,CHEBI:220052,MAPPED,unique
+Pyruvate,preferred_term,CHEBI:15361,Pyruvate,CHEBI:15361,MAPPED,unique
+Pyruvic acid,preferred_term,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
+Pyruvic acid sodium salt,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+"pyruvic acid, sodium salt",synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Quassin,preferred_term,CHEBI:8692,Quassin,CHEBI:8692,MAPPED,unique
+Quebrachitol,preferred_term,CHEBI:111,Quebrachitol,CHEBI:111,MAPPED,unique
+Quercetin,preferred_term,CHEBI:16243,Quercetin,CHEBI:16243,MAPPED,unique
+Quercinitol,synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+Quinate,preferred_term,CHEBI:26490,Quinate,CHEBI:26490,MAPPED,unique
+Quinic acid,preferred_term,CHEBI:26493,Quinic acid,CHEBI:26493,MAPPED,unique
+Quinine Hdrochloride,preferred_term,cas:6119-47-7,Quinine Hdrochloride,cas:6119-47-7,MAPPED,unique
+R agar,preferred_term,UNMAPPED_0132,R agar,,UNMAPPED,unique
+R-(+)-Lipoic acid,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+R-744,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
+R-LA,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+R2A agar,preferred_term,MICRO:0000543,R2A agar,MICRO:0000543,MAPPED,unique
+Rabbit blood,preferred_term,MICRO:0001229,Rabbit blood,MICRO:0001229,MAPPED,unique
+Rabbit serum,preferred_term,MICRO:0002392,Rabbit serum,MICRO:0002392,MAPPED,unique
+"rac-1,2-dichloropropane",ontology_label,CHEBI:82163,"1,2-Dichloropropane",CHEBI:82163,MAPPED,unique
+"rac-2-(3,4-dimethoxyphenyl)-5-{[2-(3,4-dimethoxyphenyl)ethyl](methyl)amino}-2-isopropylpentanenitrile hydrochloride",synonym,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
+"rac-3,5-dihydroxy-3-methylpentanoic acid",synonym,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
+rac-3-Hydroxypentanoic Acid,preferred_term,CHEBI:139272,rac-3-Hydroxypentanoic Acid,CHEBI:139272,MAPPED,unique
+"rac-4-cyano-4-(3,4-dimethoxyphenyl)-N-[2-(3,4-dimethoxyphenyl)ethyl]-N,5-dimethylhexan-1-aminium chloride",synonym,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
+rac-4-hydroxy-3-(3-oxo-1-phenylbutyl)-2H-1-benzopyran-2-one,synonym,CHEBI:10033,Warfarin,CHEBI:10033,MAPPED,unique
+"rac-9-fluoro-3-methyl-10-(4-methylpiperazin-1-yl)-7-oxo-2,3-dihydro-7H-[1,4]oxazino[2,3,4-ij]quinoline-6-carboxylic acid",synonym,CHEBI:7731,Ofloxacin,CHEBI:7731,MAPPED,unique
+rac-Dithiothreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+Racemethionine,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
+racemomycin,ontology_label,kgmicrobe.compound:racemomycin_e,Racemomycin E,mesh:C019594,MAPPED,unique
+Racemomycin E,preferred_term,kgmicrobe.compound:racemomycin_e,Racemomycin E,mesh:C019594,MAPPED,unique
+Radicicol,preferred_term,CHEBI:556075,Radicicol,CHEBI:556075,MAPPED,unique
+Raffinose,preferred_term,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+Raffinose Pentahydrate,ontology_label,cas:17629-30-0,D-Raffinose pentahydrate,CHEBI:189430,MAPPED,unique
+rafinose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+raflinose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+Ramoplanin,preferred_term,CHEBI:29670,Ramoplanin,CHEBI:29670,MAPPED,unique
+RbCl,synonym,CHEBI:78672,rubidium chloride,CHEBI:78672,MAPPED,unique
+Rechtsweinsaeure,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+Red Arabinan from sugar-beet,preferred_term,UNMAPPED_0166,Red Arabinan from sugar-beet,,UNMAPPED,unique
+reduced coenzyme M,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+reduced CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+Reduced glutathione,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+reduction: amorphous fe(iii) oxyhydroxid,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+reduction: amorphous iron (iii) oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
+reduction: arsenate detoxification,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+Reinforced clostridial medium,preferred_term,UNMAPPED_0507,Reinforced clostridial medium,,UNMAPPED,unique
+"rel-(2R,3R)-1,4-disulfanylbutane-2,3-diol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+"rel-(2R,3R,4R,5S)-hexane-1,2,3,4,5,6-hexol",synonym,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
+Renilla luciferyl sulfate anion,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Resazurin,preferred_term,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+resazurin sodium salt,synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resistomycin,preferred_term,CHEBI:29671,Resistomycin,CHEBI:29671,MAPPED,unique
+Resveratrol,preferred_term,CHEBI:27881,Resveratrol,CHEBI:27881,MAPPED,unique
+RFP,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+Rhamnogalacturonan - from potato,preferred_term,UNMAPPED_0175,Rhamnogalacturonan - from potato,,UNMAPPED,unique
+Rhamnogalacturonan from soy bean pectic fibre,preferred_term,cas:39280-21-2,Rhamnogalacturonan from soy bean pectic fibre,cas:39280-21-2,MAPPED,unique
+Rhamnogalacturonan I from potato pectic fiber,preferred_term,cas:39280-21-2,Rhamnogalacturonan I from potato pectic fiber,cas:39280-21-2,MAPPED,unique
+Rhamnogalacturonan-II from apple juice concentrate,preferred_term,UNMAPPED_0240,Rhamnogalacturonan-II from apple juice concentrate,,UNMAPPED,unique
+Rhamnolipid,preferred_term,CHEBI:62570,Rhamnolipid,CHEBI:62570,MAPPED,unique
+Rhamnose,preferred_term,CHEBI:26546,Rhamnose,CHEBI:26546,MAPPED,unique
+Rhocya,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+Rhodinyl Acetate,preferred_term,cas:141-11-7,Rhodinyl Acetate,cas:141-11-7,MAPPED,unique
+Rhodocladonic Acid,preferred_term,CHEBI:144215,Rhodocladonic Acid,CHEBI:144215,MAPPED,unique
+rhodomycin,ontology_label,kgmicrobe.compound:rhodomycin_a,Rhodomycin A,mesh:C004977,MAPPED,unique
+Rhodomycin A,preferred_term,kgmicrobe.compound:rhodomycin_a,Rhodomycin A,mesh:C004977,MAPPED,unique
+Rhodomycin B,preferred_term,CHEBI:81879,Rhodomycin B,CHEBI:81879,MAPPED,unique
+Rib,synonym,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
+Ribitol,preferred_term,CHEBI:15963,Ribitol,CHEBI:15963,MAPPED,unique
+ribo-pentose,synonym,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
+Riboflavin,preferred_term,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+"Riboflavin 5'-(trihydrogen diphosphate), 5'-5'-ester with adenosine",synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+Riboflavin 5'-adenosine diphosphate,synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+Riboflavin solution see Medium No. 462,preferred_term,UNMAPPED_0508,Riboflavin solution see Medium No. 462,,UNMAPPED,unique
+Riboflavine,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavine (B2),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+ribonucleic acid,ontology_label,kgmicrobe.ingredient:ribonucleic_acid_from_torula_yeast_type_vi,Ribonucleic acid from torula yeast type VI,CHEBI:33697,MAPPED,unique
+Ribonucleic acid from torula yeast type VI,preferred_term,kgmicrobe.ingredient:ribonucleic_acid_from_torula_yeast_type_vi,Ribonucleic acid from torula yeast type VI,CHEBI:33697,MAPPED,unique
+ribonucleic acids,synonym,kgmicrobe.ingredient:ribonucleic_acid_from_torula_yeast_type_vi,Ribonucleic acid from torula yeast type VI,CHEBI:33697,MAPPED,unique
+Ribose,preferred_term,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
+ribosylthymidine,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+ribothymidine,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+Rice starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Rifabutin,preferred_term,CHEBI:45367,Rifabutin,CHEBI:45367,MAPPED,unique
+rifamcin,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+Rifampicin,preferred_term,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+rifampicina,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+rifampicinum,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+Rifampin,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
+Rifamycin,preferred_term,NCIT:C29406,Rifamycin,NCIT:C29406,MAPPED,unique
+Rifamycin B,preferred_term,CHEBI:17876,Rifamycin B,CHEBI:17876,MAPPED,unique
+Rifamycin O,preferred_term,CHEBI:16324,Rifamycin O,CHEBI:16324,MAPPED,unique
+Rifamycin S,preferred_term,CHEBI:34948,Rifamycin S,CHEBI:34948,MAPPED,unique
+Rifamycin Sv,preferred_term,CHEBI:29673,Rifamycin Sv,CHEBI:29673,MAPPED,unique
+ristocetin,ontology_label,kgmicrobe.compound:ristocetin_b,Ristocetin B,CHEBI:85129,MAPPED,unique
+Ristocetin A,preferred_term,mesh:C016719,Ristocetin A,mesh:C016719,MAPPED,unique
+Ristocetin B,preferred_term,kgmicrobe.compound:ristocetin_b,Ristocetin B,CHEBI:85129,MAPPED,unique
+RLA,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+Rna,preferred_term,mesh:D012313,Rna,mesh:D012313,MAPPED,unique
+Robustic Acid,preferred_term,cas:5307-59-5,Robustic Acid,mesh:C105206,MAPPED,unique
+Roccellic Acid,preferred_term,CHEBI:144218,Roccellic Acid,CHEBI:144218,MAPPED,unique
+rock salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Rolled oats,preferred_term,FOODON:03307110,Rolled oats,FOODON:03307110,MAPPED,unique
+Rosaramicin,preferred_term,CHEBI:87084,Rosaramicin,CHEBI:87084,MAPPED,unique
+Roseoflavin,preferred_term,CHEBI:72346,Roseoflavin,CHEBI:72346,MAPPED,unique
+Rosmarinic acid,preferred_term,CHEBI:17226,Rosmarinic acid,CHEBI:17226,MAPPED,unique
+Rosuvastatin calcium,preferred_term,CHEBI:77249,Rosuvastatin calcium,CHEBI:77249,MAPPED,unique
+Rotenone,preferred_term,CHEBI:28201,Rotenone,CHEBI:28201,MAPPED,unique
+Roxithromycin,preferred_term,CHEBI:48844,Roxithromycin,CHEBI:48844,MAPPED,unique
+rubidium chloride,preferred_term,CHEBI:78672,rubidium chloride,CHEBI:78672,MAPPED,unique
+rubradirin,preferred_term,CHEBI:223718,rubradirin,CHEBI:223718,MAPPED,unique
+Rubradirin B,ontology_label,CHEBI:223718,rubradirin,CHEBI:223718,MAPPED,unique
+Rubrolone,preferred_term,CHEBI:140148,Rubrolone,CHEBI:140148,MAPPED,unique
+Rumen fluid,preferred_term,UBERON:0010228,Rumen fluid,UBERON:0010228,MAPPED,unique
+ruminal fluid,ontology_label,UBERON:0010228,Rumen fluid,UBERON:0010228,MAPPED,unique
+Rutilantinone,preferred_term,cas:21288-61-9,Rutilantinone,cas:21288-61-9,MAPPED,unique
+Rutin,preferred_term,CHEBI:28527,Rutin,CHEBI:28527,MAPPED,unique
+rye flour,ontology_label,FOODON:03302492,Arabinoxylan (Rye Flour),FOODON:03302492,MAPPED,unique
+Rye grass,preferred_term,UNMAPPED_0511,Rye grass,,UNMAPPED,unique
+S(O)Me2,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+"S,S-dimethyl-beta-propiothetin",ontology_label,CHEBI:16457,Dimethylsulfoniopropionate hydrochloride,CHEBI:16457,MAPPED,unique
+S-(5′-Adenosyl)-L-homocysteine,synonym,cas:9789-92-0,S-adenosyl Homocysteine,cas:9789-92-0,MAPPED,unique
+S-adenosyl Homocysteine,preferred_term,cas:9789-92-0,S-adenosyl Homocysteine,cas:9789-92-0,MAPPED,unique
+S-allylcysteine,ontology_label,CHEBI:74077,L-Deoxyalliin,CHEBI:74077,MAPPED,unique
+S-Isocorydine (),preferred_term,CHEBI:6000,S-Isocorydine (),CHEBI:6000,MAPPED,unique
+S-LA,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+S-prop-2-en-1-yl-L-cysteine,synonym,CHEBI:74077,L-Deoxyalliin,CHEBI:74077,MAPPED,unique
+S6 medium,preferred_term,UNMAPPED_0512,S6 medium,,UNMAPPED,unique
+SABOURAUD- Glucose-Bouillon,preferred_term,UNMAPPED_0513,SABOURAUD- Glucose-Bouillon,,UNMAPPED,unique
+sacarosa,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Saccharin,preferred_term,CHEBI:32111,Saccharin,CHEBI:32111,MAPPED,unique
+Saccharomyces cerevisiae,ontology_label,cas:9036-88-8,Mannan from Saccharomyces cerevisiae,NCIT:C14271,MAPPED,unique
+Saccharose,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Sacharose,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Safrole,preferred_term,CHEBI:8994,Safrole,CHEBI:8994,MAPPED,unique
+Salicin,preferred_term,CHEBI:17814,Salicin,CHEBI:17814,MAPPED,unique
+Salicylic acid,preferred_term,CHEBI:16914,Salicylic acid,CHEBI:16914,MAPPED,unique
+Salidroside,preferred_term,CHEBI:9009,Salidroside,CHEBI:9009,MAPPED,unique
+saline water,ontology_label,ENVO:00002010,Salt water,ENVO:00002010,MAPPED,unique
+Salinomycin,preferred_term,CHEBI:80025,Salinomycin,CHEBI:80025,MAPPED,unique
+Salsoline,preferred_term,CHEBI:112,Salsoline,CHEBI:112,MAPPED,unique
+salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+salt cake,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+Salt peter,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Salt Solution II,preferred_term,kgmicrobe.ingredient:salt_solution_ii,Salt Solution II,kgmicrobe.ingredient:salt_solution_ii,MAPPED,unique
+Salt water,preferred_term,ENVO:00002010,Salt water,ENVO:00002010,MAPPED,unique
+saltpetre,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
+Salts solution,preferred_term,kgmicrobe.ingredient:salts_solution,Salts solution,kgmicrobe.ingredient:salts_solution,MAPPED,unique
+Salvinorin A,preferred_term,CHEBI:67900,Salvinorin A,CHEBI:67900,MAPPED,unique
+Sandramycin,preferred_term,CHEBI:221703,Sandramycin,CHEBI:221703,MAPPED,unique
+Sarcidin,preferred_term,kgmicrobe.compound:sarcidin,Sarcidin,kgmicrobe.compound:sarcidin,MAPPED,unique
+sarcosine,preferred_term,CHEBI:15611,sarcosine,CHEBI:15611,MAPPED,unique
+saures Natriumsulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+Schwefel,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+Schwefelsaeureloesungen,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+schweres Wasser,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
+Sclareolide,preferred_term,cas:564-20-5,Sclareolide,mesh:C109395,MAPPED,unique
+Scopoletin,preferred_term,CHEBI:17488,Scopoletin,CHEBI:17488,MAPPED,unique
+Scutellarein 7-O-beta-D-glucuronide,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Scutellarein 7-O-beta-D-glucuronide,synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Scutellarein-7-glucuronide,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Scutellarein-7-glucuronide,synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Scutellarein-7-O-beta-D-glucuronide,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Scutellarein-7-O-beta-D-glucuronide,synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Scutellarein-7beta-D-glucuronide,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Scutellarein-7beta-D-glucuronide,synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Scutellarein-7beta-D-glucuronoside,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Scutellarein-7beta-D-glucuronoside,synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Scyllitol,synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+scyllo-Inositol,synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
+SDM_noCarbon,preferred_term,UNMAPPED_0286,SDM_noCarbon,,UNMAPPED,unique
+SDS,synonym,CHEBI:8984,Sodium Dodecyl Sulfate,CHEBI:8984,MAPPED,unique
+Se-acid,preferred_term,UNMAPPED_0517,Se-acid,,UNMAPPED,unique
+sea salt,ontology_label,MICRO:0001647,Artificial Sea Salt,MICRO:0001647,MAPPED,unresolved:no_chemistry
+Sea Salt,ontology_label,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unresolved:no_chemistry
+Sea salts,preferred_term,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unique
+sea salts (Sigma),synonym,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unique
+Sea water,preferred_term,ENVO:00002149,Sea water,ENVO:00002149,REJECTED,resolved:owned
+Sea water,synonym,ENVO:00002149,Seawater,ENVO:00002149,MAPPED,resolved:owned
+sea water,ontology_label,kgmicrobe.ingredient:natural_sea_water,Natural sea water,ENVO:00002149,MAPPED,resolved:owned
+sea water,ontology_label,kgmicrobe.ingredient:pasteurized_seawater,Pasteurized Seawater,ENVO:00002149,MAPPED,resolved:owned
+sea water,ontology_label,kgmicrobe.ingredient:supplemented_seawater,Supplemented Seawater,ENVO:00002149,MAPPED,resolved:owned
+Seawater,preferred_term,ENVO:00002149,Seawater,ENVO:00002149,MAPPED,unique
+Seawater (30 ppt),synonym,ENVO:00002149,Seawater,ENVO:00002149,MAPPED,unique
+Seawater(non-sterilized),synonym,ENVO:00002149,Seawater,ENVO:00002149,MAPPED,unique
+Sebacic acid,preferred_term,CHEBI:41865,Sebacic acid,CHEBI:41865,MAPPED,unique
+sec-propanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+secondary calcium phosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+See source for composition,preferred_term,UNMAPPED_0002,See source for composition,,UNMAPPED,unique
+Selenate,preferred_term,CHEBI:15075,Selenate,CHEBI:15075,MAPPED,unique
+selenige Saeure,synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+selenious acid,synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+selenious acid (H2SeO3) disodium salt,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+selenious acid disodium salt,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+"Selenious acid disodium salt, pentahydrate",synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+"selenious acid, disodium salt",synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+"selenious acid, sodium salt (1:2)",synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Selenite,preferred_term,CHEBI:18212,Selenite,CHEBI:18212,MAPPED,unique
+selenite(2-),ontology_label,CHEBI:18212,Selenite,CHEBI:18212,MAPPED,unique
+Selenite-tungstate solution see Medium No. 431,preferred_term,UNMAPPED_0519,Selenite-tungstate solution see Medium No. 431,,UNMAPPED,unique
+Selenous acid,synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
+Sepharose,synonym,CHEBI:2511,Agarose,CHEBI:2511,MAPPED,unique
+Serine,preferred_term,CHEBI:17822,Serine,CHEBI:17822,MAPPED,unique
+Serine hydroxamate,preferred_term,CHEBI:75494,Serine hydroxamate,CHEBI:75494,MAPPED,unique
+Serotonin,preferred_term,CHEBI:28790,Serotonin,CHEBI:28790,MAPPED,unique
+Serum,preferred_term,UBERON:0001977,Serum,UBERON:0001977,MAPPED,unique
+Setamycin,preferred_term,mesh:C032953,Setamycin,mesh:C032953,MAPPED,unique
+Shikimate,synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+Shikimic Acid,preferred_term,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
+Showdomycin,preferred_term,CHEBI:226519,Showdomycin,CHEBI:226519,MAPPED,unique
+Sialyllacto-N-neotetraose c,ontology_label,CHEBI:89905,Sialyllacto-N-tetraose c,CHEBI:89905,MAPPED,unique
+Sialyllacto-N-tetraose a,preferred_term,CHEBI:89919,Sialyllacto-N-tetraose a,CHEBI:89919,MAPPED,unique
+Sialyllacto-N-tetraose c,preferred_term,CHEBI:89905,Sialyllacto-N-tetraose c,CHEBI:89905,MAPPED,unique
+Sialyllacto-N-tetraose d,preferred_term,cas:100789-83-1,Sialyllacto-N-tetraose d,cas:100789-83-1,MAPPED,unique
+Siderophore,preferred_term,CHEBI:26672,Siderophore,CHEBI:26672,MAPPED,unique
+Sigmacell alpha Type 50,preferred_term,UNMAPPED_0520,Sigmacell alpha Type 50,,UNMAPPED,unique
+Silibinin,preferred_term,CHEBI:9144,Silibinin,CHEBI:9144,MAPPED,unique
+silica,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+"Silica, amorphous",synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+silicic anhydride,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+silicon dioxide,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+silicon(IV) oxide,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+Siliziumdioxid,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+silver chloride,preferred_term,CHEBI:30341,silver chloride,CHEBI:30341,MAPPED,unique
+silver monochloride,ontology_label,CHEBI:30341,silver chloride,CHEBI:30341,MAPPED,unique
+silver sulfate,preferred_term,cas:10294-26-5,silver sulfate,cas:10294-26-5,MAPPED,unique
+silver(1+) chloride,synonym,CHEBI:30341,silver chloride,CHEBI:30341,MAPPED,unique
+silver(I) chloride,synonym,CHEBI:30341,silver chloride,CHEBI:30341,MAPPED,unique
+Simvastatin,preferred_term,CHEBI:9150,Simvastatin,CHEBI:9150,MAPPED,unique
+simvastatin hydroxy acid,ontology_label,cas:139893-43-9,Simvastatin Hydroxy Acid Ammonium Salt,CHEBI:169041,MAPPED,unique
+Simvastatin Hydroxy Acid Ammonium Salt,preferred_term,cas:139893-43-9,Simvastatin Hydroxy Acid Ammonium Salt,CHEBI:169041,MAPPED,unique
+sinapic acid,preferred_term,CHEBI:77131,sinapic acid,CHEBI:77131,MAPPED,unique
+sinapinaldehyde,preferred_term,CHEBI:27949,sinapinaldehyde,CHEBI:27949,MAPPED,unique
+Sinomenine,preferred_term,CHEBI:9163,Sinomenine,CHEBI:9163,MAPPED,unique
+SiO2,preferred_term,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
+Sisomicin sulfate salt,preferred_term,cas:53179-09-2,Sisomicin sulfate salt,CHEBI:35175,MAPPED,unique
+skim milk food product,ontology_label,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
+Skimmed milk,preferred_term,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
+Skirrow supplement,preferred_term,kgmicrobe.ingredient:skirrow_supplement,Skirrow supplement,kgmicrobe.ingredient:skirrow_supplement,MAPPED,unique
+SLA,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+Sludge,preferred_term,ENVO:00002044,Sludge,ENVO:00002044,MAPPED,unique
+sn-3-GPC,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+sn-glycero-3-phosphocholine,preferred_term,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
+sn-glycerol 3-(dihydrogen phosphate),synonym,cas:17989-41-2,sn-Glycerol 3-phosphate lithium salt,CHEBI:15978,MAPPED,conflict:different_substances
+sn-glycerol 3-(dihydrogen phosphate),synonym,cas:29849-82-9,sn-Glycerol 3-phosphate bis(cyclohexylammonium) salt,CHEBI:15978,MAPPED,conflict:different_substances
+sn-glycerol 3-phosphate,ontology_label,CHEBI:15978,Glycerol 3-phosphate,CHEBI:15978,MAPPED,conflict:different_substances
+sn-glycerol 3-phosphate,ontology_label,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,conflict:different_substances
+sn-glycerol 3-phosphate,ontology_label,cas:17989-41-2,sn-Glycerol 3-phosphate lithium salt,CHEBI:15978,MAPPED,conflict:different_substances
+sn-glycerol 3-phosphate,ontology_label,cas:29849-82-9,sn-Glycerol 3-phosphate bis(cyclohexylammonium) salt,CHEBI:15978,MAPPED,conflict:different_substances
+sn-Glycerol 3-phosphate bis(cyclohexylammonium) salt,preferred_term,cas:29849-82-9,sn-Glycerol 3-phosphate bis(cyclohexylammonium) salt,CHEBI:15978,MAPPED,unique
+sn-Glycerol 3-phosphate lithium salt,preferred_term,cas:17989-41-2,sn-Glycerol 3-phosphate lithium salt,CHEBI:15978,MAPPED,unique
+SnCl2 x 2 H2O,preferred_term,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+SnCl2 x 2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+SnCl2.2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+SnCl2·2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+soda lye,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+Sodim deoxycholate monohydrate,synonym,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,unique
+sodium (2E)-3-(4-hydroxy-3-methoxyphenyl)prop-2-enoate,synonym,CHEBI:114954,Sodium ferulate,CHEBI:114954,MAPPED,unique
+"sodium (2R)-2-[(1S)-1,2-dihydroxyethyl]-4-hydroxy-5-oxo-2,5-dihydrofuran-3-olate",synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+"sodium (2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanoate",synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+sodium (2S)-2-azaniumylpentanedioate,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+"sodium (2S,5R,6R)-6-{[(2R)-2-amino-2-phenylacetyl]amino}-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo[3.2.0]heptane-2-carboxylate",synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+"sodium (6R,7R)-3-(acetoxymethyl)-8-oxo-7-[(2-thienylacetyl)amino]-5-thia-1-azabicyclo[4.2.0]oct-2-ene-2-carboxylate",synonym,CHEBI:3542,Cephalothin sodium salt,CHEBI:3542,MAPPED,unique
+"Sodium 1,2,3,6-tetrahydro-2,6-dioxopyrimidine-4-carboxylate",synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+"sodium 1,3,5,7-tetrahydroxybicyclo[3.3.1]tetraboroxane-1,5-diide",synonym,CHEBI:38892,Na2B4O7,CHEBI:38892,MAPPED,unique
+"sodium 2,2-dimethyl-6beta-(5-methyl-3-phenyl-1,2-oxazole-4-carboxamido)penam-3alpha-carboxylate",synonym,CHEBI:52134,Oxacillin sodium salt,CHEBI:52134,MAPPED,unique
+"sodium 2,2-dimethyl-6beta-(phenylacetamido)penam-3alpha-carboxylate",synonym,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
+"sodium 2,2-dimethyl-6beta-({[5-methyl-3-(2-chlorophenyl)isoxazol-4-yl]carbonyl}amino)penam-3alpha-carboxylate hydrate",synonym,CHEBI:34978,Cloxacillin sodium salt monohydrate,CHEBI:34978,MAPPED,unique
+"sodium 2,2-dimethyl-6beta-[(2R)-2-{[(2-oxoimidazolidin-1-yl)carbonyl]amino}-2-phenylacetamido]penam-3alpha-carboxylate",synonym,CHEBI:51864,Azlocillin sodium salt,CHEBI:51864,MAPPED,unique
+"sodium 2,6-dioxo-1,2,3,6-tetrahydropyrimidine-4-carboxylate",synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+sodium 2-(morpholin-4-yl)ethanesulfonate,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+sodium 2-(N-morpholino)ethanesulfonate,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+sodium 2-ammoniopentanedioate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+sodium 2-azaniumylpentanedioate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+Sodium 2-bromoethanesulfonate,preferred_term,cas:4263-52-9,Sodium 2-bromoethanesulfonate,cas:4263-52-9,MAPPED,unique
+Sodium 2-glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+sodium 2-hydroxypropanoate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Sodium 2-mercaptoethanesulfonate,preferred_term,CHEBI:31824,Sodium 2-mercaptoethanesulfonate,CHEBI:31824,MAPPED,unique
+Sodium 2-mercatoethanoate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+"sodium 2-methyl-1,4-dioxo-1,2,3,4-tetrahydronaphthalene-2-sulfonate",synonym,CHEBI:63928,Menadione sodium bisulfate,CHEBI:63928,MAPPED,unique
+sodium 2-morpholin-4-ylethanesulfonate,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+Sodium 2-oxobutyrate,synonym,cas:2013-26-5,2-oxobutyric acid sodium salt,CHEBI:16763,MAPPED,unique
+sodium 2-oxopropanoate,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Sodium 2-sulfanylacetate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+"sodium 3,4,5-trihydroxybenzoate",synonym,CHEBI:115197,Na-gallate,CHEBI:115197,MAPPED,unique
+"sodium 3-(acetoxymethyl)-7beta-{[(2Z)-2-(2-amino-1,3-thiazol-4-yl)-2-(methoxyimino)acetyl]amino}-3,4-didehydrocepham-4-carboxylate",synonym,CHEBI:3498,Cefotaxime sodium salt,CHEBI:3498,MAPPED,unique
+sodium 3-hydroxybutanoate,synonym,CHEBI:113373,Na-3-hydroxybutyrate,CHEBI:113373,MAPPED,unique
+sodium 3-hydroxybutyrate,synonym,CHEBI:113373,Na-3-hydroxybutyrate,CHEBI:113373,MAPPED,unique
+"sodium 3-{[(5-methyl-1,3,4-thiadiazol-2-yl)sulfanyl]methyl}-7beta-[(1H-tetrazol-1-ylacetyl)amino]-3,4-didehydrocepham-4-carboxylate",synonym,CHEBI:3483,Cefazolin sodium salt,CHEBI:3483,MAPPED,unique
+"sodium 3alpha,12alpha-dihydroxy-5beta-cholan-24-oate",synonym,CHEBI:9177,sodium Deoxycholate,CHEBI:9177,MAPPED,conflict:different_substances
+"sodium 3alpha,12alpha-dihydroxy-5beta-cholan-24-oate",synonym,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,conflict:different_substances
+"sodium 3alpha,7alpha,12alpha-trihydroxy-5beta-cholan-24-oate",synonym,cas:206986-87-0,Sodium cholate hydrate,CHEBI:26711,MAPPED,unique
+sodium 4-hydroxy-3-methoxybenzoate,synonym,CHEBI:132748,Na-vanillate,CHEBI:132748,MAPPED,unique
+Sodium 4-Hydroxybenzoate,preferred_term,CHEBI:113449,Sodium 4-Hydroxybenzoate,CHEBI:113449,MAPPED,unique
+Sodium 4-methyl-2-oxovalerate,synonym,cas:4502-00-5,4-Methyl-2-oxopentanoic acid sodium salt,CHEBI:48430,MAPPED,unique
+Sodium 4-morpholin-1-ylethylsulphonate,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+"Sodium 5,5'-indigotindisulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+"sodium 6beta-[(2-ethoxy-1-naphthoyl)amino]-2,2-dimethylpenam-3alpha-carboxylate hydrate",synonym,CHEBI:51919,Nafcillin sodium salt monohydrate,CHEBI:51919,MAPPED,unique
+"sodium 6beta-[(2R)-2-amino-2-phenylacetamido]-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+"sodium 6beta-[(2R)-2-amino-2-phenylacetamido]-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:34535,Ampicillin sodium salt,CHEBI:34535,REJECTED,unique
+"sodium 6beta-{(2R)-2-[(4-ethyl-2,3-dioxopiperazin-1-yl)carboxamido]-2-phenylacetamido}-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:8233,Piperacillin sodium salt,CHEBI:8233,MAPPED,unique
+"sodium 6beta-{[3-(2,6-dichlorophenyl)-5-methyl-1,2-oxazol-4-yl]carboxamido}-2,2-dimethylpenam-3alpha-carboxylate--water (1/1)",synonym,CHEBI:52019,Dicloxacillin sodium salt monohydrate,CHEBI:52019,MAPPED,unique
+Sodium acetate,preferred_term,CHEBI:32954,Sodium acetate,CHEBI:32954,REJECTED,unique
+Sodium Acetate,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+sodium acetate anhydrous,synonym,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
+Sodium acetate trihydrate,preferred_term,CHEBI:32138,Sodium acetate trihydrate,CHEBI:32138,MAPPED,unique
+sodium acetate trihydrate,ontology_label,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
+Sodium acetate x 3 H2O,synonym,CHEBI:32138,Sodium acetate trihydrate,CHEBI:32138,MAPPED,unique
+Sodium acetate(Fisher BP 333),synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Sodium acetate(Fisher BP 333),synonym,CHEBI:32954,Sodium acetate,CHEBI:32954,REJECTED,unique
+sodium acetate--water (1/3),synonym,CHEBI:32138,Sodium acetate trihydrate,CHEBI:32138,MAPPED,unique
+Sodium acetate·3H2O,preferred_term,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
+Sodium acetate·3H2O,synonym,CHEBI:32138,Sodium acetate trihydrate,CHEBI:32138,MAPPED,unique
+Sodium acetate・3H2O,synonym,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
+"Sodium acid arsenate, heptahydrate",synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+sodium acid carbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Sodium adipate,preferred_term,cas:7486-38-6,Sodium adipate,FOODON:03413240,MAPPED,unique
+Sodium alginate,preferred_term,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Sodium alpha-hydroxypropionate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+sodium ampicillin,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+Sodium antimonate,preferred_term,cas:15432-85-6,Sodium antimonate,mesh:C034426,MAPPED,unique
+sodium arsenite,ontology_label,CHEBI:29678,Sodium m-arsenite,CHEBI:29678,MAPPED,unique
+Sodium Ascorbate,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Sodium azide,preferred_term,CHEBI:278547,Sodium azide,CHEBI:278547,MAPPED,unique
+Sodium benzoate,synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+Sodium beta-glycerol phosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Sodium beta-glycerophosphate,preferred_term,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+sodium beta-hydroxybutanoate,synonym,CHEBI:113373,Na-3-hydroxybutyrate,CHEBI:113373,MAPPED,unique
+sodium beta-Hydroxybutyrate,synonym,CHEBI:113373,Na-3-hydroxybutyrate,CHEBI:113373,MAPPED,unique
+Sodium Bicarbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Sodium Bisulfite,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+sodium bisulphite,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+sodium borate decahydrate,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Sodium bromate,preferred_term,CHEBI:75229,Sodium bromate,CHEBI:75229,MAPPED,unique
+sodium bromide,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
+sodium bromoethanesulfonate,synonym,cas:4263-52-9,Sodium 2-bromoethanesulfonate,cas:4263-52-9,MAPPED,unique
+sodium butanoate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Sodium butyrate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Sodium caproate,synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Sodium capronate,synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Sodium caprylate,synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+Sodium carbonate,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,conflict:different_substances
+sodium carbonate,ontology_label,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,conflict:different_substances
+sodium carbonate,ontology_label,cas:5968-11-6,sodium carbonate monohydrate,CHEBI:29377,MAPPED,conflict:different_substances
+sodium carbonate monohydrate,preferred_term,cas:5968-11-6,sodium carbonate monohydrate,CHEBI:29377,MAPPED,unique
+Sodium carbonate solution,preferred_term,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
+sodium chlorate,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
+Sodium Chloride,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Sodium Chlorite,preferred_term,CHEBI:78667,Sodium Chlorite,CHEBI:78667,MAPPED,unique
+sodium cholate,ontology_label,cas:206986-87-0,Sodium cholate hydrate,CHEBI:26711,MAPPED,unique
+Sodium cholate hydrate,preferred_term,cas:206986-87-0,Sodium cholate hydrate,CHEBI:26711,MAPPED,unique
+Sodium Chromate,preferred_term,CHEBI:78671,Sodium Chromate,CHEBI:78671,MAPPED,unique
+Sodium Citrate,preferred_term,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,resolved:owned
+Sodium Citrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,resolved:owned
+Sodium citrate,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,resolved:owned
+Sodium citrate dihydrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+sodium citrate dihydrate,ontology_label,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+sodium citrate dihydrate,ontology_label,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+Sodium citrate hydrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Sodium crotonate,preferred_term,UNMAPPED_0524,Sodium crotonate,,UNMAPPED,unique
+Sodium cyanide,preferred_term,CHEBI:33192,Sodium cyanide,CHEBI:33192,MAPPED,unique
+"Sodium D,L-Lactate",synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+sodium D-(-)-alpha-aminobenzylpenicillin,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+Sodium D-Lactate,preferred_term,cas:920-49-0,Sodium D-Lactate,cas:920-49-0,MAPPED,unique
+sodium Deoxycholate,preferred_term,CHEBI:9177,sodium Deoxycholate,CHEBI:9177,MAPPED,resolved:owned
+sodium deoxycholate,ontology_label,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,resolved:owned
+Sodium deoxycholate monohydrate,preferred_term,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,unique
+Sodium dihydrogen phosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+sodium dihydrogen phosphate--water (1/1),synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+sodium dihydrogenphosphate,ontology_label,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+sodium dihydrogenphosphate,ontology_label,cas:10049-21-5,NaH2PO4•H2O,CHEBI:37585,MAPPED,conflict:different_substances
+sodium dihydrogenphosphate,ontology_label,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+sodium dihydrogenphosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+sodium dioxido(dioxo)molybdenum,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
+sodium dioxido(dioxo)molybdenum,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
+sodium dioxido(dioxo)molybdenum--water (1/2),synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+sodium dioxido(dioxo)molybdenum--water (1/7),synonym,CHEBI:86473,Na2MoO4 x 7 H2O,CHEBI:86473,MAPPED,unique
+sodium dioxido(dioxo)tungsten--water (1/2),synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Sodium diphenyldiazo-bis-alpha-naphthylaminesulfonate,synonym,CHEBI:34653,Congo red,CHEBI:34653,MAPPED,unique
+sodium diphosphate,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+sodium disulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Sodium dithionite,preferred_term,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+sodium dithionite,ontology_label,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
+Sodium DL-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+Sodium DL-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+sodium dodecanoate,synonym,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
+Sodium Dodecyl Sulfate,preferred_term,CHEBI:8984,Sodium Dodecyl Sulfate,CHEBI:8984,MAPPED,unique
+Sodium ethyl sulfate,preferred_term,cas:546-74-7,Sodium ethyl sulfate,cas:546-74-7,MAPPED,unique
+sodium feredetate,ontology_label,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+Sodium ferric EDTA,preferred_term,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+Sodium ferulate,preferred_term,CHEBI:114954,Sodium ferulate,CHEBI:114954,MAPPED,unique
+Sodium Fluoride,synonym,CHEBI:28741,NaF,CHEBI:28741,MAPPED,unique
+Sodium Fluoroacetate,preferred_term,CHEBI:38699,Sodium Fluoroacetate,CHEBI:38699,MAPPED,unique
+Sodium Fluorophosphate,preferred_term,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
+Sodium Formate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+sodium formiate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Sodium fumarate,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
+sodium gallate,synonym,CHEBI:115197,Na-gallate,CHEBI:115197,MAPPED,unique
+Sodium gluconate,preferred_term,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+Sodium glutamate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
+Sodium glutamate monohydrate,preferred_term,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+sodium glutarate,ontology_label,cas:13521-83-0,Disodium Glutarate,mesh:C000730144,MAPPED,unique
+sodium glycerol 2-phosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+sodium glyoxalate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
+sodium glyoxylate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
+sodium hexanoate,synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Sodium hydrogen arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+sodium hydrogen carbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+sodium hydrogen sulfite,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+Sodium hydrogencarbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unresolved:partial_chemistry
+sodium hydrogencarbonate,ontology_label,kgmicrobe.ingredient:84_gl_nahco3_solution,84 g/L NaHCO3 solution,CHEBI:32139,MAPPED,unresolved:partial_chemistry
+sodium hydrogensulfite,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+sodium hydrosulfite,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+Sodium Hydroxide,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+Sodium hypochlorite,preferred_term,CHEBI:32146,Sodium hypochlorite,CHEBI:32146,MAPPED,unique
+sodium hypophosphite,ontology_label,cas:10039-56-2,Sodium hypophosphite monohydrate,CHEBI:234148,MAPPED,unique
+Sodium hypophosphite monohydrate,preferred_term,cas:10039-56-2,Sodium hypophosphite monohydrate,CHEBI:234148,MAPPED,unique
+Sodium hyposulfite,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+"Sodium indigo-5,5'-bisulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
+sodium iodate,preferred_term,CHEBI:81708,sodium iodate,CHEBI:81708,MAPPED,unique
+sodium iodide,preferred_term,CHEBI:33167,sodium iodide,CHEBI:33167,MAPPED,unique
+Sodium iodoacetate,preferred_term,CHEBI:234594,Sodium iodoacetate,CHEBI:234594,MAPPED,unique
+sodium isethionate,preferred_term,cas:1562-00-1,sodium isethionate,cas:1562-00-1,MAPPED,unique
+Sodium L-(+)-tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+sodium L-ascorbate,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Sodium L-glutamate,preferred_term,CHEBI:64243,Sodium L-glutamate,CHEBI:64243,MAPPED,unique
+Sodium L-lactate,preferred_term,CHEBI:232798,Sodium L-lactate,CHEBI:232798,REJECTED,unique
+Sodium L-lactate,synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+Sodium L-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+sodium L-tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+sodium L-tartrate,ontology_label,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+Sodium lactate,preferred_term,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
+sodium lactate,ontology_label,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+sodium laurate,synonym,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
+Sodium m-arsenite,preferred_term,CHEBI:29678,Sodium m-arsenite,CHEBI:29678,MAPPED,unique
+Sodium malate,preferred_term,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Sodium Malate And,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
+Sodium maleate,preferred_term,CHEBI:91263,Sodium maleate,CHEBI:91263,MAPPED,unique
+Sodium Malonate,preferred_term,CHEBI:62983,Sodium Malonate,CHEBI:62983,MAPPED,unique
+Sodium mercaptoacetate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+sodium MES,synonym,CHEBI:62955,MES sodium salt,CHEBI:62955,MAPPED,unique
+sodium metabisulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Sodium metabisulphite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Sodium Metasilicate,preferred_term,mesh:C025349,Sodium Metasilicate,mesh:C025349,MAPPED,unique
+sodium metasilicate,ontology_label,mesh:C025349,Sodium metasilicate (silicate for diatom frustules),mesh:C025349,REJECTED,unique
+Sodium metasilicate (silicate for diatom frustules),preferred_term,mesh:C025349,Sodium metasilicate (silicate for diatom frustules),mesh:C025349,REJECTED,unique
+Sodium metasilicate (silicate for diatom frustules),synonym,mesh:C025349,Sodium Metasilicate,mesh:C025349,MAPPED,unique
+sodium metavanadate,synonym,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
+sodium metavanadate hydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+sodium metavanadate monohydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+Sodium methanesulfonate,preferred_term,cas:2386-57-4,Sodium methanesulfonate,cas:2386-57-4,MAPPED,unique
+Sodium methanoate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Sodium molybdate,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+sodium molybdate (anhydrous),ontology_label,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Sodium Molybdate Dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+sodium molybdate dihydrate,ontology_label,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,unique
+sodium molybdate heptahydrate,synonym,CHEBI:86473,Na2MoO4 x 7 H2O,CHEBI:86473,MAPPED,unique
+Sodium molybdate(VI),synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Sodium molybdate(VI) dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Sodium monofluorophosphate,synonym,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
+sodium monosulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+sodium monosulfide.9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Sodium n-butyrate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+Sodium n-caproate,synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Sodium n-octanoate,synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+sodium nitrate,synonym,kgmicrobe.ingredient:sodium_nitrate_~28070_m_stock~29,Sodium nitrate (0.70 M stock),CHEBI:63005,MAPPED,unresolved:partial_chemistry
+sodium nitrate,ontology_label,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unresolved:partial_chemistry
+sodium nitrate,ontology_label,CHEBI:63005,Sodium nitrate (nitrogen source),CHEBI:63005,REJECTED,unresolved:partial_chemistry
+Sodium nitrate (0.70 M stock),preferred_term,kgmicrobe.ingredient:sodium_nitrate_~28070_m_stock~29,Sodium nitrate (0.70 M stock),CHEBI:63005,MAPPED,unique
+Sodium nitrate (nitrogen source),preferred_term,CHEBI:63005,Sodium nitrate (nitrogen source),CHEBI:63005,REJECTED,unique
+Sodium nitrate (nitrogen source),synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+sodium nitrilotriacetate,ontology_label,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+sodium nitrite,synonym,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
+sodium o-vanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium octadecanoate,synonym,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
+Sodium octanoate,preferred_term,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
+Sodium oleate,preferred_term,CHEBI:81860,Sodium oleate,CHEBI:81860,MAPPED,unique
+sodium orotate,synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
+Sodium orthoarsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+sodium orthomolybdate dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+sodium orthotungstate dihydrate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+sodium orthovanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium oxalate,ontology_label,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
+Sodium oxide sulfide,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+sodium oxido(dioxo)vanadium,synonym,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
+sodium oxido(dioxo)vanadium--water (1/1),synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+sodium oxoacetate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
+sodium oxosilanebis(olate)--water (1/9),synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Sodium palmitate,preferred_term,CHEBI:234557,Sodium palmitate,CHEBI:234557,MAPPED,unique
+Sodium pectate,synonym,cas:9049-37-0,Polygalacturonic acid sodium salt,CHEBI:62969,MAPPED,unique
+Sodium perchlorate,preferred_term,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,resolved:owned
+sodium perchlorate,ontology_label,cas:7791-07-3,Sodium perchlorate monohydrate,CHEBI:132103,MAPPED,resolved:owned
+Sodium perchlorate monohydrate,preferred_term,cas:7791-07-3,Sodium perchlorate monohydrate,CHEBI:132103,MAPPED,unique
+Sodium periodate,preferred_term,CHEBI:75226,Sodium periodate,CHEBI:75226,MAPPED,unique
+Sodium Persulfate,preferred_term,cas:7775-27-1,Sodium Persulfate,mesh:C024625,MAPPED,unique
+sodium pervanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium phosphate,ontology_label,UNMAPPED_0615,Sodium phosphate monobasic (phosphorus source),CHEBI:37586,UNMAPPED,unique
+Sodium phosphate buffer,preferred_term,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
+Sodium phosphate dibasic,preferred_term,CHEBI:37583,Sodium phosphate dibasic,CHEBI:37583,MAPPED,unique
+Sodium phosphate monobasic,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+Sodium phosphate monobasic (phosphorus source),preferred_term,UNMAPPED_0615,Sodium phosphate monobasic (phosphorus source),CHEBI:37586,UNMAPPED,unique
+sodium phosphate monobasic anhydrous,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
+sodium phosphate monobasic anhydrous,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
+Sodium phosphate monobasic monohydrate,preferred_term,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+Sodium phosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+"sodium phosphate, monobasic",synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
+Sodium phosphite dibasic pentahydrate,preferred_term,cas:13517-23-2,Sodium phosphite dibasic pentahydrate,CHEBI:36361,MAPPED,unique
+Sodium polymannuronate,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
+Sodium polysilicate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Sodium Potassium phosphate buffer,preferred_term,kgmicrobe.ingredient:sodium_potassium_phosphate_buffer,Sodium Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+Sodium propanecarboxylate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
+sodium propanoate,synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Sodium propionate,synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
+Sodium pyrophosphate,preferred_term,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,resolved:owned
+Sodium Pyrophosphate,ontology_label,cas:7758-16-9,Sodium pyrophosphate dibasic,NCIT:C77500,MAPPED,resolved:owned
+Sodium pyrophosphate dibasic,preferred_term,cas:7758-16-9,Sodium pyrophosphate dibasic,NCIT:C77500,MAPPED,unique
+Sodium pyrosulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+sodium pyrosulphite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
+Sodium Pyruvate,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+Sodium resazurin,synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Sodium salicylate,preferred_term,CHEBI:9180,Sodium salicylate,CHEBI:9180,MAPPED,unique
+sodium salt,ontology_label,cas:128596-80-5,3'-sialyllactose sodium salt,CHEBI:26714,MAPPED,conflict:different_substances
+sodium salt,ontology_label,cas:157574-76-0,6'-O-sialyllactose sodium salt,CHEBI:26714,MAPPED,conflict:different_substances
+sodium salt,ontology_label,cas:967-80-6,Sulfaquinoxaline sodium salt,CHEBI:26714,MAPPED,conflict:different_substances
+Sodium saltpeter,synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+sodium selenate,ontology_label,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+Sodium selenite,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+sodium selenite hydrate,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+Sodium selenite pentahydrate,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+sodium selenite--water (1/5),synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+Sodium sesquisilicate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Sodium Silicate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Sodium silicate glass,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+sodium silicate nonahydrate,ontology_label,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Sodium siliconate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+sodium stearate,synonym,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
+Sodium succinate,preferred_term,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+sodium succinate (anhydrous),ontology_label,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unresolved:partial_chemistry
+sodium succinate (anhydrous),ontology_label,cas:150-90-3,Sodium succinate dibasic,CHEBI:63675,MAPPED,unresolved:partial_chemistry
+Sodium succinate dibasic,preferred_term,cas:150-90-3,Sodium succinate dibasic,CHEBI:63675,MAPPED,unique
+Sodium succinate dibasic hexahydrate,preferred_term,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+sodium succinate hexahydrate,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+sodium succinate.6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+sodium sulfanylacetate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Sodium Sulfate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+sodium sulfate decahydrate,synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
+sodium sulfate--water (1/10),synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
+Sodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+sodium sulfide (anh.),synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+sodium sulfide (anhydrous),ontology_label,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+sodium sulfide nonahydrate,ontology_label,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+sodium sulfide.9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+sodium sulfite,ontology_label,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+sodium sulfite,ontology_label,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,unique
+Sodium sulfite anhydrous,synonym,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,unique
+sodium sulfoxylate,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
+sodium sulfuret,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+sodium sulfurothioate hydrate (2:1:5),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+sodium sulfurothioate--water (1/5),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+sodium sulfurothioate--water (1/5),synonym,CHEBI:32150,Sodium Thiosulfate Pentahydrate,CHEBI:32150,REJECTED,unique
+sodium sulphate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+sodium sulphide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+Sodium sulphite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+Sodium tartrate,preferred_term,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+sodium tetraborate decahydrate,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+sodium tetradecyl sulfate,ontology_label,CHEBI:75273,Niaproof,CHEBI:75273,MAPPED,unique
+sodium tetraoxidovanadate(3-),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium tetraoxidovanadate(V),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+Sodium thioglycolate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Sodium thioglycollate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Sodium thiophosphate tribasic hydrate,preferred_term,cas:10489-48-2,Sodium thiophosphate tribasic hydrate,CHEBI:46612,MAPPED,unique
+sodium thiosulfate,ontology_label,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+Sodium Thiosulfate Pentahydrate,preferred_term,CHEBI:32150,Sodium Thiosulfate Pentahydrate,CHEBI:32150,REJECTED,unique
+Sodium thiosulfate pentahydrate,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+"Sodium Thiosulfate Pentahydrate (agar media only,sterile)(Baker 3946)",synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+"Sodium Thiosulfate Pentahydrate (agar media only,sterile)(Baker 3946)",synonym,CHEBI:32150,Sodium Thiosulfate Pentahydrate,CHEBI:32150,REJECTED,unique
+Sodium thiosulphate,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+sodium trioxidonitrate(1-),synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unresolved:partial_chemistry
+sodium trioxidonitrate(1-),synonym,kgmicrobe.ingredient:sodium_nitrate_~28070_m_stock~29,Sodium nitrate (0.70 M stock),CHEBI:63005,MAPPED,unresolved:partial_chemistry
+sodium trioxidonitrate(1-),synonym,CHEBI:63005,Sodium nitrate (nitrogen source),CHEBI:63005,REJECTED,unresolved:partial_chemistry
+Sodium trioxovanadate,synonym,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
+sodium tripolyphosphate,ontology_label,cas:15091-98-2,Pentasodium tripolyphosphate hexahydrate,FOODON:03530244,MAPPED,unique
+sodium tungstate,ontology_label,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
+Sodium tungstate dihydrate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+sodium tungstate(VI) dihydrate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+sodium vanadate (ortho),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium vanadate hydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+sodium vanadate monohydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
+sodium vanillate,synonym,CHEBI:132748,Na-vanillate,CHEBI:132748,MAPPED,unique
+"sodium {2,2',2'',2'''-[ethane-1,2-diyldi(nitrilo-kappaN)]tetraacetato-kappaO(4-)}ferrate(1-)",synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+Sodium(+),preferred_term,CHEBI:29101,Sodium(+),CHEBI:29101,MAPPED,unique
+sodium(1+),ontology_label,CHEBI:29101,Sodium(+),CHEBI:29101,MAPPED,unique
+Sodium(I) nitrate (1:1),synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
+Sodium-3-methyl-2-oxobutyrate,ontology_label,CHEBI:189431,3-Methyl-2-oxobutanoic acid sodium salt,CHEBI:189431,MAPPED,unique
+"sodium;(2R)-2-[(2R,3S,6R)-6-[[(2S,4R,5R,6R,7R,9R)-2-[(2R,5S)-5-[(2R,3S,5R)-5-[(2S,3S,5R,6R)-6-hydroxy-6-(hydroxymethyl)-3,5-dimethyloxan-2-yl]-3-methyloxolan-2-yl]-5-methyloxolan-2-yl]-7-methoxy-2,4,6-trimethyl-1,10-dioxaspiro[4.5]decan-9-yl]methyl]-3-methyloxan-2-yl]propanoate",synonym,cas:28643-80-3,Nigericin sodium salt,CHEBI:201444,MAPPED,unique
+sodium;(2S)-2-hydroxypropanoate,synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
+"sodium;(2S,3S,4R,5R,6R)-3-[(2S,3R,5S,6R)-3-acetamido-5-hydroxy-6-(hydroxymethyl)oxan-2-yl]oxy-4,5,6-trihydroxyoxane-2-carboxylate",synonym,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
+sodium;1-oxidopyridine-2-thione,synonym,CHEBI:201738,2-Mercaptopyridine N-oxide sodium salt,CHEBI:201738,MAPPED,unique
+sodium;2-(1H-indol-3-yl)acetate,synonym,cas:6505-45-9,indole 3-acetic acid sodium salt,CHEBI:230840,MAPPED,unique
+"sodium;2-[[(4R)-4-[(3R,5S,7R,8R,9S,10S,12S,13R,14S,17R)-3,7,12-trihydroxy-10,13-dimethyl-2,3,4,5,6,7,8,9,11,12,14,15,16,17-tetradecahydro-1H-cyclopenta[a]phenanthren-17-yl]pentanoyl]amino]ethanesulonate;hydrate",synonym,CHEBI:181226,Taurocholic acid sodium salt hydrate,CHEBI:181226,MAPPED,unique
+sodium;2-[dodecanoyl(methyl)amino]acetate,synonym,CHEBI:183704,N-lauroylsarcosine sodium salt,CHEBI:183704,MAPPED,unique
+sodium;3-[ormyl(hydroxy)amino]propyl-hydroxyphosphinate,synonym,cas:66508-37-0,Fosmidomycin sodium salt hydrate,CHEBI:201600,MAPPED,unique
+sodium;3-methyl-2-oxobutanoate,synonym,CHEBI:189431,3-Methyl-2-oxobutanoic acid sodium salt,CHEBI:189431,MAPPED,unique
+sodium;hexadecanoate,synonym,CHEBI:234557,Sodium palmitate,CHEBI:234557,MAPPED,unique
+Sodiumbenzoate,synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+Sodiumcitrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Soil,preferred_term,ENVO:00001998,Soil,ENVO:00001998,MAPPED,resolved:owned
+soil,ontology_label,ENVO:00001998,CR1 Soil,ENVO:00001998,MAPPED,resolved:owned
+soil,ontology_label,kgmicrobe.ingredient:green_house_soil,Green House Soil,ENVO:00001998,MAPPED,resolved:owned
+soil,ontology_label,kgmicrobe.ingredient:vermont_soil,Vermont Soil,ENVO:00001998,MAPPED,resolved:owned
+Soil Defined Carbon Mix,preferred_term,UNMAPPED_0303,Soil Defined Carbon Mix,,UNMAPPED,unique
+Soil extract,preferred_term,MICRO:0000457,Soil extract,MICRO:0000457,MAPPED,unique
+Soil+Seawater Medium,preferred_term,UNMAPPED_0055,Soil+Seawater Medium,,UNMAPPED,unique
+Soilwater: GR+ Medium,preferred_term,UNMAPPED_0012,Soilwater: GR+ Medium,,UNMAPPED,unique
+Soilwater: GR- Medium,preferred_term,UNMAPPED_0078,Soilwater: GR- Medium,,UNMAPPED,unique
+Soilwater: Peat Medium,preferred_term,UNMAPPED_0103,Soilwater: Peat Medium,,UNMAPPED,unique
+Solanesol,preferred_term,CHEBI:26718,Solanesol,CHEBI:26718,MAPPED,unique
+Soluble starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Solvent blue 8,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Sorbitol,preferred_term,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
+Sorbose,preferred_term,CHEBI:27922,Sorbose,CHEBI:27922,MAPPED,unique
+Sorensen's potassium phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Sorgoleone,preferred_term,CHEBI:61117,Sorgoleone,CHEBI:61117,MAPPED,unique
+soude caustique,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+soufre,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+Soy flour,preferred_term,FOODON:03302142,Soy flour,FOODON:03302142,MAPPED,unique
+Soy peptone,preferred_term,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Soy phospholipids,synonym,UNMAPPED_0232,Asolectin from soybean,,UNMAPPED,unique
+Soya pepton,preferred_term,FOODON:03315720,Soya pepton,FOODON:03315720,MAPPED,unique
+Soya peptone,preferred_term,FOODON:03315720,Soya peptone,FOODON:03315720,MAPPED,unique
+soybean flour,ontology_label,FOODON:03302142,Soy flour,FOODON:03302142,MAPPED,unique
+Soybean peptone,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Soyton,preferred_term,kgmicrobe.ingredient:soyton,Soyton,kgmicrobe.ingredient:soyton,MAPPED,unique
+Soytone,synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Soytone,synonym,FOODON:03315720,Bacto Soytone,FOODON:03315720,REJECTED,unique
+Soytone (BD-Difco) or Phytone peptone (BD-BBL),synonym,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+Sparassol,preferred_term,cas:520-43-4,Sparassol,cas:520-43-4,MAPPED,unique
+Spectinomycin,preferred_term,CHEBI:9215,Spectinomycin,CHEBI:9215,MAPPED,unique
+Spectinomycin dihydrochloride pentahydrate,preferred_term,CHEBI:9217,Spectinomycin dihydrochloride pentahydrate,CHEBI:9217,MAPPED,unique
+spectinomycin hydrochloride hydrate,ontology_label,CHEBI:9217,Spectinomycin dihydrochloride pentahydrate,CHEBI:9217,MAPPED,unique
+Spermidin,synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+spermidine,preferred_term,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
+Spermidine trihydrochloride,preferred_term,CHEBI:233088,Spermidine trihydrochloride,CHEBI:233088,MAPPED,unique
+Sphagnum extract,preferred_term,UNMAPPED_0098,Sphagnum extract,,UNMAPPED,unique
+Sphondin,preferred_term,CHEBI:81486,Sphondin,CHEBI:81486,MAPPED,unique
+Spinosyn,preferred_term,CHEBI:39207,Spinosyn,CHEBI:39207,MAPPED,unique
+Spir solution,preferred_term,kgmicrobe.ingredient:spir_solution,Spir solution,kgmicrobe.ingredient:spir_solution,MAPPED,unique
+Spir solution 1,synonym,kgmicrobe.ingredient:spir_solution,Spir solution,kgmicrobe.ingredient:spir_solution,MAPPED,unique
+Spir solution 2,synonym,kgmicrobe.ingredient:spir_solution,Spir solution,kgmicrobe.ingredient:spir_solution,MAPPED,unique
+Spiramycin,preferred_term,cas:8025-81-8,Spiramycin,NCIT:C839,MAPPED,unique
+Spiramycin II,preferred_term,CHEBI:31168,Spiramycin II,CHEBI:31168,MAPPED,unique
+spirit of amber,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+spirit of wood,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+spiritus vini,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+Sporangiomycin,preferred_term,mesh:C003339,Sporangiomycin,mesh:C003339,MAPPED,unique
+Spring sampling GW821 filtered with 0.2uM filter,preferred_term,UNMAPPED_0275,Spring sampling GW821 filtered with 0.2uM filter,,UNMAPPED,unique
+SrCl,synonym,CHEBI:36383,SrCl2,CHEBI:36383,MAPPED,unique
+SrCl 2,synonym,CHEBI:36383,SrCl2,CHEBI:36383,MAPPED,unique
+SrCl2,preferred_term,CHEBI:36383,SrCl2,CHEBI:36383,MAPPED,unique
+SrCl2 . 6H2O,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+SrCl2 x 6 H2O,preferred_term,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+SrCl2 x 6 H2O (0.1% w/v),synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+SrCl2.6H2O,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+SrCl2·6H2O,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+SrCl2・6H2O,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+stachyose,ontology_label,CHEBI:17164,Stachyose - 70%,CHEBI:17164,MAPPED,agree:same_substance
+stachyose,ontology_label,cas:54261-98-2,Stachyose hydrate,CHEBI:17164,MAPPED,agree:same_substance
+Stachyose - 70%,preferred_term,CHEBI:17164,Stachyose - 70%,CHEBI:17164,MAPPED,unique
+Stachyose hydrate,preferred_term,cas:54261-98-2,Stachyose hydrate,CHEBI:17164,MAPPED,unique
+Staerke,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Stallimycin,preferred_term,CHEBI:41958,Stallimycin,CHEBI:41958,MAPPED,unique
+Standard I Broth,preferred_term,UNMAPPED_0532,Standard I Broth,,UNMAPPED,unique
+stannous chloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+Staphylomycin M1,preferred_term,NCIT:C1295,Staphylomycin M1,NCIT:C1295,MAPPED,unique
+Starch,preferred_term,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Starch soluble,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Staurosporine,preferred_term,CHEBI:15738,Staurosporine,CHEBI:15738,MAPPED,unique
+Stearic acid,preferred_term,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+"Stearic acid, sodium salt",synonym,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
+Stearinsaeure,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
+Steffimycin,preferred_term,NCIT:C152426,Steffimycin,NCIT:C152426,MAPPED,unique
+Steric solution,preferred_term,kgmicrobe.ingredient:steric_solution,Steric solution,kgmicrobe.ingredient:steric_solution,MAPPED,unique
+Sterile serum,preferred_term,UNMAPPED_0534,Sterile serum,,UNMAPPED,unique
+Sterol,preferred_term,CHEBI:15889,Sterol,CHEBI:15889,MAPPED,unique
+Streptogramin A,ontology_label,NCIT:C1295,Staphylomycin M1,NCIT:C1295,MAPPED,unique
+Streptolydigin,preferred_term,CHEBI:45773,Streptolydigin,CHEBI:45773,MAPPED,unique
+Streptomycin,preferred_term,CHEBI:17076,Streptomycin,CHEBI:17076,MAPPED,unique
+streptomycin sulfate,ontology_label,CHEBI:32158,Streptomycin sulfate salt,CHEBI:32158,MAPPED,unique
+Streptomycin sulfate salt,preferred_term,CHEBI:32158,Streptomycin sulfate salt,CHEBI:32158,MAPPED,unique
+Streptonigrin,preferred_term,CHEBI:9287,Streptonigrin,CHEBI:9287,MAPPED,unique
+Streptovaricin,preferred_term,CHEBI:26790,Streptovaricin,CHEBI:26790,MAPPED,unique
+Strontium Chloride,synonym,CHEBI:36383,SrCl2,CHEBI:36383,MAPPED,unique
+Strontium chloride hexahydrate,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+strontium dichloride,synonym,CHEBI:36383,SrCl2,CHEBI:36383,MAPPED,unique
+strontium dichloride hexahydrate,synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+strontium dichloride--water (1/6),synonym,CHEBI:36385,SrCl2 x 6 H2O,CHEBI:36385,MAPPED,unique
+Strychnine Sulfate,preferred_term,CHEBI:233239,Strychnine Sulfate,CHEBI:233239,MAPPED,unique
+stubomycin,ontology_label,mesh:C031780,Hitachimycin,mesh:C031780,MAPPED,unique
+Suberic acid,preferred_term,CHEBI:9300,Suberic acid,CHEBI:9300,MAPPED,unique
+Substrate,preferred_term,NCIT:C120264,Substrate,NCIT:C120264,MAPPED,unique
+Succinamate,preferred_term,CHEBI:143136,Succinamate,CHEBI:143136,MAPPED,unique
+Succinate,preferred_term,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+succinate anion,synonym,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+succinates,synonym,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+Succinic acid,preferred_term,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
+succinic acid anion,synonym,CHEBI:26806,Succinate,CHEBI:26806,MAPPED,unique
+Succinic acid disodium salt,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+Succinic acid disodium salt hexahydrate,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+Sucrose,preferred_term,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+sucrose,ontology_label,CHEBI:17992,D-Sucrose,CHEBI:17992,REJECTED,unique
+Sucrose + Yeast Extract,preferred_term,kgmicrobe.ingredient:sucrose_yeast_extract,Sucrose + Yeast Extract,kgmicrobe.ingredient:sucrose_yeast_extract,MAPPED,unique
+Sucrose-6-monophosphate dipotassium salt,preferred_term,cas:36064-19-4,Sucrose-6-monophosphate dipotassium salt,cas:36064-19-4,MAPPED,unique
+Sugar,preferred_term,NCIT:C71939,Sugar,NCIT:C71939,MAPPED,unique
+sugar beet,ontology_label,FOODON:00003412,Sugar beet molasses,FOODON:00003412,MAPPED,unresolved:no_chemistry
+sugar beet,ontology_label,cas:11078-27-6,Arabinan from Sugar Beet,FOODON:00003412,MAPPED,unresolved:no_chemistry
+Sugar beet molasses,preferred_term,FOODON:00003412,Sugar beet molasses,FOODON:00003412,MAPPED,unique
+Sugarcane straw (lignocellulose substrate),preferred_term,UNMAPPED_0616,Sugarcane straw (lignocellulose substrate),,UNMAPPED,unique
+Sugars,preferred_term,kgmicrobe.compound:sugars,Sugars,CHEBI:16646,MAPPED,unique
+Sulbactam,preferred_term,CHEBI:9321,Sulbactam,CHEBI:9321,MAPPED,unique
+Sulfadimethoxine,preferred_term,CHEBI:32161,Sulfadimethoxine,CHEBI:32161,MAPPED,unique
+Sulfamerazine,preferred_term,CHEBI:102130,Sulfamerazine,CHEBI:102130,MAPPED,unique
+sulfamethazine,ontology_label,cas:1981-58-4,Sulfamethazine sodium salt,CHEBI:102265,MAPPED,unique
+Sulfamethazine sodium salt,preferred_term,cas:1981-58-4,Sulfamethazine sodium salt,CHEBI:102265,MAPPED,unique
+Sulfamethizole,preferred_term,CHEBI:9331,Sulfamethizole,CHEBI:9331,MAPPED,unique
+Sulfamethoxazole,preferred_term,CHEBI:9332,Sulfamethoxazole,CHEBI:9332,MAPPED,unique
+Sulfamethoxydiazine,preferred_term,CHEBI:53727,Sulfamethoxydiazine,CHEBI:53727,MAPPED,unique
+Sulfamonomethoxine,preferred_term,CHEBI:32164,Sulfamonomethoxine,CHEBI:32164,MAPPED,unique
+sulfane,synonym,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,unique
+Sulfanilamide,preferred_term,CHEBI:45373,Sulfanilamide,CHEBI:45373,MAPPED,unique
+Sulfaquinoxaline,preferred_term,cas:59-40-5,Sulfaquinoxaline,CHEBI:94719,MAPPED,unique
+Sulfaquinoxaline sodium salt,preferred_term,cas:967-80-6,Sulfaquinoxaline sodium salt,CHEBI:26714,MAPPED,unique
+Sulfasalazine,preferred_term,CHEBI:9334,Sulfasalazine,CHEBI:9334,MAPPED,unique
+Sulfate,preferred_term,CHEBI:16189,Sulfate,CHEBI:16189,MAPPED,unique
+sulfate salt,ontology_label,cas:53179-09-2,Sisomicin sulfate salt,CHEBI:35175,MAPPED,unresolved:partial_chemistry
+sulfate salt,ontology_label,cas:79645-27-5,Tobramycin sulfate salt,CHEBI:35175,MAPPED,unresolved:partial_chemistry
+Sulfide,preferred_term,CHEBI:26822,Sulfide,CHEBI:26822,MAPPED,unique
+sulfidoacetate,synonym,CHEBI:47869,Thioglycolate,CHEBI:47869,MAPPED,unique
+sulfinylbis(methane),synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+Sulfisoxazole,preferred_term,CHEBI:102484,Sulfisoxazole,CHEBI:102484,MAPPED,unique
+Sulfite,preferred_term,CHEBI:17359,Sulfite,CHEBI:17359,MAPPED,unique
+Sulfoacetic acid,preferred_term,CHEBI:50519,Sulfoacetic acid,CHEBI:50519,MAPPED,unique
+Sulfonamide,preferred_term,CHEBI:35358,Sulfonamide,CHEBI:35358,MAPPED,unique
+sulfonyldimethane,ontology_label,CHEBI:9349,dimethyl sulfone,CHEBI:9349,MAPPED,unique
+Sulfur,preferred_term,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,resolved:owned
+Sulfur,synonym,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,resolved:owned
+sulfur,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,resolved:owned
+Sulfur (powder),preferred_term,kgmicrobe.compound:sulfur_powder,Sulfur (powder),CHEBI:33403,MAPPED,unique
+sulfur atom,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+Sulfur compounds,preferred_term,CHEBI:26835,Sulfur compounds,CHEBI:26835,MAPPED,unique
+Sulfur free mineral mix,preferred_term,kgmicrobe.ingredient:sulfur_free_mineral_mix,Sulfur free mineral mix,kgmicrobe.ingredient:sulfur_free_mineral_mix,MAPPED,unique
+sulfur molecular entity,ontology_label,CHEBI:26835,Sulfur compounds,CHEBI:26835,MAPPED,unique
+Sulfur powder,synonym,kgmicrobe.compound:sulfur_powder,Sulfur (powder),CHEBI:33403,MAPPED,unique
+"sulfur, homopolymer",synonym,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
+"Sulfur, precipitated",synonym,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
+Sulfur-free DL minerals,preferred_term,kgmicrobe.ingredient:sulfur-free_dl_minerals,Sulfur-free DL minerals,kgmicrobe.ingredient:sulfur-free_dl_minerals,MAPPED,unique
+Sulfuric acid,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+sulfuric acid ammonium salt (1:2),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+sulfuric acid magnesium salt heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+sulfuric acid magnesium salt heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+"sulfuric acid, calcium salt (1:1), dihydrate",synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+"sulfuric acid, calcium(2+) salt, dihydrate",synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+"sulfuric acid, diammonium salt",synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+sulfurous acid monosodium salt,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+sulfurous acid sodium salt,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+"Sulfurous acid, disodium salt",synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
+"sulfurous acid, monosodium salt",synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+"sulfurous acid, sodium salt (1:1)",synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
+sulphate of ammonia,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+Sulphur,preferred_term,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
+sulphuric acid,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+Sunfiber,preferred_term,UNMAPPED_0217,Sunfiber,,UNMAPPED,unique
+Sunflower oil,preferred_term,cas:8001-21-6,Sunflower oil,NCIT:C1241,MAPPED,unique
+Supplemented Seawater,preferred_term,kgmicrobe.ingredient:supplemented_seawater,Supplemented Seawater,ENVO:00002149,MAPPED,unique
+Surfactant,preferred_term,CHEBI:35195,Surfactant,CHEBI:35195,MAPPED,unique
+Sutezolid,preferred_term,cas:168828-58-8,Sutezolid,NCIT:C152482,MAPPED,unique
+Swine serum,preferred_term,UNMAPPED_0536,Swine serum,,UNMAPPED,unique
+Swiss blue,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+sylvite,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
+Sym-dimethylethylene glycol,synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+Synanthrin,preferred_term,kgmicrobe.compound:synanthrin,Synanthrin,kgmicrobe.compound:synanthrin,MAPPED,unique
+synephrine,ontology_label,CHEBI:29081,Oxedrine,CHEBI:29081,MAPPED,unique
+Synephrine Tartrate,preferred_term,cas:16589-24-5,Synephrine Tartrate,cas:16589-24-5,MAPPED,unique
+Synergistin A,preferred_term,mesh:C003372,Synergistin A,mesh:C003372,MAPPED,unique
+Synthetic Sea Salts (sss),preferred_term,kgmicrobe.compound:synthetic_sea_salts_sss,Synthetic Sea Salts (sss),kgmicrobe.compound:synthetic_sea_salts_sss,MAPPED,unique
+syringaldehyde,preferred_term,CHEBI:67380,syringaldehyde,CHEBI:67380,MAPPED,unique
+Syringic Acid,preferred_term,CHEBI:68329,Syringic Acid,CHEBI:68329,MAPPED,unique
+table salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+table sugar,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Tagatose,preferred_term,CHEBI:33954,Tagatose,CHEBI:33954,MAPPED,unique
+Takara_DO_Supp_MinusHisLeuTrp,preferred_term,kgmicrobe.ingredient:takara_do_supp_minushisleutrp,Takara_DO_Supp_MinusHisLeuTrp,kgmicrobe.ingredient:takara_do_supp_minushisleutrp,MAPPED,unique
+tangeretin,ontology_label,CHEBI:9400,Tangeritin,CHEBI:9400,MAPPED,unique
+Tangeritin,preferred_term,CHEBI:9400,Tangeritin,CHEBI:9400,MAPPED,unique
+tannic acid,preferred_term,CHEBI:75211,tannic acid,CHEBI:75211,MAPPED,unique
+TAPS,synonym,cas:91000-53-2,TAPS sodium salt,CHEBI:191055,MAPPED,unique
+TAPS sodium salt,preferred_term,cas:91000-53-2,TAPS sodium salt,CHEBI:191055,MAPPED,unique
+TAPSO,preferred_term,cas:68399-81-5,TAPSO,cas:68399-81-5,MAPPED,unique
+Tara gum,preferred_term,cas:39300-88-4,Tara gum,FOODON:03413299,MAPPED,unique
+"Tartaric acid, disodium salt",synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
+Tartate,synonym,CHEBI:132950,Tartrate,CHEBI:132950,MAPPED,unique
+Tartrate,preferred_term,CHEBI:132950,Tartrate,CHEBI:132950,MAPPED,unique
+Taurine,preferred_term,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+Taurocholate,preferred_term,CHEBI:36257,Taurocholate,CHEBI:36257,MAPPED,unique
+Taurocholic acid sodium salt hydrate,preferred_term,CHEBI:181226,Taurocholic acid sodium salt hydrate,CHEBI:181226,MAPPED,unique
+Tazobactam,preferred_term,CHEBI:9421,Tazobactam,CHEBI:9421,MAPPED,unique
+TCE,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Teicoplanin,preferred_term,CHEBI:29687,Teicoplanin,CHEBI:29687,MAPPED,unique
+telluric acid,ontology_label,cas:314041-10-6,potassium tellurate hydrate,CHEBI:30463,MAPPED,unique
+Tellurite,preferred_term,CHEBI:30477,Tellurite,CHEBI:30477,MAPPED,unique
+Terephthalate,preferred_term,CHEBI:30043,Terephthalate,CHEBI:30043,MAPPED,unique
+terephthalate(2-),ontology_label,CHEBI:30043,Terephthalate,CHEBI:30043,MAPPED,unique
+Terpene hydrate,preferred_term,cas:2451-01-6,Terpene hydrate,CHEBI:134806,MAPPED,unique
+terpin,ontology_label,cas:2451-01-6,Terpene hydrate,CHEBI:134806,MAPPED,unique
+Tertiomycin A,preferred_term,kgmicrobe.compound:tertiomycin_a,Tertiomycin A,kgmicrobe.compound:tertiomycin_a,MAPPED,unique
+Tertiomycin B,preferred_term,kgmicrobe.compound:tertiomycin_b,Tertiomycin B,kgmicrobe.compound:tertiomycin_b,MAPPED,unique
+TES,preferred_term,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
+TES buffer,synonym,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
+TES buffer(Sigma T 1375),synonym,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
+Tetrabromopyrrole,preferred_term,kgmicrobe.compound:tetrabromopyrrole,Tetrabromopyrrole,kgmicrobe.compound:tetrabromopyrrole,MAPPED,unique
+tetrabutylammonium salt,ontology_label,cas:100683-54-3,Malondialdehyde tetrabutylammonium salt,CHEBI:51992,MAPPED,unique
+Tetrachloraethen,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+tetrachlorethylene,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+Tetrachloroethene,preferred_term,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+tetrachloroethylene,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
+Tetracycline,preferred_term,CHEBI:27902,Tetracycline,CHEBI:27902,MAPPED,unique
+Tetracycline hydrochloride,preferred_term,CHEBI:35006,Tetracycline hydrochloride,CHEBI:35006,MAPPED,unique
+tetradecanoic acid,ontology_label,CHEBI:28875,Myristic acid,CHEBI:28875,MAPPED,unique
+tetrahydridocarbon,synonym,CHEBI:16183,methane,CHEBI:16183,MAPPED,unique
+tetrahydro-2H-pyran-2-one,synonym,CHEBI:16545,Valerolactone,CHEBI:16545,MAPPED,unique
+tetrairon tris(diphosphate),synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Tetrairon tris(pyrophosphate),synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+Tetrakis(hydroxymethyl)phosphonium sulfate,preferred_term,cas:55566-30-8,Tetrakis(hydroxymethyl)phosphonium sulfate,cas:55566-30-8,MAPPED,unique
+Tetramethyl ammonium,preferred_term,CHEBI:46020,Tetramethyl ammonium,CHEBI:46020,MAPPED,unique
+Tetramethyl ammonium chloride,preferred_term,kgmicrobe.compound:tetramethyl_ammonium_chloride,Tetramethyl ammonium chloride,CHEBI:46020,MAPPED,unique
+tetramethylammonium,synonym,CHEBI:46020,Tetramethyl ammonium,CHEBI:46020,MAPPED,unresolved:partial_chemistry
+tetramethylammonium,ontology_label,kgmicrobe.compound:tetramethyl_ammonium_chloride,Tetramethyl ammonium chloride,CHEBI:46020,MAPPED,unresolved:partial_chemistry
+TETRAMETHYLAMMONIUM ION,synonym,CHEBI:46020,Tetramethyl ammonium,CHEBI:46020,MAPPED,unique
+tetramethylazanium,synonym,CHEBI:46020,Tetramethyl ammonium,CHEBI:46020,MAPPED,unique
+Tetramethylendiamin,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+Tetramethylenediamine,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
+Tetrandrine,preferred_term,CHEBI:49,Tetrandrine,CHEBI:49,MAPPED,unique
+tetraoxidoarsenate(3-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+tetraoxidotungstate(2-),synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+tetraoxidotungstate(VI),synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+tetraoxoarsenate(3-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+tetraoxoarsenate(V),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+tetraoxosulfuric acid,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+Tetraphene,preferred_term,CHEBI:51348,Tetraphene,CHEBI:51348,MAPPED,unique
+Tetrasodium pyrophosphate,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+Tetrathionate,preferred_term,CHEBI:15226,Tetrathionate,CHEBI:15226,MAPPED,unique
+tetrathionate(2-),ontology_label,CHEBI:15226,Tetrathionate,CHEBI:15226,MAPPED,unique
+"Tetrathionic acid, dipotassium salt",synonym,CHEBI:86466,K2S4O6,CHEBI:86466,MAPPED,unique
+Tetrazolium,preferred_term,UNMAPPED_0734,Tetrazolium,,REJECTED,unique
+Tetrazolium Blue,preferred_term,CHEBI:75198,Tetrazolium Blue,CHEBI:75198,MAPPED,unique
+Tetrazolium violet,preferred_term,CHEBI:75193,Tetrazolium violet,CHEBI:75193,MAPPED,unique
+Tetrodotoxin,preferred_term,CHEBI:9506,Tetrodotoxin,CHEBI:9506,MAPPED,unique
+Texazone,preferred_term,CHEBI:197442,Texazone,CHEBI:197442,MAPPED,unique
+thallium(1+) acetate,synonym,CHEBI:75192,Thallium(I) acetate,CHEBI:75192,MAPPED,unique
+Thallium(I) acetate,preferred_term,CHEBI:75192,Thallium(I) acetate,CHEBI:75192,MAPPED,unique
+THAM,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Thauer's vitamin mix,preferred_term,kgmicrobe.ingredient:thauers_vitamin_mix,Thauer's vitamin mix,kgmicrobe.ingredient:thauers_vitamin_mix,MAPPED,unique
+Thauer's vitamin mix no Biotin,preferred_term,kgmicrobe.ingredient:thauers_vitamin_mix_no_biotin,Thauer's vitamin mix no Biotin,kgmicrobe.ingredient:thauers_vitamin_mix_no_biotin,MAPPED,unique
+ThDP,synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+Theaflavin,preferred_term,CHEBI:136609,Theaflavin,CHEBI:136609,MAPPED,unique
+Theaflavin Digallate,preferred_term,cas:30462-35-2,Theaflavin Digallate,CHEBI:185495,MAPPED,unique
+theion,synonym,CHEBI:26833,Sulfur,CHEBI:26833,MAPPED,unique
+Theobromine,preferred_term,CHEBI:28946,Theobromine,CHEBI:28946,MAPPED,unique
+Theophylline,preferred_term,CHEBI:28177,Theophylline,CHEBI:28177,MAPPED,unique
+Thiamin,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamin dichloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamin HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamin hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamin pyrophosphate,preferred_term,CHEBI:45931,Thiamin pyrophosphate,CHEBI:45931,MAPPED,unique
+Thiamin-HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine,preferred_term,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Thiamine (B1),synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine cation,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine chloride hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamine chloride hydrochloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+thiamine dichloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamine dichloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+Thiamine Dihydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamine diphosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiamine diphosphoric acid ester chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Thiamine HCl,preferred_term,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine HCl (B ) -,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine HCl (Vitamin B ),synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine HCl (Vitamin B1),synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamine hydrochloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+thiamine ion,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Thiamine pyrophosphate,preferred_term,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiamine pyrophosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Thiamine solution see Medium No. 403,preferred_term,UNMAPPED_0538,Thiamine solution see Medium No. 403,,UNMAPPED,unique
+Thiamine Vitamin Solution,preferred_term,kgmicrobe.ingredient:thiamine_vitamin_solution,Thiamine Vitamin Solution,MICRO:0000460,MAPPED,unique
+thiamine(1+),ontology_label,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine(1+) diphosphate,ontology_label,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiamine(1+) diphosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiamine(1+) diphosphate(1-),ontology_label,CHEBI:45931,Thiamin pyrophosphate,CHEBI:45931,MAPPED,unique
+thiamine(1+) ion,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine(2+) dichloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiamine(2+) dichloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+Thiamine-HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine-HCl x 2 H2O,preferred_term,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+Thiamine-HCl·2H2O,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
+thiamine-pyrophosphate,synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+thiamines,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Thiamine HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine·HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine・HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiaminium,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiaminium chloride hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+thiaminium diphosphoric acid ester chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiaminium pyrophosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiaminium pyrophosphoric acid ester chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+thiamins,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+"Thiazolium, 3-((4-amino-2-methyl-5-pyrimidinyl)methyl)-4-methyl-5-(4,6,6-trihydroxy-3,5-dioxa-4,6-diphosphahex-1-yl)-, chloride, P,P'-dioxide",synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Thioctansaeure,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Thioctic acid,preferred_term,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+Thioctic acid d-form,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
+thioctic acid l-form,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+Thioctsaeure,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Thioglycol,synonym,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
+Thioglycolate,preferred_term,CHEBI:47869,Thioglycolate,CHEBI:47869,MAPPED,unique
+Thioglycolate sodium,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+thioglycolate(2-),ontology_label,CHEBI:47869,Thioglycolate,CHEBI:47869,MAPPED,unique
+thioglycolic acid,ontology_label,CHEBI:30065,Thioglycollic acid,CHEBI:30065,MAPPED,unique
+Thioglycollic acid,preferred_term,CHEBI:30065,Thioglycollic acid,CHEBI:30065,MAPPED,unique
+"Thioglycollic acid, sodium salt",synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
+Thioktsaeure,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Thiolutin,preferred_term,CHEBI:156450,Thiolutin,CHEBI:156450,MAPPED,unique
+Thioridazine hydrochloride,preferred_term,CHEBI:48566,Thioridazine hydrochloride,CHEBI:48566,MAPPED,unique
+Thiostrepton,preferred_term,CHEBI:29693,Thiostrepton,CHEBI:29693,MAPPED,unique
+Thiosulfate,preferred_term,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+thiosulfate ester,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+thiosulfate esters,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+thiosulfates,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+"Thiosulfuric acid, disodium salt",synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+"thiosulfuric acid, disodium salt, pentahydrate",synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+thiosulphates,synonym,CHEBI:26977,Thiosulfate,CHEBI:26977,MAPPED,unique
+Thiourea,preferred_term,CHEBI:36946,Thiourea,CHEBI:36946,MAPPED,unique
+ThPP,synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0.2% Thiamine pyrophosphate,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,MAPPED,unique
+THPS,synonym,cas:55566-30-8,Tetrakis(hydroxymethyl)phosphonium sulfate,cas:55566-30-8,MAPPED,unique
+Threonine,preferred_term,CHEBI:26986,Threonine,CHEBI:26986,MAPPED,unique
+Thy,synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+Thymidine,preferred_term,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+Thymin,synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+Thymine,preferred_term,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+thymine 2'-deoxyriboside,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
+Thymine riboside,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+Thymoquinone,preferred_term,CHEBI:113532,Thymoquinone,CHEBI:113532,MAPPED,unique
+thymus nucleic acid,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
+Tiamulin,preferred_term,CHEBI:44137,Tiamulin,CHEBI:44137,MAPPED,unique
+Ticarcillin,preferred_term,CHEBI:9587,Ticarcillin,CHEBI:9587,MAPPED,unique
+ticarcillin disodium,ontology_label,CHEBI:35017,Ticarcillin disodium salt,CHEBI:35017,MAPPED,unique
+Ticarcillin disodium salt,preferred_term,CHEBI:35017,Ticarcillin disodium salt,CHEBI:35017,MAPPED,unique
+TiCl3,preferred_term,mesh:C039460,TiCl3,mesh:C039460,MAPPED,unique
+Tigecycline,preferred_term,CHEBI:149836,Tigecycline,CHEBI:149836,MAPPED,unique
+tiglic acid,ontology_label,CHEBI:9592,Trans-2-methyl-2-butenoic acid,CHEBI:9592,MAPPED,unique
+Timentin,preferred_term,cas:86482-18-0,Timentin,cas:86482-18-0,MAPPED,unique
+tin dichloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+tin dichloride.2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+tin(II) chloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+titanium trichloride,ontology_label,mesh:C039460,TiCl3,mesh:C039460,MAPPED,unique
+Titanium(III) citrate,preferred_term,UNMAPPED_0618,Titanium(III) citrate,,UNMAPPED,unique
+TitaniumIII chloride,preferred_term,cas:7705-07-9,TitaniumIII chloride,cas:7705-07-9,MAPPED,unique
+Titriplex1,preferred_term,UNMAPPED_0542,Titriplex1,,UNMAPPED,unique
+TNM-FH Medium,preferred_term,UNMAPPED_0543,TNM-FH Medium,,UNMAPPED,unique
+TNT,synonym,CHEBI:27135,Trinitrotoluene,CHEBI:27135,MAPPED,unique
+Tobramycin,preferred_term,CHEBI:28864,Tobramycin,CHEBI:28864,MAPPED,unique
+Tobramycin sulfate salt,preferred_term,cas:79645-27-5,Tobramycin sulfate salt,CHEBI:35175,MAPPED,unique
+Todd Hewitt Broth,preferred_term,UNMAPPED_0544,Todd Hewitt Broth,,UNMAPPED,unique
+Toluen,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
+Toluene,preferred_term,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
+Toluol,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
+tomatidine,ontology_label,cas:69004-03-1,Tomatidine Hydrochloride,CHEBI:9629,MAPPED,unique
+Tomatidine Hydrochloride,preferred_term,cas:69004-03-1,Tomatidine Hydrochloride,CHEBI:9629,MAPPED,unique
+Tomato extract,preferred_term,UNMAPPED_0545,Tomato extract,,UNMAPPED,unique
+Tomato juice,preferred_term,FOODON:03301454,Tomato juice,FOODON:03301454,MAPPED,unique
+Toray Silicone,ontology_label,mesh:C069668,Toray silicone SH 5535,mesh:C069668,MAPPED,unique
+Toray silicone SH 5535,preferred_term,mesh:C069668,Toray silicone SH 5535,mesh:C069668,MAPPED,unique
+Totarol,preferred_term,CHEBI:69241,Totarol,CHEBI:69241,MAPPED,unique
+Toxicarol,ontology_label,CHEBI:9643,Alpha-Toxicarol (Dl),CHEBI:9643,MAPPED,unique
+Toyocamycin,preferred_term,CHEBI:134606,Toyocamycin,CHEBI:134606,MAPPED,unique
+TPP,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+Trace Element,ontology_label,NCIT:C896,Trace element solution,NCIT:C896,MAPPED,unresolved:no_chemistry
+Trace Element,ontology_label,NCIT:C896,Trace element solution SL-10,NCIT:C896,MAPPED,unresolved:no_chemistry
+Trace Element,ontology_label,NCIT:C896,Zeikus trace element solution,NCIT:C896,MAPPED,unresolved:no_chemistry
+Trace Element,ontology_label,kgmicrobe.ingredient:trace_element_solution_see_medium_no_187,Trace element solution see Medium No. 187,NCIT:C896,MAPPED,unresolved:no_chemistry
+Trace element solution,preferred_term,NCIT:C896,Trace element solution,NCIT:C896,MAPPED,unique
+Trace element solution see Medium No. 187,preferred_term,kgmicrobe.ingredient:trace_element_solution_see_medium_no_187,Trace element solution see Medium No. 187,NCIT:C896,MAPPED,unique
+Trace element solution SL-10,preferred_term,NCIT:C896,Trace element solution SL-10,NCIT:C896,MAPPED,unique
+Trace Elements,ontology_label,mesh:D014131,Desulfovibrio trace elements,mesh:D014131,MAPPED,unique
+trace elements solution,ontology_label,MICRO:0000455,Algal Trace Elements Solution,MICRO:0000455,MAPPED,unique
+trace elements solution,ontology_label,MICRO:0000455,WC Trace Elements Solution,MICRO:0000455,MAPPED,unique
+Trace metal mix A5,preferred_term,MICRO:0001349,Trace metal mix A5,MICRO:0001349,MAPPED,unique
+Trace metal solution,preferred_term,kgmicrobe.ingredient:trace_metal_solution,Trace metal solution,kgmicrobe.ingredient:trace_metal_solution,MAPPED,unique
+Trace Metals Solution,preferred_term,kgmicrobe.ingredient:trace_metals_solution,Trace Metals Solution,kgmicrobe.ingredient:trace_metals_solution,MAPPED,unique
+Trace mineral solution,preferred_term,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace minerals,preferred_term,kgmicrobe.ingredient:trace_minerals,Trace minerals,kgmicrobe.ingredient:trace_minerals,MAPPED,unique
+Trace minerals see Medium No. 151,preferred_term,UNMAPPED_0553,Trace minerals see Medium No. 151,,UNMAPPED,unique
+Trace minerals see Medium No. 197,preferred_term,UNMAPPED_0554,Trace minerals see Medium No. 197,,UNMAPPED,unique
+Trace vitamins solution see Medium No. 284,preferred_term,UNMAPPED_0555,Trace vitamins solution see Medium No. 284,,UNMAPPED,unique
+Trans Styrylacetic Acid,preferred_term,kgmicrobe.compound:trans_styrylacetic_acid,Trans Styrylacetic Acid,kgmicrobe.compound:trans_styrylacetic_acid,MAPPED,unique
+"Trans,Trans-Farnesol",preferred_term,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
+"trans-1,2-ethylenedicarboxylic acid",synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+trans-2-butenoate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+trans-2-Butenoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+Trans-2-methyl-2-butenoic acid,preferred_term,CHEBI:9592,Trans-2-methyl-2-butenoic acid,CHEBI:9592,MAPPED,unique
+trans-2-Pentenoic acid,preferred_term,CHEBI:38366,trans-2-Pentenoic acid,CHEBI:38366,MAPPED,unique
+trans-3-phenylacrylic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+trans-4-coumaric acid,ontology_label,CHEBI:32374,p-Coumaric acid,CHEBI:32374,MAPPED,unique
+trans-4-Hydroxy-3-methoxycinnamic acid,synonym,CHEBI:193350,Ferulic Acid,CHEBI:193350,MAPPED,unique
+trans-4-Hydroxy-L-proline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+trans-aconitic acid,preferred_term,CHEBI:32806,trans-aconitic acid,CHEBI:32806,MAPPED,unique
+trans-beta-carboxystyrene,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+trans-but-2-enedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+trans-Butenedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+trans-Cinnamic acid,preferred_term,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+trans-crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
+trans-Crotonic Acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+"trans-ethene-1,2-dioic acid",synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
+trans-ferulic acid,ontology_label,CHEBI:17620,Ferulate,CHEBI:17620,MAPPED,unique
+trans-Hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+trans-L-Hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+trans-methylferulate,ontology_label,cas:22329-76-6,methyl ferulate,CHEBI:67379,MAPPED,unique
+trans-pent-2-enoic acid,ontology_label,CHEBI:38366,trans-2-Pentenoic acid,CHEBI:38366,MAPPED,unique
+trans-styrylacetic acid,synonym,kgmicrobe.compound:trans_styrylacetic_acid,Trans Styrylacetic Acid,kgmicrobe.compound:trans_styrylacetic_acid,MAPPED,unique
+trans-Zimtsaeure,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
+Transvalencin A,preferred_term,mesh:C498222,Transvalencin A,mesh:C498222,MAPPED,unique
+Traubenzucker,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
+Trehalose,preferred_term,CHEBI:27082,Trehalose,CHEBI:27082,MAPPED,unique
+trehalose dihydrate,synonym,CHEBI:232797,D-Trehalose dihydrate,CHEBI:232797,MAPPED,unique
+"tri(azaniumyl) 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+tri(carboxymethyl)amine,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Tri-sodium citrate,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,unique
+"triammonium 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+Triammonium citrate,synonym,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
+tribenuron methyl,ontology_label,CHEBI:9678,Tribenuron-methyl,CHEBI:9678,MAPPED,unique
+Tribenuron-methyl,preferred_term,CHEBI:9678,Tribenuron-methyl,CHEBI:9678,MAPPED,unique
+Tributyrin,preferred_term,CHEBI:35020,Tributyrin,CHEBI:35020,MAPPED,unique
+tricalcium bis(phosphate),ontology_label,CHEBI:9679,Tricalcium phosphate,CHEBI:9679,MAPPED,unique
+Tricalcium phosphate,preferred_term,CHEBI:9679,Tricalcium phosphate,CHEBI:9679,MAPPED,unique
+trichlor,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Trichloraethen,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Trichloraethylen,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+trichloraethylenum pro narcosi,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+trichlorethylene,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+trichloridoaluminium,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+trichloridocerium,synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,conflict:different_substances
+trichloridocerium,synonym,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:35458,MAPPED,conflict:different_substances
+trichloroalumane,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+Trichloroethene,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Trichloroethylene,preferred_term,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+trichloroethylenum,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+trichloroiron--water (1/6),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+triciene,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Tricine,preferred_term,CHEBI:46760,Tricine,CHEBI:46760,MAPPED,unique
+triclosan,ontology_label,CHEBI:164200,Irgasan,CHEBI:164200,MAPPED,unique
+tridimethylaminomethane,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+Triethanolamine,preferred_term,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+triglycine,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Triglycollamic acid,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+Trigonelline,preferred_term,mesh:C009560,Trigonelline,mesh:C009560,MAPPED,unique
+Trigonelline HCl,preferred_term,CHEBI:229203,Trigonelline HCl,CHEBI:229203,MAPPED,unique
+trihydrogen trioxophosphate(3-),synonym,CHEBI:36361,phosphorous acid,CHEBI:36361,MAPPED,unique
+trihydroxidoboron,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+trihydroxidophosphorus,synonym,CHEBI:36361,phosphorous acid,CHEBI:36361,MAPPED,unique
+Trihydroxypropane,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
+Trihydroxypropane,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+triisocyanate,synonym,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+triisocyanates,synonym,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+Trilon A,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+trimagnesium dicitrate,ontology_label,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
+Trimethoprim,preferred_term,CHEBI:45924,Trimethoprim,CHEBI:45924,MAPPED,unique
+Trimethoxybenzoate,synonym,CHEBI:58989,"3,4,5-trimethoxybenzoate",CHEBI:58989,MAPPED,unique
+Trimethyl(2-hydroxyethyl)ammonium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
+Trimethylamin,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+Trimethylamine,preferred_term,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+trimethylamine hydrochloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+trimethylamine monohydrochloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+trimethylamine N-oxide,ontology_label,CHEBI:15724,Trimethylamine-N-oxide,CHEBI:15724,MAPPED,unique
+Trimethylamine-HCl,preferred_term,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+Trimethylamine-N-oxide,preferred_term,CHEBI:15724,Trimethylamine-N-oxide,CHEBI:15724,MAPPED,unique
+Trimethylamine·HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+Trimethylaminoacetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Trimethylammonioacetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Trimethylammonium chloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+trimethylenediamine,ontology_label,CHEBI:15725,Propandiamine,CHEBI:15725,MAPPED,unique
+Trimethyleneglycol,synonym,CHEBI:16109,"1,3-Propanediol",CHEBI:16109,MAPPED,unique
+trimethylethanolamine,synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+Trimethylglycine,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+trimethylglycocoll,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
+Trinitrotoluene,preferred_term,CHEBI:27135,Trinitrotoluene,CHEBI:27135,MAPPED,unique
+trioxophosphoric(3-) acid,synonym,CHEBI:36361,phosphorous acid,CHEBI:36361,MAPPED,unique
+Triphenyltetrazolium Chloride,synonym,CHEBI:78019,"2,3,5-Triphenyltetrazolium chloride",CHEBI:78019,MAPPED,unique
+Tripticase peptone,synonym,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+triptofano,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+triptohypol C,synonym,CHEBI:132340,Dihydrocelastrol,CHEBI:132340,MAPPED,unique
+Triptolide,preferred_term,CHEBI:9747,Triptolide,CHEBI:9747,MAPPED,unique
+Tris,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris (hydroxymethyl aminomethane),synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris [tris(hydroxymethyl)aminomethane],synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+tris acetate,ontology_label,CHEBI:66869,Tris Acetate Stock Solution,CHEBI:66869,MAPPED,unique
+Tris Acetate Stock Solution,preferred_term,CHEBI:66869,Tris Acetate Stock Solution,CHEBI:66869,MAPPED,unique
+Tris amino,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris base,preferred_term,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris base (buffer),synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris buffer,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris buffer 1M,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris HCl,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris hydrochloride,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+tris(2-hydroxyethyl)amine,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+tris(beta-hydroxyethyl)amine,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+Tris(hydroxymethyl)aminomethane,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris(hydroxymethyl)methylamine,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris-base,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris-HCl buffer,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+"trisodium 2,2',2''-nitrilotriacetate",synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+"trisodium 2,2'-({2-[(carboxylatomethyl)(carboxymethyl)amino]ethyl}imino)diacetate",synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+"trisodium 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,conflict:different_substances
+"trisodium 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,conflict:different_substances
+"trisodium 2-hydroxypropane-1,2,3-tricarboxylate",synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,conflict:different_substances
+"trisodium 2-hydroxypropane-1,2,3-tricarboxylate--water (1/2)",synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+"trisodium 2-hydroxypropane-1,2,3-tricarboxylate--water (1/2)",synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Trisodium aminotriacetate,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+Trisodium citrate,preferred_term,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,resolved:owned
+trisodium citrate,ontology_label,mesh:C514290,Trisodium citrate x H2O,mesh:C514290,MAPPED,resolved:owned
+Trisodium citrate dehydrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
+Trisodium Citrate Dihydrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Trisodium citrate x 2 H2O,preferred_term,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+Trisodium citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Trisodium citrate x H2O,preferred_term,mesh:C514290,Trisodium citrate x H2O,mesh:C514290,MAPPED,unique
+Trisodium citrate·2H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+Trisodium citrate·3H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+Trisodium citrate・2H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+trisodium ethylenediaminetetraacetate,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+"Trisodium N,N-bis(carboxymethyl)glycinate",synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+Trisodium nitrilotriacetate,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+Trisodium NTA,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
+trisodium orthovanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+trisodium phosphate,ontology_label,CHEBI:37583,Sodium phosphate dibasic,CHEBI:37583,MAPPED,unique
+trisodium salt of ethylenediaminetetraacetic acid,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+trisodium tetraoxovanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+Trisodium tribromide,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
+trisodium trioxido(oxo)vanadium,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+trisodium vanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+"trisodium;1-hydroxypropane-1,2,3-tricarboxylate",synonym,kgmicrobe.compound:dl-isocitric_acid_trisodium_salt_hydrate,DL-Isocitric acid trisodium salt hydrate,CHEBI:172950,MAPPED,unique
+Tris [tris(hydroxymethyl)aminomethane],synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Trithionate,preferred_term,CHEBI:15987,Trithionate,CHEBI:15987,MAPPED,unique
+trithionate(2-),ontology_label,CHEBI:15987,Trithionate,CHEBI:15987,MAPPED,unique
+Triton X-100,preferred_term,CHEBI:9750,Triton X-100,CHEBI:9750,MAPPED,unique
+Trizma,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Trizma Base pH,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Trizma Base pH 8.2,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Trolamine,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
+Troleandomycin,preferred_term,CHEBI:45735,Troleandomycin,CHEBI:45735,MAPPED,unique
+Trometamol,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tromethamine,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tryptamine,preferred_term,CHEBI:16765,Tryptamine,CHEBI:16765,MAPPED,unique
+tryptic soy agar,ontology_label,MICRO:0000114,Bacto Tryptic Soy Agar,MICRO:0000114,MAPPED,unique
+tryptic soy agar,ontology_label,MICRO:0000114,Bacto Tryptic Soy Agar (Difco),MICRO:0000114,REJECTED,unique
+tryptic soy broth,ontology_label,MICRO:0000113,Bacto Tryptic Soy Broth,MICRO:0000113,MAPPED,unique
+tryptic soy broth,ontology_label,MICRO:0000113,Bacto Tryptic Soy Broth (Difco),MICRO:0000113,REJECTED,unique
+Trypticase,preferred_term,MICRO:0000175,Trypticase,MICRO:0000175,MAPPED,unique
+trypticase,synonym,MICRO:0000175,Trypticase,MICRO:0000175,MAPPED,unique
+Trypticase peptone,preferred_term,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+Trypticase peptone,ontology_label,MICRO:0000175,Trypticase,MICRO:0000175,MAPPED,unique
+Trypticase Peptone (BBL),synonym,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+Trypticase Peptone (BD 211921),synonym,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+Trypticase peptone (BD BBL),synonym,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+Trypticase peptone (BD-BBL),synonym,MICRO:0000175,Trypticase peptone,MICRO:0000175,MAPPED,unique
+Trypticase soy agar,preferred_term,UNMAPPED_0557,Trypticase soy agar,,UNMAPPED,unique
+Trypticase soy broth,preferred_term,UNMAPPED_0252,Trypticase soy broth,,UNMAPPED,unique
+Trypticase-glucose-yeast Extract,preferred_term,kgmicrobe.ingredient:trypticase_glucose_yeast_extract,Trypticase-glucose-yeast Extract,kgmicrobe.ingredient:trypticase_glucose_yeast_extract,MAPPED,unique
+Tryptone,preferred_term,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+tryptone,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+tryptone,ontology_label,MICRO:0000182,Bacto-tryptone,MICRO:0000182,MAPPED,unique
+tryptone,ontology_label,MICRO:0000182,Tryptone peptone,MICRO:0000182,MAPPED,unique
+Tryptone (Bacto Trypton 211705),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD 211705),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD BACTO),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD Bacto),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD BBL),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD--Difco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (BD-Difco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+tryptone (BD-Difco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (Difco 0123),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (Difco),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (Diffico),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone (Sigma T 9410),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+"Tryptone (VWR, J859-500G)",synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+tryptone [Difco],synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone peptone,preferred_term,MICRO:0000182,Tryptone peptone,MICRO:0000182,MAPPED,unique
+Tryptone soya broth (Oxoid),preferred_term,UNMAPPED_0138,Tryptone soya broth (Oxoid),,UNMAPPED,unique
+Tryptone(CAS: 91079-40-2),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone(Sigma T 9410),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone(Sigma T 9410)),synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
+Tryptone/yeast/beef (tyb),preferred_term,kgmicrobe.ingredient:tryptone_yeast_beef_tyb,Tryptone/yeast/beef (tyb),kgmicrobe.ingredient:tryptone_yeast_beef_tyb,MAPPED,unique
+Tryptophan,preferred_term,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,resolved:owned
+Tryptophan,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,resolved:owned
+tryptophane,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
+Tryptose,preferred_term,MICRO:0000183,Tryptose,MICRO:0000183,MAPPED,unique
+Tryptose-phosphate,preferred_term,UNMAPPED_0560,Tryptose-phosphate,,UNMAPPED,unique
+Tryptose-phosphate broth,preferred_term,UNMAPPED_0561,Tryptose-phosphate broth,,UNMAPPED,unique
+TSPP,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
+Tubelactomicin A,preferred_term,CHEBI:66279,Tubelactomicin A,CHEBI:66279,MAPPED,unique
+Tuberactinamine A,preferred_term,mesh:C108556,Tuberactinamine A,mesh:C108556,MAPPED,unique
+Tuberactinomycin,preferred_term,mesh:C015563,Tuberactinomycin,mesh:C015563,MAPPED,unique
+Tubercidin,preferred_term,CHEBI:48267,Tubercidin,CHEBI:48267,MAPPED,unique
+Tungstate,preferred_term,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+TUNGSTATE(VI)ION,synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+tungstic acid,ontology_label,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+"Tungstic acid, sodium salt, dihydrate",synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+tungstic(VI) acid,synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+Tunicamycin,preferred_term,CHEBI:29699,Tunicamycin,CHEBI:29699,MAPPED,unique
+turanose,ontology_label,CHEBI:32528,D-(+)-Turanose,CHEBI:32528,MAPPED,unique
+Tween,preferred_term,mesh:D011136,Tween,mesh:D011136,MAPPED,unique
+Tween 20,preferred_term,CHEBI:53424,Tween 20,CHEBI:53424,MAPPED,unique
+Tween 40,preferred_term,CHEBI:53423,Tween 40,CHEBI:53423,MAPPED,unique
+Tween 60,preferred_term,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
+Tween 80,preferred_term,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+TYG salts solution,preferred_term,kgmicrobe.ingredient:tyg_salts_solution,TYG salts solution,kgmicrobe.ingredient:tyg_salts_solution,MAPPED,unique
+TYGVS + Glucose,preferred_term,kgmicrobe.ingredient:tygvs_glucose,TYGVS + Glucose,kgmicrobe.ingredient:tygvs_glucose,MAPPED,unique
+Tyloxapol,preferred_term,CHEBI:141517,Tyloxapol,CHEBI:141517,MAPPED,unique
+TYROSINE,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unresolved:partial_chemistry
+tyrosine,ontology_label,CHEBI:18186,DL-Tyrosine,CHEBI:18186,MAPPED,unresolved:partial_chemistry
+undec-1-ene,synonym,CHEBI:77444,undecene,CHEBI:77444,MAPPED,unique
+undecan-2-ol,ontology_label,CHEBI:77930,2-undecanol,CHEBI:77930,MAPPED,unique
+undecene,preferred_term,CHEBI:77444,undecene,CHEBI:77444,MAPPED,unique
+Universal peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+Universal peptone (Merck),synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
+ur,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Ura,synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+Uracil,preferred_term,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+Uracil-6-carboxylic acid,synonym,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
+Uranyl acetate,preferred_term,cas:541-09-3,Uranyl acetate,mesh:C005460,MAPPED,resolved:owned
+uranyl acetate,ontology_label,cas:6159-44-0,Uranyl Acetate Dihydrate,mesh:C005460,MAPPED,resolved:owned
+Uranyl Acetate Dihydrate,preferred_term,cas:6159-44-0,Uranyl Acetate Dihydrate,mesh:C005460,MAPPED,unique
+Urazil,synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+Urd,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+Urea,preferred_term,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+uree,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Uric acid,preferred_term,CHEBI:27226,Uric acid,CHEBI:27226,MAPPED,unique
+uric acids,synonym,CHEBI:27226,Uric acid,CHEBI:27226,MAPPED,unique
+Uridin,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+Uridine,preferred_term,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
+Uridine 5-monophosphate disodium salt,preferred_term,cas:3387-36-8,Uridine 5-monophosphate disodium salt,cas:3387-36-8,MAPPED,unique
+Urocanic Acid,preferred_term,CHEBI:27248,Urocanic Acid,CHEBI:27248,MAPPED,unique
+Ursololactone Acetate,preferred_term,cas:28290-51-9,Ursololactone Acetate,cas:28290-51-9,MAPPED,unique
+Usnic Acid,preferred_term,CHEBI:38319,Usnic Acid,CHEBI:38319,MAPPED,unique
+UW concentrated base,preferred_term,kgmicrobe.ingredient:uw_concentrated_base,UW concentrated base,kgmicrobe.ingredient:uw_concentrated_base,MAPPED,unique
+UW concentrated base no Mo,preferred_term,kgmicrobe.ingredient:uw_concentrated_base_no_mo,UW concentrated base no Mo,kgmicrobe.ingredient:uw_concentrated_base_no_mo,MAPPED,unique
+UW concentrated base no sulfur,preferred_term,kgmicrobe.ingredient:uw_concentrated_base_no_sulfur,UW concentrated base no sulfur,kgmicrobe.ingredient:uw_concentrated_base_no_sulfur,MAPPED,unique
+V-8 Juice,preferred_term,MICRO:0002250,V-8 Juice,MICRO:0002250,MAPPED,unique
+V8 canned vegetable juice,preferred_term,UNMAPPED_0564,V8 canned vegetable juice,,UNMAPPED,unique
+Valerate,preferred_term,CHEBI:31011,Valerate,CHEBI:31011,MAPPED,unique
+Valerianic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+Valeriansaeure,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+Valeric acid,preferred_term,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+"valeric acid, normal",synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+Valerolactone,preferred_term,CHEBI:16545,Valerolactone,CHEBI:16545,MAPPED,unique
+Valine,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
+"vanadate (VO4(3-)), trisodium",synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+"vanadic acid (H3VO4), sodium salt",synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+"Vanadic acid, monosodium salt",synonym,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
+"vanadic acid, trisodium salt",synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+vanadic sulfate dihydrate,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+vanadic sulfate pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+vanadium chloride,preferred_term,cas:7718-98-1,vanadium chloride,cas:7718-98-1,MAPPED,unique
+vanadium oxide sulfate dihydrate,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+vanadium oxide sulfate pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+vanadium oxysulfate dihydrate,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+vanadium oxysulfate pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+vanadium(IV) oxide sulfate dihydrate,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+vanadium(IV) oxide sulfate pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+vanadyl sulfate dihydrate,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+vanadyl sulfate hydrate,ontology_label,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+vanadyl sulfate pentahydrate,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+Vancomycin,preferred_term,CHEBI:28001,Vancomycin,CHEBI:28001,MAPPED,unique
+Vancomycin hydrochloride,ontology_label,CHEBI:9932,Vancomycin Hydrochloride from Streptomyces orientalis,CHEBI:9932,MAPPED,agree:same_substance
+Vancomycin hydrochloride,ontology_label,cas:123409-00-7,Vancomycin Hydrochloride Hydrate,CHEBI:9932,MAPPED,agree:same_substance
+Vancomycin Hydrochloride from Streptomyces orientalis,preferred_term,CHEBI:9932,Vancomycin Hydrochloride from Streptomyces orientalis,CHEBI:9932,MAPPED,unique
+Vancomycin Hydrochloride Hydrate,preferred_term,cas:123409-00-7,Vancomycin Hydrochloride Hydrate,CHEBI:9932,MAPPED,unique
+Vancomycin x HCl,synonym,CHEBI:9932,Vancomycin Hydrochloride from Streptomyces orientalis,CHEBI:9932,MAPPED,unique
+Vancoresmycin,preferred_term,CHEBI:213208,Vancoresmycin,CHEBI:213208,MAPPED,unique
+Vanillic Acid,preferred_term,CHEBI:30816,Vanillic Acid,CHEBI:30816,MAPPED,unique
+Vanillin,preferred_term,CHEBI:18346,Vanillin,CHEBI:18346,MAPPED,unique
+Vanillyl Alcohol,preferred_term,CHEBI:18353,Vanillyl Alcohol,CHEBI:18353,MAPPED,unique
+vanillylmandelic acid,preferred_term,CHEBI:20106,vanillylmandelic acid,CHEBI:20106,MAPPED,unique
+Veal infusion broth,preferred_term,UNMAPPED_0566,Veal infusion broth,,UNMAPPED,unique
+"vegetable protein, hydrolyzed",ontology_label,FOODON:03315720,Phytone,FOODON:03315720,MAPPED,unique
+"vegetable protein, hydrolyzed",ontology_label,FOODON:03315720,Soy peptone,FOODON:03315720,MAPPED,unique
+"vegetable protein, hydrolyzed",ontology_label,FOODON:03315720,Soya pepton,FOODON:03315720,MAPPED,unique
+"vegetable protein, hydrolyzed",ontology_label,FOODON:03315720,Soya peptone,FOODON:03315720,MAPPED,unique
+"vegetable protein, hydrolyzed",ontology_label,FOODON:03315720,Bacto Soytone,FOODON:03315720,REJECTED,unique
+Venturicidin B,preferred_term,mesh:C068160,Venturicidin B,mesh:C068160,MAPPED,unique
+verapamil hydrochloride,ontology_label,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
+Veratric Acid,preferred_term,CHEBI:296881,Veratric Acid,CHEBI:296881,MAPPED,unique
+Veratrine hydrochloride,preferred_term,cas:17666-25-0,Veratrine hydrochloride,cas:17666-25-0,MAPPED,unique
+Verbascose,preferred_term,CHEBI:28586,Verbascose,CHEBI:28586,MAPPED,unique
+Vermont Soil,preferred_term,kgmicrobe.ingredient:vermont_soil,Vermont Soil,ENVO:00001998,MAPPED,unique
+Vibriostat,preferred_term,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unique
+Vibriostatic Agent O/129,synonym,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unique
+victoria green B,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+Viomycin,preferred_term,CHEBI:15782,Viomycin,CHEBI:15782,MAPPED,unique
+Virginiamycin,preferred_term,CHEBI:87209,Virginiamycin,CHEBI:87209,MAPPED,unique
+Viridogrisein,synonym,mesh:C004910,Etamycin,mesh:C004910,MAPPED,unique
+Visnagin,preferred_term,CHEBI:10002,Visnagin,CHEBI:10002,MAPPED,unique
+Vitafiber,preferred_term,UNMAPPED_0204,Vitafiber,,UNMAPPED,unique
+Vitagos 5650,preferred_term,UNMAPPED_0214,Vitagos 5650,,UNMAPPED,unique
+Vitamin,ontology_label,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
+Vitamin B,preferred_term,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
+vitamin B-12,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+vitamin B-12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+vitamin B1 pyrophosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
+vitamin B1 vitamer,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+vitamin B1 vitamers,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+vitamin B11,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Vitamin B12,preferred_term,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,resolved:owned
+Vitamin B12,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,resolved:owned
+Vitamin B12,synonym,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,resolved:owned
+Vitamin B12 (cyanocobalamin),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unique
+Vitamin B12 complex,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Vitamin B12 complex,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Vitamin B12 solution see Medium No. 403,preferred_term,UNMAPPED_0567,Vitamin B12 solution see Medium No. 403,,UNMAPPED,unique
+vitamin B12 vitamer,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+vitamin B12 vitamer,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+vitamin B12 vitamers,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unique
+vitamin B6,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+vitamin B7,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+vitamin B9,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+vitamin C sodium,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+"vitamin C, sodium salt",synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Vitamin H,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Vitamin K1,preferred_term,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Vitamin K3,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Vitamin PP,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Vitamin solution,preferred_term,MICRO:0000460,Vitamin solution,MICRO:0000460,MAPPED,resolved:owned
+vitamin solution,ontology_label,kgmicrobe.ingredient:biotin_vitamin_solution,Biotin Vitamin Solution,MICRO:0000460,MAPPED,resolved:owned
+vitamin solution,ontology_label,kgmicrobe.ingredient:kao_and_michayluk_vitamin_solution,Kao and Michayluk vitamin solution,MICRO:0000460,MAPPED,resolved:owned
+vitamin solution,ontology_label,kgmicrobe.ingredient:thiamine_vitamin_solution,Thiamine Vitamin Solution,MICRO:0000460,MAPPED,resolved:owned
+vitamin solution,ontology_label,kgmicrobe.ingredient:vitamin_solution_see_medium_no_403,Vitamin solution see Medium No. 403,MICRO:0000460,MAPPED,resolved:owned
+vitamin solution,ontology_label,kgmicrobe.ingredient:vitamin_solution_~28thermophilic_formulation~29,Vitamin solution (thermophilic formulation),MICRO:0000460,MAPPED,resolved:owned
+Vitamin solution (thermophilic formulation),preferred_term,kgmicrobe.ingredient:vitamin_solution_~28thermophilic_formulation~29,Vitamin solution (thermophilic formulation),MICRO:0000460,MAPPED,unique
+Vitamin solution see Medium No. 403,preferred_term,kgmicrobe.ingredient:vitamin_solution_see_medium_no_403,Vitamin solution see Medium No. 403,MICRO:0000460,MAPPED,unique
+VitaminB12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unique
+Vitamine B12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unique
+vitamins B1,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+vitamins B12,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unique
+Vitamins solution,preferred_term,kgmicrobe.ingredient:vitamins_solution,Vitamins solution,kgmicrobe.ingredient:vitamins_solution,MAPPED,unique
+Vitamins solution,ontology_label,kgmicrobe.ingredient:vitamins_solution,Vitamins-solution,kgmicrobe.ingredient:vitamins_solution,REJECTED,unique
+Vitamins-solution,preferred_term,kgmicrobe.ingredient:vitamins_solution,Vitamins-solution,kgmicrobe.ingredient:vitamins_solution,REJECTED,unique
+Vitamins-solution,synonym,kgmicrobe.ingredient:vitamins_solution,Vitamins solution,kgmicrobe.ingredient:vitamins_solution,MAPPED,unique
+Vitamin B12  (4),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Vitamin B12  (4),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Vitamin B12  (8),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Vitamin B12  (8),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Vitamin B12  (9),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
+Vitamin B12  (9),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Vitox,preferred_term,kgmicrobe.ingredient:vitox,Vitox,kgmicrobe.ingredient:vitox,MAPPED,unique
+Volvox Medium,preferred_term,UNMAPPED_0072,Volvox Medium,,UNMAPPED,unique
+VOSO4 . 2H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4 . 5H2O,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+VOSO4 x 2 H2O,preferred_term,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4 x 5 H2O,preferred_term,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+VOSO4 x 5 H2O (0.01% w/v),synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+VOSO4 x H2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4 x n H2O,preferred_term,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4 · 2 H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4(H2O)n,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4(H2O)x,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4.2H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4.5H2O,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
+VOSO4.nH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4.xH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4·2 H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4·2H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4·xH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+Vulgamycin,preferred_term,mesh:C012306,Vulgamycin,mesh:C012306,MAPPED,unique
+Vulpinic acid,preferred_term,CHEBI:144250,Vulpinic acid,CHEBI:144250,MAPPED,unique
+Wako Isomaltooligosaccharides,preferred_term,UNMAPPED_0222,Wako Isomaltooligosaccharides,,UNMAPPED,unique
+Warfarin,preferred_term,CHEBI:10033,Warfarin,CHEBI:10033,MAPPED,unique
+Waris Medium,preferred_term,UNMAPPED_0063,Waris Medium,,UNMAPPED,unique
+Wasser,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Wasserstoffchlorid,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+WATER,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+water distilled or tapwater,preferred_term,UNMAPPED_0575,water distilled or tapwater,,UNMAPPED,unique
+WC Trace Elements Solution,preferred_term,MICRO:0000455,WC Trace Elements Solution,MICRO:0000455,MAPPED,unique
+Weinsteinsaeure,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+Wheat Arabinoxylan,preferred_term,CHEBI:28427,Wheat Arabinoxylan,CHEBI:28427,MAPPED,unique
+Wheat Grains,preferred_term,UNMAPPED_0576,Wheat Grains,,UNMAPPED,unique
+White sugar,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+White wine,preferred_term,NCIT:C84877,White wine,NCIT:C84877,MAPPED,unique
+Whole egg,preferred_term,UNMAPPED_0577,Whole egg,,UNMAPPED,unique
+Whole eggs,synonym,UNMAPPED_0577,Whole egg,,UNMAPPED,unique
+Wilkins Chalgrene Anaerobe Broth,preferred_term,UNMAPPED_0578,Wilkins Chalgrene Anaerobe Broth,,UNMAPPED,unique
+Wilkins-Chalgren-Anaerobe-Broth,preferred_term,UNMAPPED_0579,Wilkins-Chalgren-Anaerobe-Broth,,UNMAPPED,unique
+Wolfe's mineral mix,preferred_term,kgmicrobe.ingredient:wolfes_mineral_mix,Wolfe's mineral mix,kgmicrobe.ingredient:wolfes_mineral_mix,MAPPED,unique
+Wolfe's mineral mix_minus_Nitrilotriacetic_acid,preferred_term,kgmicrobe.ingredient:wolfes_mineral_mix_minus_nitrilotriacetic_acid,Wolfe's mineral mix_minus_Nitrilotriacetic_acid,kgmicrobe.ingredient:wolfes_mineral_mix_minus_nitrilotriacetic_acid,MAPPED,unique
+Wolfe's vitamin mix,preferred_term,kgmicrobe.ingredient:wolfes_vitamin_mix,Wolfe's vitamin mix,kgmicrobe.ingredient:wolfes_vitamin_mix,MAPPED,unique
+Wolframat,synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+wolframate,synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
+wood alcohol,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+wood naphtha,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+wood spirit,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+X,preferred_term,UNMAPPED_0818,X,,UNMAPPED,unique
+X10 Jamarin S,preferred_term,kgmicrobe.ingredient:x10_jamarin_s,X10 Jamarin S,kgmicrobe.ingredient:x10_jamarin_s,MAPPED,unique
+Xan,synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+Xanthan,preferred_term,CHEBI:189560,Xanthan,CHEBI:189560,MAPPED,unique
+Xanthan from Xanthomonas campestris,preferred_term,cas:11138-66-2,Xanthan from Xanthomonas campestris,mesh:D016959,MAPPED,unique
+Xanthine,preferred_term,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
+xanthine 9-beta-D-ribofuranoside,synonym,CHEBI:18107,Xanthosine,CHEBI:18107,MAPPED,unique
+Xanthine riboside,synonym,CHEBI:18107,Xanthosine,CHEBI:18107,MAPPED,unique
+Xanthocidin,preferred_term,kgmicrobe.compound:xanthocidin,Xanthocidin,kgmicrobe.compound:xanthocidin,MAPPED,unique
+Xanthomonas campestris,ontology_label,cas:11138-66-2,Xanthan from Xanthomonas campestris,mesh:D016959,MAPPED,unique
+Xanthosine,preferred_term,CHEBI:18107,Xanthosine,CHEBI:18107,MAPPED,unique
+Xanthyletin,preferred_term,CHEBI:10073,Xanthyletin,CHEBI:10073,MAPPED,unique
+xi-5-Dodecanolide,ontology_label,CHEBI:171817,Delta-Dodecalactone,CHEBI:171817,MAPPED,unique
+Xyl,synonym,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
+Xylan,preferred_term,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
+Xylan (hemicellulose substrate),synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
+Xylan from Beechwood,preferred_term,CHEBI:15447,Xylan from Beechwood,CHEBI:15447,MAPPED,unique
+xylans,synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
+Xylit,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+xylite,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+Xylitol,preferred_term,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
+xylo-pentose,synonym,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
+Xylobiose,preferred_term,CHEBI:28309,Xylobiose,CHEBI:28309,MAPPED,unique
+xyloglucan,ontology_label,UNMAPPED_0174,Xyloglucan (hepta+octa+nona saccharides),CHEBI:18233,UNMAPPED,unique
+Xyloglucan (hepta+octa+nona saccharides),preferred_term,UNMAPPED_0174,Xyloglucan (hepta+octa+nona saccharides),CHEBI:18233,UNMAPPED,unique
+Xyloglucan from tamarind,preferred_term,cas:37294-28-3,Xyloglucan from tamarind,cas:37294-28-3,MAPPED,unique
+Xylose,preferred_term,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
+Xylotetraose,preferred_term,CHEBI:62972,Xylotetraose,CHEBI:62972,MAPPED,unique
+Xylotriose,preferred_term,CHEBI:149429,Xylotriose,CHEBI:149429,MAPPED,unique
+Yacontrol (Yacon root syrup),preferred_term,UNMAPPED_0208,Yacontrol (Yacon root syrup),,UNMAPPED,unique
+Yeast + Meat Extract + H2,preferred_term,kgmicrobe.ingredient:yeast_meat_extract_h2,Yeast + Meat Extract + H2,kgmicrobe.ingredient:yeast_meat_extract_h2,MAPPED,unique
+Yeast cell paste,preferred_term,UNMAPPED_0581,Yeast cell paste,,UNMAPPED,unique
+Yeast extract,preferred_term,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+yeast extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract (0.01 %,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (BBL),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract (BD 211928),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract (BD 212750),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (BD Bacto),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+yeast extract (BD Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+"Yeast Extract (BD, 212750)",synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (BD--Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (BD-BBL),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (BD-Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+yeast extract (BD-Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (Difco or Oxoid),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+yeast extract (Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract (Hardy C7340),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+"yeast extract (Nacalai Tesque, Kyoto, Japan)",synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+"Yeast extract (Oxoid LP0021, BD 212750)",synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (OXOID),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract (Oxoid),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract + Gluconate,preferred_term,kgmicrobe.ingredient:yeast_extract_gluconate,Yeast Extract + Gluconate,kgmicrobe.ingredient:yeast_extract_gluconate,MAPPED,unique
+Yeast Extract + Glucose,preferred_term,kgmicrobe.ingredient:yeast_extract_glucose,Yeast Extract + Glucose,kgmicrobe.ingredient:yeast_extract_glucose,MAPPED,unique
+Yeast Extract + Peptone,preferred_term,kgmicrobe.ingredient:yeast_extract_peptone,Yeast Extract + Peptone,kgmicrobe.ingredient:yeast_extract_peptone,MAPPED,unique
+Yeast Extract + Sulfur,preferred_term,kgmicrobe.ingredient:yeast_extract_sulfur,Yeast Extract + Sulfur,kgmicrobe.ingredient:yeast_extract_sulfur,MAPPED,unique
+"Yeast extract(Bacto, Difco)",synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract(CAS: 8013-01-2),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast Extract(Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract(Oxoid),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Yeast extract-malt extract agar,preferred_term,kgmicrobe.ingredient:yeast_extract_malt_extract_agar,Yeast extract-malt extract agar,FOODON:03301056,MAPPED,unique
+YM broth,preferred_term,UNMAPPED_0583,YM broth,,UNMAPPED,unique
+Zafirlukast,preferred_term,CHEBI:10100,Zafirlukast,CHEBI:10100,MAPPED,unique
+Zeikus trace element solution,preferred_term,NCIT:C896,Zeikus trace element solution,NCIT:C896,MAPPED,unique
+Zerenex,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Zetan,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+Zinc Chloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+zinc dichloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+Zinc Pyrithione,preferred_term,CHEBI:32076,Zinc Pyrithione,CHEBI:32076,MAPPED,unique
+Zinc sulfate,preferred_term,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+zinc sulfate (1:1),synonym,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+zinc sulfate (1:1) heptahydrate,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+Zinc sulfate heptahydrate,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+zinc sulfate heptahydrate (1:1:7),synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+zinc sulfate hexahydrate,synonym,CHEBI:132762,ZnSO4 x 6 H2O,CHEBI:132762,MAPPED,unique
+zinc sulfate--water (1/6),synonym,CHEBI:132762,ZnSO4 x 6 H2O,CHEBI:132762,MAPPED,unique
+zinc sulphate,synonym,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+zinc(2+) chloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+zinc(2+) sulfate,synonym,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+zinc(2+) sulfate heptahydrate,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+zinc(2+) sulfate--water (1/7),synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+zinc(II) chloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+zinc(II) sulfate,synonym,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+Zinc-NTA,preferred_term,UNMAPPED_0150,Zinc-NTA,,UNMAPPED,unique
+Zinkchlorid,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+ZMB,preferred_term,UNMAPPED_0290,ZMB,,UNMAPPED,unique
+ZMB_ALS,preferred_term,UNMAPPED_0272,ZMB_ALS,,UNMAPPED,unique
+Zn2SO4·7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnCl,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+ZnCl 2,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+ZnCl2,preferred_term,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+ZnSO .7H O,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
+ZnSO4,synonym,CHEBI:35176,Zinc sulfate,CHEBI:35176,MAPPED,unique
+ZnSO4 . 7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 .7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 x 6 H2O,preferred_term,CHEBI:132762,ZnSO4 x 6 H2O,CHEBI:132762,MAPPED,unique
+ZnSO4 x 7 H2O,preferred_term,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 x 7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 · 7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 × 7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4 ⋅ 7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4*7 H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4*7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4-7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4.6H2O,synonym,CHEBI:132762,ZnSO4 x 6 H2O,CHEBI:132762,MAPPED,unique
+ZnSO4.7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4·7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4∙7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4⋅7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4・7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+ZnSO4･7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+Zykloheximid,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
+Zymosan,preferred_term,cas:9010-72-4,Zymosan,NCIT:C183132,MAPPED,unique
+Zystein,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+Zytidin,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
+Zytosin,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+"{(1R,2R)-3-oxo-2-[(2Z)-pent-2-en-1-yl]cyclopentyl}acetic acid",synonym,CHEBI:18292,Jasmonic acid,CHEBI:18292,MAPPED,unique
+{[4-(trifluoromethoxy)phenyl]hydrazono}malononitrile,synonym,CHEBI:75458,FCCP,CHEBI:75458,MAPPED,unique
+ß-NAD,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+ß-nicotinamide adenine dinucleotide,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+α-D-Glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
+α-D-Glucose monohydrate,preferred_term,UNMAPPED_0587,α-D-Glucose monohydrate,,UNMAPPED,unique
+α-lipoic acid,preferred_term,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+α-Methylbutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
+α1-Acid Glycoprotein from bovine plasma,preferred_term,cas:66455-27-4,α1-Acid Glycoprotein from bovine plasma,cas:66455-27-4,MAPPED,unique

--- a/src/culturemech/data/mediaingredientmech/label_index.metadata.json
+++ b/src/culturemech/data/mediaingredientmech/label_index.metadata.json
@@ -1,0 +1,18 @@
+{
+  "byte_count": 854426,
+  "consumer_contract_version": 1,
+  "data_row_count": 9115,
+  "header": [
+    "label",
+    "match_type",
+    "identifier",
+    "preferred_term",
+    "ontology_id",
+    "mapping_status",
+    "ambiguity"
+  ],
+  "repository": "https://github.com/CultureBotAI/MediaIngredientMech",
+  "sha256": "7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac",
+  "source_commit": "82694054f5bbf74b5392bf8858c9962c2152a35a",
+  "source_path": "docs/data/label_index.csv"
+}

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -21,16 +21,16 @@ Primary Edges:
    - Object: Solution
    - Qualifiers: concentration (volume added)
 
-3. Solution → has_part (biolink:has_part) → Ingredient (CHEBI)
+3. Solution → has_part (biolink:has_part) → Ingredient (MIM-resolved identity)
    - Subject: Solution
    - Predicate: biolink:has_part
-   - Object: Ingredient (CHEBI ID)
+   - Object: Ingredient (MIM-resolved ontology or registry CURIE)
    - Qualifiers: concentration, role
 
-4. Medium → has_part (biolink:has_part) → Ingredient (CHEBI)
+4. Medium → has_part (biolink:has_part) → Ingredient (MIM-resolved identity)
    - Subject: Medium
    - Predicate: biolink:has_part
-   - Object: Ingredient (CHEBI ID)
+   - Object: Ingredient (MIM-resolved ontology or registry CURIE)
    - Qualifiers: concentration, role
 
 5. Medium → has_attribute (biolink:has_attribute) → Medium Type
@@ -49,9 +49,11 @@ Legacy Edges (for backward compatibility):
 """
 
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from typing import Any
+
+from culturemech.ingredients.mim_label_index import GroundingDecision, resolve_ingredient
 
 try:
     import koza
@@ -83,7 +85,13 @@ HAS_SOLUTION_COMPONENT = "biolink:has_part"  # For medium→solution (also uses 
 # ================================================================
 
 
-def transform(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
+IngredientResolver = Callable[[Mapping[str, Any]], GroundingDecision]
+
+
+def transform(
+    record: dict[str, Any],
+    ingredient_resolver: IngredientResolver = resolve_ingredient,
+) -> Iterator[dict[str, Any]]:
     """
     Pure transform function - testable without Koza.
 
@@ -120,13 +128,17 @@ def transform(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
         # Extract ingredients from solution composition
         solution_id = _create_solution_id(solution.get("preferred_term", ""))
         for ingredient in solution.get("composition", []):
-            edge = solution_to_ingredient_edge(solution_id, ingredient)
+            edge = solution_to_ingredient_edge(
+                solution_id, ingredient, ingredient_resolver=ingredient_resolver
+            )
             if edge:
                 yield edge
 
     # Edge Type 4: Medium → Ingredient (has_part)
     for ingredient in record.get("ingredients", []):
-        edge = medium_to_ingredient_edge(medium_id, ingredient)
+        edge = medium_to_ingredient_edge(
+            medium_id, ingredient, ingredient_resolver=ingredient_resolver
+        )
         if edge:
             yield edge
 
@@ -452,14 +464,18 @@ def medium_to_solution_edge(medium_id: str, solution: dict) -> dict | None:
     )
 
 
-def solution_to_ingredient_edge(solution_id: str, ingredient: dict) -> dict | None:
+def solution_to_ingredient_edge(
+    solution_id: str,
+    ingredient: dict,
+    ingredient_resolver: IngredientResolver = resolve_ingredient,
+) -> dict | None:
     """
-    Solution → has_part (biolink:has_part) → Ingredient (CHEBI)
+    Solution → has_part (biolink:has_part) → Ingredient (MIM-resolved identity)
 
     Following cmm-ai-automation pattern:
     - subject: solution
     - predicate: biolink:has_part
-    - object: ingredient (CHEBI ID)
+    - object: ingredient (ontology, registry, or curated identity)
 
     Qualifiers:
     - concentration: amount in solution
@@ -467,7 +483,7 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: dict) -> dict | No
 
     Data preserved: Chemical ID, concentration, role
     """
-    chem_id = _get_term_id(ingredient, ["term", "id"])
+    chem_id = _resolved_ingredient_id(ingredient, ingredient_resolver)
     if not chem_id:
         return None
 
@@ -504,14 +520,18 @@ def solution_to_ingredient_edge(solution_id: str, ingredient: dict) -> dict | No
     )
 
 
-def medium_to_ingredient_edge(medium_id: str, ingredient: dict) -> dict | None:
+def medium_to_ingredient_edge(
+    medium_id: str,
+    ingredient: dict,
+    ingredient_resolver: IngredientResolver = resolve_ingredient,
+) -> dict | None:
     """
-    Medium → has_part (biolink:has_part) → Ingredient (CHEBI)
+    Medium → has_part (biolink:has_part) → Ingredient (MIM-resolved identity)
 
     Following cmm-ai-automation pattern (renamed from ingredient_to_edge):
     - subject: medium
     - predicate: biolink:has_part
-    - object: ingredient (CHEBI ID)
+    - object: ingredient (ontology, registry, or curated identity)
 
     Qualifiers:
     - concentration: amount
@@ -520,7 +540,7 @@ def medium_to_ingredient_edge(medium_id: str, ingredient: dict) -> dict | None:
     Data preserved: Chemical ID, concentration, role
     Data lost: Supplier info, preparation notes, chemical formula
     """
-    chem_id = _get_term_id(ingredient, ["term", "id"])
+    chem_id = _resolved_ingredient_id(ingredient, ingredient_resolver)
     if not chem_id:
         return None
 
@@ -583,7 +603,11 @@ def medium_to_type_edge(medium_id: str, medium_type: str) -> dict | None:
     )
 
 
-def ingredient_to_edge(medium_id: str, ingredient: dict) -> dict | None:
+def ingredient_to_edge(
+    medium_id: str,
+    ingredient: dict,
+    ingredient_resolver: IngredientResolver = resolve_ingredient,
+) -> dict | None:
     """
     Medium (culturemech:LB_Broth) → has_part → Glucose (CHEBI:17234)
 
@@ -593,7 +617,7 @@ def ingredient_to_edge(medium_id: str, ingredient: dict) -> dict | None:
     Data preserved: Chemical ID, concentration
     Data lost: Supplier info, preparation notes, chemical formula
     """
-    chem_id = _get_term_id(ingredient, ["term", "id"])
+    chem_id = _resolved_ingredient_id(ingredient, ingredient_resolver)
     if not chem_id:
         return None
 
@@ -760,6 +784,14 @@ def _get_term_id(data: dict, path: list[str]) -> str | None:
         if current is None:
             return None
     return current
+
+
+def _resolved_ingredient_id(
+    ingredient: Mapping[str, Any], ingredient_resolver: IngredientResolver
+) -> str | None:
+    """Resolve an ingredient through MIM, retaining local identity only as fallback."""
+
+    return ingredient_resolver(ingredient).identifier
 
 
 def _format_evidence(evidence_items: list[dict] | None) -> tuple:

--- a/src/culturemech/ingredients/__init__.py
+++ b/src/culturemech/ingredients/__init__.py
@@ -1,0 +1,17 @@
+"""Ingredient identity resolution shared by CultureMech consumers."""
+
+from culturemech.ingredients.mim_label_index import (
+    GroundingDecision,
+    MIMLabelIndex,
+    ResolutionSource,
+    get_default_mim_label_index,
+    resolve_ingredient,
+)
+
+__all__ = [
+    "GroundingDecision",
+    "MIMLabelIndex",
+    "ResolutionSource",
+    "get_default_mim_label_index",
+    "resolve_ingredient",
+]

--- a/src/culturemech/ingredients/mim_label_index.py
+++ b/src/culturemech/ingredients/mim_label_index.py
@@ -1,0 +1,560 @@
+"""Resolve recipe ingredient labels through MIM's pinned label index.
+
+MediaIngredientMech (MIM) publishes ``docs/data/label_index.csv`` specifically
+for label-to-identity resolution.  CultureMech vendors one immutable revision
+of that artifact so normal builds are offline and reproducible.  The resolver
+implements MIM's row-order and ambiguity contract; it never fuzzy-matches and
+never treats ``ontology_id`` as the selected identity.
+
+Hydration state is identity-significant.  Exact matching is tried first.  The
+only weaker normalization collapses whitespace, ASCII hyphen, and underscore;
+digits and chemical punctuation are preserved.  A weak collision is accepted
+only when every matching MIM label group independently yields the same safe
+answer.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import re
+import unicodedata
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import Enum
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+INDEX_HEADER = (
+    "label",
+    "match_type",
+    "identifier",
+    "preferred_term",
+    "ontology_id",
+    "mapping_status",
+    "ambiguity",
+)
+MATCH_TYPES = frozenset({"preferred_term", "synonym", "ontology_label"})
+MAPPING_STATUSES = frozenset({"MAPPED", "UNMAPPED", "REJECTED"})
+SAFE_AMBIGUITIES = frozenset({"unique", "resolved:owned", "agree:same_substance"})
+AMBIGUITIES = SAFE_AMBIGUITIES | frozenset(
+    {
+        "conflict:different_substances",
+        "unresolved:partial_chemistry",
+        "unresolved:no_chemistry",
+    }
+)
+
+CONTRACT_VERSION = 1
+MIM_REPOSITORY = "https://github.com/CultureBotAI/MediaIngredientMech"
+MIM_SOURCE_PATH = "docs/data/label_index.csv"
+_RESOURCE_DIR = ("data", "mediaingredientmech")
+_INDEX_NAME = "label_index.csv"
+_METADATA_NAME = "label_index.metadata.json"
+_FULL_SHA = re.compile(r"[0-9a-f]{40}\Z")
+_WEAK_SEPARATORS = re.compile(r"[\s\-_]+")
+
+
+class LabelIndexError(ValueError):
+    """The pinned artifact or its consumption contract is invalid."""
+
+
+class ResolutionSource(str, Enum):
+    """How the final ingredient identity was selected."""
+
+    MIM_EXACT = "mim_exact"
+    MIM_NORMALIZED = "mim_normalized"
+    AUTHORITATIVE_UNMAPPED = "authoritative_unmapped"
+    LOCAL_FALLBACK = "local_fallback"
+    AMBIGUOUS_LOCAL_FALLBACK = "ambiguous_local_fallback"
+    AMBIGUOUS = "ambiguous"
+    NOT_FOUND = "not_found"
+
+
+@dataclass(frozen=True)
+class LabelIndexRow:
+    """One row in MIM's ordered label index."""
+
+    label: str
+    match_type: str
+    identifier: str
+    preferred_term: str
+    ontology_id: str
+    mapping_status: str
+    ambiguity: str
+
+
+@dataclass(frozen=True)
+class GroundingDecision:
+    """A resolver result, including enough provenance to audit the choice."""
+
+    query_label: str
+    identifier: str | None
+    ontology_id: str | None
+    mim_preferred_term: str | None
+    matched_label: str | None
+    match_type: str | None
+    mapping_status: str | None
+    ambiguity: str | None
+    resolution_source: ResolutionSource
+    local_identifier: str | None
+    source_compound_id: str | None
+    reason: str
+
+    @property
+    def is_resolved(self) -> bool:
+        """Whether this decision selects an identity for KG publication."""
+
+        return self.identifier is not None
+
+
+def strong_label_key(value: str) -> str:
+    """Case-insensitive exact key with whitespace trim and Unicode NFC only."""
+
+    return unicodedata.normalize("NFC", value).strip().casefold()
+
+
+def weak_label_key(value: str) -> str:
+    """Weak key that preserves formula punctuation and all hydration digits."""
+
+    return _WEAK_SEPARATORS.sub(" ", strong_label_key(value)).strip()
+
+
+class MIMLabelIndex:
+    """Immutable in-memory view of MIM's ordered per-label decisions."""
+
+    def __init__(
+        self,
+        rows: Sequence[LabelIndexRow],
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not rows:
+            raise LabelIndexError("MIM label index has no data rows")
+        _validate_row_sequence(rows)
+        _validate_rejected_targets(rows)
+
+        groups: dict[str, list[LabelIndexRow]] = defaultdict(list)
+        group_order: list[str] = []
+        for row in rows:
+            key = strong_label_key(row.label)
+            if key not in groups:
+                group_order.append(key)
+            groups[key].append(row)
+
+        weak_groups: dict[str, list[str]] = defaultdict(list)
+        for key in group_order:
+            weak = weak_label_key(groups[key][0].label)
+            if key not in weak_groups[weak]:
+                weak_groups[weak].append(key)
+
+        self.rows = tuple(rows)
+        self.metadata = dict(metadata or {})
+        self._groups = {key: tuple(group) for key, group in groups.items()}
+        self._weak_groups = {key: tuple(value) for key, value in weak_groups.items()}
+        self._live_identifiers = frozenset(
+            row.identifier for row in rows if row.mapping_status == "MAPPED"
+        )
+
+    @classmethod
+    def from_csv_bytes(
+        cls,
+        data: bytes,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        verify_metadata: bool = False,
+    ) -> MIMLabelIndex:
+        """Parse bytes, optionally enforcing the immutable-pin metadata."""
+
+        if verify_metadata:
+            if metadata is None:
+                raise LabelIndexError("metadata is required when verify_metadata=True")
+            _verify_metadata(data, metadata)
+        rows = _parse_csv(data)
+        if metadata is not None:
+            expected_rows = metadata.get("data_row_count")
+            if not isinstance(expected_rows, int) or expected_rows != len(rows):
+                raise LabelIndexError(
+                    "metadata data_row_count does not match label index: "
+                    f"{expected_rows!r} != {len(rows)}"
+                )
+        return cls(rows, metadata=metadata)
+
+    @classmethod
+    def from_csv_text(cls, text: str) -> MIMLabelIndex:
+        """Build a resolver from an in-memory CSV fixture."""
+
+        return cls.from_csv_bytes(text.encode("utf-8"))
+
+    @classmethod
+    def from_paths(cls, index_path: Path, metadata_path: Path) -> MIMLabelIndex:
+        """Load and verify a filesystem-backed pinned artifact."""
+
+        data = index_path.read_bytes()
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        return cls.from_csv_bytes(data, metadata=metadata, verify_metadata=True)
+
+    @classmethod
+    def from_package(cls) -> MIMLabelIndex:
+        """Load and verify the label index shipped inside the wheel."""
+
+        root = resources.files("culturemech")
+        for component in _RESOURCE_DIR:
+            root = root.joinpath(component)
+        data = root.joinpath(_INDEX_NAME).read_bytes()
+        metadata = json.loads(root.joinpath(_METADATA_NAME).read_text(encoding="utf-8"))
+        return cls.from_csv_bytes(data, metadata=metadata, verify_metadata=True)
+
+    def resolve(self, ingredient: Mapping[str, Any]) -> GroundingDecision:
+        """Resolve one IngredientDescriptor, with local terms as fallback only."""
+
+        label_value = ingredient.get("preferred_term")
+        label = label_value if isinstance(label_value, str) else ""
+        local_identifier, source_compound_id = _local_identifiers(ingredient)
+        return self.resolve_label(
+            label,
+            local_identifier=local_identifier,
+            source_compound_id=source_compound_id,
+        )
+
+    def resolve_label(
+        self,
+        label: str,
+        *,
+        local_identifier: str | None = None,
+        source_compound_id: str | None = None,
+    ) -> GroundingDecision:
+        """Resolve a label, retaining explicit local/source identity diagnostics."""
+
+        exact = self._groups.get(strong_label_key(label)) if label.strip() else None
+        if exact:
+            return self._decision_for_groups(
+                label,
+                (exact,),
+                ResolutionSource.MIM_EXACT,
+                local_identifier,
+                source_compound_id,
+            )
+
+        weak_keys = self._weak_groups.get(weak_label_key(label), ()) if label.strip() else ()
+        if weak_keys:
+            groups = tuple(self._groups[key] for key in weak_keys)
+            return self._decision_for_groups(
+                label,
+                groups,
+                ResolutionSource.MIM_NORMALIZED,
+                local_identifier,
+                source_compound_id,
+            )
+
+        if local_identifier:
+            return _local_decision(
+                label,
+                local_identifier,
+                source_compound_id,
+                source=ResolutionSource.LOCAL_FALLBACK,
+                reason="label not found in pinned MIM index; retained local identity",
+            )
+        return GroundingDecision(
+            query_label=label,
+            identifier=None,
+            ontology_id=None,
+            mim_preferred_term=None,
+            matched_label=None,
+            match_type=None,
+            mapping_status=None,
+            ambiguity=None,
+            resolution_source=ResolutionSource.NOT_FOUND,
+            local_identifier=None,
+            source_compound_id=source_compound_id,
+            reason="label not found in pinned MIM index and no usable local identity",
+        )
+
+    def semantic_answers(self) -> dict[str, tuple[str | None, str, str]]:
+        """Stable exact-label signatures used to review dependency refreshes."""
+
+        answers: dict[str, tuple[str | None, str, str]] = {}
+        for key, group in self._groups.items():
+            state, row = self._group_state(group)
+            identifier = row.identifier if state == "mapped" else None
+            answers[key] = (identifier, state, row.ambiguity)
+        return answers
+
+    def _decision_for_groups(
+        self,
+        query_label: str,
+        groups: Sequence[Sequence[LabelIndexRow]],
+        mapped_source: ResolutionSource,
+        local_identifier: str | None,
+        source_compound_id: str | None,
+    ) -> GroundingDecision:
+        states = [self._group_state(group) for group in groups]
+        representative = states[0][1]
+
+        if all(state == "mapped" for state, _row in states):
+            identifiers = {row.identifier for _state, row in states}
+            if len(identifiers) == 1:
+                return _mim_decision(
+                    query_label,
+                    representative,
+                    representative.identifier,
+                    mapped_source,
+                    local_identifier,
+                    source_compound_id,
+                    "trusted MIM label-index answer",
+                )
+
+        if all(state == "unmapped" for state, _row in states):
+            return _mim_decision(
+                query_label,
+                representative,
+                None,
+                ResolutionSource.AUTHORITATIVE_UNMAPPED,
+                local_identifier,
+                source_compound_id,
+                "MIM explicitly leaves this label unmapped; local grounding suppressed",
+            )
+
+        reason = (
+            "MIM label is chemically ambiguous"
+            if len(groups) == 1
+            else "weak normalization reaches incompatible MIM label groups"
+        )
+        if local_identifier:
+            decision = _local_decision(
+                query_label,
+                local_identifier,
+                source_compound_id,
+                source=ResolutionSource.AMBIGUOUS_LOCAL_FALLBACK,
+                reason=f"{reason}; retained explicitly labelled local fallback",
+            )
+            return replace(
+                decision,
+                ontology_id=representative.ontology_id or None,
+                mim_preferred_term=representative.preferred_term,
+                matched_label=representative.label,
+                match_type=representative.match_type,
+                mapping_status=representative.mapping_status,
+                ambiguity=representative.ambiguity,
+            )
+        return _mim_decision(
+            query_label,
+            representative,
+            None,
+            ResolutionSource.AMBIGUOUS,
+            None,
+            source_compound_id,
+            f"{reason}; failed closed",
+        )
+
+    def _group_state(self, group: Sequence[LabelIndexRow]) -> tuple[str, LabelIndexRow]:
+        first = group[0]
+        if first.ambiguity not in SAFE_AMBIGUITIES:
+            return "ambiguous", first
+        if first.mapping_status == "MAPPED":
+            return "mapped", first
+        if first.mapping_status == "UNMAPPED":
+            return "unmapped", first
+        if first.identifier.startswith("UNMAPPED_"):
+            return "unmapped", first
+        if first.identifier in self._live_identifiers:
+            return "mapped", first
+        return "ambiguous", first  # constructor validation makes this defensive only
+
+
+def _mim_decision(
+    query_label: str,
+    row: LabelIndexRow,
+    identifier: str | None,
+    source: ResolutionSource,
+    local_identifier: str | None,
+    source_compound_id: str | None,
+    reason: str,
+) -> GroundingDecision:
+    return GroundingDecision(
+        query_label=query_label,
+        identifier=identifier,
+        ontology_id=row.ontology_id or None,
+        mim_preferred_term=row.preferred_term,
+        matched_label=row.label,
+        match_type=row.match_type,
+        mapping_status=row.mapping_status,
+        ambiguity=row.ambiguity,
+        resolution_source=source,
+        local_identifier=local_identifier,
+        source_compound_id=source_compound_id,
+        reason=reason,
+    )
+
+
+def _local_decision(
+    label: str,
+    identifier: str,
+    source_compound_id: str | None,
+    *,
+    source: ResolutionSource,
+    reason: str,
+) -> GroundingDecision:
+    return GroundingDecision(
+        query_label=label,
+        identifier=identifier,
+        ontology_id=None,
+        mim_preferred_term=None,
+        matched_label=None,
+        match_type=None,
+        mapping_status=None,
+        ambiguity=None,
+        resolution_source=source,
+        local_identifier=identifier,
+        source_compound_id=source_compound_id,
+        reason=reason,
+    )
+
+
+def _nested_identifier(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    identifier = value.get("id")
+    if not isinstance(identifier, str) or not identifier.strip():
+        return None
+    return identifier.strip()
+
+
+def _is_source_compound(identifier: str) -> bool:
+    return identifier.casefold().startswith("mediadive.compound:")
+
+
+def _local_identifiers(ingredient: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    term_id = _nested_identifier(ingredient.get("term"))
+    chebi_term_id = _nested_identifier(ingredient.get("chebi_term"))
+    source_compound_id = term_id if term_id and _is_source_compound(term_id) else None
+
+    if chebi_term_id and not _is_source_compound(chebi_term_id):
+        return chebi_term_id, source_compound_id
+    if term_id and not _is_source_compound(term_id):
+        return term_id, source_compound_id
+    return None, source_compound_id
+
+
+def _parse_csv(data: bytes) -> list[LabelIndexRow]:
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise LabelIndexError("MIM label index is not UTF-8") from exc
+    reader = csv.DictReader(io.StringIO(text, newline=""))
+    if tuple(reader.fieldnames or ()) != INDEX_HEADER:
+        raise LabelIndexError(
+            f"unexpected MIM label-index header: {reader.fieldnames!r}; expected {INDEX_HEADER!r}"
+        )
+
+    rows: list[LabelIndexRow] = []
+    for line_number, raw in enumerate(reader, start=2):
+        if None in raw:
+            raise LabelIndexError(f"row {line_number} has columns beyond the contract header")
+        row = LabelIndexRow(**{field: raw[field] for field in INDEX_HEADER})
+        _validate_row(row, line_number)
+        rows.append(row)
+    return rows
+
+
+def _validate_row(row: LabelIndexRow, line_number: int) -> None:
+    for field in ("label", "identifier", "preferred_term"):
+        if not getattr(row, field).strip():
+            raise LabelIndexError(f"row {line_number} has an empty {field}")
+    if row.match_type not in MATCH_TYPES:
+        raise LabelIndexError(f"row {line_number} has unknown match_type {row.match_type!r}")
+    if row.mapping_status not in MAPPING_STATUSES:
+        raise LabelIndexError(
+            f"row {line_number} has unknown mapping_status {row.mapping_status!r}"
+        )
+    if row.ambiguity not in AMBIGUITIES:
+        raise LabelIndexError(f"row {line_number} has unknown ambiguity {row.ambiguity!r}")
+
+
+def _validate_row_sequence(rows: Sequence[LabelIndexRow]) -> None:
+    closed: set[str] = set()
+    current: str | None = None
+    group_ambiguity: str | None = None
+    for position, row in enumerate(rows, start=2):
+        key = strong_label_key(row.label)
+        if not key:
+            raise LabelIndexError(f"row {position} has an empty normalized label")
+        if key != current:
+            if current is not None:
+                closed.add(current)
+            if key in closed:
+                raise LabelIndexError(
+                    f"label group {row.label!r} is not contiguous at row {position}"
+                )
+            current = key
+            group_ambiguity = row.ambiguity
+        elif row.ambiguity != group_ambiguity:
+            raise LabelIndexError(
+                f"label group {row.label!r} has inconsistent ambiguity at row {position}"
+            )
+
+
+def _validate_rejected_targets(rows: Sequence[LabelIndexRow]) -> None:
+    """Require every merge tombstone to point at a live published identity."""
+
+    live_identifiers = {row.identifier for row in rows if row.mapping_status == "MAPPED"}
+    dangling = sorted(
+        {
+            row.identifier
+            for row in rows
+            if row.mapping_status == "REJECTED"
+            and not row.identifier.startswith("UNMAPPED_")
+            and row.identifier not in live_identifiers
+        }
+    )
+    if dangling:
+        preview = ", ".join(dangling[:10])
+        suffix = f" (+{len(dangling) - 10} more)" if len(dangling) > 10 else ""
+        raise LabelIndexError(
+            "REJECTED merge tombstone identifier is not held by a live MAPPED row: "
+            f"{preview}{suffix}"
+        )
+
+
+def _verify_metadata(data: bytes, metadata: Mapping[str, Any]) -> None:
+    if metadata.get("consumer_contract_version") != CONTRACT_VERSION:
+        raise LabelIndexError(
+            "unsupported MIM label-index consumer contract version: "
+            f"{metadata.get('consumer_contract_version')!r}"
+        )
+    if metadata.get("repository") != MIM_REPOSITORY:
+        raise LabelIndexError(f"unexpected MIM repository: {metadata.get('repository')!r}")
+    if metadata.get("source_path") != MIM_SOURCE_PATH:
+        raise LabelIndexError(f"unexpected MIM source path: {metadata.get('source_path')!r}")
+    source_commit = metadata.get("source_commit")
+    if not isinstance(source_commit, str) or not _FULL_SHA.fullmatch(source_commit):
+        raise LabelIndexError("source_commit must be a full lowercase 40-character Git SHA")
+    if metadata.get("header") != list(INDEX_HEADER):
+        raise LabelIndexError("metadata header does not match the consumer contract")
+    if metadata.get("byte_count") != len(data):
+        raise LabelIndexError(
+            f"metadata byte_count does not match artifact: {metadata.get('byte_count')!r} != {len(data)}"
+        )
+    actual_digest = hashlib.sha256(data).hexdigest()
+    if metadata.get("sha256") != actual_digest:
+        raise LabelIndexError(
+            f"metadata sha256 does not match artifact: {metadata.get('sha256')!r} != {actual_digest}"
+        )
+
+
+@lru_cache(maxsize=1)
+def get_default_mim_label_index() -> MIMLabelIndex:
+    """Return the verified packaged resolver, loading it only once per process."""
+
+    return MIMLabelIndex.from_package()
+
+
+def resolve_ingredient(ingredient: Mapping[str, Any]) -> GroundingDecision:
+    """Resolve with the pinned default index."""
+
+    return get_default_mim_label_index().resolve(ingredient)

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -39,14 +39,19 @@ class TestIngredientToEdge:
         assert edge["qualifiers"] is not None
         assert any("10 G_PER_L" in str(q) for q in edge["qualifiers"])
 
-    def test_without_term_returns_none(self):
-        """Test ingredient without term is skipped."""
+    def test_mim_resolves_ingredient_without_local_term(self):
+        """The pinned MIM index supplies identities absent from recipe YAML."""
         ingredient = {
             "preferred_term": "Yeast Extract",
             "concentration": {"value": "5", "unit": "G_PER_L"},
         }
         edge = ingredient_to_edge("culturemech:LB", ingredient)
-        assert edge is None
+        assert edge is not None
+        assert edge["object"] == "FOODON:03315426"
+
+    def test_unknown_ingredient_without_term_returns_none(self):
+        ingredient = {"preferred_term": "CultureMech test-only missing ingredient 260"}
+        assert ingredient_to_edge("culturemech:LB", ingredient) is None
 
     def test_with_evidence(self):
         """Test ingredient with evidence includes publications."""
@@ -59,9 +64,9 @@ class TestIngredientToEdge:
                 {
                     "reference": "PMID:12345678",
                     "supports": "SUPPORT",
-                    "explanation": "Test evidence"
+                    "explanation": "Test evidence",
                 }
-            ]
+            ],
         }
         edge = ingredient_to_edge(medium_id, ingredient)
 
@@ -88,10 +93,7 @@ class TestOrganismToEdge:
 
     def test_without_term_returns_none(self):
         """Test organism without term is skipped."""
-        organism = {
-            "preferred_term": "Escherichia coli",
-            "strain": "K-12"
-        }
+        organism = {"preferred_term": "Escherichia coli", "strain": "K-12"}
         edge = organism_to_edge("culturemech:LB", organism)
         assert edge is None
 
@@ -155,10 +157,7 @@ class TestVariantToEdge:
 
     def test_creates_variant_edge(self):
         """Test variant creates subclass_of edge."""
-        variant = {
-            "name": "LB Agar",
-            "description": "Solidified LB"
-        }
+        variant = {"name": "LB Agar", "description": "Solidified LB"}
         edge = variant_to_edge("culturemech:LB_Broth", variant)
 
         assert edge is not None
@@ -250,7 +249,7 @@ class TestHelperFunctions:
         """Test formatting evidence with references."""
         evidence = [
             {"reference": "PMID:12345", "explanation": "Test"},
-            {"reference": "DOI:10.1234/test", "explanation": "Test 2"}
+            {"reference": "DOI:10.1234/test", "explanation": "Test 2"},
         ]
         pubs, _ = _format_evidence(evidence)
         assert len(pubs) == 2

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -50,7 +50,10 @@ RECORD = {
             "term": {"id": "CHEBI:17234"},
             "concentration": {"value": "10", "unit": "G_PER_L"},
             "nutritional_roles": ["CARBON_SOURCE"],
-        }
+        },
+        {"preferred_term": "EDTA", "term": {"id": "CHEBI:64755"}},
+        {"preferred_term": "Beef heart", "term": {"id": "UBERON:0000948"}},
+        {"preferred_term": "Calf brains", "term": {"id": "UBERON:0000955"}},
     ],
     "target_organisms": [
         {"preferred_term": "Escherichia coli", "term": {"id": "NCBITaxon:562"}, "strain": "K-12"}
@@ -318,6 +321,18 @@ def test_ontology_ids_are_referenced_but_not_declared(exported):
     external = {r for r in referenced if not r.startswith("culturemech:")}
     assert external, "fixture must reference ontology terms"
     assert external & declared == set()
+
+
+def test_tsv_export_uses_mim_identity_decisions(exported):
+    """The real Koza path must override, retain non-CHEBI, and suppress unmapped."""
+
+    _node_rows, edge_rows = exported
+    objects = {row["object"] for row in edge_rows}
+    assert "CHEBI:4735" in objects  # EDTA: MIM overrides local EDTA(2-)
+    assert "FOODON:00004410" in objects  # Beef heart is a food product
+    assert "CHEBI:64755" not in objects
+    assert "UBERON:0000948" not in objects
+    assert "UBERON:0000955" not in objects  # Calf brains is authoritatively unmapped
 
 
 def test_qualified_edges_reach_the_tsv(exported):

--- a/tests/test_mim_label_index.py
+++ b/tests/test_mim_label_index.py
@@ -1,0 +1,285 @@
+"""Contract tests for the pinned MediaIngredientMech label resolver (#260)."""
+
+from __future__ import annotations
+
+import csv
+import io
+
+import pytest
+
+from culturemech.export.kgx_export import transform
+from culturemech.ingredients.mim_label_index import (
+    INDEX_HEADER,
+    LabelIndexError,
+    MIMLabelIndex,
+    ResolutionSource,
+    get_default_mim_label_index,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _csv(*rows: dict[str, str]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=INDEX_HEADER, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _row(
+    label: str,
+    identifier: str,
+    *,
+    preferred_term: str | None = None,
+    match_type: str = "preferred_term",
+    ontology_id: str | None = None,
+    mapping_status: str = "MAPPED",
+    ambiguity: str = "unique",
+) -> dict[str, str]:
+    return {
+        "label": label,
+        "match_type": match_type,
+        "identifier": identifier,
+        "preferred_term": preferred_term or label,
+        "ontology_id": ontology_id if ontology_id is not None else identifier,
+        "mapping_status": mapping_status,
+        "ambiguity": ambiguity,
+    }
+
+
+def test_packaged_artifact_is_verified_and_pinned():
+    index = get_default_mim_label_index()
+    assert len(index.rows) == 9115
+    assert index.metadata["source_commit"] == "82694054f5bbf74b5392bf8858c9962c2152a35a"
+    assert index.metadata["sha256"] == (
+        "7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac"
+    )
+
+
+def test_mim_overrides_a_conflicting_local_grounding():
+    decision = get_default_mim_label_index().resolve(
+        {"preferred_term": "EDTA", "term": {"id": "CHEBI:64755"}}
+    )
+    assert decision.identifier == "CHEBI:4735"
+    assert decision.local_identifier == "CHEBI:64755"
+    assert decision.resolution_source is ResolutionSource.MIM_EXACT
+
+
+def test_non_chebi_mim_identity_is_retained():
+    decision = get_default_mim_label_index().resolve(
+        {"preferred_term": "Beef heart", "term": {"id": "UBERON:0000948"}}
+    )
+    assert decision.identifier == "FOODON:00004410"
+
+
+def test_paba_and_registry_identifiers_follow_mim_identifier():
+    index = get_default_mim_label_index()
+    assert index.resolve_label("4-Aminobenzoic Acid").identifier == "CHEBI:30753"
+    assert index.resolve_label("1,3-Hexanediol").identifier == "cas:21531-91-9"
+
+    diagnostic_only = MIMLabelIndex.from_csv_text(
+        _csv(_row("Registry reagent", "cas:1-23-4", ontology_id="CHEBI:999"))
+    ).resolve_label("Registry reagent")
+    assert diagnostic_only.identifier == "cas:1-23-4"
+    assert diagnostic_only.ontology_id == "CHEBI:999"
+
+
+@pytest.mark.parametrize("label", ["Calf brains", "Infusion from Potatoes"])
+def test_authoritative_unmapped_suppresses_a_local_term(label: str):
+    decision = get_default_mim_label_index().resolve(
+        {"preferred_term": label, "term": {"id": "UBERON:0000955"}}
+    )
+    assert decision.identifier is None
+    assert decision.resolution_source is ResolutionSource.AUTHORITATIVE_UNMAPPED
+    assert decision.local_identifier == "UBERON:0000955"
+
+
+def test_missing_mim_label_prefers_chebi_term_and_preserves_source_compound():
+    decision = get_default_mim_label_index().resolve(
+        {
+            "preferred_term": "CultureMech test-only missing ingredient 260",
+            "term": {"id": "mediadive.compound:999999"},
+            "chebi_term": {"id": "CHEBI:12345"},
+        }
+    )
+    assert decision.identifier == "CHEBI:12345"
+    assert decision.source_compound_id == "mediadive.compound:999999"
+    assert decision.resolution_source is ResolutionSource.LOCAL_FALLBACK
+
+
+def test_source_compound_is_not_promoted_to_semantic_identity():
+    decision = get_default_mim_label_index().resolve(
+        {
+            "preferred_term": "CultureMech test-only missing ingredient 260",
+            "term": {"id": "mediadive.compound:999999"},
+        }
+    )
+    assert decision.identifier is None
+    assert decision.source_compound_id == "mediadive.compound:999999"
+
+
+def test_merged_tombstone_resolves_only_when_a_live_record_holds_the_identifier():
+    index = MIMLabelIndex.from_csv_text(
+        _csv(
+            _row("Legacy", "CHEBI:1", mapping_status="REJECTED"),
+            _row("Live", "CHEBI:1"),
+        )
+    )
+    assert index.resolve_label("Legacy").identifier == "CHEBI:1"
+
+    with pytest.raises(LabelIndexError, match="not held by a live MAPPED row"):
+        MIMLabelIndex.from_csv_text(_csv(_row("Legacy", "CHEBI:1", mapping_status="REJECTED")))
+
+
+def test_invalid_retirement_is_authoritatively_unmapped():
+    invalid = MIMLabelIndex.from_csv_text(
+        _csv(
+            _row(
+                "Invalid label",
+                "UNMAPPED_0001",
+                ontology_id="",
+                mapping_status="REJECTED",
+            )
+        )
+    )
+    decision = invalid.resolve_label("Invalid label", local_identifier="CHEBI:2")
+    assert decision.identifier is None
+    assert decision.resolution_source is ResolutionSource.AUTHORITATIVE_UNMAPPED
+
+
+def test_unsafe_ambiguity_fails_closed_but_labels_a_local_fallback():
+    index = MIMLabelIndex.from_csv_text(
+        _csv(
+            _row(
+                "Shared",
+                "CHEBI:1",
+                match_type="synonym",
+                preferred_term="One",
+                ambiguity="conflict:different_substances",
+            ),
+            _row(
+                "shared",
+                "CHEBI:2",
+                match_type="synonym",
+                preferred_term="Two",
+                ambiguity="conflict:different_substances",
+            ),
+        )
+    )
+    unresolved = index.resolve_label("SHARED")
+    assert unresolved.identifier is None
+    assert unresolved.resolution_source is ResolutionSource.AMBIGUOUS
+
+    fallback = index.resolve_label("SHARED", local_identifier="CHEBI:3")
+    assert fallback.identifier == "CHEBI:3"
+    assert fallback.ambiguity == "conflict:different_substances"
+    assert fallback.resolution_source is ResolutionSource.AMBIGUOUS_LOCAL_FALLBACK
+
+
+@pytest.mark.parametrize("ambiguity", ["unique", "resolved:owned", "agree:same_substance"])
+def test_every_safe_ambiguity_class_is_accepted(ambiguity: str):
+    index = MIMLabelIndex.from_csv_text(_csv(_row("Safe", "CHEBI:1", ambiguity=ambiguity)))
+    assert index.resolve_label("Safe").identifier == "CHEBI:1"
+
+
+@pytest.mark.parametrize(
+    "ambiguity",
+    [
+        "conflict:different_substances",
+        "unresolved:partial_chemistry",
+        "unresolved:no_chemistry",
+    ],
+)
+def test_every_unsafe_ambiguity_class_is_refused(ambiguity: str):
+    index = MIMLabelIndex.from_csv_text(_csv(_row("Unsafe", "CHEBI:1", ambiguity=ambiguity)))
+    assert index.resolve_label("Unsafe").resolution_source is ResolutionSource.AMBIGUOUS
+
+
+def test_weak_normalization_is_safe_only_for_one_semantic_answer():
+    safe = MIMLabelIndex.from_csv_text(_csv(_row("Sodium-chloride", "CHEBI:26710")))
+    decision = safe.resolve_label("sodium chloride")
+    assert decision.identifier == "CHEBI:26710"
+    assert decision.resolution_source is ResolutionSource.MIM_NORMALIZED
+
+    collision = MIMLabelIndex.from_csv_text(_csv(_row("A-B", "CHEBI:1"), _row("A B", "CHEBI:2")))
+    assert collision.resolve_label("A-B").identifier == "CHEBI:1"  # exact wins
+    ambiguous = collision.resolve_label("A_B")
+    assert ambiguous.identifier is None
+    assert ambiguous.resolution_source is ResolutionSource.AMBIGUOUS
+
+    agreement = MIMLabelIndex.from_csv_text(_csv(_row("C-D", "CHEBI:3"), _row("C D", "CHEBI:3")))
+    assert agreement.resolve_label("C_D").identifier == "CHEBI:3"
+
+
+def test_hydration_digits_and_formula_punctuation_never_collapse():
+    index = MIMLabelIndex.from_csv_text(
+        _csv(
+            _row("CaCl2 x 2 H2O", "CHEBI:86124"),
+            _row("CaCl2 x 6 H2O", "CHEBI:91243"),
+        )
+    )
+    decision = index.resolve_label("CaCl2 x 7 H2O")
+    assert decision.identifier is None
+    assert decision.resolution_source is ResolutionSource.NOT_FOUND
+
+
+def test_invalid_header_and_noncontiguous_groups_are_rejected():
+    with pytest.raises(LabelIndexError, match="header"):
+        MIMLabelIndex.from_csv_text("label,identifier\nA,CHEBI:1\n")
+
+    with pytest.raises(LabelIndexError, match="not contiguous"):
+        MIMLabelIndex.from_csv_text(
+            _csv(
+                _row("A", "CHEBI:1"),
+                _row("B", "CHEBI:2"),
+                _row("a", "CHEBI:1", match_type="synonym"),
+            )
+        )
+
+    with pytest.raises(LabelIndexError, match="unknown mapping_status"):
+        MIMLabelIndex.from_csv_text(_csv(_row("A", "CHEBI:1", mapping_status="PENDING_REVIEW")))
+
+    with pytest.raises(LabelIndexError, match="inconsistent ambiguity"):
+        MIMLabelIndex.from_csv_text(
+            _csv(
+                _row("A", "CHEBI:1"),
+                _row("a", "CHEBI:1", match_type="synonym", ambiguity="resolved:owned"),
+            )
+        )
+
+
+def test_kgx_uses_mim_for_override_non_chebi_and_authoritative_unmapped():
+    record = {
+        "name": "Resolver Canary",
+        "ingredients": [
+            {"preferred_term": "EDTA", "term": {"id": "CHEBI:64755"}},
+            {"preferred_term": "Beef heart", "term": {"id": "UBERON:0000948"}},
+            {"preferred_term": "Calf brains", "term": {"id": "UBERON:0000955"}},
+        ],
+    }
+    ingredient_objects = {
+        edge["object"] for edge in transform(record) if edge["predicate"] == "biolink:has_part"
+    }
+    assert ingredient_objects == {"CHEBI:4735", "FOODON:00004410"}
+
+
+def test_kgx_labels_ambiguous_and_source_anchored_local_fallbacks():
+    record = {
+        "name": "Fallback Canary",
+        "ingredients": [
+            {
+                "preferred_term": "(2S)-2-aminobutanedioic acid",
+                "term": {"id": "CHEBI:17053"},
+            },
+            {
+                "preferred_term": "CultureMech test-only missing ingredient 260",
+                "term": {"id": "mediadive.compound:999999"},
+                "chebi_term": {"id": "CHEBI:12345"},
+            },
+        ],
+    }
+    ingredient_objects = {
+        edge["object"] for edge in transform(record) if edge["predicate"] == "biolink:has_part"
+    }
+    assert ingredient_objects == {"CHEBI:17053", "CHEBI:12345"}

--- a/tests/test_refresh_mim_label_index.py
+++ b/tests/test_refresh_mim_label_index.py
@@ -1,0 +1,62 @@
+"""Safety tests for explicit MIM dependency refreshes (#260)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.fast
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_refresh_module():
+    path = ROOT / "scripts" / "refresh_mim_label_index.py"
+    spec = importlib.util.spec_from_file_location("refresh_mim_label_index", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _isolated_pin(module, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> bytes:
+    data = module.INDEX_PATH.read_bytes()
+    metadata = module.METADATA_PATH.read_bytes()
+    index_path = tmp_path / "label_index.csv"
+    metadata_path = tmp_path / "label_index.metadata.json"
+    index_path.write_bytes(data)
+    metadata_path.write_bytes(metadata)
+    monkeypatch.setattr(module, "INDEX_PATH", index_path)
+    monkeypatch.setattr(module, "METADATA_PATH", metadata_path)
+    return data
+
+
+def test_refresh_is_preview_only_unless_apply_is_explicit(tmp_path, monkeypatch, capsys):
+    module = _load_refresh_module()
+    data = _isolated_pin(module, tmp_path, monkeypatch)
+    before = module.METADATA_PATH.read_bytes()
+
+    assert module.refresh("0" * 40, data) == (0, 0, 0)
+    assert module.METADATA_PATH.read_bytes() == before
+    assert "Preview only" in capsys.readouterr().out
+
+
+def test_apply_updates_only_the_isolated_pin_after_validation(tmp_path, monkeypatch):
+    module = _load_refresh_module()
+    data = _isolated_pin(module, tmp_path, monkeypatch)
+
+    module.refresh("0" * 40, data, apply=True)
+    metadata = json.loads(module.METADATA_PATH.read_text(encoding="utf-8"))
+    assert metadata["source_commit"] == "0" * 40
+    assert module.INDEX_PATH.read_bytes() == data
+
+
+def test_short_or_moving_revision_is_rejected(tmp_path, monkeypatch):
+    module = _load_refresh_module()
+    data = _isolated_pin(module, tmp_path, monkeypatch)
+    with pytest.raises(SystemExit, match="full lowercase 40-character"):
+        module.refresh("main", data)


### PR DESCRIPTION
Summary
- vendor and integrity-pin the MIM label index at commit 82694054f5bbf74b5392bf8858c9962c2152a35a
- add a shared, fail-closed resolver with exact-first hydrate-sensitive matching, ambiguity handling, authoritative UNMAPPED behavior, and safe local fallback
- route all current KGX ingredient edge paths through that resolver while retaining non-CHEBI identities
- add offline verification, explicit full-SHA refresh tooling, wheel resource smoke coverage, and updated consumer documentation

Validation
- full suite: 1,342 passed, 16 skipped; 20.23% coverage
- focused resolver/refresh/KGX/Koza tests: 69 passed
- changed-Python Ruff and Black gate passed
- new resolver and maintenance scripts pass mypy
- installed wheel smoke from /tmp resolved EDTA to CHEBI:4735
- two independent semantic reviews found no blockers; all 8,367 exact label groups matched the MIM contract

The vendored CSV is intentionally marked binary so Git preserves the immutable upstream CRLF bytes used by the SHA-256 gate.

Closes #260