### PR TITLE
Resolve KGX export paths to absolute before handing them to koza (#371)

### DIFF
--- a/scripts/export_kgx.py
+++ b/scripts/export_kgx.py
@@ -43,7 +43,7 @@ def find_records(records_dir: Path) -> list[str]:
     first record. Resolving here fixes every caller at once rather than asking
     each one to remember.
     """
-    return [str(p) for p in sorted(records_dir.resolve().glob("*/*.yaml"))]
+    return [str(p) for p in sorted(records_dir.expanduser().resolve().glob("*/*.yaml"))]
 
 
 def run(records_dir: Path, output_dir: Path, limit: int = 0) -> tuple[int, int]:
@@ -53,9 +53,13 @@ def run(records_dir: Path, output_dir: Path, limit: int = 0) -> tuple[int, int]:
 
     sys.path.insert(0, str(REPO_ROOT / "src"))
 
-    # Absolute for the same reason as `find_records` (#371): koza resolves a
-    # relative output path against its config file's directory too, which would
-    # scatter TSVs inside the package tree.
+    # The asymmetry is the point of #371, and it is one-sided: koza resolves
+    # relative INPUT paths against its configuration file's directory, but the
+    # output directory against the working directory like anything else
+    # (measured — a relative output dir lands in the CWD, not beside kgx.yaml).
+    # So only the input side was broken. The output is resolved anyway, to keep
+    # the run independent of a later chdir and to keep `_display`'s
+    # `relative_to(REPO_ROOT)` meaningful.
     records_dir = records_dir.expanduser().resolve()
     output_dir = output_dir.expanduser().resolve()
 

--- a/scripts/export_kgx.py
+++ b/scripts/export_kgx.py
@@ -28,13 +28,21 @@ CONFIG = REPO_ROOT / "src" / "culturemech" / "export" / "kgx.yaml"
 
 
 def find_records(records_dir: Path) -> list[str]:
-    """Every record YAML under `records_dir`, one directory deep.
+    """Every record YAML under `records_dir`, one directory deep, as absolute paths.
 
     Matches the corpus layout `data/normalized_yaml/<category>/<slug>.yaml`. The
     sibling `*_index.json` files live at the top level and are not YAML, so the
     `*/*.yaml` shape excludes them without needing a filter.
+
+    The paths must be absolute (#371). koza resolves a relative input path
+    against the directory holding its *configuration file*
+    (`src/culturemech/export/kgx.yaml`), not the working directory, so a
+    relative `--records-dir` produced
+    `src/culturemech/export/data/normalized_yaml/...` and the run died on the
+    first record. Resolving here fixes every caller at once rather than asking
+    each one to remember.
     """
-    return [str(p) for p in sorted(records_dir.glob("*/*.yaml"))]
+    return [str(p) for p in sorted(records_dir.resolve().glob("*/*.yaml"))]
 
 
 def run(records_dir: Path, output_dir: Path, limit: int = 0) -> tuple[int, int]:
@@ -43,6 +51,12 @@ def run(records_dir: Path, output_dir: Path, limit: int = 0) -> tuple[int, int]:
     from koza.runner import KozaRunner
 
     sys.path.insert(0, str(REPO_ROOT / "src"))
+
+    # Absolute for the same reason as `find_records` (#371): koza resolves a
+    # relative output path against its config file's directory too, which would
+    # scatter TSVs inside the package tree.
+    records_dir = records_dir.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
 
     files = find_records(records_dir)
     if not files:

--- a/scripts/export_kgx.py
+++ b/scripts/export_kgx.py
@@ -15,6 +15,7 @@ Reports node and edge counts, and fails loudly if either file is missing or
 holds only its header — a silent empty export is the failure mode #294 was
 about.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -471,3 +471,17 @@ def test_find_records_returns_absolute_paths(tmp_path, monkeypatch):
 
     assert files, "fixture record was not discovered"
     assert all(Path(f).is_absolute() for f in files)
+
+
+def test_find_records_expands_a_tilde_path(tmp_path, monkeypatch):
+    """`run()` expanduser'd and `find_records` did not, though both are public."""
+    import export_kgx
+
+    (tmp_path / "records" / "canary").mkdir(parents=True)
+    (tmp_path / "records" / "canary" / "r.yaml").write_text("name: X\n")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    files = export_kgx.find_records(Path("~/records"))
+
+    assert files, "a ~-prefixed records dir found nothing"
+    assert all(Path(f).is_absolute() and "~" not in f for f in files)

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -434,3 +434,40 @@ def test_an_empty_corpus_fails_loudly(tmp_path):
     (tmp_path / "records" / "empty").mkdir(parents=True)
     with pytest.raises(SystemExit, match="No record YAMLs"):
         export_kgx.run(tmp_path / "records", tmp_path / "out")
+
+
+def test_a_relative_records_dir_still_finds_the_corpus(tmp_path, monkeypatch):
+    """#371: `just kgx-export` passed the tracked relative default and died.
+
+    koza resolves a relative input path against the directory holding its
+    configuration file, not the working directory, so the run looked for
+    `src/culturemech/export/data/normalized_yaml/...`. Every other end-to-end
+    test here hands `run()` a `tmp_path`, which is absolute — the exact shape
+    the real recipe never used.
+    """
+    import export_kgx
+    import yaml
+
+    records_dir = tmp_path / "records" / "canary"
+    records_dir.mkdir(parents=True)
+    (records_dir / "record.yaml").write_text(yaml.safe_dump(RECORD))
+
+    monkeypatch.chdir(tmp_path)
+    node_count, edge_count = export_kgx.run(Path("records"), Path("out"))
+
+    assert node_count > 0 and edge_count > 0
+    assert (tmp_path / "out" / "culturemech_nodes.tsv").exists()
+
+
+def test_find_records_returns_absolute_paths(tmp_path, monkeypatch):
+    """The narrow invariant behind #371, without paying for a koza run."""
+    import export_kgx
+
+    (tmp_path / "records" / "canary").mkdir(parents=True)
+    (tmp_path / "records" / "canary" / "record.yaml").write_text("name: X\n")
+
+    monkeypatch.chdir(tmp_path)
+    files = export_kgx.find_records(Path("records"))
+
+    assert files, "fixture record was not discovered"
+    assert all(Path(f).is_absolute() for f in files)


### PR DESCRIPTION
Closes #371.

`just kgx-export` had never run. koza resolves a relative input path against the
directory holding its **configuration file** (`src/culturemech/export/kgx.yaml`),
not the working directory, so the tracked relative default became
`src/culturemech/export/data/normalized_yaml/...` and the run died on the first
record.

## The fix

`find_records` resolves the records directory before globbing, so every path
handed to koza is absolute; `run()` resolves the output directory for the same
reason. Fixing it in the driver rather than the justfile fixes every caller at
once instead of asking each one to remember.

## Why nothing caught it

Every existing end-to-end test hands `run()` a `tmp_path` — absolute.
`kgx-export-sample` builds its records dir with `mktemp -d` — also absolute. The
canary recipe exercised a path the real recipe never took, which is the worst
arrangement available: the sample greens up and the thing it de-risks is broken.

Two new tests cover that gap. Both fail without the fix (verified by stashing
it: `2 failed, 19 deselected`).

## Verification

`just kgx-export` now completes over the full corpus:

```
Reading 15877 records from /Users/.../data/normalized_yaml
  output/kgx/culturemech_nodes.tsv: 9,375 rows
  output/kgx/culturemech_edges.tsv: 163,864 rows
```

Identical to the manual absolute-path run recorded in #371.
`just kgx-export-sample algae` still passes (338 nodes, 2,217 edges).

## What this PR does *not* do

No workflow runs the corpus export, so CI still cannot catch a regression of
this kind — only the two unit tests can. Making the export a CI artifact is
part of #374, not this PR.