### PR TITLE
Let a dependency change trigger the corpus gates (#369)

### DIFF
--- a/.github/workflows/chebi-consistency.yaml
+++ b/.github/workflows/chebi-consistency.yaml
@@ -19,6 +19,8 @@ on:
       - 'data/merge_yaml/**'
       - 'scripts/audit_chebi_consistency.py'
       - 'project.justfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - '.github/workflows/chebi-consistency.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -29,6 +29,8 @@ on:
       - 'data/merge_yaml/**'
       - 'scripts/audit_concentration_plausibility.py'
       - 'project.justfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - '.github/workflows/concentration-plausibility.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -26,6 +26,8 @@ on:
       - "data/merge_yaml/**"
       - "history/**"
       - "src/culturemech/schema/history.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/curation-history.yaml"
   push:
     branches: [main]
@@ -34,6 +36,8 @@ on:
       - "data/merge_yaml/**"
       - "history/**"
       - "src/culturemech/schema/history.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/curation-history.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -25,6 +25,8 @@ on:
       - "src/culturemech/schema/**"
       - "scripts/validate_id_label_correspondence.py"
       - "conf/id_label_targets.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
       - ".github/workflows/label-correspondence.yaml"
   push:
     branches: [main]

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -14,6 +14,8 @@ on:
       - 'src/culturemech/schema/**'
       - 'scripts/validate_strict.py'
       - 'project.justfile'
+      - 'pyproject.toml'
+      - 'uv.lock'
       - '.github/workflows/validate-strict.yaml'
   workflow_dispatch:
 

--- a/tests/test_workflow_dependency_paths.py
+++ b/tests/test_workflow_dependency_paths.py
@@ -1,0 +1,87 @@
+"""Every path-filtered workflow must watch `pyproject.toml` and `uv.lock` (#369).
+
+A `paths:` filter decides whether a gate runs at all. Before this, none of the
+five corpus gates listed the dependency files, so a PR that changed only
+`pyproject.toml` and `uv.lock` started `tests.yaml` — which has no filter — and
+nothing else. `label-correspondence` was the sharpest case: it runs the OAK
+id-label check and caches `~/.data/oaklib`, so it is precisely the gate that
+would notice an oaklib regression, and precisely the one a lockfile edit could
+not start.
+
+#365 hid this. It bumped oaklib and showed 7 green checks, but the gates ran only
+because the forced linkml upgrade regenerated files under
+`src/culturemech/schema/**`, which *is* filtered on. Had the change stayed the
+pin-only edit it was scoped as, the gates would have been skipped and the PR
+would have looked just as green. A coincidence was standing in for a gate.
+
+MediaIngredientMech#495 and TraitMech#566 are the same finding in the sibling
+repos; MIM fixed it first and MediaIngredientMech#499 confirmed the fix works —
+that PR touched only `pyproject.toml`, `uv.lock` and a file under `tests/`, which
+is not in MIM's filter, and `id-label-gate` still ran.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+DEPENDENCY_FILES = ("pyproject.toml", "uv.lock")
+
+
+def _paths_blocks(document: dict) -> list[tuple[str, list[str]]]:
+    """Every trigger in one workflow that carries a `paths:` filter.
+
+    `on` is quoted deliberately: YAML 1.1 reads a bare `on:` key as the boolean
+    True, so `document["on"]` misses it and a test written that way passes by
+    finding nothing at all.
+    """
+    triggers = document.get(True, document.get("on"))
+    if not isinstance(triggers, dict):
+        return []
+    return [
+        (name, config["paths"])
+        for name, config in triggers.items()
+        if isinstance(config, dict) and isinstance(config.get("paths"), list)
+    ]
+
+
+def _blocks() -> list[tuple[str, str, list[str]]]:
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yaml")):
+        for trigger, paths in _paths_blocks(yaml.safe_load(path.read_text())):
+            found.append((path.name, trigger, paths))
+    return found
+
+
+@pytest.mark.parametrize(
+    "workflow,trigger,paths",
+    _blocks(),
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_a_path_filtered_workflow_watches_the_dependency_files(workflow, trigger, paths):
+    missing = [f for f in DEPENDENCY_FILES if f not in paths]
+    assert not missing, (
+        f"{workflow} [{trigger}] does not watch {', '.join(missing)}, so a "
+        "dependency-only change cannot trigger it — the shape that let #365 show "
+        "green without running the gates"
+    )
+
+
+def test_the_guard_is_not_vacuous():
+    """Parametrising over a discovered set can silently collect nothing.
+
+    If `_paths_blocks` stops finding filters — the `on:`-is-True trap above is
+    the likely way — every case above vanishes and the suite still passes.
+    """
+    blocks = _blocks()
+    assert len(blocks) >= 8, f"expected the known path-filtered blocks, found {len(blocks)}"
+    assert {w for w, _, _ in blocks} >= {
+        "chebi-consistency.yaml",
+        "concentration-plausibility.yaml",
+        "curation-history.yaml",
+        "label-correspondence.yaml",
+        "validate-strict.yaml",
+    }

--- a/tests/test_workflow_dependency_paths.py
+++ b/tests/test_workflow_dependency_paths.py
@@ -48,9 +48,17 @@ def _paths_blocks(document: dict) -> list[tuple[str, list[str]]]:
     ]
 
 
+def _workflow_files() -> list[Path]:
+    """Both suffixes. GitHub accepts `.yml` and `.yaml` interchangeably, and
+    `.yml` is what most templates emit. Globbing one of them would let a new
+    gate arrive unguarded while this file kept reporting all-clear — the same
+    failure shape it exists to catch, one level up (#376)."""
+    return sorted({*WORKFLOWS.glob("*.yaml"), *WORKFLOWS.glob("*.yml")})
+
+
 def _blocks() -> list[tuple[str, str, list[str]]]:
     found = []
-    for path in sorted(WORKFLOWS.glob("*.yaml")):
+    for path in _workflow_files():
         for trigger, paths in _paths_blocks(yaml.safe_load(path.read_text())):
             found.append((path.name, trigger, paths))
     return found
@@ -78,6 +86,7 @@ def test_the_guard_is_not_vacuous():
     """
     blocks = _blocks()
     assert len(blocks) >= 8, f"expected the known path-filtered blocks, found {len(blocks)}"
+    assert len(_workflow_files()) >= 10, "workflow discovery found almost nothing"
     assert {w for w, _, _ in blocks} >= {
         "chebi-consistency.yaml",
         "concentration-plausibility.yaml",


### PR DESCRIPTION
Closes #369.

## The gap

None of the five corpus gates watched `pyproject.toml` or `uv.lock`. A PR
changing only those two files triggered `tests.yaml` — which has no path filter —
and nothing else.

`label-correspondence` is the sharpest case: it runs the OAK id↔label check and
caches `~/.data/oaklib`, so it is precisely the gate that would notice an oaklib
regression, and precisely the one a lockfile edit could not start.

## #365 hid this rather than exposing it

That PR bumped oaklib and showed **7 green checks**. The gates ran only because
the forced linkml upgrade regenerated files under `src/culturemech/schema/**`,
which *is* filtered on. Had the change stayed the pin-only edit it was scoped as,
every gate would have been skipped — and the PR would have looked exactly as
green.

A coincidence was standing in for a gate.

## The change

12 additive lines across 5 workflows, covering all **9** path-filtered blocks:

| workflow | blocks | note |
|---|---|---|
| `chebi-consistency` | 1 | |
| `concentration-plausibility` | 1 | |
| `curation-history` | 2 | two duplicated blocks, no anchor |
| `label-correspondence` | 1 | `&trigger_paths` anchor covers both triggers |
| `validate-strict` | 1 | |
| `generate-pages` | — | already watched both |

Verified by parsing every workflow, not by reading the diff:

```
chebi-consistency.yaml [pull_request]:        7 paths, deps-watched=True
concentration-plausibility.yaml [pull_request]: 7 paths, deps-watched=True
curation-history.yaml [pull_request]:         7 paths, deps-watched=True
curation-history.yaml [push]:                 7 paths, deps-watched=True
generate-pages.yaml [push]:                  12 paths, deps-watched=True
label-correspondence.yaml [pull_request]:     9 paths, deps-watched=True
label-correspondence.yaml [push]:             9 paths, deps-watched=True
validate-strict.yaml [pull_request]:          8 paths, deps-watched=True
```

## The guard

`tests/test_workflow_dependency_paths.py` **discovers** the filtered blocks rather
than listing them, so a new path-filtered workflow is covered the moment it lands.
Two details worth keeping:

- **`on` is read as `document.get(True, ...)`.** YAML 1.1 parses a bare `on:` key
  as the boolean `True`, so the obvious `document["on"]` finds nothing — and the
  test then passes by collecting zero cases.
- **`test_the_guard_is_not_vacuous`** asserts the discovered set is non-empty and
  names the five known workflows, because a parametrised test over a discovered
  set passes silently when discovery breaks. That is the same failure this PR is
  about, one level up.

Checked non-vacuous rather than assumed:

```
$ git stash push .github/workflows/ && pytest tests/test_workflow_dependency_paths.py
7 failed, 2 passed
$ git stash pop && pytest tests/test_workflow_dependency_paths.py
9 passed
```

## Review finding — #376, fixed in a6f2499c17

The guard globbed `*.yaml` only. GitHub accepts `.yml` and `.yaml`
interchangeably, and `.yml` is what most templates emit — so a gate added under
that suffix would have arrived unfiltered for dependency changes while this file
kept reporting `9 passed`. That is the same failure shape this PR is about, one
level up: something looks covered because the thing checking it never looked.

Latent rather than live (all 10 workflows here are `.yaml` today), which is also
why nothing would have surfaced it. Proven by construction rather than argued —
with a scratch `.github/workflows/zz-scratch.yml` carrying a paths filter and no
dependency entries:

```
FAILED ...test_a_path_filtered_workflow_watches_the_dependency_files[zz-scratch.yml-pull_request-]
1 failed, 9 passed
```

and `9 passed` once removed. Before the fix that file was invisible.

## What this PR does *not* prove

Worth being explicit: **#375 is not evidence of its own fix.** All five gates ran
here because the PR edits the workflow files, and every `paths:` block
self-references its own file. A dependency-only PR is the real test, and this one
isn't that.

MediaIngredientMech#499 is: it touched only `pyproject.toml`, `uv.lock` and a
file under `tests/` — not in MIM's filter — and `id-label-gate` ran anyway. The
next dependency bump here will be the local confirmation.

A second known boundary, recorded rather than fixed: the guard protects the
dependency entries *inside* existing `paths:` blocks, but does not pin the number
of blocks, so deleting one from an existing workflow removes a parametrised case
and still passes. Pinning block counts would be brittle against legitimate
workflow changes.

## Fleet context

Found three times independently: MediaIngredientMech#495 and TraitMech#566 are
the same finding. MIM fixed it first, and MediaIngredientMech#499 confirmed the
fix works — that PR touched only `pyproject.toml`, `uv.lock` and a file under
`tests/` (not in MIM's filter), and `id-label-gate` still ran.

Related but not addressed here: #277 (GitHub evaluates path filters against only
the first 300 changed files). A dependency bump is small, so the 300 limit is not
the binding constraint for this case, but the two share a mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

