### PR TITLE
Publish lossless direct ingredient occurrences

### DIFF
--- a/docs/DATA_LAYERS.md
+++ b/docs/DATA_LAYERS.md
@@ -50,6 +50,54 @@ bump is preview-only by default and requires a full MIM commit plus an explicit
 `--apply`; see
 [`mediaingredientmech_enrichment.md`](mediaingredientmech_enrichment.md).
 
+## Generated direct ingredient occurrences
+
+`just aggregate-all-ingredients` projects Layer 3 recipe content and the pinned
+MIM identity snapshot into four generated files under `output/`:
+
+- `ingredient_occurrences.tsv` is the canonical, complete direct-containment
+  table.
+- `mapped_ingredients.yaml` and `unmapped_ingredients.yaml` are summaries of
+  that same table.
+- `ingredient_aggregation_errors.tsv` reports YAML and extraction-blocking
+  schema/shape failures.
+
+The traversal follows root schema shape: MediaRecipe-shaped records contribute
+`ingredients`, while SolutionRecipe-shaped records contribute `composition`.
+The two fields are not concatenated, solution placeholder `ingredients` are not
+counted, and nested `solutions[].composition` is not expanded. This is direct
+root containment, distinct from any transitive recipe-to-solution expansion.
+
+Every occurrence carries `(recipe_id, component_field, component_index)` as its
+stable coordinate. `recipe_id` is the root `CultureMech:NNNNNN` identifier;
+recipe labels are display metadata only. `source_path` is a POSIX path relative
+to the selected input root, so custom scans do not embed worktree locations.
+`occurrence_count` is the number of complete rows and `distinct_recipe_count`
+is the number of unique stable recipe IDs, so neither count can be clipped by
+an examples limit.
+
+The #260 resolver partitions rows by whether `GroundingDecision.identifier` is
+present. `mim_exact`, `mim_normalized`, `local_fallback`, and
+`ambiguous_local_fallback` are mapped; `authoritative_unmapped`, `ambiguous`,
+and `not_found` are unmapped. The selected identity is
+`resolved_identifier`. MIM's `ontology_id` remains
+`mim_ontology_id_diagnostic`, and an upstream `mediadive.compound:*` remains
+`source_compound_id`; neither is silently promoted to semantic identity.
+
+The outputs are sorted, LF-terminated, uncapped, and contain no wall-clock
+`generation_date`, making identical reruns byte-identical. A fatal input error
+is always written to the error TSV and returns nonzero regardless of
+`--verbose`. Occurrence and summary outputs are staged as one publication set
+only after a successful complete scan. Each destination is replaced atomically,
+and an in-process replacement failure rolls the set back to the last successful
+artifacts.
+
+These files are reproducible projections, not a fifth curation layer. They are
+ignored by Git, must not be hand-edited, and never rewrite
+`data/normalized_yaml/`. See the
+[unmapped ingredient occurrence guide](unmapped_ingredients_guide.md) for the
+row and count contracts.
+
 ---
 
 ## Layer 1: Raw Data (`raw/`)

--- a/docs/mediaingredientmech_enrichment.md
+++ b/docs/mediaingredientmech_enrichment.md
@@ -93,12 +93,51 @@ tests. Koza uses the verified packaged default lazily. A wheel smoke test loads
 it from `/tmp`, proving an installed distribution does not rely on the source
 checkout.
 
-The occurrence pipeline tracked by #337 must import this same resolver. That
-issue owns structural traversal, including the distinction between
-`MediaRecipe.ingredients` and root `SolutionRecipe.composition`, stable
-occurrence coordinates, placeholder exclusion, uncapped outputs, and parse
-errors. #260 deliberately does not conceal the existing root-solution traversal
-gap inside KGX.
+The ingredient-occurrence pipeline imports this same resolver and partitions
+its structured decisions without reinterpreting CURIE syntax:
+
+- `mim_exact`, `mim_normalized`, `local_fallback`, and
+  `ambiguous_local_fallback` are mapped because `GroundingDecision.identifier`
+  is present.
+- `authoritative_unmapped`, `ambiguous`, and `not_found` are unmapped because
+  the decision has no selected identifier.
+
+The selected value is exported as `resolved_identifier`. The accompanying
+`mim_ontology_id_diagnostic` is publisher metadata only. Likewise,
+`mediadive.compound:*` remains `source_compound_id`; a colon in an upstream ID
+does not make it an ontology grounding. `local_identifier`, MIM match/status/
+ambiguity fields, and `grounding_reason` remain available for audit.
+
+### Direct occurrence contract
+
+Occurrence extraction follows the root record's schema shape:
+
+- a MediaRecipe-shaped root contributes `ingredients`;
+- a SolutionRecipe-shaped root contributes `composition`.
+
+The fields are alternatives, not lists to concatenate. A solution's legacy
+`ingredients: [{preferred_term: See source for composition}]` stub is therefore
+not an occurrence, and nested `solutions[].composition` is not expanded once
+per referencing medium. The pipeline records direct containment only.
+
+Every occurrence carries the stable coordinate
+`(recipe_id, component_field, component_index)`, where `recipe_id` is the root
+`CultureMech:NNNNNN` identifier. Recipe labels are display metadata and are
+never used for identity or distinct-recipe counts.
+
+The canonical TSV is complete and uncapped. `occurrence_count` is the number of
+its rows in a group, while `distinct_recipe_count` is the number of unique
+`recipe_id` values. Summary YAML may retain convenient display fields, but no
+count is derived from an example sample.
+
+Input paths and occurrence coordinates are sorted before serialization. The
+outputs deliberately omit a wall-clock `generation_date`, use LF line endings,
+and atomically replace each destination from a fully staged publication set, so
+rerunning against identical recipe data and the same pinned MIM index is
+byte-identical. YAML/shape failures are always written
+to the machine-readable error TSV; `--verbose` affects progress only. Any such
+failure exits nonzero and leaves the last successful artifacts intact; a later
+replacement error rolls already-replaced members of the set back in-process.
 
 ## Refreshing the pin
 

--- a/docs/unmapped_ingredients_guide.md
+++ b/docs/unmapped_ingredients_guide.md
@@ -1,199 +1,177 @@
-# Unmapped Ingredients Aggregation Guide
+# Unmapped ingredient occurrence guide
 
-## Overview
+## Purpose
 
-This guide describes the system for aggregating and tracking unmapped media ingredients that need ontology term mapping.
+CultureMech classifies ingredient occurrences through the pinned
+MediaIngredientMech (MIM) label resolver. An occurrence is unmapped when the
+resolver returns no `resolved_identifier`; it is not classified from the mere
+presence or absence of a colon in a local field.
 
-## What are Unmapped Ingredients?
+The canonical artifact is a complete direct-occurrence TSV. The mapped and
+unmapped YAML files are deterministic summaries of that same row population,
+not independent scans.
 
-Unmapped ingredients are media components that lack proper ontology term mappings in the `preferred_term` field. They are identified by:
+## Direct-root traversal
 
-- **Numeric placeholders**: '1', '2', '3', etc.
-- **Generic placeholders**: 'See source for composition', 'variable', etc.
-- **Empty values**: Missing or blank `preferred_term` fields
+The extractor selects exactly one component field from each normalized root
+record according to its schema shape:
 
-## Components
+- MediaRecipe-shaped roots contribute `ingredients`.
+- SolutionRecipe-shaped roots contribute `composition`.
 
-### 1. LinkML Schema
+These fields are alternatives. They are never concatenated. Consequently,
+`See source for composition` entries retained in a SolutionRecipe's legacy
+`ingredients` field are not ingredients, and nested
+`solutions[].composition` entries are not expanded once per referencing
+medium. The artifact represents direct root containment only.
 
-**Location**: `src/culturemech/schema/unmapped_ingredients_schema.yaml`
+Each occurrence is identified by the stable tuple:
 
-Defines the structured format for aggregated unmapped ingredients with the following key classes:
-
-- `UnmappedIngredientsCollection`: Root container with metadata and summaries
-- `UnmappedIngredient`: Individual unmapped ingredient with occurrences and parsed info
-- `MediaOccurrence`: Reference to specific media containing the ingredient
-- `ConcentrationInfo`: Concentration data for ingredients
-- `SuggestedMapping`: Future ontology term suggestions
-- `CategorySummary`: Statistics by media category
-
-### 2. Aggregation Script
-
-**Location**: `scripts/aggregate_unmapped_ingredients.py`
-
-Python script that:
-- Scans all media YAML files in `data/normalized_yaml/`
-- Identifies unmapped ingredients
-- Extracts chemical names from notes fields
-- Aggregates occurrences across media
-- Generates structured YAML output
-
-### 3. Output File
-
-**Location**: `output/unmapped_ingredients.yaml`
-
-Structured YAML file conforming to the schema, containing:
-- Generation timestamp
-- Total counts and statistics
-- Detailed unmapped ingredient entries
-- Category-wise summaries
-
-## Usage
-
-### Basic Usage
-
-```bash
-# Generate unmapped ingredients aggregation
-python scripts/aggregate_unmapped_ingredients.py
-
-# With custom options
-python scripts/aggregate_unmapped_ingredients.py \
-    --output output/unmapped_ingredients.yaml \
-    --input-dir data/normalized_yaml \
-    --min-occurrences 2 \
-    --verbose
+```text
+(recipe_id, component_field, component_index)
 ```
 
-### Options
+`recipe_id` is the root `CultureMech:NNNNNN` identifier. `component_field` is
+`ingredients` or `composition`, and `component_index` is zero-based. Recipe
+labels are display metadata; duplicate labels never merge distinct recipes.
+`source_path` is a POSIX path relative to `--input-dir`, keeping custom corpus
+scans portable and byte-identical across worktrees.
 
-- `--output PATH`: Output file path (default: `output/unmapped_ingredients.yaml`)
-- `--input-dir PATH`: Input directory with media YAML files (default: `data/normalized_yaml`)
-- `--min-occurrences N`: Only include ingredients appearing at least N times (default: 1)
-- `--verbose`: Enable verbose logging
+For display, the extractor uses a root `preferred_term` when present and falls
+back to `name` only for MediaRecipe-shaped legacy records. It never falls back
+to a filename stem. The canonical TSV records that choice in `label_source` as
+`preferred_term` or `legacy_name`.
 
-### Example Output Structure
+## Resolver partition
+
+The occurrence pipeline imports the same `GroundingDecision` resolver used by
+KGX:
+
+- Resolved: `mim_exact`, `mim_normalized`, `local_fallback`, and
+  `ambiguous_local_fallback` have a non-empty `resolved_identifier` and enter
+  the mapped summary.
+- Unresolved: `authoritative_unmapped`, `ambiguous`, and `not_found` have no
+  selected identifier and enter the unmapped summary.
+
+An explicit MIM `UNMAPPED` decision suppresses a conflicting local grounding.
+An unsafe ambiguity may retain a local identity only through the visibly named
+`ambiguous_local_fallback` result.
+
+MediaDive compound IDs are provenance, not ontology mappings. They remain in
+`source_compound_id` even when the same component has a CHEBI `chebi_term` or a
+MIM-selected identity. The TSV also retains `local_identifier`, MIM match type,
+mapping status, ambiguity, diagnostic ontology ID, and `grounding_reason`.
+
+See [MediaIngredientMech ingredient identity resolution](mediaingredientmech_enrichment.md)
+for the pinned artifact and matching rules.
+
+## Generated artifacts
+
+Run:
+
+```bash
+just aggregate-all-ingredients
+```
+
+The command invokes `scripts/aggregate_ingredients.py` once and writes:
+
+- `output/ingredient_occurrences.tsv` — complete mapped and unmapped direct
+  occurrences, with no row cap.
+- `output/mapped_ingredients.yaml` — identity-first mapped summary.
+- `output/unmapped_ingredients.yaml` — unresolved label summary.
+- `output/ingredient_aggregation_errors.tsv` — machine-readable input failures.
+
+The standalone mapped and unmapped commands use the same shared scanner; they
+do not maintain separate traversal or grounding rules.
+
+`--min-occurrences` filters only summary groups in the compatibility YAML
+views. It never removes rows from `ingredient_occurrences.tsv`.
+
+`output/` is a generated-data directory. Do not hand-edit or commit these
+artifacts.
+
+## Count definitions
+
+For each summary row:
+
+- `occurrence_count` is the number of complete TSV rows in the group.
+- `distinct_recipe_count` is the number of unique `recipe_id` values in those
+  rows.
+- `recipe_occurrences` is complete and uncapped.
+
+Collection `recipe_count` and category `recipes_with_mapped` /
+`recipes_with_unmapped` values likewise use stable recipe IDs. Counts are never
+derived from display labels or a retained sample. Repeated positions for the
+same ingredient in one recipe increase `occurrence_count` but increase
+`distinct_recipe_count` only once.
+
+## Unmapped summary shape
+
+The standalone schema is
+`src/culturemech/schema/unmapped_ingredients_schema.yaml`. A summary entry keeps
+the source query label and the full resolver provenance:
 
 ```yaml
-generation_date: '2026-03-05T23:04:00.677404'
-total_unmapped_count: 136
-media_count: 522
+total_unmapped_count: 1
+total_instances: 2
+recipe_count: 2
 unmapped_ingredients:
-- placeholder_id: '1'
-  raw_ingredient_text:
-  - 'Original amount: NaNO3(Fisher BP360-500)'
-  parsed_chemical_name: NaNO3
-  occurrence_count: 243
-  media_occurrences:
-  - medium_name: BG-11 Medium
-    medium_category: ALGAE
-    medium_file_path: normalized_yaml/algae/BG-11_Medium.yaml
-    ingredient_index: 0
-  concentration_info:
-  - value: variable
-    unit: G_PER_L
+- preferred_term: Calf brains
+  occurrence_count: 2
+  distinct_recipe_count: 2
   mapping_status: UNMAPPED
-
-summary_by_category:
-- category: ALGAE
-  media_with_unmapped: 235
-  total_unmapped_instances: 641
-  unique_unmapped_count: 14
-- category: BACTERIAL
-  media_with_unmapped: 270
-  total_unmapped_instances: 2439
-  unique_unmapped_count: 139
+  recipe_occurrences:
+  - recipe_id: CultureMech:000021
+    recipe_label: Example medium A
+    recipe_category: BACTERIAL
+    source_path: bacterial/example_a.yaml
+    component_field: ingredients
+    component_index: 4
+    preferred_term: Calf brains
+    local_identifier: UBERON:0000955
+    resolution_source: authoritative_unmapped
+    mim_mapping_status: UNMAPPED
+    grounding_reason: MIM explicitly leaves this label unmapped; local grounding suppressed
+  - recipe_id: CultureMech:000022
+    recipe_label: Example medium B
+    recipe_category: BACTERIAL
+    source_path: bacterial/example_b.yaml
+    component_field: ingredients
+    component_index: 2
+    preferred_term: Calf brains
+    local_identifier: UBERON:0000955
+    resolution_source: authoritative_unmapped
+    mim_mapping_status: UNMAPPED
+    grounding_reason: MIM explicitly leaves this label unmapped; local grounding suppressed
 ```
 
-## Current Statistics (as of 2026-03-05)
+There is deliberately no wall-clock `generation_date`. Input paths and stable
+coordinates are sorted, TSV files use LF line endings, and reruns over identical
+recipes plus the same pinned MIM index are byte-identical.
 
-- **Total unmapped ingredients**: 136 (appearing ≥2 times)
-- **Media with unmapped ingredients**: 522 out of 10,657 total
-- **Breakdown by category**:
-  - ALGAE: 235 media, 641 instances, 14 unique
-  - BACTERIAL: 270 media, 2,439 instances, 139 unique
-  - FUNGAL: 11 media, 11 instances, 1 unique
-  - SPECIALIZED: 8 media, 8 instances, 1 unique
-  - ARCHAEA: 1 medium, 1 instance, 1 unique
+## Failure and publication semantics
 
-## Workflow for Mapping
+YAML parse failures and extraction-blocking schema/shape failures are written
+to `output/ingredient_aggregation_errors.tsv` whether or not `--verbose` is
+enabled. `--verbose` controls progress messages only.
 
-### 1. Generate Current Aggregation
+If a fatal error occurs, the command exits nonzero. The error report is updated,
+but the occurrence and summary files are not partially replaced. Successful
+outputs are staged as one publication set only after the complete scan and all
+consistency checks pass. Each destination is atomically replaced; an in-process
+failure on a later replacement rolls earlier members back to their prior files.
 
-```bash
-python scripts/aggregate_unmapped_ingredients.py --verbose
-```
+## Curation workflow
 
-### 2. Review Unmapped Ingredients
+Use the unmapped summary to prioritize labels, but fix identity authority in the
+appropriate layer:
 
-Open `output/unmapped_ingredients.yaml` and review:
-- Most frequent unmapped ingredients (sorted by occurrence_count)
-- Parsed chemical names extracted from notes
-- Media where each ingredient appears
+1. If the recipe label itself is missing or demonstrably wrong, correct the
+   source recipe through the normal CultureMech curation workflow.
+2. If the label is source-faithful but lacks an identity, curate or mint the
+   record in MIM and refresh CultureMech's pinned label index explicitly.
+3. Do not insert a guessed CURIE into recipe YAML merely to make the mapped count
+   increase.
+4. Rerun `just aggregate-all-ingredients` and review the semantic diff.
 
-### 3. Map to Ontology Terms
-
-For each unmapped ingredient:
-
-1. **Identify the chemical**: Use `parsed_chemical_name` and `raw_ingredient_text`
-2. **Search ontologies**: Look in CHEBI, FOODON, or other appropriate ontologies
-3. **Update media files**: Replace numeric placeholder with proper ontology term
-4. **Verify**: Re-run aggregation to confirm mapping
-
-Example mapping in media YAML:
-
-```yaml
-# Before (unmapped)
-ingredients:
-- preferred_term: '1'
-  concentration:
-    value: 1.5
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3'
-
-# After (mapped)
-ingredients:
-- preferred_term: sodium nitrate
-  term:
-    id: CHEBI:63041
-    label: sodium nitrate
-  concentration:
-    value: 1.5
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3'
-```
-
-### 4. Track Progress
-
-Re-run the aggregation periodically to track progress:
-
-```bash
-# Check progress
-python scripts/aggregate_unmapped_ingredients.py --verbose
-
-# Compare counts over time
-diff previous_unmapped.yaml output/unmapped_ingredients.yaml
-```
-
-## Integration with Data Quality
-
-The unmapped ingredients system integrates with the existing data quality framework:
-
-- Media with unmapped ingredients are tagged with `incomplete_composition` flag
-- The aggregation helps prioritize mapping efforts
-- Statistics guide resource allocation for curation
-
-## Future Enhancements
-
-Planned improvements:
-
-1. **Automated mapping suggestions**: Use text matching and ML to suggest CHEBI/FOODON terms
-2. **Batch mapping tool**: UI/CLI tool to map multiple ingredients at once
-3. **Confidence scoring**: Score mapping suggestions based on string similarity
-4. **Integration with ontology APIs**: Query CHEBI/FOODON APIs for candidate terms
-5. **Tracking system**: Monitor mapping progress over time with metrics
-
-## Support
-
-For questions or issues:
-- File an issue: https://github.com/CultureBotAI/CommunityMech/issues
-- See main README: `README.md`
+The generated summaries never rewrite curated recipe data.

--- a/project.justfile
+++ b/project.justfile
@@ -2650,39 +2650,61 @@ gen-media-umap-force-reload embeddings_path=kg_microbe_embeddings:
     echo ""
     echo "✓ UMAP visualization regenerated!"
 
-# Generate mapped ingredients file (ingredients with CHEBI/ontology IDs)
+# Generate mapped ingredients compatibility view through the shared occurrence scanner
 [group('Ingredients')]
 aggregate-mapped-ingredients output="output/mapped_ingredients.yaml" min_occurrences="1":
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Aggregating mapped ingredients from media YAML files..."
-    mkdir -p $(dirname {{output}})
+    mkdir -p -- "$(dirname -- "{{output}}")"
     uv run python scripts/aggregate_mapped_ingredients.py \
-        --output {{output}} \
-        --input-dir {{normalized_yaml_dir}} \
-        --min-occurrences {{min_occurrences}} \
+        --output "{{output}}" \
+        --input-dir "{{normalized_yaml_dir}}" \
+        --min-occurrences "{{min_occurrences}}" \
+        --occurrences-output "output/ingredient_occurrences.tsv" \
+        --errors-output "output/ingredient_aggregation_errors.tsv" \
         --verbose
     echo "✓ Mapped ingredients saved to {{output}}"
 
-# Generate unmapped ingredients file (ingredients without ontology mappings)
+# Generate unmapped ingredients compatibility view through the shared occurrence scanner
 [group('Ingredients')]
 aggregate-unmapped-ingredients output="output/unmapped_ingredients.yaml" min_occurrences="1":
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Aggregating unmapped ingredients from media YAML files..."
-    mkdir -p $(dirname {{output}})
+    mkdir -p -- "$(dirname -- "{{output}}")"
     uv run python scripts/aggregate_unmapped_ingredients.py \
-        --output {{output}} \
-        --input-dir {{normalized_yaml_dir}} \
-        --min-occurrences {{min_occurrences}} \
+        --output "{{output}}" \
+        --input-dir "{{normalized_yaml_dir}}" \
+        --min-occurrences "{{min_occurrences}}" \
+        --occurrences-output "output/ingredient_occurrences.tsv" \
+        --errors-output "output/ingredient_aggregation_errors.tsv" \
         --verbose
     echo "✓ Unmapped ingredients saved to {{output}}"
 
-# Generate both mapped and unmapped ingredient files
+# Scan once and generate the canonical occurrence table plus both compatibility views
 [group('Ingredients')]
-aggregate-all-ingredients: (aggregate-mapped-ingredients) (aggregate-unmapped-ingredients)
-    @echo ""
-    @echo "✓ Ingredient aggregation complete!"
-    @echo "  Mapped:   output/mapped_ingredients.yaml"
-    @echo "  Unmapped: output/unmapped_ingredients.yaml"
+aggregate-all-ingredients mapped_output="output/mapped_ingredients.yaml" unmapped_output="output/unmapped_ingredients.yaml" occurrences_output="output/ingredient_occurrences.tsv" errors_output="output/ingredient_aggregation_errors.tsv" min_occurrences="1":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p -- \
+        "$(dirname -- "{{mapped_output}}")" \
+        "$(dirname -- "{{unmapped_output}}")" \
+        "$(dirname -- "{{occurrences_output}}")" \
+        "$(dirname -- "{{errors_output}}")"
+    uv run python scripts/aggregate_ingredients.py \
+        --input-dir "{{normalized_yaml_dir}}" \
+        --mapped-output "{{mapped_output}}" \
+        --unmapped-output "{{unmapped_output}}" \
+        --occurrences-output "{{occurrences_output}}" \
+        --errors-output "{{errors_output}}" \
+        --min-occurrences "{{min_occurrences}}" \
+        --verbose
+    echo "✓ Ingredient aggregation complete!"
+    echo "  Occurrences: {{occurrences_output}}"
+    echo "  Mapped:      {{mapped_output}}"
+    echo "  Unmapped:    {{unmapped_output}}"
+    echo "  Errors:      {{errors_output}}"
 
 # =============================================================================
 # INGREDIENT UMAP VISUALIZATION

--- a/scripts/aggregate_ingredients.py
+++ b/scripts/aggregate_ingredients.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Build CultureMech's lossless direct ingredient-occurrence artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ingredient_occurrences import run_aggregation
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("data/normalized_yaml"),
+        help="Directory containing normalized recipe YAML files.",
+    )
+    parser.add_argument(
+        "--occurrences-output",
+        type=Path,
+        default=Path("output/ingredient_occurrences.tsv"),
+        help="Canonical uncapped occurrence TSV.",
+    )
+    parser.add_argument(
+        "--mapped-output",
+        type=Path,
+        default=Path("output/mapped_ingredients.yaml"),
+        help="Mapped compatibility-view YAML.",
+    )
+    parser.add_argument(
+        "--unmapped-output",
+        type=Path,
+        default=Path("output/unmapped_ingredients.yaml"),
+        help="Unmapped compatibility-view YAML.",
+    )
+    parser.add_argument(
+        "--errors-output",
+        type=Path,
+        default=Path("output/ingredient_aggregation_errors.tsv"),
+        help="Machine-readable input error report.",
+    )
+    parser.add_argument(
+        "--min-occurrences",
+        type=int,
+        default=1,
+        help="Minimum group size retained in YAML views; TSV is always complete.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Print a compact summary.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return run_aggregation(
+        input_dir=args.input_dir,
+        occurrences_output=args.occurrences_output,
+        mapped_output=args.mapped_output,
+        unmapped_output=args.unmapped_output,
+        errors_output=args.errors_output,
+        min_occurrences=args.min_occurrences,
+        verbose=args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aggregate_mapped_ingredients.py
+++ b/scripts/aggregate_mapped_ingredients.py
@@ -1,377 +1,67 @@
 #!/usr/bin/env python3
+"""Compatibility CLI for the mapped ingredient aggregation view.
+
+The canonical ``aggregate-all-ingredients`` command scans once and writes both
+partitions.  This wrapper keeps the historical command-line interface while
+delegating traversal, validation, identity resolution, and counting to the
+shared #337 occurrence collector.
 """
-Aggregate Mapped Media Ingredients
 
-This script scans all media YAML files, identifies ingredients with proper ontology
-mappings, and outputs a structured YAML file conforming to the mapped_ingredients_schema.
-
-Mapped ingredients are identified by having a term.id field with an ontology reference
-(e.g., CHEBI:12345, FOODON:00001234).
-
-Usage:
-    python scripts/aggregate_mapped_ingredients.py [options]
-
-Options:
-    --output PATH       Output file path (default: output/mapped_ingredients.yaml)
-    --input-dir PATH    Input directory with media YAML files (default: data/normalized_yaml)
-    --min-occurrences N Only include ingredients appearing at least N times (default: 1)
-    --verbose           Enable verbose logging
-"""
+from __future__ import annotations
 
 import argparse
-import glob
-import re
-import sys
-from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
 
-import yaml
-
-
-class MappedIngredientAggregator:
-    """Aggregates mapped ingredients from media YAML files."""
-
-    def __init__(self, input_dir: str = "data/normalized_yaml", min_occurrences: int = 1, verbose: bool = False):
-        self.input_dir = Path(input_dir)
-        self.min_occurrences = min_occurrences
-        self.verbose = verbose
-
-        # Data structures for aggregation
-        self.mapped_ingredients: Dict[str, Dict] = defaultdict(lambda: {
-            'preferred_term': '',
-            'ontology_id': '',
-            'ontology_label': '',
-            'ontology_source': '',
-            'occurrence_count': 0,
-            'media_occurrences': [],
-            'concentration_info': [],
-            'synonyms': set()
-        })
-
-        self.category_stats = defaultdict(lambda: {
-            'media_with_mapped': set(),
-            'total_mapped_instances': 0,
-            'unique_mapped': set()
-        })
-
-        self.ontology_stats = defaultdict(lambda: {
-            'unique_terms': set(),
-            'total_instances': 0
-        })
-
-        self.total_media_processed = 0
-        self.total_ingredients_processed = 0
-        self.media_with_mapped = set()
-
-    def extract_ontology_source(self, term_id: str) -> str:
-        """Extract ontology source from term ID."""
-        if not term_id:
-            return "OTHER"
-
-        if term_id.startswith("CHEBI:"):
-            return "CHEBI"
-        elif term_id.startswith("FOODON:"):
-            return "FOODON"
-        elif term_id.startswith("NCIT:"):
-            return "NCIT"
-        elif term_id.startswith("MESH:"):
-            return "MESH"
-        elif term_id.startswith("UBERON:"):
-            return "UBERON"
-        elif term_id.startswith("ENVO:"):
-            return "ENVO"
-        else:
-            return "OTHER"
-
-    def is_mapped_ingredient(self, ingredient: dict) -> bool:
-        """Check if an ingredient has proper ontology mapping."""
-        # Check for term.id field
-        if 'term' in ingredient and isinstance(ingredient['term'], dict):
-            term_id = ingredient['term'].get('id', '')
-            if term_id and ':' in term_id:
-                return True
-
-        # Alternative: agent_term.id field
-        if 'agent_term' in ingredient and isinstance(ingredient['agent_term'], dict):
-            if 'term' in ingredient['agent_term'] and isinstance(ingredient['agent_term']['term'], dict):
-                term_id = ingredient['agent_term']['term'].get('id', '')
-                if term_id and ':' in term_id:
-                    return True
-
-        return False
-
-    def extract_term_info(self, ingredient: dict) -> Tuple[str, str, str]:
-        """Extract term ID, label, and preferred term from ingredient."""
-        term_id = ""
-        term_label = ""
-        preferred_term = ""
-
-        # Check term structure
-        if 'term' in ingredient and isinstance(ingredient['term'], dict):
-            term_id = ingredient['term'].get('id', '')
-            term_label = ingredient['term'].get('label', '')
-
-        # Check agent_term structure
-        if 'agent_term' in ingredient and isinstance(ingredient['agent_term'], dict):
-            preferred_term = ingredient['agent_term'].get('preferred_term', '')
-            if 'term' in ingredient['agent_term'] and isinstance(ingredient['agent_term']['term'], dict):
-                term_id = ingredient['agent_term']['term'].get('id', '')
-                term_label = ingredient['agent_term']['term'].get('label', '')
-
-        # Fallback to preferred_term at root level
-        if not preferred_term:
-            preferred_term = ingredient.get('preferred_term', term_label)
-
-        return term_id, term_label, preferred_term
-
-    def process_medium_file(self, file_path: Path) -> None:
-        """Process a single medium YAML file."""
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                data = yaml.safe_load(f)
-
-            if not data or 'ingredients' not in data:
-                return
-
-            medium_name = data.get('name', file_path.stem)
-            medium_category = data.get('category', 'UNKNOWN').upper()
-
-            has_mapped = False
-
-            for idx, ingredient in enumerate(data['ingredients']):
-                self.total_ingredients_processed += 1
-
-                if self.is_mapped_ingredient(ingredient):
-                    has_mapped = True
-
-                    term_id, term_label, preferred_term = self.extract_term_info(ingredient)
-
-                    if not preferred_term:
-                        preferred_term = term_label or term_id
-
-                    ontology_source = self.extract_ontology_source(term_id)
-
-                    # Use preferred_term as key for aggregation
-                    key = preferred_term
-
-                    # Add to aggregation
-                    ing_data = self.mapped_ingredients[key]
-                    ing_data['preferred_term'] = preferred_term
-                    ing_data['ontology_id'] = term_id
-                    ing_data['ontology_label'] = term_label
-                    ing_data['ontology_source'] = ontology_source
-                    ing_data['occurrence_count'] += 1
-
-                    # Add media occurrence
-                    ing_data['media_occurrences'].append({
-                        'medium_name': medium_name,
-                        'medium_category': medium_category,
-                        'medium_file_path': str(file_path.relative_to(self.input_dir.parent)),
-                        'ingredient_index': idx
-                    })
-
-                    # Add concentration info
-                    if 'concentration' in ingredient:
-                        conc = ingredient['concentration']
-                        conc_info = {
-                            'value': str(conc.get('value', 'variable')),
-                            'unit': conc.get('unit', 'VARIABLE'),
-                            'notes': ingredient.get('notes', '')
-                        }
-                        ing_data['concentration_info'].append(conc_info)
-
-                    # Track synonyms
-                    notes = ingredient.get('notes', '')
-                    if notes:
-                        ing_data['synonyms'].add(notes[:100])  # Limit length
-
-                    # Update category stats
-                    self.category_stats[medium_category]['media_with_mapped'].add(medium_name)
-                    self.category_stats[medium_category]['total_mapped_instances'] += 1
-                    self.category_stats[medium_category]['unique_mapped'].add(key)
-
-                    # Update ontology stats
-                    self.ontology_stats[ontology_source]['unique_terms'].add(term_id)
-                    self.ontology_stats[ontology_source]['total_instances'] += 1
-
-            if has_mapped:
-                self.media_with_mapped.add(medium_name)
-
-            self.total_media_processed += 1
-
-            if self.verbose and self.total_media_processed % 100 == 0:
-                print(f"Processed {self.total_media_processed} media files...", file=sys.stderr)
-
-        except Exception as e:
-            if self.verbose:
-                print(f"Error processing {file_path}: {e}", file=sys.stderr)
-
-    def scan_all_media(self) -> None:
-        """Scan all media YAML files in the input directory."""
-        if not self.input_dir.exists():
-            raise ValueError(f"Input directory not found: {self.input_dir}")
-
-        pattern = str(self.input_dir / "**/*.yaml")
-        media_files = glob.glob(pattern, recursive=True)
-
-        if self.verbose:
-            print(f"Found {len(media_files)} media files to process", file=sys.stderr)
-
-        for file_path in media_files:
-            self.process_medium_file(Path(file_path))
-
-        if self.verbose:
-            print(f"Completed processing {self.total_media_processed} media files", file=sys.stderr)
-            print(f"Total ingredients processed: {self.total_ingredients_processed}", file=sys.stderr)
-
-    def generate_output(self) -> Dict:
-        """Generate the structured output conforming to the schema."""
-        # Filter by minimum occurrences
-        filtered_ingredients = {
-            k: v for k, v in self.mapped_ingredients.items()
-            if v['occurrence_count'] >= self.min_occurrences
-        }
-
-        # Convert sets to lists and prepare output
-        mapped_list = []
-        for preferred_term, data in sorted(filtered_ingredients.items(),
-                                          key=lambda x: x[1]['occurrence_count'],
-                                          reverse=True):
-            ingredient_entry = {
-                'preferred_term': preferred_term,
-                'ontology_id': data['ontology_id'],
-                'ontology_label': data['ontology_label'],
-                'ontology_source': data['ontology_source'],
-                'occurrence_count': data['occurrence_count'],
-                'media_occurrences': data['media_occurrences'][:50],  # Limit to 50 examples
-                'mapping_quality': 'DIRECT_MATCH'  # Default assumption
-            }
-
-            # Add unique concentration info
-            unique_conc = []
-            seen_conc = set()
-            for conc in data['concentration_info']:
-                key = (conc['value'], conc['unit'])
-                if key not in seen_conc:
-                    seen_conc.add(key)
-                    unique_conc.append(conc)
-            ingredient_entry['concentration_info'] = unique_conc[:10]  # Limit to 10 examples
-
-            # Add synonyms if any
-            if data['synonyms']:
-                ingredient_entry['synonyms'] = sorted(data['synonyms'])[:5]  # Limit to 5
-
-            mapped_list.append(ingredient_entry)
-
-        # Prepare category summary
-        category_summary = []
-        for category, stats in sorted(self.category_stats.items()):
-            category_summary.append({
-                'category': category,
-                'media_with_mapped': len(stats['media_with_mapped']),
-                'total_mapped_instances': stats['total_mapped_instances'],
-                'unique_mapped_count': len(stats['unique_mapped'])
-            })
-
-        # Prepare ontology summary
-        total_instances = sum(stats['total_instances'] for stats in self.ontology_stats.values())
-        ontology_summary = []
-        for ontology, stats in sorted(self.ontology_stats.items(),
-                                     key=lambda x: x[1]['total_instances'],
-                                     reverse=True):
-            coverage_pct = (stats['total_instances'] / total_instances * 100) if total_instances > 0 else 0
-            ontology_summary.append({
-                'ontology_source': ontology,
-                'unique_terms_count': len(stats['unique_terms']),
-                'total_instances': stats['total_instances'],
-                'coverage_percentage': round(coverage_pct, 2)
-            })
-
-        # Calculate total instances
-        total_instances_count = sum(ing['occurrence_count'] for ing in mapped_list)
-
-        # Build final output
-        output = {
-            'generation_date': datetime.now().isoformat(),
-            'total_mapped_count': len(filtered_ingredients),
-            'total_instances': total_instances_count,
-            'media_count': len(self.media_with_mapped),
-            'mapped_ingredients': mapped_list,
-            'summary_by_category': category_summary,
-            'summary_by_ontology': ontology_summary
-        }
-
-        return output
-
-    def save_output(self, output_path: str) -> None:
-        """Save the aggregated output to a YAML file."""
-        output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        output_data = self.generate_output()
-
-        with open(output_path, 'w', encoding='utf-8') as f:
-            yaml.dump(output_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-        if self.verbose:
-            print(f"\nOutput saved to: {output_path}", file=sys.stderr)
-            print(f"Total mapped ingredients: {output_data['total_mapped_count']}", file=sys.stderr)
-            print(f"Total instances: {output_data['total_instances']}", file=sys.stderr)
-            print(f"Media with mapped ingredients: {output_data['media_count']}", file=sys.stderr)
+from ingredient_occurrences import (
+    build_mapped_output,
+    ensure_distinct_output_paths,
+    scan_ingredient_occurrences,
+    write_error_report,
+    write_occurrences_and_yaml,
+)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Aggregate mapped media ingredients into structured YAML',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__
-    )
-
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=Path("output/mapped_ingredients.yaml"))
+    parser.add_argument("--input-dir", type=Path, default=Path("data/normalized_yaml"))
+    parser.add_argument("--min-occurrences", type=int, default=1)
     parser.add_argument(
-        '--output',
-        default='output/mapped_ingredients.yaml',
-        help='Output file path (default: output/mapped_ingredients.yaml)'
+        "--occurrences-output",
+        type=Path,
+        default=Path("output/ingredient_occurrences.tsv"),
     )
-
     parser.add_argument(
-        '--input-dir',
-        default='data/normalized_yaml',
-        help='Input directory with media YAML files (default: data/normalized_yaml)'
+        "--errors-output",
+        type=Path,
+        default=Path("output/ingredient_aggregation_errors.tsv"),
     )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    if args.min_occurrences < 1:
+        parser.error("--min-occurrences must be at least 1")
+    ensure_distinct_output_paths(args.output, args.occurrences_output, args.errors_output)
 
-    parser.add_argument(
-        '--min-occurrences',
-        type=int,
-        default=1,
-        help='Only include ingredients appearing at least N times (default: 1)'
+    result = scan_ingredient_occurrences(args.input_dir)
+    write_error_report(args.errors_output, result.errors)
+    if result.errors:
+        if args.verbose:
+            print(f"Mapped aggregation failed with {len(result.errors)} input error(s)")
+        return 1
+    output = build_mapped_output(result.occurrences, args.min_occurrences)
+    write_occurrences_and_yaml(
+        args.occurrences_output,
+        result.occurrences,
+        args.output,
+        output,
     )
-
-    parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose logging'
-    )
-
-    args = parser.parse_args()
-
-    try:
-        aggregator = MappedIngredientAggregator(
-            input_dir=args.input_dir,
-            min_occurrences=args.min_occurrences,
-            verbose=args.verbose
+    if args.verbose:
+        print(
+            f"Mapped aggregation complete: {output['total_instances']} occurrences "
+            f"across {output['total_mapped_count']} identities"
         )
-
-        aggregator.scan_all_media()
-        aggregator.save_output(args.output)
-
-        print(f"✅ Successfully aggregated mapped ingredients to {args.output}")
-
-    except Exception as e:
-        print(f"❌ Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aggregate_unmapped_ingredients.py
+++ b/scripts/aggregate_unmapped_ingredients.py
@@ -1,337 +1,67 @@
 #!/usr/bin/env python3
+"""Compatibility CLI for the unresolved ingredient aggregation view.
+
+The canonical ``aggregate-all-ingredients`` command scans once and writes both
+partitions.  This wrapper keeps the historical command-line interface while
+delegating traversal, validation, identity resolution, and counting to the
+shared #337 occurrence collector.
 """
-Aggregate Unmapped Media Ingredients
 
-This script scans all media YAML files, identifies unmapped ingredients,
-and outputs a structured YAML file conforming to the unmapped_ingredients_schema.
-
-Unmapped ingredients are identified by:
-- Numeric placeholder IDs (e.g., '1', '2', '3')
-- Generic placeholders like 'See source for composition'
-- Empty or missing preferred_term values
-
-Usage:
-    python scripts/aggregate_unmapped_ingredients.py [options]
-
-Options:
-    --output PATH       Output file path (default: output/unmapped_ingredients.yaml)
-    --input-dir PATH    Input directory with media YAML files (default: data/normalized_yaml)
-    --min-occurrences N Only include ingredients appearing at least N times (default: 1)
-    --verbose           Enable verbose logging
-"""
+from __future__ import annotations
 
 import argparse
-import glob
-import re
-import sys
-from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
 
-import yaml
-
-
-class UnmappedIngredientAggregator:
-    """Aggregates unmapped ingredients from media YAML files."""
-
-    def __init__(self, input_dir: str = "data/normalized_yaml", min_occurrences: int = 1, verbose: bool = False):
-        self.input_dir = Path(input_dir)
-        self.min_occurrences = min_occurrences
-        self.verbose = verbose
-
-        # Data structures for aggregation
-        self.unmapped_ingredients: Dict[str, Dict] = defaultdict(lambda: {
-            'placeholder_id': '',
-            'raw_ingredient_text': set(),
-            'occurrence_count': 0,
-            'media_occurrences': [],
-            'concentration_info': []
-        })
-
-        self.category_stats = defaultdict(lambda: {
-            'media_with_unmapped': set(),
-            'total_unmapped_instances': 0,
-            'unique_unmapped': set()
-        })
-
-        self.total_media_processed = 0
-        self.media_with_unmapped = set()
-
-    def is_unmapped_ingredient(self, preferred_term: str) -> bool:
-        """Check if an ingredient is unmapped based on its preferred_term."""
-        if not preferred_term or preferred_term.strip() == '':
-            return True
-
-        # Numeric placeholders
-        if preferred_term.isdigit():
-            return True
-
-        # Generic placeholders
-        generic_placeholders = [
-            'See source for composition',
-            'variable',
-            'See source',
-            'Not specified',
-            'Unknown'
-        ]
-
-        if any(placeholder.lower() in preferred_term.lower() for placeholder in generic_placeholders):
-            return True
-
-        return False
-
-    def extract_chemical_name(self, notes: str) -> str:
-        """Extract chemical name from notes field."""
-        if not notes:
-            return ""
-
-        # Try to extract from "Original amount: <chemical>" pattern
-        match = re.search(r'Original amount:\s*([^\(]+)', notes)
-        if match:
-            chemical = match.group(1).strip()
-            # Remove any trailing numbers or special chars
-            chemical = re.sub(r'\s*[\d.]+\s*$', '', chemical)
-            return chemical
-
-        # Try to extract before parentheses
-        match = re.search(r'^([^\(]+)', notes)
-        if match:
-            return match.group(1).strip()
-
-        return notes.strip()
-
-    def process_medium_file(self, file_path: Path) -> None:
-        """Process a single medium YAML file."""
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                data = yaml.safe_load(f)
-
-            if not data or 'ingredients' not in data:
-                return
-
-            medium_name = data.get('name', file_path.stem)
-            medium_category = data.get('category', 'UNKNOWN').upper()
-
-            has_unmapped = False
-
-            for idx, ingredient in enumerate(data['ingredients']):
-                preferred_term = ingredient.get('preferred_term', '')
-
-                if self.is_unmapped_ingredient(preferred_term):
-                    # Skip completely empty ingredients (data quality issue)
-                    notes = ingredient.get('notes', '')
-                    if not preferred_term and not notes:
-                        if self.verbose:
-                            print(f"Skipping empty ingredient at index {idx} in {medium_name}", file=sys.stderr)
-                        continue
-
-                    has_unmapped = True
-
-                    # Extract chemical name from notes
-                    chemical_name = self.extract_chemical_name(notes)
-
-                    # Use chemical name as aggregation key (not placeholder_id which gets reused)
-                    # Fallback to notes if no chemical name, then preferred_term
-                    aggregation_key = chemical_name or notes or preferred_term or f'empty_{idx}'
-                    placeholder_id = preferred_term if preferred_term else f'empty_{idx}'
-
-                    # Add to aggregation
-                    ing_data = self.unmapped_ingredients[aggregation_key]
-                    ing_data['placeholder_id'] = placeholder_id
-
-                    if notes:
-                        ing_data['raw_ingredient_text'].add(notes)
-                    if chemical_name:
-                        if 'parsed_chemical_names' not in ing_data:
-                            ing_data['parsed_chemical_names'] = set()
-                        ing_data['parsed_chemical_names'].add(chemical_name)
-
-                    ing_data['occurrence_count'] += 1
-
-                    # Add media occurrence
-                    ing_data['media_occurrences'].append({
-                        'medium_name': medium_name,
-                        'medium_category': medium_category,
-                        'medium_file_path': str(file_path.relative_to(self.input_dir.parent)),
-                        'ingredient_index': idx
-                    })
-
-                    # Add concentration info
-                    if 'concentration' in ingredient:
-                        conc = ingredient['concentration']
-                        conc_info = {
-                            'value': str(conc.get('value', 'variable')),
-                            'unit': conc.get('unit', 'VARIABLE'),
-                            'notes': notes
-                        }
-                        ing_data['concentration_info'].append(conc_info)
-
-                    # Update category stats
-                    self.category_stats[medium_category]['media_with_unmapped'].add(medium_name)
-                    self.category_stats[medium_category]['total_unmapped_instances'] += 1
-                    self.category_stats[medium_category]['unique_unmapped'].add(placeholder_id)
-
-            if has_unmapped:
-                self.media_with_unmapped.add(medium_name)
-
-            self.total_media_processed += 1
-
-            if self.verbose and self.total_media_processed % 100 == 0:
-                print(f"Processed {self.total_media_processed} media files...", file=sys.stderr)
-
-        except Exception as e:
-            if self.verbose:
-                print(f"Error processing {file_path}: {e}", file=sys.stderr)
-
-    def scan_all_media(self) -> None:
-        """Scan all media YAML files in the input directory."""
-        if not self.input_dir.exists():
-            raise ValueError(f"Input directory not found: {self.input_dir}")
-
-        pattern = str(self.input_dir / "**/*.yaml")
-        media_files = glob.glob(pattern, recursive=True)
-
-        if self.verbose:
-            print(f"Found {len(media_files)} media files to process", file=sys.stderr)
-
-        for file_path in media_files:
-            self.process_medium_file(Path(file_path))
-
-        if self.verbose:
-            print(f"Completed processing {self.total_media_processed} media files", file=sys.stderr)
-
-    def generate_output(self) -> Dict:
-        """Generate the structured output conforming to the schema."""
-        # Filter by minimum occurrences
-        filtered_ingredients = {
-            k: v for k, v in self.unmapped_ingredients.items()
-            if v['occurrence_count'] >= self.min_occurrences
-        }
-
-        # Convert sets to lists and prepare output
-        unmapped_list = []
-        for aggregation_key, data in sorted(filtered_ingredients.items(),
-                                          key=lambda x: x[1]['occurrence_count'],
-                                          reverse=True):
-            # Get the stored placeholder_id from the first occurrence
-            actual_placeholder_id = data.get('placeholder_id', aggregation_key)
-
-            ingredient_entry = {
-                'placeholder_id': actual_placeholder_id,
-                'raw_ingredient_text': sorted(data['raw_ingredient_text']),
-                'occurrence_count': data['occurrence_count'],
-                'media_occurrences': data['media_occurrences'],
-                'mapping_status': 'UNMAPPED'
-            }
-
-            # Add parsed chemical name (use aggregation_key if it looks like a chemical name)
-            if 'parsed_chemical_names' in data and data['parsed_chemical_names']:
-                # Use the most common one or first one
-                ingredient_entry['parsed_chemical_name'] = sorted(data['parsed_chemical_names'])[0]
-            elif aggregation_key and not aggregation_key.startswith('empty_'):
-                # Use aggregation_key as parsed name if it's not an empty placeholder
-                ingredient_entry['parsed_chemical_name'] = aggregation_key
-
-            # Add unique concentration info
-            unique_conc = []
-            seen_conc = set()
-            for conc in data['concentration_info']:
-                key = (conc['value'], conc['unit'])
-                if key not in seen_conc:
-                    seen_conc.add(key)
-                    unique_conc.append(conc)
-            ingredient_entry['concentration_info'] = unique_conc[:10]  # Limit to 10 examples
-
-            unmapped_list.append(ingredient_entry)
-
-        # Prepare category summary
-        summary_list = []
-        for category, stats in sorted(self.category_stats.items()):
-            summary_list.append({
-                'category': category,
-                'media_with_unmapped': len(stats['media_with_unmapped']),
-                'total_unmapped_instances': stats['total_unmapped_instances'],
-                'unique_unmapped_count': len(stats['unique_unmapped'])
-            })
-
-        # Build final output
-        output = {
-            'generation_date': datetime.now().isoformat(),
-            'total_unmapped_count': len(filtered_ingredients),
-            'media_count': len(self.media_with_unmapped),
-            'unmapped_ingredients': unmapped_list,
-            'summary_by_category': summary_list
-        }
-
-        return output
-
-    def save_output(self, output_path: str) -> None:
-        """Save the aggregated output to a YAML file."""
-        output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        output_data = self.generate_output()
-
-        with open(output_path, 'w', encoding='utf-8') as f:
-            yaml.dump(output_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
-
-        if self.verbose:
-            print(f"\nOutput saved to: {output_path}", file=sys.stderr)
-            print(f"Total unmapped ingredients: {output_data['total_unmapped_count']}", file=sys.stderr)
-            print(f"Media with unmapped ingredients: {output_data['media_count']}", file=sys.stderr)
+from ingredient_occurrences import (
+    build_unmapped_output,
+    ensure_distinct_output_paths,
+    scan_ingredient_occurrences,
+    write_error_report,
+    write_occurrences_and_yaml,
+)
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Aggregate unmapped media ingredients into structured YAML',
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__
-    )
-
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=Path("output/unmapped_ingredients.yaml"))
+    parser.add_argument("--input-dir", type=Path, default=Path("data/normalized_yaml"))
+    parser.add_argument("--min-occurrences", type=int, default=1)
     parser.add_argument(
-        '--output',
-        default='output/unmapped_ingredients.yaml',
-        help='Output file path (default: output/unmapped_ingredients.yaml)'
+        "--occurrences-output",
+        type=Path,
+        default=Path("output/ingredient_occurrences.tsv"),
     )
-
     parser.add_argument(
-        '--input-dir',
-        default='data/normalized_yaml',
-        help='Input directory with media YAML files (default: data/normalized_yaml)'
+        "--errors-output",
+        type=Path,
+        default=Path("output/ingredient_aggregation_errors.tsv"),
     )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    if args.min_occurrences < 1:
+        parser.error("--min-occurrences must be at least 1")
+    ensure_distinct_output_paths(args.output, args.occurrences_output, args.errors_output)
 
-    parser.add_argument(
-        '--min-occurrences',
-        type=int,
-        default=1,
-        help='Only include ingredients appearing at least N times (default: 1)'
+    result = scan_ingredient_occurrences(args.input_dir)
+    write_error_report(args.errors_output, result.errors)
+    if result.errors:
+        if args.verbose:
+            print(f"Unmapped aggregation failed with {len(result.errors)} input error(s)")
+        return 1
+    output = build_unmapped_output(result.occurrences, args.min_occurrences)
+    write_occurrences_and_yaml(
+        args.occurrences_output,
+        result.occurrences,
+        args.output,
+        output,
     )
-
-    parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose logging'
-    )
-
-    args = parser.parse_args()
-
-    try:
-        aggregator = UnmappedIngredientAggregator(
-            input_dir=args.input_dir,
-            min_occurrences=args.min_occurrences,
-            verbose=args.verbose
+    if args.verbose:
+        print(
+            f"Unmapped aggregation complete: {output['total_instances']} occurrences "
+            f"across {output['total_unmapped_count']} unresolved groups"
         )
-
-        aggregator.scan_all_media()
-        aggregator.save_output(args.output)
-
-        print(f"✅ Successfully aggregated unmapped ingredients to {args.output}")
-
-    except Exception as e:
-        print(f"❌ Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ingredient_occurrences.py
+++ b/scripts/ingredient_occurrences.py
@@ -1,0 +1,1011 @@
+"""Lossless direct ingredient-occurrence collection and aggregation (#337).
+
+The source corpus has two root record contracts.  MediaRecipe-shaped records
+own ``ingredients``; SolutionRecipe-shaped records own ``composition``.  This
+module selects exactly one of those fields, records every direct descriptor
+with stable coordinates, and resolves its identity through the pinned
+MediaIngredientMech label index introduced by #260.
+
+The TSV occurrence artifact is canonical.  The mapped and unmapped YAML files
+are deterministic compatibility views derived from the same in-memory rows.
+Input errors are collected before any successful artifact is replaced.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import stat
+import tempfile
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO, cast
+
+import yaml
+from linkml.validator.report import Severity
+from record_kinds import has_solution_shape
+from validate_strict import _get_validator, classify, infer_target_class
+
+from culturemech.ingredients.mim_label_index import (
+    GroundingDecision,
+    ResolutionSource,
+    resolve_ingredient,
+)
+
+OCCURRENCE_FIELDS = (
+    "recipe_id",
+    "recipe_label",
+    "recipe_category",
+    "source_path",
+    "record_class",
+    "component_field",
+    "component_index",
+    "preferred_term",
+    "label_source",
+    "resolved_identifier",
+    "resolution_source",
+    "local_identifier",
+    "source_compound_id",
+    "mim_preferred_term",
+    "mim_matched_label",
+    "mim_match_type",
+    "mim_mapping_status",
+    "mim_ambiguity",
+    "mim_ontology_id_diagnostic",
+    "grounding_reason",
+    "concentration_value",
+    "concentration_unit",
+    "ingredient_json",
+)
+ERROR_FIELDS = ("file", "layer", "category", "detail", "path", "message")
+
+
+@dataclass(frozen=True)
+class AggregationError:
+    """One row in the shared machine-readable error report."""
+
+    file: str
+    layer: str
+    category: str
+    detail: str
+    path: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {field: str(getattr(self, field)) for field in ERROR_FIELDS}
+
+
+@dataclass(frozen=True)
+class IngredientOccurrence:
+    """One direct root-recipe ingredient descriptor and its grounding audit."""
+
+    recipe_id: str
+    recipe_label: str
+    recipe_category: str
+    source_path: str
+    record_class: str
+    component_field: str
+    component_index: int
+    preferred_term: str
+    label_source: str
+    resolved_identifier: str
+    resolution_source: str
+    local_identifier: str
+    source_compound_id: str
+    mim_preferred_term: str
+    mim_matched_label: str
+    mim_match_type: str
+    mim_mapping_status: str
+    mim_ambiguity: str
+    mim_ontology_id_diagnostic: str
+    grounding_reason: str
+    concentration_value: str
+    concentration_unit: str
+    ingredient_json: str
+
+    @property
+    def key(self) -> tuple[str, str, int]:
+        """Stable occurrence coordinate within the CultureMech corpus."""
+
+        return self.recipe_id, self.component_field, self.component_index
+
+    @property
+    def is_resolved(self) -> bool:
+        return bool(self.resolved_identifier)
+
+    @property
+    def ingredient_label(self) -> str:
+        """Compatibility alias for callers that use the longer field name."""
+
+        return self.preferred_term
+
+    @property
+    def grounding_id(self) -> str:
+        """Compatibility alias; ``resolved_identifier`` is the canonical name."""
+
+        return self.resolved_identifier
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {field: getattr(self, field) for field in OCCURRENCE_FIELDS}
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """Complete deterministic scan result, including all fatal input errors."""
+
+    occurrences: tuple[IngredientOccurrence, ...]
+    errors: tuple[AggregationError, ...]
+
+
+Resolver = Callable[[Mapping[str, Any]], GroundingDecision]
+
+
+def _cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _error(
+    source_path: str,
+    category: str,
+    message: str,
+    *,
+    path: str = "",
+    detail: str = "",
+    layer: str = "occurrence",
+) -> AggregationError:
+    return AggregationError(
+        file=source_path,
+        layer=layer,
+        category=category,
+        detail=detail,
+        path=path,
+        message=message[:300],
+    )
+
+
+def _schema_errors(instance: dict[str, Any], source_path: str) -> list[AggregationError]:
+    try:
+        report = _get_validator().validate(
+            instance,
+            target_class=infer_target_class(instance),
+        )
+    except Exception as exc:  # noqa: BLE001 - preserve validate-strict's failure contract
+        return [
+            _error(
+                source_path,
+                "validator_crash",
+                str(exc),
+                detail=type(exc).__name__,
+                layer="schema",
+            )
+        ]
+    errors: list[AggregationError] = []
+    for result in report.results:
+        if result.severity != Severity.ERROR:
+            continue
+        category, detail = classify(result.message)
+        errors.append(
+            _error(
+                source_path,
+                category,
+                result.message,
+                detail=detail,
+                path=result.instance_index or "",
+                layer="schema",
+            )
+        )
+    return errors
+
+
+def _recipe_label(instance: Mapping[str, Any], record_class: str) -> tuple[str, str]:
+    preferred = instance.get("preferred_term")
+    if isinstance(preferred, str) and preferred.strip():
+        return preferred, "preferred_term"
+    name = instance.get("name")
+    if record_class == "MediaRecipe" and isinstance(name, str) and name.strip():
+        return name, "legacy_name"
+    return "", "blank"
+
+
+def _decision_value(value: str | None) -> str:
+    return value or ""
+
+
+def _occurrence_from_descriptor(
+    *,
+    recipe_id: str,
+    recipe_label: str,
+    recipe_label_source: str,
+    recipe_category: str,
+    source_path: str,
+    record_class: str,
+    component_field: str,
+    component_index: int,
+    descriptor: Mapping[str, Any],
+    resolver: Resolver,
+) -> IngredientOccurrence:
+    label_value = descriptor.get("preferred_term")
+    label = label_value if isinstance(label_value, str) else ""
+    decision = resolver(descriptor)
+    concentration = descriptor.get("concentration")
+    if not isinstance(concentration, Mapping):
+        concentration = {}
+    return IngredientOccurrence(
+        recipe_id=recipe_id,
+        recipe_label=recipe_label,
+        recipe_category=recipe_category,
+        source_path=source_path,
+        record_class=record_class,
+        component_field=component_field,
+        component_index=component_index,
+        preferred_term=label,
+        label_source=recipe_label_source,
+        resolved_identifier=_decision_value(decision.identifier),
+        resolution_source=decision.resolution_source.value,
+        local_identifier=_decision_value(decision.local_identifier),
+        source_compound_id=_decision_value(decision.source_compound_id),
+        mim_preferred_term=_decision_value(decision.mim_preferred_term),
+        mim_matched_label=_decision_value(decision.matched_label),
+        mim_match_type=_decision_value(decision.match_type),
+        mim_mapping_status=_decision_value(decision.mapping_status),
+        mim_ambiguity=_decision_value(decision.ambiguity),
+        mim_ontology_id_diagnostic=_decision_value(decision.ontology_id),
+        grounding_reason=decision.reason,
+        concentration_value=_cell(concentration.get("value")),
+        concentration_unit=_cell(concentration.get("unit")),
+        ingredient_json=json.dumps(
+            dict(descriptor),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+
+
+def scan_ingredient_occurrences(
+    input_dir: str | Path,
+    resolver: Resolver = resolve_ingredient,
+) -> ScanResult:
+    """Scan all YAML roots and collect their authoritative direct components.
+
+    Every file is parsed and checked against the same closed LinkML schema used
+    by ``validate_strict.py``.  Any error makes the scan unsuitable for
+    publication, but all files are still visited so the error report is
+    complete.
+    """
+
+    root = Path(input_dir)
+    if not root.is_dir():
+        return ScanResult(
+            occurrences=(),
+            errors=(
+                _error(
+                    root.as_posix(),
+                    "invalid_input_dir",
+                    "input directory does not exist or is not a directory",
+                ),
+            ),
+        )
+
+    occurrences: list[IngredientOccurrence] = []
+    errors: list[AggregationError] = []
+    seen_keys: dict[tuple[str, str, int], str] = {}
+    seen_recipe_ids: dict[str, str] = {}
+
+    files = sorted(root.rglob("*.yaml"), key=lambda item: item.as_posix())
+    if not files:
+        return ScanResult(
+            occurrences=(),
+            errors=(
+                _error(
+                    root.as_posix(),
+                    "no_input_files",
+                    "input directory contains no YAML files",
+                ),
+            ),
+        )
+
+    for path in files:
+        source_path = path.relative_to(root).as_posix()
+        try:
+            instance = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError as exc:
+            errors.append(
+                _error(
+                    source_path,
+                    "input_decode_error",
+                    str(exc),
+                    detail="expected UTF-8",
+                    layer="schema",
+                )
+            )
+            continue
+        except yaml.YAMLError as exc:
+            errors.append(
+                _error(
+                    source_path,
+                    "yaml_parse_error",
+                    str(exc).splitlines()[0],
+                    layer="schema",
+                )
+            )
+            continue
+        except OSError as exc:
+            errors.append(
+                _error(
+                    source_path,
+                    "input_read_error",
+                    str(exc),
+                    detail=type(exc).__name__,
+                )
+            )
+            continue
+
+        if instance is None:
+            errors.append(
+                _error(
+                    source_path,
+                    "empty_file",
+                    "file parsed as None",
+                    layer="schema",
+                )
+            )
+            continue
+        if not isinstance(instance, dict):
+            errors.append(
+                _error(
+                    source_path,
+                    "invalid_record_root",
+                    "root YAML value must be a mapping",
+                )
+            )
+            continue
+
+        validation_errors = _schema_errors(instance, source_path)
+        if validation_errors:
+            errors.extend(validation_errors)
+            continue
+
+        record_class = "SolutionRecipe" if has_solution_shape(instance) else "MediaRecipe"
+        component_field = "composition" if record_class == "SolutionRecipe" else "ingredients"
+        recipe_id_value = instance.get("id")
+        if not isinstance(recipe_id_value, str) or not recipe_id_value.strip():
+            errors.append(
+                _error(
+                    source_path,
+                    "missing_recipe_id",
+                    "root record has no usable CultureMech id",
+                    path="/id",
+                )
+            )
+            continue
+        recipe_id = recipe_id_value.strip()
+        previous_recipe_path = seen_recipe_ids.get(recipe_id)
+        if previous_recipe_path is not None:
+            errors.append(
+                _error(
+                    source_path,
+                    "duplicate_recipe_id",
+                    f"root recipe id also appears in {previous_recipe_path}",
+                    path="/id",
+                    detail=recipe_id,
+                )
+            )
+            continue
+        seen_recipe_ids[recipe_id] = source_path
+        recipe_label, recipe_label_source = _recipe_label(instance, record_class)
+        if not recipe_label:
+            errors.append(
+                _error(
+                    source_path,
+                    "missing_recipe_label",
+                    "root record has no canonical display label",
+                    path="/preferred_term" if record_class == "SolutionRecipe" else "/name",
+                )
+            )
+            continue
+
+        components = instance.get(component_field)
+        if not isinstance(components, list):
+            errors.append(
+                _error(
+                    source_path,
+                    "invalid_component_collection",
+                    f"{component_field} must be a list",
+                    path=f"/{component_field}",
+                )
+            )
+            continue
+
+        recipe_category = _cell(instance.get("category") or "UNKNOWN").upper()
+        for index, descriptor in enumerate(components):
+            descriptor_path = f"/{component_field}/{index}"
+            if not isinstance(descriptor, Mapping):
+                errors.append(
+                    _error(
+                        source_path,
+                        "invalid_component",
+                        "ingredient descriptor must be a mapping",
+                        path=descriptor_path,
+                    )
+                )
+                continue
+            try:
+                occurrence = _occurrence_from_descriptor(
+                    recipe_id=recipe_id,
+                    recipe_label=recipe_label,
+                    recipe_label_source=recipe_label_source,
+                    recipe_category=recipe_category,
+                    source_path=source_path,
+                    record_class=record_class,
+                    component_field=component_field,
+                    component_index=index,
+                    descriptor=descriptor,
+                    resolver=resolver,
+                )
+            except Exception as exc:  # noqa: BLE001 - report instead of silently skipping
+                errors.append(
+                    _error(
+                        source_path,
+                        "resolver_error",
+                        str(exc),
+                        path=descriptor_path,
+                        detail=type(exc).__name__,
+                    )
+                )
+                continue
+            previous_path = seen_keys.get(occurrence.key)
+            if previous_path is not None:
+                errors.append(
+                    _error(
+                        source_path,
+                        "duplicate_occurrence_key",
+                        "stable occurrence coordinate also appears in " + previous_path,
+                        path=descriptor_path,
+                        detail="|".join(map(str, occurrence.key)),
+                    )
+                )
+                continue
+            seen_keys[occurrence.key] = source_path
+            occurrences.append(occurrence)
+
+    occurrences.sort(
+        key=lambda row: (
+            row.recipe_id,
+            row.component_field,
+            row.component_index,
+            row.source_path,
+        )
+    )
+    errors.sort(
+        key=lambda row: (
+            row.file,
+            row.layer,
+            row.path,
+            row.category,
+            row.message,
+        )
+    )
+    return ScanResult(tuple(occurrences), tuple(errors))
+
+
+def _write_tsv(
+    stream: TextIO,
+    fieldnames: Sequence[str],
+    rows: Sequence[Mapping[str, Any]],
+) -> None:
+    writer = csv.DictWriter(
+        stream,
+        fieldnames=fieldnames,
+        delimiter="\t",
+        quoting=csv.QUOTE_MINIMAL,
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+
+
+def _write_occurrences_stream(
+    stream: TextIO,
+    occurrences: Sequence[IngredientOccurrence],
+) -> None:
+    writer = csv.DictWriter(
+        stream,
+        fieldnames=OCCURRENCE_FIELDS,
+        delimiter="\t",
+        quoting=csv.QUOTE_MINIMAL,
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    for row in occurrences:
+        writer.writerow(row.as_dict())
+
+
+def _write_errors_stream(stream: TextIO, errors: Sequence[AggregationError]) -> None:
+    _write_tsv(stream, ERROR_FIELDS, [row.as_dict() for row in errors])
+
+
+def _safe_dump(value: Any, stream: TextIO) -> None:
+    yaml.safe_dump(
+        value,
+        stream,
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+
+def _write_yaml_collection_stream(stream: TextIO, value: Mapping[str, Any]) -> None:
+    """Write one top-level collection without representing its full row list.
+
+    PyYAML constructs an in-memory representation graph for a whole value before
+    emitting it.  Dumping each top-level list entry separately preserves the
+    same YAML data model and ordering while keeping the 200k-row mapped view
+    within a practical memory bound.
+    """
+
+    scalar_values = {key: item for key, item in value.items() if not isinstance(item, list)}
+    if scalar_values:
+        _safe_dump(scalar_values, stream)
+    for key, items in value.items():
+        if not isinstance(items, list):
+            continue
+        if not items:
+            stream.write(f"{key}: []\n")
+            continue
+        stream.write(f"{key}:\n")
+        for item in items:
+            _safe_dump([item], stream)
+
+
+ArtifactWriter = Callable[[TextIO], None]
+
+
+def _stage_writer(path: Path, writer: ArtifactWriter) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        newline="\n",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    staged = Path(handle.name)
+    try:
+        with handle:
+            writer(cast(TextIO, handle))
+            handle.flush()
+            os.fsync(handle.fileno())
+        mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o644
+        staged.chmod(mode)
+    except Exception:
+        staged.unlink(missing_ok=True)
+        raise
+    return staged
+
+
+def _backup_destination(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    descriptor, backup_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".bak",
+    )
+    os.close(descriptor)
+    backup = Path(backup_name)
+    backup.unlink()
+    os.link(path, backup)
+    return backup
+
+
+def _atomic_write_many(artifacts: Sequence[tuple[Path, ArtifactWriter]]) -> None:
+    resolved_destinations = [destination.resolve() for destination, _writer in artifacts]
+    if len(resolved_destinations) != len(set(resolved_destinations)):
+        raise ValueError("artifact destinations must be distinct")
+    staged: list[tuple[Path, Path]] = []
+    backups: dict[Path, Path | None] = {}
+    replaced: list[Path] = []
+    try:
+        for destination, writer in artifacts:
+            staged.append((_stage_writer(destination, writer), destination))
+        for _temporary, destination in staged:
+            backups[destination] = _backup_destination(destination)
+        for temporary, destination in staged:
+            os.replace(temporary, destination)
+            replaced.append(destination)
+    except Exception:
+        for destination in reversed(replaced):
+            backup = backups.get(destination)
+            if backup is None:
+                destination.unlink(missing_ok=True)
+            else:
+                os.replace(backup, destination)
+        raise
+    finally:
+        for temporary, _destination in staged:
+            temporary.unlink(missing_ok=True)
+        for backup in backups.values():
+            if backup is not None:
+                backup.unlink(missing_ok=True)
+
+
+def write_occurrences_tsv(
+    path: str | Path,
+    occurrences: Sequence[IngredientOccurrence],
+) -> None:
+    """Atomically write the canonical, uncapped occurrence table."""
+
+    _atomic_write_many(
+        [(Path(path), lambda stream: _write_occurrences_stream(stream, occurrences))]
+    )
+
+
+def write_error_report(path: str | Path, errors: Sequence[AggregationError]) -> None:
+    """Atomically write the shared error header even when there are no rows."""
+
+    _atomic_write_many([(Path(path), lambda stream: _write_errors_stream(stream, errors))])
+
+
+def write_yaml_output(path: str | Path, value: Mapping[str, Any]) -> None:
+    """Atomically write one deterministic compatibility-view YAML file."""
+
+    _atomic_write_many([(Path(path), lambda stream: _write_yaml_collection_stream(stream, value))])
+
+
+def write_occurrences_and_yaml(
+    occurrences_path: str | Path,
+    occurrences: Sequence[IngredientOccurrence],
+    yaml_path: str | Path,
+    value: Mapping[str, Any],
+) -> None:
+    """Publish a compatibility wrapper's two outputs as one staged set."""
+
+    _atomic_write_many(
+        [
+            (
+                Path(occurrences_path),
+                lambda stream: _write_occurrences_stream(stream, occurrences),
+            ),
+            (
+                Path(yaml_path),
+                lambda stream: _write_yaml_collection_stream(stream, value),
+            ),
+        ]
+    )
+
+
+def ensure_distinct_output_paths(*paths: str | Path) -> None:
+    """Reject CLI output aliases before any error or success artifact is touched."""
+
+    resolved = [Path(path).resolve() for path in paths]
+    if len(resolved) != len(set(resolved)):
+        raise ValueError("ingredient aggregation output paths must be distinct")
+
+
+def _occurrence_dict(row: IngredientOccurrence) -> dict[str, Any]:
+    occurrence = {
+        "recipe_id": row.recipe_id,
+        "recipe_label": row.recipe_label,
+        "recipe_category": row.recipe_category,
+        "source_path": row.source_path,
+        "component_field": row.component_field,
+        "component_index": row.component_index,
+        "preferred_term": row.preferred_term,
+        "resolution_source": row.resolution_source,
+        "grounding_reason": row.grounding_reason,
+    }
+    optional = {
+        "resolved_identifier": row.resolved_identifier,
+        "source_compound_id": row.source_compound_id,
+        "local_identifier": row.local_identifier,
+        "mim_preferred_term": row.mim_preferred_term,
+        "mim_matched_label": row.mim_matched_label,
+        "mim_match_type": row.mim_match_type,
+        "mim_mapping_status": row.mim_mapping_status,
+        "mim_ambiguity": row.mim_ambiguity,
+        "mim_ontology_id_diagnostic": row.mim_ontology_id_diagnostic,
+    }
+    occurrence.update({key: value for key, value in optional.items() if value})
+    return occurrence
+
+
+def _ingredient(row: IngredientOccurrence) -> dict[str, Any]:
+    value = json.loads(row.ingredient_json)
+    if not isinstance(value, dict):  # pragma: no cover - constructor guarantees it
+        raise TypeError("ingredient_json must encode a mapping")
+    return value
+
+
+def _concentration_rows(rows: Sequence[IngredientOccurrence]) -> list[dict[str, str]]:
+    unique: dict[tuple[str, str, str], dict[str, str]] = {}
+    for row in rows:
+        ingredient = _ingredient(row)
+        notes = _cell(ingredient.get("notes"))
+        if not row.concentration_value and not row.concentration_unit and not notes:
+            continue
+        key = row.concentration_value, row.concentration_unit, notes
+        unique[key] = {
+            "value": row.concentration_value,
+            "unit": row.concentration_unit,
+            "notes": notes,
+        }
+    return [unique[key] for key in sorted(unique)]
+
+
+def _ontology_source(identifier: str) -> str:
+    prefix = identifier.partition(":")[0].upper()
+    if prefix in {"CHEBI", "FOODON", "NCIT", "MESH", "UBERON", "ENVO"}:
+        return prefix
+    return "OTHER"
+
+
+def _canonical_term(rows: Sequence[IngredientOccurrence]) -> str:
+    mim_terms = sorted({row.mim_preferred_term for row in rows if row.mim_preferred_term})
+    if mim_terms:
+        return mim_terms[0]
+    source_terms = sorted({row.preferred_term for row in rows if row.preferred_term})
+    return source_terms[0] if source_terms else rows[0].resolved_identifier
+
+
+def _mapping_quality(rows: Sequence[IngredientOccurrence]) -> str:
+    match_types = {row.mim_match_type for row in rows if row.mim_match_type}
+    resolution_sources = {row.resolution_source for row in rows}
+    if match_types & {"synonym", "ontology_label"} or ResolutionSource.MIM_NORMALIZED.value in (
+        resolution_sources
+    ):
+        return "SYNONYM_MATCH"
+    if resolution_sources <= {
+        ResolutionSource.MIM_EXACT.value,
+        ResolutionSource.MIM_NORMALIZED.value,
+    }:
+        return "DIRECT_MATCH"
+    return "INFERRED"
+
+
+def _category_summary(
+    rows: Sequence[IngredientOccurrence],
+    *,
+    mapped: bool,
+) -> list[dict[str, Any]]:
+    by_category: dict[str, list[IngredientOccurrence]] = defaultdict(list)
+    for row in rows:
+        by_category[row.recipe_category or "UNKNOWN"].append(row)
+    summary: list[dict[str, Any]] = []
+    for category in sorted(by_category):
+        category_rows = by_category[category]
+        unique_keys = {
+            row.resolved_identifier if mapped else _unmapped_group_key(row) for row in category_rows
+        }
+        summary.append(
+            {
+                "category": category,
+                "recipes_with_mapped" if mapped else "recipes_with_unmapped": len(
+                    {row.recipe_id for row in category_rows}
+                ),
+                "total_mapped_instances" if mapped else "total_unmapped_instances": len(
+                    category_rows
+                ),
+                "unique_mapped_count" if mapped else "unique_unmapped_count": len(unique_keys),
+            }
+        )
+    return summary
+
+
+def build_mapped_output(
+    occurrences: Sequence[IngredientOccurrence],
+    min_occurrences: int = 1,
+) -> dict[str, Any]:
+    """Build the identity-first mapped compatibility view."""
+
+    groups: dict[str, list[IngredientOccurrence]] = defaultdict(list)
+    for row in occurrences:
+        if row.is_resolved:
+            groups[row.resolved_identifier].append(row)
+
+    entries: list[dict[str, Any]] = []
+    included_rows: list[IngredientOccurrence] = []
+    for identifier, group in groups.items():
+        rows = sorted(group, key=lambda row: row.key + (row.source_path,))
+        if len(rows) < min_occurrences:
+            continue
+        included_rows.extend(rows)
+        canonical_term = _canonical_term(rows)
+        source_labels = sorted({row.preferred_term for row in rows if row.preferred_term})
+        entries.append(
+            {
+                "preferred_term": canonical_term,
+                "resolved_identifier": identifier,
+                "ontology_label": canonical_term,
+                "ontology_source": _ontology_source(identifier),
+                "occurrence_count": len(rows),
+                "distinct_recipe_count": len({row.recipe_id for row in rows}),
+                "recipe_occurrences": [_occurrence_dict(row) for row in rows],
+                "concentration_info": _concentration_rows(rows),
+                "synonyms": [label for label in source_labels if label != canonical_term],
+                "mapping_quality": _mapping_quality(rows),
+            }
+        )
+
+    entries.sort(key=lambda entry: (-entry["occurrence_count"], entry["resolved_identifier"]))
+    ontology_rows: dict[str, list[IngredientOccurrence]] = defaultdict(list)
+    for row in included_rows:
+        ontology_rows[_ontology_source(row.resolved_identifier)].append(row)
+    total = len(included_rows)
+    ontology_summary = []
+    for source in sorted(ontology_rows):
+        rows = ontology_rows[source]
+        ontology_summary.append(
+            {
+                "ontology_source": source,
+                "unique_terms_count": len({row.resolved_identifier for row in rows}),
+                "total_instances": len(rows),
+                "coverage_percentage": round((len(rows) * 100.0 / total), 6) if total else 0.0,
+            }
+        )
+    return {
+        "total_mapped_count": len(entries),
+        "total_instances": total,
+        "recipe_count": len({row.recipe_id for row in included_rows}),
+        "mapped_ingredients": entries,
+        "summary_by_category": _category_summary(included_rows, mapped=True),
+        "summary_by_ontology": ontology_summary,
+    }
+
+
+def _unmapped_group_key(row: IngredientOccurrence) -> tuple[str, ...]:
+    if not row.preferred_term.strip():
+        return (
+            "blank",
+            row.recipe_id,
+            row.component_field,
+            str(row.component_index),
+        )
+    return (
+        "label",
+        row.preferred_term,
+        row.resolution_source,
+        row.mim_mapping_status,
+        row.mim_ambiguity,
+    )
+
+
+def _unmapped_status(rows: Sequence[IngredientOccurrence]) -> str:
+    if any(row.resolution_source == ResolutionSource.AMBIGUOUS.value for row in rows):
+        return "AMBIGUOUS"
+    return "UNMAPPED"
+
+
+def build_unmapped_output(
+    occurrences: Sequence[IngredientOccurrence],
+    min_occurrences: int = 1,
+) -> dict[str, Any]:
+    """Build the unresolved compatibility view without dropping blank labels."""
+
+    groups: dict[tuple[str, ...], list[IngredientOccurrence]] = defaultdict(list)
+    for row in occurrences:
+        if not row.is_resolved:
+            groups[_unmapped_group_key(row)].append(row)
+
+    entries: list[dict[str, Any]] = []
+    included_rows: list[IngredientOccurrence] = []
+    for key, group in groups.items():
+        rows = sorted(group, key=lambda row: row.key + (row.source_path,))
+        if len(rows) < min_occurrences:
+            continue
+        included_rows.extend(rows)
+        first = rows[0]
+        notes = sorted(
+            {
+                _cell(_ingredient(row).get("notes"))
+                for row in rows
+                if _cell(_ingredient(row).get("notes"))
+            }
+        )
+        placeholder_id = (
+            first.preferred_term
+            if first.preferred_term
+            else f"blank:{first.recipe_id}:{first.component_field}:{first.component_index}"
+        )
+        entries.append(
+            {
+                "preferred_term": first.preferred_term,
+                "placeholder_id": placeholder_id,
+                "raw_ingredient_text": notes,
+                "parsed_chemical_name": first.preferred_term or (notes[0] if notes else ""),
+                "occurrence_count": len(rows),
+                "distinct_recipe_count": len({row.recipe_id for row in rows}),
+                "recipe_occurrences": [_occurrence_dict(row) for row in rows],
+                "concentration_info": _concentration_rows(rows),
+                "mapping_status": _unmapped_status(rows),
+                "_sort_key": key,
+            }
+        )
+
+    entries.sort(
+        key=lambda entry: (
+            -entry["occurrence_count"],
+            entry["preferred_term"],
+            entry["placeholder_id"],
+            entry["_sort_key"],
+        )
+    )
+    for entry in entries:
+        entry.pop("_sort_key")
+    return {
+        "total_unmapped_count": len(entries),
+        "total_instances": len(included_rows),
+        "recipe_count": len({row.recipe_id for row in included_rows}),
+        "unmapped_ingredients": entries,
+        "summary_by_category": _category_summary(included_rows, mapped=False),
+    }
+
+
+def run_aggregation(
+    input_dir: str | Path,
+    occurrences_output: str | Path,
+    mapped_output: str | Path,
+    unmapped_output: str | Path,
+    errors_output: str | Path,
+    min_occurrences: int = 1,
+    verbose: bool = False,
+    resolver: Resolver = resolve_ingredient,
+) -> int:
+    """Scan once and publish all deterministic views, or only the error report."""
+
+    if min_occurrences < 1:
+        raise ValueError("min_occurrences must be at least 1")
+    ensure_distinct_output_paths(
+        occurrences_output,
+        mapped_output,
+        unmapped_output,
+        errors_output,
+    )
+    result = scan_ingredient_occurrences(input_dir, resolver=resolver)
+    write_error_report(errors_output, result.errors)
+    if result.errors:
+        if verbose:
+            print(
+                f"Ingredient aggregation failed with {len(result.errors)} input error(s); "
+                f"see {errors_output}"
+            )
+        return 1
+
+    mapped = build_mapped_output(result.occurrences, min_occurrences=min_occurrences)
+    unmapped = build_unmapped_output(result.occurrences, min_occurrences=min_occurrences)
+    _atomic_write_many(
+        [
+            (
+                Path(occurrences_output),
+                lambda stream: _write_occurrences_stream(stream, result.occurrences),
+            ),
+            (
+                Path(mapped_output),
+                lambda stream: _write_yaml_collection_stream(stream, mapped),
+            ),
+            (
+                Path(unmapped_output),
+                lambda stream: _write_yaml_collection_stream(stream, unmapped),
+            ),
+        ]
+    )
+    if verbose:
+        print(
+            "Ingredient aggregation complete: "
+            f"{len(result.occurrences)} occurrences, "
+            f"{mapped['total_instances']} mapped, {unmapped['total_instances']} unmapped"
+        )
+    return 0

--- a/scripts/unmapped_ingredients_stats.py
+++ b/scripts/unmapped_ingredients_stats.py
@@ -1,187 +1,164 @@
 #!/usr/bin/env python3
-"""
-Generate statistics and reports from unmapped ingredients data.
+"""Generate a human-readable report from the #337 unresolved summary."""
 
-Usage:
-    python scripts/unmapped_ingredients_stats.py [--input FILE] [--top N]
-"""
+from __future__ import annotations
 
 import argparse
 import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 
-def load_unmapped_data(file_path: str) -> dict:
-    """Load the unmapped ingredients YAML file."""
-    with open(file_path, 'r') as f:
-        return yaml.safe_load(f)
+def load_unmapped_data(file_path: str | Path) -> dict[str, Any]:
+    """Load one deterministic unmapped-ingredients YAML view."""
+
+    with Path(file_path).open(encoding="utf-8") as stream:
+        value = yaml.safe_load(stream)
+    if not isinstance(value, dict):
+        raise ValueError("unmapped ingredient report root must be a mapping")
+    return value
 
 
-def print_summary(data: dict):
+def print_summary(data: dict[str, Any]) -> None:
     """Print high-level summary statistics."""
+
     print("=" * 70)
     print("UNMAPPED INGREDIENTS SUMMARY")
     print("=" * 70)
-    print(f"Generation Date: {data['generation_date']}")
-    print(f"Total Unmapped Ingredients: {data['total_unmapped_count']}")
-    print(f"Media with Unmapped: {data['media_count']}")
+    print(f"Total unresolved groups: {data['total_unmapped_count']}")
+    print(f"Total direct occurrences: {data['total_instances']}")
+    print(f"Recipes with unresolved ingredients: {data['recipe_count']}")
     print()
 
 
-def print_category_breakdown(data: dict):
+def print_category_breakdown(data: dict[str, Any]) -> None:
     """Print category-wise breakdown."""
+
     print("BREAKDOWN BY CATEGORY")
     print("-" * 70)
-    print(f"{'Category':<15} {'Media':<10} {'Instances':<12} {'Unique':<10}")
+    print(f"{'Category':<15} {'Recipes':<10} {'Instances':<12} {'Unique':<10}")
     print("-" * 70)
-
-    for cat in data['summary_by_category']:
-        print(f"{cat['category']:<15} "
-              f"{cat['media_with_unmapped']:<10} "
-              f"{cat['total_unmapped_instances']:<12} "
-              f"{cat['unique_unmapped_count']:<10}")
-
+    for category in data["summary_by_category"]:
+        print(
+            f"{category['category']:<15} "
+            f"{category['recipes_with_unmapped']:<10} "
+            f"{category['total_unmapped_instances']:<12} "
+            f"{category['unique_unmapped_count']:<10}"
+        )
     print()
 
 
-def print_top_unmapped(data: dict, top_n: int = 20):
-    """Print top N most frequent unmapped ingredients."""
+def print_top_unmapped(data: dict[str, Any], top_n: int = 20) -> None:
+    """Print the most frequent unresolved groups."""
+
     print(f"TOP {top_n} MOST FREQUENT UNMAPPED INGREDIENTS")
     print("-" * 70)
-
-    ingredients = data['unmapped_ingredients'][:top_n]
-
-    for i, ing in enumerate(ingredients, 1):
-        placeholder = ing['placeholder_id']
-        count = ing['occurrence_count']
-        parsed = ing.get('parsed_chemical_name', 'N/A')
-
-        print(f"{i}. Placeholder: '{placeholder}' (occurs {count} times)")
-        if parsed != 'N/A':
+    for index, ingredient in enumerate(data["unmapped_ingredients"][:top_n], 1):
+        placeholder = ingredient["placeholder_id"]
+        count = ingredient["occurrence_count"]
+        parsed = ingredient.get("parsed_chemical_name") or "N/A"
+        print(f"{index}. Placeholder: '{placeholder}' (occurs {count} times)")
+        if parsed != "N/A":
             print(f"   Parsed name: {parsed}")
-
-        # Show first few raw texts
-        if ing['raw_ingredient_text']:
-            first_raw = ing['raw_ingredient_text'][0]
+        raw_texts = ingredient.get("raw_ingredient_text") or []
+        if raw_texts:
+            first_raw = str(raw_texts[0])
             if len(first_raw) > 80:
                 first_raw = first_raw[:77] + "..."
             print(f"   Raw text: {first_raw}")
-
         print()
 
 
-def print_mapping_coverage(data: dict):
-    """Calculate and print mapping coverage statistics."""
+def print_mapping_coverage(data: dict[str, Any]) -> None:
+    """Print occurrence-frequency statistics for unresolved groups."""
+
     print("MAPPING COVERAGE ANALYSIS")
     print("-" * 70)
-
-    total_ingredients = data['total_unmapped_count']
-    total_instances = sum(ing['occurrence_count'] for ing in data['unmapped_ingredients'])
-
-    # Calculate ingredients by occurrence frequency
-    freq_ranges = {
-        '1-5': 0,
-        '6-20': 0,
-        '21-50': 0,
-        '51-100': 0,
-        '100+': 0
-    }
-
-    for ing in data['unmapped_ingredients']:
-        count = ing['occurrence_count']
+    total_groups = int(data["total_unmapped_count"])
+    total_instances = int(data["total_instances"])
+    frequency_ranges = {"1-5": 0, "6-20": 0, "21-50": 0, "51-100": 0, "100+": 0}
+    for ingredient in data["unmapped_ingredients"]:
+        count = int(ingredient["occurrence_count"])
         if count <= 5:
-            freq_ranges['1-5'] += 1
+            frequency_ranges["1-5"] += 1
         elif count <= 20:
-            freq_ranges['6-20'] += 1
+            frequency_ranges["6-20"] += 1
         elif count <= 50:
-            freq_ranges['21-50'] += 1
+            frequency_ranges["21-50"] += 1
         elif count <= 100:
-            freq_ranges['51-100'] += 1
+            frequency_ranges["51-100"] += 1
         else:
-            freq_ranges['100+'] += 1
+            frequency_ranges["100+"] += 1
 
-    print(f"Total unique unmapped: {total_ingredients}")
-    print(f"Total instances: {total_instances}")
-    print(f"Average occurrences per ingredient: {total_instances / total_ingredients:.1f}")
+    average = total_instances / total_groups if total_groups else 0.0
+    print(f"Total unresolved groups: {total_groups}")
+    print(f"Total direct occurrences: {total_instances}")
+    print(f"Average occurrences per group: {average:.1f}")
     print()
     print("Frequency distribution:")
-    for range_name, count in freq_ranges.items():
-        pct = (count / total_ingredients * 100) if total_ingredients > 0 else 0
-        print(f"  {range_name} occurrences: {count} ingredients ({pct:.1f}%)")
-
+    for range_name, count in frequency_ranges.items():
+        percentage = count / total_groups * 100 if total_groups else 0.0
+        print(f"  {range_name} occurrences: {count} groups ({percentage:.1f}%)")
     print()
 
 
-def print_category_priorities(data: dict):
-    """Suggest priorities for mapping efforts by category."""
+def print_category_priorities(data: dict[str, Any]) -> None:
+    """Suggest mapping priorities by complete direct-occurrence count."""
+
     print("MAPPING PRIORITY RECOMMENDATIONS")
     print("-" * 70)
-
     categories = sorted(
-        data['summary_by_category'],
-        key=lambda x: x['total_unmapped_instances'],
-        reverse=True
+        data["summary_by_category"],
+        key=lambda value: (-value["total_unmapped_instances"], value["category"]),
     )
-
-    print("Priority order based on instance count:")
-    for i, cat in enumerate(categories, 1):
-        category = cat['category']
-        instances = cat['total_unmapped_instances']
-        unique = cat['unique_unmapped_count']
-        media = cat['media_with_unmapped']
-
-        print(f"{i}. {category}: {instances} instances across {media} media")
-        print(f"   ({unique} unique ingredients to map)")
-
+    print("Priority order based on direct-occurrence count:")
+    for index, category in enumerate(categories, 1):
+        name = category["category"]
+        instances = category["total_unmapped_instances"]
+        unique = category["unique_unmapped_count"]
+        recipes = category["recipes_with_unmapped"]
+        print(f"{index}. {name}: {instances} occurrences across {recipes} recipes")
+        print(f"   ({unique} unresolved groups to map)")
     print()
 
 
-def generate_report(input_file: str, top_n: int = 20):
-    """Generate complete statistics report."""
+def generate_report(input_file: str | Path, top_n: int = 20) -> int:
+    """Generate the complete report, returning a process exit code."""
+
     try:
         data = load_unmapped_data(input_file)
-
         print_summary(data)
         print_category_breakdown(data)
         print_top_unmapped(data, top_n)
         print_mapping_coverage(data)
         print_category_priorities(data)
-
         print("=" * 70)
         print("For detailed data, see:", input_file)
         print("=" * 70)
-
-    except FileNotFoundError:
-        print(f"Error: File not found: {input_file}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    except (OSError, KeyError, TypeError, ValueError, yaml.YAMLError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Generate statistics from unmapped ingredients data'
-    )
-
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '--input',
-        default='output/unmapped_ingredients.yaml',
-        help='Input unmapped ingredients YAML file'
+        "--input",
+        default="output/unmapped_ingredients.yaml",
+        help="Input unmapped ingredients YAML file",
     )
-
     parser.add_argument(
-        '--top',
+        "--top",
         type=int,
         default=20,
-        help='Number of top ingredients to show (default: 20)'
+        help="Number of top unresolved groups to show (default: 20)",
     )
+    args = parser.parse_args(argv)
+    return generate_report(args.input, args.top)
 
-    args = parser.parse_args()
-    generate_report(args.input, args.top)
 
-
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/culturemech/schema/mapped_ingredients_schema.yaml
+++ b/src/culturemech/schema/mapped_ingredients_schema.yaml
@@ -1,10 +1,11 @@
 id: https://w3id.org/culturemech/mapped-ingredients
 name: mapped-ingredients-schema
-title: Mapped Media Ingredients Schema
+title: Mapped Recipe Ingredients Schema
 description: >-
-  LinkML schema for aggregating successfully mapped media ingredients with proper ontology terms.
-  This provides statistics and tracking for ingredients that have been successfully mapped to
-  ontology terms (CHEBI, FOODON, etc.).
+  LinkML schema for deterministic summaries of direct recipe-ingredient
+  occurrences whose semantic identity was resolved through the pinned
+  MediaIngredientMech label index or an explicitly reported local fallback.
+  Identities are not CHEBI-only and upstream source identifiers remain separate.
 
 license: MIT
 see_also:
@@ -25,30 +26,30 @@ imports:
 classes:
   MappedIngredientsCollection:
     tree_root: true
-    description: Root container for all successfully mapped media ingredients
+    description: >-
+      Root container derived from the complete, uncapped direct-occurrence
+      population. It has no wall-clock generation field so identical inputs
+      produce byte-identical output.
     attributes:
-      generation_date:
-        range: datetime
-        description: Timestamp when this aggregation was generated
       total_mapped_count:
         range: integer
-        description: Total number of unique mapped ingredients found
+        description: Total number of mapped ingredient summary rows
       total_instances:
         range: integer
-        description: Total instances of mapped ingredients across all media
-      media_count:
+        description: Total direct occurrence rows represented by this collection
+      recipe_count:
         range: integer
-        description: Number of media containing mapped ingredients
+        description: Number of root recipes containing a mapped occurrence
       mapped_ingredients:
         range: MappedIngredient
         multivalued: true
         inlined_as_list: true
-        description: List of all mapped ingredients with ontology terms
+        description: List of all mapped ingredients with selected identities
       summary_by_category:
         range: MappedCategorySummary
         multivalued: true
         inlined_as_list: true
-        description: Summary statistics by media category
+        description: Summary statistics by root recipe category
       summary_by_ontology:
         range: OntologySummary
         multivalued: true
@@ -56,52 +57,114 @@ classes:
         description: Summary statistics by ontology source
 
   MappedIngredient:
-    description: A media ingredient with proper ontology mapping
+    description: A direct recipe ingredient with a selected semantic identity
     attributes:
       preferred_term:
+        required: true
+        description: Canonical display term for the selected identity
+      resolved_identifier:
         identifier: true
-        description: The preferred term label for the ingredient
+        required: true
+        description: >-
+          Semantic identity selected by GroundingDecision.identifier. May be
+          CHEBI, FOODON, CAS, MeSH, or a curated local identifier.
       ontology_id:
-        description: Ontology term ID (e.g., CHEBI:12345, FOODON:00001234)
+        description: >-
+          Legacy field retained for compatibility. It must not be populated
+          from MIM's diagnostic ontology_id in place of resolved_identifier.
       ontology_label:
-        description: Official label from the ontology
+        description: Human-readable label associated with resolved_identifier
       ontology_source:
         range: OntologySourceEnum
         description: Source ontology for this term
       occurrence_count:
         range: integer
-        description: Number of times this ingredient appears across all media
-      media_occurrences:
-        range: MappedMediaOccurrence
+        description: Number of complete direct-occurrence rows in this group
+      distinct_recipe_count:
+        range: integer
+        description: >-
+          Number of unique recipe_id values in the complete occurrence group;
+          never derived from a retained example list
+      recipe_occurrences:
+        range: MappedRecipeOccurrence
         multivalued: true
         inlined_as_list: true
-        description: List of media where this ingredient appears
+        description: Complete, uncapped direct occurrences in deterministic order
       concentration_info:
         range: MappedConcentrationInfo
         multivalued: true
         inlined_as_list: true
         description: Concentration values found for this ingredient
       synonyms:
-        description: Alternative names or synonyms found in media
+        description: Alternative names or synonyms found in recipe occurrences
         multivalued: true
       mapping_quality:
         range: MappingQualityEnum
         description: Quality assessment of the mapping
 
-  MappedMediaOccurrence:
-    description: Reference to a specific medium containing the mapped ingredient
+  MappedRecipeOccurrence:
+    description: >-
+      One direct root-recipe occurrence. The stable coordinate is the tuple
+      (recipe_id, component_field, component_index).
     attributes:
-      medium_name:
+      recipe_id:
         required: true
-        description: Name of the medium
-      medium_category:
+        pattern: "^CultureMech:(?!000000)\\d{6}$"
+        description: Stable CultureMech identifier of the root recipe
+      recipe_label:
+        required: true
+        description: >-
+          Root preferred_term, with name used only for legacy MediaRecipe-shaped
+          records
+      recipe_category:
         range: MediaCategoryEnum
-        description: Category of the medium (algae, bacterial, etc.)
-      medium_file_path:
-        description: Relative path to the medium YAML file
-      ingredient_index:
+        description: Category of the root recipe when available
+      source_path:
+        required: true
+        description: Input-root-relative POSIX path to the source YAML
+      component_field:
+        range: ComponentFieldEnum
+        required: true
+        description: Root field traversed according to the record's schema shape
+      component_index:
         range: integer
-        description: Index of this ingredient in the medium's ingredient list
+        required: true
+        minimum_value: 0
+        description: Zero-based index in component_field
+      preferred_term:
+        required: true
+        description: Source ingredient label used as the MIM resolver query
+      resolved_identifier:
+        required: true
+        description: Semantic identity selected by the shared MIM resolver
+      source_compound_id:
+        description: >-
+          Upstream mediadive.compound identifier, preserved as provenance and
+          never promoted to semantic identity
+      local_identifier:
+        description: Local chebi_term or non-MediaDive term considered as fallback
+      resolution_source:
+        range: ResolutionSourceEnum
+        required: true
+        description: Resolver path that selected resolved_identifier
+      mim_preferred_term:
+        description: Preferred term reported by the matched MIM identity
+      mim_matched_label:
+        description: Exact MIM label-index label that matched the recipe label
+      mim_match_type:
+        range: MIMMatchTypeEnum
+        description: Which MIM label surface matched
+      mim_mapping_status:
+        range: MIMMappingStatusEnum
+        description: Mapping status carried by the matched MIM row
+      mim_ambiguity:
+        description: MIM label-group ambiguity classification
+      mim_ontology_id_diagnostic:
+        description: >-
+          MIM publisher diagnostic only; never substituted for
+          resolved_identifier
+      grounding_reason:
+        description: Human-readable explanation emitted by GroundingDecision
 
   MappedConcentrationInfo:
     description: Concentration information for a mapped ingredient
@@ -109,21 +172,21 @@ classes:
       value:
         description: Concentration value
       unit:
-        range: ConcentrationUnitEnum
-        description: Unit of measurement
+        range: string
+        description: Canonical CultureMech concentration unit value
       notes:
         description: Additional notes about concentration
 
   MappedCategorySummary:
-    description: Summary statistics for mapped ingredients in a media category
+    description: Summary statistics for mapped ingredients in a recipe category
     attributes:
       category:
         range: MediaCategoryEnum
         required: true
-        description: Media category name
-      media_with_mapped:
+        description: Root recipe category name
+      recipes_with_mapped:
         range: integer
-        description: Number of media with mapped ingredients in this category
+        description: Number of root recipes with mapped ingredients in this category
       total_mapped_instances:
         range: integer
         description: Total mapped ingredient instances in this category
@@ -149,6 +212,52 @@ classes:
         description: Percentage of all mapped ingredients from this ontology
 
 enums:
+  ComponentFieldEnum:
+    description: Root component field selected by recipe schema shape
+    permissible_values:
+      ingredients:
+        description: Direct components of a MediaRecipe-shaped root record
+      composition:
+        description: Direct components of a SolutionRecipe-shaped root record
+
+  ResolutionSourceEnum:
+    description: Structured outcome class returned by the shared MIM resolver
+    permissible_values:
+      mim_exact:
+        description: Exact label group selected a trusted MIM identity
+      mim_normalized:
+        description: Conservative weak normalization selected a trusted MIM identity
+      authoritative_unmapped:
+        description: MIM explicitly declares the matched label unmapped
+      local_fallback:
+        description: MIM had no verdict and an explicit local identity was retained
+      ambiguous_local_fallback:
+        description: MIM was ambiguous and an explicit local identity was retained
+      ambiguous:
+        description: MIM was ambiguous and no identity was selected
+      not_found:
+        description: No MIM label or usable local identity was found
+
+  MIMMatchTypeEnum:
+    description: Label surface in the MIM index that matched the recipe label
+    permissible_values:
+      preferred_term:
+        description: MIM preferred term
+      synonym:
+        description: MIM synonym
+      ontology_label:
+        description: Ontology label indexed by MIM
+
+  MIMMappingStatusEnum:
+    description: Mapping lifecycle status carried by the matched MIM row
+    permissible_values:
+      MAPPED:
+        description: Live mapped MIM row
+      UNMAPPED:
+        description: Live intentionally-unmapped MIM row
+      REJECTED:
+        description: Rejected or merged MIM tombstone row
+
   MappingQualityEnum:
     permissible_values:
       DIRECT_MATCH:
@@ -174,6 +283,8 @@ enums:
         description: Fungal culture media
       SPECIALIZED:
         description: Specialized or mixed culture media
+      IMPORTED:
+        description: Imported recipe whose source domain has not been assigned
       UNKNOWN:
         description: Category not specified
 

--- a/src/culturemech/schema/unmapped_ingredients_schema.yaml
+++ b/src/culturemech/schema/unmapped_ingredients_schema.yaml
@@ -1,13 +1,15 @@
 id: https://w3id.org/culturemech/unmapped-ingredients
 name: unmapped-ingredients-schema
-title: Unmapped Media Ingredients Schema
+title: Unmapped Recipe Ingredients Schema
 description: >-
-  LinkML schema for aggregating unmapped media ingredients that need ontology term mapping.
-  Unmapped ingredients are identified by numeric placeholder IDs or generic terms.
+  LinkML schema for deterministic summaries of direct recipe-ingredient
+  occurrences for which the pinned MediaIngredientMech resolver selected no
+  semantic identity. Resolver failures and upstream source identifiers are
+  retained explicitly rather than inferred from punctuation or placeholders.
 
 license: MIT
 see_also:
-  - https://github.com/CultureBotAI/CommunityMech
+  - https://github.com/CultureBotAI/CultureMech
 
 prefixes:
   linkml: https://w3id.org/linkml/
@@ -24,17 +26,20 @@ imports:
 classes:
   UnmappedIngredientsCollection:
     tree_root: true
-    description: Root container for all unmapped media ingredients
+    description: >-
+      Root container derived from the complete, uncapped direct-occurrence
+      population. It has no wall-clock generation field so identical inputs
+      produce byte-identical output.
     attributes:
-      generation_date:
-        range: datetime
-        description: Timestamp when this aggregation was generated
       total_unmapped_count:
         range: integer
-        description: Total number of unmapped ingredients found
-      media_count:
+        description: Total number of unresolved ingredient summary rows
+      total_instances:
         range: integer
-        description: Number of media containing unmapped ingredients
+        description: Total direct occurrence rows represented by this collection
+      recipe_count:
+        range: integer
+        description: Number of root recipes containing an unresolved occurrence
       unmapped_ingredients:
         range: UnmappedIngredient
         multivalued: true
@@ -44,14 +49,16 @@ classes:
         range: CategorySummary
         multivalued: true
         inlined_as_list: true
-        description: Summary statistics by media category
+        description: Summary statistics by root recipe category
 
   UnmappedIngredient:
-    description: A single media ingredient that lacks proper ontology mapping
+    description: A source ingredient label with no selected semantic identity
     attributes:
+      preferred_term:
+        required: true
+        description: Source ingredient label used as the MIM resolver query
       placeholder_id:
-        identifier: true
-        description: Placeholder identifier (typically numeric)
+        description: Legacy placeholder identifier retained for compatibility
       raw_ingredient_text:
         description: Raw text extracted from notes field containing chemical name
         multivalued: true
@@ -59,12 +66,17 @@ classes:
         description: Best-effort parsed chemical name from raw text
       occurrence_count:
         range: integer
-        description: Number of times this ingredient appears across all media
-      media_occurrences:
-        range: MediaOccurrence
+        description: Number of complete direct-occurrence rows in this group
+      distinct_recipe_count:
+        range: integer
+        description: >-
+          Number of unique recipe_id values in the complete occurrence group;
+          never derived from a retained example list
+      recipe_occurrences:
+        range: UnmappedRecipeOccurrence
         multivalued: true
         inlined_as_list: true
-        description: List of media where this ingredient appears
+        description: Complete, uncapped direct occurrences in deterministic order
       concentration_info:
         range: ConcentrationInfo
         multivalued: true
@@ -79,20 +91,71 @@ classes:
         range: MappingStatusEnum
         description: Current status of mapping effort
 
-  MediaOccurrence:
-    description: Reference to a specific medium containing the unmapped ingredient
+  UnmappedRecipeOccurrence:
+    description: >-
+      One unresolved direct root-recipe occurrence. The stable coordinate is the
+      tuple (recipe_id, component_field, component_index).
     attributes:
-      medium_name:
+      recipe_id:
         required: true
-        description: Name of the medium
-      medium_category:
+        pattern: "^CultureMech:(?!000000)\\d{6}$"
+        description: Stable CultureMech identifier of the root recipe
+      recipe_label:
+        required: true
+        description: >-
+          Root preferred_term, with name used only for legacy MediaRecipe-shaped
+          records
+      recipe_category:
         range: MediaCategoryEnum
-        description: Category of the medium (algae, bacterial, etc.)
-      medium_file_path:
-        description: Relative path to the medium YAML file
-      ingredient_index:
+        description: Category of the root recipe when available
+      source_path:
+        required: true
+        description: Input-root-relative POSIX path to the source YAML
+      component_field:
+        range: ComponentFieldEnum
+        required: true
+        description: Root field traversed according to the record's schema shape
+      component_index:
         range: integer
-        description: Index of this ingredient in the medium's ingredient list
+        required: true
+        minimum_value: 0
+        description: Zero-based index in component_field
+      preferred_term:
+        required: true
+        description: Source ingredient label used as the MIM resolver query
+      resolved_identifier:
+        description: >-
+          Empty for this unresolved occurrence; present in the common TSV schema
+          so mapped and unmapped rows have one stable column contract
+      source_compound_id:
+        description: >-
+          Upstream mediadive.compound identifier, preserved as provenance and
+          never promoted to semantic identity
+      local_identifier:
+        description: >-
+          Local chebi_term or non-MediaDive term considered by the resolver;
+          authoritative MIM-unmapped decisions may suppress it
+      resolution_source:
+        range: ResolutionSourceEnum
+        required: true
+        description: Why no semantic identity was selected
+      mim_preferred_term:
+        description: Preferred term reported by a matched MIM row, if any
+      mim_matched_label:
+        description: Exact MIM label-index label that matched the recipe label
+      mim_match_type:
+        range: MIMMatchTypeEnum
+        description: Which MIM label surface matched
+      mim_mapping_status:
+        range: MIMMappingStatusEnum
+        description: Mapping status carried by the matched MIM row
+      mim_ambiguity:
+        description: MIM label-group ambiguity classification
+      mim_ontology_id_diagnostic:
+        description: >-
+          MIM publisher diagnostic only; never promoted to a selected identity
+      grounding_reason:
+        description: Human-readable explanation emitted by GroundingDecision
 
   ConcentrationInfo:
     description: Concentration information for an ingredient
@@ -100,8 +163,8 @@ classes:
       value:
         description: Concentration value
       unit:
-        range: ConcentrationUnitEnum
-        description: Unit of measurement
+        range: string
+        description: Canonical CultureMech concentration unit value
       notes:
         description: Additional notes about concentration
 
@@ -122,15 +185,15 @@ classes:
         description: Method used to generate this suggestion
 
   CategorySummary:
-    description: Summary statistics for a media category
+    description: Summary statistics for a root recipe category
     attributes:
       category:
         range: MediaCategoryEnum
         required: true
-        description: Media category name
-      media_with_unmapped:
+        description: Root recipe category name
+      recipes_with_unmapped:
         range: integer
-        description: Number of media with unmapped ingredients in this category
+        description: Number of root recipes with unresolved ingredients in this category
       total_unmapped_instances:
         range: integer
         description: Total unmapped ingredient instances in this category
@@ -139,6 +202,52 @@ classes:
         description: Number of unique unmapped ingredients in this category
 
 enums:
+  ComponentFieldEnum:
+    description: Root component field selected by recipe schema shape
+    permissible_values:
+      ingredients:
+        description: Direct components of a MediaRecipe-shaped root record
+      composition:
+        description: Direct components of a SolutionRecipe-shaped root record
+
+  ResolutionSourceEnum:
+    description: Structured outcome class returned by the shared MIM resolver
+    permissible_values:
+      mim_exact:
+        description: Exact label group selected a trusted MIM identity
+      mim_normalized:
+        description: Conservative weak normalization selected a trusted MIM identity
+      authoritative_unmapped:
+        description: MIM explicitly declares the matched label unmapped
+      local_fallback:
+        description: MIM had no verdict and an explicit local identity was retained
+      ambiguous_local_fallback:
+        description: MIM was ambiguous and an explicit local identity was retained
+      ambiguous:
+        description: MIM was ambiguous and no identity was selected
+      not_found:
+        description: No MIM label or usable local identity was found
+
+  MIMMatchTypeEnum:
+    description: Label surface in the MIM index that matched the recipe label
+    permissible_values:
+      preferred_term:
+        description: MIM preferred term
+      synonym:
+        description: MIM synonym
+      ontology_label:
+        description: Ontology label indexed by MIM
+
+  MIMMappingStatusEnum:
+    description: Mapping lifecycle status carried by the matched MIM row
+    permissible_values:
+      MAPPED:
+        description: Live mapped MIM row
+      UNMAPPED:
+        description: Live intentionally-unmapped MIM row
+      REJECTED:
+        description: Rejected or merged MIM tombstone row
+
   MappingStatusEnum:
     permissible_values:
       UNMAPPED:
@@ -164,6 +273,8 @@ enums:
         description: Fungal culture media
       SPECIALIZED:
         description: Specialized or mixed culture media
+      IMPORTED:
+        description: Imported recipe whose source domain has not been assigned
       UNKNOWN:
         description: Category not specified
 

--- a/tests/test_ingredient_occurrence_aggregation.py
+++ b/tests/test_ingredient_occurrence_aggregation.py
@@ -1,0 +1,632 @@
+"""Contract tests for lossless ingredient occurrence aggregation (#337).
+
+The mapped and unmapped summaries are projections of one occurrence table.  The
+table is the load-bearing artifact: it retains the stable recipe id and component
+coordinate for every direct ingredient, while MIM decides whether the row belongs
+to the mapped or unmapped projection.
+
+These tests deliberately use tiny temporary corpora.  They exercise both recipe
+shapes without paying for another parse of the normalized production corpus (the
+shared corpus fixture already makes that parse once for the corpus test tier).
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
+from linkml.validator.report import Severity
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+def _load_script(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def occurrence_module():
+    return _load_script("ingredient_occurrences")
+
+
+@pytest.fixture(scope="module")
+def cli_module():
+    return _load_script("aggregate_ingredients")
+
+
+@pytest.fixture(scope="module")
+def stats_module():
+    return _load_script("unmapped_ingredients_stats")
+
+
+def _write(root: Path, relative: str, document: dict[str, Any] | str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = document if isinstance(document, str) else yaml.safe_dump(document, sort_keys=False)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, dict):
+        return value
+    return vars(value)
+
+
+def _rows(result: Any) -> list[dict[str, Any]]:
+    return [_mapping(row) for row in result.occurrences]
+
+
+def _coordinate(row: dict[str, Any]) -> tuple[str, str, int]:
+    return row["recipe_id"], row["component_field"], int(row["component_index"])
+
+
+def _ingredient_label(row: dict[str, Any]) -> str:
+    return row["preferred_term"]
+
+
+def _resolved_identifier(row: dict[str, Any]) -> str:
+    return row["resolved_identifier"]
+
+
+def _mapped_entry(output: dict[str, Any], label: str) -> dict[str, Any]:
+    return next(row for row in output["mapped_ingredients"] if row["preferred_term"] == label)
+
+
+def _unmapped_entry(output: dict[str, Any], label: str) -> dict[str, Any]:
+    return next(
+        row
+        for row in output["unmapped_ingredients"]
+        if row.get("preferred_term", row.get("parsed_chemical_name", row.get("placeholder_id")))
+        == label
+    )
+
+
+def _output_args(root: Path, stem: str) -> dict[str, Path]:
+    out = root / stem
+    out.mkdir(parents=True, exist_ok=True)
+    return {
+        "occurrences_output": out / "ingredient_occurrences.tsv",
+        "mapped_output": out / "mapped_ingredients.yaml",
+        "unmapped_output": out / "unmapped_ingredients.yaml",
+        "errors_output": out / "ingredient_occurrence_errors.tsv",
+    }
+
+
+def test_structural_shape_selects_one_direct_component_field(occurrence_module, tmp_path):
+    """Shape, not the semantic ``record_kind``, selects the authoritative field.
+
+    The curated solution is intentionally MediaRecipe-shaped.  Routing it via
+    ``is_solution_record`` would select its absent composition and drop the real
+    ingredient.  Conversely, a true SolutionRecipe must ignore its legacy
+    ``ingredients`` placeholder.  Nested in-recipe solution composition is not a
+    direct root containment and therefore is never expanded here.
+    """
+
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/media.yaml",
+        {
+            "id": "CultureMech:000001",
+            "name": "legacy_medium_name",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "EDTA"}],
+            "solutions": [
+                {
+                    "preferred_term": "Nested stock",
+                    "composition": [{"preferred_term": "NESTED MUST NOT EXPAND"}],
+                }
+            ],
+        },
+    )
+    _write(
+        corpus,
+        "bacterial/solution_with_placeholder.yaml",
+        {
+            "id": "CultureMech:000002",
+            "preferred_term": "Canonical stock label",
+            "term": {"id": "mediadive.solution:2"},
+            "composition": [{"preferred_term": "Biotin"}],
+            "ingredients": [{"preferred_term": "See source for composition"}],
+        },
+    )
+    _write(
+        corpus,
+        "bacterial/solution_without_ingredients.yaml",
+        {
+            "id": "CultureMech:000003",
+            "preferred_term": "Stock without stub",
+            "term": {"id": "mediadive.solution:3"},
+            "composition": [{"preferred_term": "Nicotinic acid"}],
+        },
+    )
+    _write(
+        corpus,
+        "bacterial/curated_solution_media_shape.yaml",
+        {
+            "id": "CultureMech:000004",
+            "record_kind": "SOLUTION",
+            "name": "Curated solution retaining media shape",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "PABA"}],
+        },
+    )
+
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    rows = _rows(result)
+
+    assert [(row["recipe_id"], row["component_field"], _ingredient_label(row)) for row in rows] == [
+        ("CultureMech:000001", "ingredients", "EDTA"),
+        ("CultureMech:000002", "composition", "Biotin"),
+        ("CultureMech:000003", "composition", "Nicotinic acid"),
+        ("CultureMech:000004", "ingredients", "PABA"),
+    ]
+    assert {row["recipe_label"] for row in rows if row["recipe_id"] == "CultureMech:000001"} == {
+        "legacy_medium_name"
+    }
+    assert {row["label_source"] for row in rows if row["recipe_id"] == "CultureMech:000001"} == {
+        "legacy_name"
+    }
+    assert {row["recipe_label"] for row in rows if row["recipe_id"] == "CultureMech:000002"} == {
+        "Canonical stock label"
+    }
+    assert {row["label_source"] for row in rows if row["recipe_id"] == "CultureMech:000002"} == {
+        "preferred_term"
+    }
+    assert not result.errors
+
+    paba = next(
+        entry
+        for entry in occurrence_module.build_mapped_output(result.occurrences)["mapped_ingredients"]
+        if entry["resolved_identifier"] == "CHEBI:30753"
+    )
+    assert paba["preferred_term"] == "p-Aminobenzoic acid"
+    assert paba["mapping_quality"] == "SYNONYM_MATCH"
+
+
+def test_recipe_preferred_term_precedes_legacy_media_name(occurrence_module):
+    assert occurrence_module._recipe_label(
+        {"preferred_term": "Canonical recipe label", "name": "Legacy recipe name"},
+        "MediaRecipe",
+    ) == ("Canonical recipe label", "preferred_term")
+
+
+def test_repeated_positions_and_duplicate_names_keep_stable_coordinates(
+    occurrence_module, tmp_path
+):
+    corpus = tmp_path / "corpus"
+    for suffix, recipe_id in (("a", "CultureMech:000011"), ("b", "CultureMech:000012")):
+        ingredients = [{"preferred_term": "EDTA"}]
+        if suffix == "a":
+            ingredients.append({"preferred_term": "EDTA"})
+        _write(
+            corpus,
+            f"bacterial/{suffix}.yaml",
+            {
+                "id": recipe_id,
+                "name": "Duplicate display name",
+                "physical_state": "LIQUID",
+                "ingredients": ingredients,
+            },
+        )
+
+    rows = _rows(occurrence_module.scan_ingredient_occurrences(corpus))
+    assert [_coordinate(row) for row in rows] == [
+        ("CultureMech:000011", "ingredients", 0),
+        ("CultureMech:000011", "ingredients", 1),
+        ("CultureMech:000012", "ingredients", 0),
+    ]
+    assert len({_coordinate(row) for row in rows}) == len(rows)
+    assert {row["recipe_id"] for row in rows} == {
+        "CultureMech:000011",
+        "CultureMech:000012",
+    }
+    assert all(not Path(row["source_path"]).is_absolute() for row in rows)
+
+
+def test_more_than_fifty_occurrences_remain_lossless_and_counts_use_full_rows(
+    occurrence_module, tmp_path
+):
+    corpus = tmp_path / "corpus"
+    for index in range(51):
+        ingredients = [{"preferred_term": "EDTA"}]
+        if index == 0:
+            ingredients.append({"preferred_term": "EDTA"})
+        _write(
+            corpus,
+            f"bacterial/{50 - index:03d}.yaml",  # reverse filenames versus ids
+            {
+                "id": f"CultureMech:{index + 1000:06d}",
+                "name": f"Recipe {index:02d}",
+                "physical_state": "LIQUID",
+                "ingredients": ingredients,
+            },
+        )
+
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    rows = _rows(result)
+    edta = [row for row in rows if _ingredient_label(row) == "EDTA"]
+    assert len(edta) == 52
+    assert len({_coordinate(row) for row in edta}) == 52
+
+    mapped = occurrence_module.build_mapped_output(result.occurrences)
+    entry = _mapped_entry(mapped, "EDTA")
+    assert entry["occurrence_count"] == 52
+    assert entry["distinct_recipe_count"] == 51
+    assert len(entry["recipe_occurrences"]) == 52
+
+    out = tmp_path / "occurrences.tsv"
+    occurrence_module.write_occurrences_tsv(out, result.occurrences)
+    with out.open(encoding="utf-8", newline="") as stream:
+        written = list(csv.DictReader(stream, delimiter="\t"))
+    assert len(written) == 52
+
+
+def test_real_mim_decisions_partition_rows_and_preserve_source_ids(occurrence_module, tmp_path):
+    """The projection follows #260, not the presence of a colon in ``term.id``."""
+
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/resolver_canary.yaml",
+        {
+            "id": "CultureMech:000021",
+            "name": "Resolver canary",
+            "physical_state": "LIQUID",
+            "ingredients": [
+                {"preferred_term": "EDTA", "term": {"id": "CHEBI:64755"}},
+                {"preferred_term": "Beef heart", "term": {"id": "UBERON:0000948"}},
+                {"preferred_term": "Calf brains", "term": {"id": "UBERON:0000955"}},
+                {
+                    "preferred_term": "CultureMech test-only local reagent 337",
+                    "term": {"id": "mediadive.compound:337001"},
+                    "chebi_term": {"id": "CHEBI:12345"},
+                },
+                {
+                    "preferred_term": "CultureMech test-only source reagent 337",
+                    "term": {"id": "mediadive.compound:337002"},
+                },
+            ],
+        },
+    )
+
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    rows = {_ingredient_label(row): row for row in _rows(result)}
+    assert _resolved_identifier(rows["EDTA"]) == "CHEBI:4735"
+    assert _resolved_identifier(rows["Beef heart"]).startswith("FOODON:")
+    assert _resolved_identifier(rows["Calf brains"]) == ""
+    assert _resolved_identifier(rows["CultureMech test-only local reagent 337"]) == "CHEBI:12345"
+    assert rows["CultureMech test-only local reagent 337"]["source_compound_id"] == (
+        "mediadive.compound:337001"
+    )
+    assert _resolved_identifier(rows["CultureMech test-only source reagent 337"]) == ""
+    assert rows["CultureMech test-only source reagent 337"]["source_compound_id"] == (
+        "mediadive.compound:337002"
+    )
+
+    mapped = occurrence_module.build_mapped_output(result.occurrences)
+    unmapped = occurrence_module.build_unmapped_output(result.occurrences)
+    mapped_count = sum(row["occurrence_count"] for row in mapped["mapped_ingredients"])
+    unmapped_count = sum(row["occurrence_count"] for row in unmapped["unmapped_ingredients"])
+    assert mapped_count == 3
+    assert unmapped_count == 2
+    assert mapped_count + unmapped_count == len(result.occurrences)
+    assert _unmapped_entry(unmapped, "Calf brains")["occurrence_count"] == 1
+
+
+def test_complete_runs_are_byte_identical(cli_module, tmp_path):
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/z.yaml",
+        {
+            "id": "CultureMech:000032",
+            "name": "Same count Z",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "Biotin"}],
+        },
+    )
+    _write(
+        corpus,
+        "bacterial/a.yaml",
+        {
+            "id": "CultureMech:000031",
+            "name": "Same count A",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "EDTA"}],
+        },
+    )
+
+    first = _output_args(tmp_path, "first")
+    second = _output_args(tmp_path, "second")
+
+    def run(outputs: dict[str, Path]) -> int:
+        return cli_module.main(
+            [
+                "--input-dir",
+                str(corpus),
+                "--occurrences-output",
+                str(outputs["occurrences_output"]),
+                "--mapped-output",
+                str(outputs["mapped_output"]),
+                "--unmapped-output",
+                str(outputs["unmapped_output"]),
+                "--errors-output",
+                str(outputs["errors_output"]),
+            ]
+        )
+
+    assert run(first) == 0
+    assert run(second) == 0
+    for name in first:
+        assert first[name].read_bytes() == second[name].read_bytes(), name
+        assert first[name].stat().st_mode & 0o777 == 0o644
+    assert b"\r\n" not in first["occurrences_output"].read_bytes()
+
+
+def test_fatal_errors_are_reported_without_replacing_success_artifacts(cli_module, tmp_path):
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/good.yaml",
+        {
+            "id": "CultureMech:000041",
+            "name": "Good record",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "EDTA"}],
+        },
+    )
+    _write(corpus, "bacterial/bad.yaml", "id: [unclosed\n")
+    invalid_utf8 = corpus / "bacterial" / "invalid_utf8.yaml"
+    invalid_utf8.write_bytes(b"\xff\xfe\x00")
+    _write(
+        corpus,
+        "bacterial/missing_id.yaml",
+        {
+            "name": "Schema-invalid record",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "Biotin"}],
+        },
+    )
+
+    outputs = _output_args(tmp_path, "out")
+    sentinels = {
+        name: f"existing {name}\n".encode()
+        for name in ("occurrences_output", "mapped_output", "unmapped_output")
+    }
+    for name, content in sentinels.items():
+        outputs[name].write_bytes(content)
+
+    rc = cli_module.main(
+        [
+            "--input-dir",
+            str(corpus),
+            "--occurrences-output",
+            str(outputs["occurrences_output"]),
+            "--mapped-output",
+            str(outputs["mapped_output"]),
+            "--unmapped-output",
+            str(outputs["unmapped_output"]),
+            "--errors-output",
+            str(outputs["errors_output"]),
+        ]
+    )
+    assert rc != 0
+    for name, content in sentinels.items():
+        assert outputs[name].read_bytes() == content, f"fatal run replaced {name}"
+
+    with outputs["errors_output"].open(encoding="utf-8", newline="") as stream:
+        errors = list(csv.DictReader(stream, delimiter="\t"))
+    assert errors
+    parse_error = next(row for row in errors if row["category"] == "yaml_parse_error")
+    assert parse_error["file"].endswith("bacterial/bad.yaml")
+    assert parse_error["message"]
+    decode_error = next(row for row in errors if row["category"] == "input_decode_error")
+    assert decode_error["file"].endswith("bacterial/invalid_utf8.yaml")
+    schema_error = next(row for row in errors if row["category"] == "missing_required")
+    assert schema_error["file"].endswith("bacterial/missing_id.yaml")
+
+
+def test_blank_labels_are_preserved_as_separate_occurrences(occurrence_module, tmp_path):
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/blanks.yaml",
+        {
+            "id": "CultureMech:000051",
+            "name": "Blank label canary",
+            "physical_state": "LIQUID",
+            "ingredients": [
+                {"preferred_term": "", "notes": "first blank"},
+                {"preferred_term": "", "notes": "second blank"},
+            ],
+        },
+    )
+
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    blank_rows = [row for row in _rows(result) if _ingredient_label(row) == ""]
+    assert len(blank_rows) == 2
+    assert {_coordinate(row) for row in blank_rows} == {
+        ("CultureMech:000051", "ingredients", 0),
+        ("CultureMech:000051", "ingredients", 1),
+    }
+    assert all(_resolved_identifier(row) == "" for row in blank_rows)
+
+    unmapped = occurrence_module.build_unmapped_output(result.occurrences)
+    blank_entries = [row for row in unmapped["unmapped_ingredients"] if row["preferred_term"] == ""]
+    assert len(blank_entries) == 2
+    assert [row["occurrence_count"] for row in blank_entries] == [1, 1]
+    assert {
+        (
+            row["recipe_occurrences"][0]["recipe_id"],
+            row["recipe_occurrences"][0]["component_field"],
+            row["recipe_occurrences"][0]["component_index"],
+        )
+        for row in blank_entries
+    } == {
+        ("CultureMech:000051", "ingredients", 0),
+        ("CultureMech:000051", "ingredients", 1),
+    }
+
+
+def test_unmapped_stats_consumes_recipe_level_summary(stats_module, tmp_path, capsys):
+    report = {
+        "total_unmapped_count": 1,
+        "total_instances": 2,
+        "recipe_count": 2,
+        "unmapped_ingredients": [
+            {
+                "preferred_term": "Unknown reagent",
+                "placeholder_id": "Unknown reagent",
+                "raw_ingredient_text": [],
+                "parsed_chemical_name": "Unknown reagent",
+                "occurrence_count": 2,
+            }
+        ],
+        "summary_by_category": [
+            {
+                "category": "BACTERIAL",
+                "recipes_with_unmapped": 2,
+                "total_unmapped_instances": 2,
+                "unique_unmapped_count": 1,
+            }
+        ],
+    }
+    report_path = tmp_path / "unmapped_ingredients.yaml"
+    report_path.write_text(yaml.safe_dump(report, sort_keys=False), encoding="utf-8")
+
+    assert stats_module.main(["--input", str(report_path), "--top", "1"]) == 0
+    output = capsys.readouterr().out
+    assert "Total direct occurrences: 2" in output
+    assert "Recipes with unresolved ingredients: 2" in output
+    assert "2 occurrences across 2 recipes" in output
+
+
+def test_empty_input_is_a_machine_readable_failure(occurrence_module, tmp_path):
+    result = occurrence_module.scan_ingredient_occurrences(tmp_path)
+    assert not result.occurrences
+    assert [error.category for error in result.errors] == ["no_input_files"]
+
+
+def test_multi_output_replace_failure_rolls_back_and_preserves_modes(
+    occurrence_module, tmp_path, monkeypatch
+):
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "bacterial/one.yaml",
+        {
+            "id": "CultureMech:000061",
+            "name": "Rollback canary",
+            "physical_state": "LIQUID",
+            "ingredients": [{"preferred_term": "EDTA"}],
+        },
+    )
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    mapped = occurrence_module.build_mapped_output(result.occurrences)
+    occurrences_path = tmp_path / "ingredient_occurrences.tsv"
+    mapped_path = tmp_path / "mapped_ingredients.yaml"
+    occurrences_path.write_text("old occurrences\n", encoding="utf-8")
+    mapped_path.write_text("old mapped\n", encoding="utf-8")
+    occurrences_path.chmod(0o640)
+    mapped_path.chmod(0o640)
+
+    real_replace = occurrence_module.os.replace
+    replace_count = 0
+
+    def fail_second_replace(source, destination):
+        nonlocal replace_count
+        replace_count += 1
+        if replace_count == 2:
+            raise OSError("synthetic second replacement failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(occurrence_module.os, "replace", fail_second_replace)
+    with pytest.raises(OSError, match="synthetic second replacement failure"):
+        occurrence_module.write_occurrences_and_yaml(
+            occurrences_path,
+            result.occurrences,
+            mapped_path,
+            mapped,
+        )
+
+    assert occurrences_path.read_text(encoding="utf-8") == "old occurrences\n"
+    assert mapped_path.read_text(encoding="utf-8") == "old mapped\n"
+    assert occurrences_path.stat().st_mode & 0o777 == 0o640
+    assert mapped_path.stat().st_mode & 0o777 == 0o640
+
+
+def test_imported_category_outputs_validate_against_closed_summary_schemas(
+    occurrence_module, tmp_path
+):
+    corpus = tmp_path / "corpus"
+    _write(
+        corpus,
+        "imported/one.yaml",
+        {
+            "id": "CultureMech:000071",
+            "name": "Imported category canary",
+            "category": "imported",
+            "physical_state": "LIQUID",
+            "ingredients": [
+                {"preferred_term": "EDTA"},
+                {
+                    "preferred_term": "CultureMech test-only source reagent 337 schema",
+                    "term": {"id": "mediadive.compound:337071"},
+                },
+            ],
+        },
+    )
+    result = occurrence_module.scan_ingredient_occurrences(corpus)
+    assert not result.errors
+    jobs = [
+        (
+            occurrence_module.build_mapped_output(result.occurrences),
+            REPO_ROOT / "src/culturemech/schema/mapped_ingredients_schema.yaml",
+            "MappedIngredientsCollection",
+        ),
+        (
+            occurrence_module.build_unmapped_output(result.occurrences),
+            REPO_ROOT / "src/culturemech/schema/unmapped_ingredients_schema.yaml",
+            "UnmappedIngredientsCollection",
+        ),
+    ]
+    for index, (output, schema, target_class) in enumerate(jobs):
+        path = tmp_path / f"summary-{index}.yaml"
+        occurrence_module.write_yaml_output(path, output)
+        report = Validator(
+            schema=str(schema),
+            validation_plugins=[JsonschemaValidationPlugin(closed=True)],
+        ).validate(yaml.safe_load(path.read_text(encoding="utf-8")), target_class=target_class)
+        assert not [result for result in report.results if result.severity == Severity.ERROR]
+
+
+def test_output_paths_must_be_distinct_before_publication(occurrence_module, tmp_path):
+    shared = tmp_path / "shared.tsv"
+    with pytest.raises(ValueError, match="output paths must be distinct"):
+        occurrence_module.run_aggregation(
+            input_dir=tmp_path,
+            occurrences_output=shared,
+            mapped_output=shared,
+            unmapped_output=tmp_path / "unmapped.yaml",
+            errors_output=tmp_path / "errors.tsv",
+        )
+    assert not shared.exists()


### PR DESCRIPTION
## Summary

- replace the two divergent ingredient scanners with one shared, closed-schema direct-occurrence collector
- select `ingredients` for MediaRecipe-shaped roots and `composition` for SolutionRecipe-shaped roots, without concatenating placeholders or expanding nested solutions
- resolve every row through the pinned #260 MIM label index, retaining local/MIM/source provenance and never promoting `mediadive.compound:*` to semantic identity
- publish an uncapped canonical TSV plus mapped/unmapped compatibility YAML and a machine-readable error report with deterministic ordering and staged rollback-safe replacement
- update the standalone LinkML schemas, downstream unmapped statistics consumer, Just recipes, and data-layer documentation
- grade synonym and ontology-label resolution as `SYNONYM_MATCH` instead of the legacy blanket direct/exact assumption (related to #317 and #438)

## Current-corpus verification

- 200,242 direct occurrences: 194,137 resolved and 6,105 unresolved
- 165,233 `MediaRecipe.ingredients` rows and 35,009 `SolutionRecipe.composition` rows
- 0 duplicate `(recipe_id, component_field, component_index)` coordinates
- 34,965 rows retain a MediaDive compound source ID; 0 source IDs are promoted as `resolved_identifier`
- full mapped and unmapped outputs validate with 0 errors under the closed standalone schemas
- streamed full run peaks at about 520 MiB RSS, down from about 2.69 GiB before streaming

## Validation

- `just test` — 1,462 passed, 25 skipped
- `just test-fast` — 1,097 passed, 22 skipped
- `uv run pytest -q --no-cov tests/test_ingredient_occurrence_aggregation.py tests/test_mim_label_index.py tests/test_record_kinds.py tests/test_artifact_writers.py` — 73 passed
- `uv run python scripts/check_changed_python.py --base origin/main`
- `just check-mim-label-index`
- `just check-readme-stats`
- full-corpus aggregation and closed-schema validation

Closes #337
