### PR TITLE
Restore the real UTEX ingredient names and amounts; show chemical structure on the pages

### DIFF
--- a/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
+++ b/data/normalized_yaml/algae/1_1_dyiii_pea_gr_medium.yaml
@@ -7,26 +7,26 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: DYIII Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DYIII Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 90 mL'
+- preferred_term: Pea
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pea'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 per 200 mL'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '4'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 90 mL'
+- preferred_term: DAS Vitamin Cocktail
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DAS Vitamin Cocktail'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 4 drops'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +95,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:10.356852+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-to-one-dyiii-pea-gr-plus-medium
 - reference: https://utex.org/products/one-to-one-dyiii-pea-gr-plus-medium

--- a/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 11.5 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 0.5 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.408480+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-half-chev-diatom-medium
 - reference: https://utex.org/products/one-half-chev-diatom-medium

--- a/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/1_2_Enriched_Seawater.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Enriched Seawater Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enriched Seawater Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 500 mL'
+- preferred_term: sterile dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: sterile dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 500 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.415953+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-half-enriched-seawater-medium
 - reference: https://utex.org/products/one-half-enriched-seawater-medium

--- a/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
+++ b/data/normalized_yaml/algae/1_2_Erdschreiber_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Erdschreiber's Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Erdschreiber''s Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 500 mL'
+- preferred_term: sterile dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: sterile dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 500 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.422429+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-half-erdschreibers-medium
 - reference: https://utex.org/products/one-half-erdschreibers-medium

--- a/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_2_soil_seawater_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional) (Fisher C 64)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 100 mL'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 100 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.429222+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-half-soil-plus-seawater-medium
 - reference: https://utex.org/products/one-half-soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_3_CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 7 drops'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.436155+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-third-chev-diatom-medium
 - reference: https://utex.org/products/one-third-chev-diatom-medium

--- a/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_3_soil_seawater_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional) (Fisher C 64)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 67 mL'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 133 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.442802+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-third-soil-plus-seawater-medium
 - reference: https://utex.org/products/one-third-soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_erdschreibers_medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Erdschreiber's Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Erdschreiber''s Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 250 mL'
+- preferred_term: sterile dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: sterile dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 750 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.449170+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-fourth-erdschreibers-medium
 - reference: https://utex.org/products/one-fourth-erdschreibers-medium

--- a/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_4_soil_seawater_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional) (Fisher C 64)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 50 mL'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 150 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.455575+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-fourth-soil-plus-seawater-medium
 - reference: https://utex.org/products/one-fourth-soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/1_5_CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 4 drops'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.462214+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-fifth-chev-diatom-medium
 - reference: https://utex.org/products/one-fifth-chev-diatom-medium

--- a/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/1_5_soil_seawater_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional) (Fisher C 64)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 40 mL'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 160 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.469163+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:one-fifth-soil-plus-seawater-medium
 - reference: https://utex.org/products/one-fifth-soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/1_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/1_F_2_Medium.yaml
@@ -7,51 +7,60 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Seawater(non-sterilized)
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Seawater(non-sterilized)'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 285 mL'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 600 mL'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '4'
+    value: '880'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 7.5 g/100 mL dH20; final 880 µM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: NaH2PO4•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaH2PO4•H2O(MCIB 742)'
-- preferred_term: '5'
+    value: '36'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.5 g/100 mL dH20; final 36 µM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: '742'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '6'
+    value: '70'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL dH20; final 70 µM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Trace Metals Solution'
-- preferred_term: '7'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '8'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -120,6 +129,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.476528+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:1-percent-f-2-medium
 - reference: https://utex.org/products/1-percent-f-2-medium

--- a/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
+++ b/data/normalized_yaml/algae/20_allen_80_erdschreiber_1_4_medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Allen Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Allen Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
+- preferred_term: Erdschreiber's Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Erdschreiber''s Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 800 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.484573+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:20-percent-allen-plus-80-percent-erdschreibers-medium
 - reference: https://utex.org/products/20-percent-allen-plus-80-percent-erdschreibers-medium

--- a/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2X_CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 10 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 2 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.491164+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:2x-chev-diatom-medium
 - reference: https://utex.org/products/2x-chev-diatom-medium

--- a/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/2_3_CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 13 drops'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.497831+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:two-thirds-chev-diatom-medium
 - reference: https://utex.org/products/two-thirds-chev-diatom-medium

--- a/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
+++ b/data/normalized_yaml/algae/2_3_Enriched_Seawater.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Enriched Seawater Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enriched Seawater Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 665 mL'
+- preferred_term: sterile dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: sterile dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 335 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.504892+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:two-thirds-enriched-seawater-medium
 - reference: https://utex.org/products/two-thirds-enriched-seawater-medium

--- a/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/2x_erdschreibers_medium.yaml
@@ -7,36 +7,42 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Supplemented Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Supplemented Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 3 L'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '3'
+    value: '12'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 36 mL/3 L'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '4'
+    value: '2.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/3 L; stock 0.7 M; final 2.3 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: Na2HPO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2HPO4•7H2O(Sigma S-9390)'
-- preferred_term: '5'
+    value: '0.067'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/3 L; stock 0.02 M; final 0.067 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: S-9390
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '6'
+    value: '50'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 150 mL/3 L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 3 mL/3 L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -106,6 +112,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.527184+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 6 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:2x-erdschreibers-medium
 - reference: https://utex.org/products/2x-erdschreibers-medium

--- a/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/2x_soil_seawater_medium.yaml
@@ -7,21 +7,24 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
+  concentration:
+    value: '25'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 5 mL/200 mL of Supplemented Seawater'
+- preferred_term: CaCO3
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg/200 mL of Supplemented Seawater; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: Supplemented Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(Fisher C 64)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Supplemented Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -91,6 +94,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.534434+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:2x-soil-plus-seawater-medium
 - reference: https://utex.org/products/2x-soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
+++ b/data/normalized_yaml/algae/5_3_soil_seawater_agar_medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Soil+Seawater Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soil+Seawater Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Natural sea-salt
   concentration:
-    value: variable
+    value: '15'
     unit: G_PER_L
-  notes: 'Original amount: Natural sea-salt'
+  notes: 'UTEX lists: amount 15 g/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.547165+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:five-thirds-soil-plus-seawater-agar-medium
 - reference: https://utex.org/products/five-thirds-soil-plus-seawater-agar-medium

--- a/data/normalized_yaml/algae/5_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/5_F_2_Medium.yaml
@@ -7,51 +7,60 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Seawater(non-sterilized)
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Seawater(non-sterilized)'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Natural sea-salt
   concentration:
-    value: variable
+    value: '15'
     unit: G_PER_L
-  notes: 'Original amount: Natural sea-salt'
-- preferred_term: '3'
+  notes: 'UTEX lists: amount 15 g/L'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '4'
+    value: '880'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 7.5 g/100 mL dH20; final 880 µM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: NaH2PO4•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaH2PO4•H2O(MCIB 742)'
-- preferred_term: '5'
+    value: '36'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 0.5 g/100 mL dH20; final 36 µM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: '742'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '6'
+    value: '70'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 2 g/100 mL dH20; final 70 µM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Trace Metals Solution'
-- preferred_term: '7'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '8'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -120,6 +129,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.554508+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:5-percent-f-2-medium
 - reference: https://utex.org/products/5-percent-f-2-medium

--- a/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/8_ppt_F_2_Medium.yaml
@@ -7,41 +7,50 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '880'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 7.5 g/100 mL dH20; final 880 µM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: NaH2PO4•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaH2PO4•H2O(MCIB 742)'
-- preferred_term: '3'
+    value: '36'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 0.5 g/100 mL dH20; final 36 µM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: '742'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '4'
+    value: '106'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 3 g/100 mL dH20; final 106 µM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Trace Metals Solution'
-- preferred_term: '5'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '6'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '7'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -111,6 +120,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.562272+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 7 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:8-ppt-f-2-medium
 - reference: https://utex.org/products/8-ppt-f-2-medium

--- a/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Ag_Diatom_Medium.yaml
@@ -7,21 +7,24 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: Modified Bold 3N Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Modified Bold 3N Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +93,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.569974+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:ag-diatom-medium
 - reference: https://utex.org/products/ag-diatom-medium

--- a/data/normalized_yaml/algae/Allen_Medium.yaml
+++ b/data/normalized_yaml/algae/Allen_Medium.yaml
@@ -7,51 +7,75 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: HEPES buffer
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: HEPES buffer(Sigma H-3375)'
-- preferred_term: '2'
+    value: '0.01'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 2.3 g/L; final 0.01 M'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: H-3375
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '3'
+    value: '0.018'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 1.5 g/L; final 0.018 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '4'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
+    value: '0.215'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 5 mL/L; stock 1.5 g/200 mL dH2O; final 0.215 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '6'
+    value: '0.152'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 5 mL/L; stock 1.5 g/200 mL dH2O; final 0.152 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: Na2CO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2CO3(Baker 3604)'
-- preferred_term: '7'
+    value: '0.19'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 5 mL/L; stock 0.8 g/200 mL dH2O; final 0.19 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3604'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '8'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.5 g/200 mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '9'
+    value: '0.204'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1.16 g/200 mL dH2O; final 0.204 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: Citric Acid•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Citric Acid•H2O(Fisher A 104)'
+    value: '0.029'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1.2 g/200 mL dH2O; final 0.029 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A 104
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -119,6 +143,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.578348+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:allen-medium
 - reference: https://utex.org/products/allen-medium

--- a/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Artificial_Seawater_Medium.yaml
@@ -7,61 +7,85 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '2'
+    value: '0.31'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 18 g/L; final 0.31 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '10.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 26 g/100 mL dH20; final 10.5 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(Fisher P 217)'
-- preferred_term: '4'
+    value: '8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 6 g/100 mL dH20; final 8 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: P 217
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '5'
+    value: '11.8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/100 mL dH20; final 11.8 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '6'
+    value: '2'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/100 mL dH20; final 2 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '7'
+    value: '0.37'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.5 g/100 mL dH20; final 0.37 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: Tricine (adjust to pH 8)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Tricine (adjust to pH 8)(Sigma T-5816-256)'
-- preferred_term: '8'
+    value: '25'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 20 mL/L; stock 22.4 g/100 mL dH20; final 25 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T-5816-256
+- preferred_term: P-II Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-II Metal Solution'
-- preferred_term: '9'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: Chelated Iron Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Chelated Iron Solution'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: NH4Cl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4Cl(Fisher A 649-500)'
-- preferred_term: '11'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2.7 g/100 mL dH20; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A 649-500
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -127,6 +151,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 3 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:30.589517+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 11 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:artificial-seawater-medium
 - reference: https://utex.org/products/artificial-seawater-medium

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_1_1_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bold 1NV Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bold 1NV Medium'
-- preferred_term: '2'
+    value: '500'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 500 mL/L'
+- preferred_term: Erdschreiber's Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Erdschreiber''s Medium'
+    value: '500'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 500 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.599227+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bold-1nv-erdschreibers-one-to-one-medium
 - reference: https://utex.org/products/bold-1nv-erdschreibers-one-to-one-medium

--- a/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Erdshreiber_4_1_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bold 1NV Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bold 1NV Medium'
-- preferred_term: '2'
+    value: '800'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 800 mL/L'
+- preferred_term: Erdschreiber's Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Erdschreiber''s Medium'
+    value: '200'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 200 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.605268+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bold-1nv-erdschreibers-four-to-one-medium
 - reference: https://utex.org/products/bold-1nv-erdschreibers-four-to-one-medium

--- a/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_1NV_Medium.yaml
@@ -7,56 +7,74 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '2.94'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/400mL dH2O; final 2.94 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '3'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '6'
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7 g/400mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '7'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '8'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -125,6 +143,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.612597+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 10 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bold-1nv-medium
 - reference: https://utex.org/products/bold-1nv-medium

--- a/data/normalized_yaml/algae/Bold_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_3N_Medium.yaml
@@ -7,51 +7,69 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '8.82'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 30 mL/L; stock 10 g/400mL dH2O; final 8.82 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '3'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '6'
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7 g/400mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '7'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '8'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '9'
+    value: '40'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 40 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -120,6 +138,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.621253+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bold-3n-medium
 - reference: https://utex.org/products/bold-3n-medium

--- a/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
+++ b/data/normalized_yaml/algae/Bold_Basal_Medium.yaml
@@ -7,56 +7,74 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
+  concentration:
+    value: '2.94'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/400mL dH2O; final 2.94 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
+  concentration:
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
+  concentration:
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
+  concentration:
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
+  concentration:
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7 g/400mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
+  concentration:
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: EDTA Stock
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 drop(0.05 mL)'
+- preferred_term: Iron Stock
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O (Sigma C-3881)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 drop(0.05 mL)'
+- preferred_term: Boron Stock
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O (Sigma 230391)'
-- preferred_term: '4'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 drop(0.05 mL)'
+- preferred_term: Bold Trace Stock
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '6'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl (Fisher S271-500)'
-- preferred_term: '7'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: EDTA Stock'
-- preferred_term: '8'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Iron Stock'
-- preferred_term: '9'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Boron Stock'
-- preferred_term: '10'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bold Trace Stock'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 drop(0.05 mL)'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -134,6 +152,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:30.632073+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 10 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bold-basal-medium
 - reference: https://utex.org/products/bold-basal-medium

--- a/data/normalized_yaml/algae/Botryococcus_Medium.yaml
+++ b/data/normalized_yaml/algae/Botryococcus_Medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 940 mL'
+- preferred_term: (NH4)2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
+    value: '0.151'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL; final 0.151 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A686
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +88,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.640980+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:botryococcus-medium
 - reference: https://utex.org/products/botryococcus-medium

--- a/data/normalized_yaml/algae/Bristol_Medium.yaml
+++ b/data/normalized_yaml/algae/Bristol_Medium.yaml
@@ -7,36 +7,54 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '2.94'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/400mL dH2O; final 2.94 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O (Sigma C-3881)'
-- preferred_term: '3'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O (Sigma 230391)'
-- preferred_term: '4'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '6'
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7 g/400mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl (Fisher S271-500)'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -101,6 +119,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:30.648112+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 6 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bristol-medium
 - reference: https://utex.org/products/bristol-medium

--- a/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CHEV_Diatom_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 11 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.698623+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:chev-diatom-medium
 - reference: https://utex.org/products/chev-diatom-medium

--- a/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1+_Diatom_Medium.yaml
@@ -7,21 +7,21 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 drop'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +90,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.705233+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:cr1-plus-diatom-medium
 - reference: https://utex.org/products/cr1-plus-diatom-medium

--- a/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/CR1_Diatom_Medium.yaml
@@ -7,21 +7,24 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +93,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.711491+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:cr1-diatom-medium
 - reference: https://utex.org/products/cr1-diatom-medium

--- a/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/Combo_Diatom_Medium.yaml
@@ -7,21 +7,24 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: Modified COMBO Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Modified COMBO Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +93,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.717792+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:combo-diatom-medium
 - reference: https://utex.org/products/combo-diatom-medium

--- a/data/normalized_yaml/algae/Cyanidium_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanidium_Medium.yaml
@@ -7,26 +7,35 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: (NH4)2SO4
+  concentration:
+    value: '3.78'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 g/500 mL; final 3.78 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A 702
+- preferred_term: K2HPO4
+  concentration:
+    value: '0.057'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.01 g/500 mL; final 0.057 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: MgSO4•7H2O
+  concentration:
+    value: '0.041'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.01 g/500 mL; final 0.041 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: (NH4)2SO4(Fisher A 702)'
-- preferred_term: '2'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 15 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +104,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.724459+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:cyanidium-medium
 - reference: https://utex.org/products/cyanidium-medium

--- a/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
+++ b/data/normalized_yaml/algae/Cyanophycean_Medium.yaml
@@ -7,26 +7,35 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '2'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: KNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KNO3(Baker 3190)'
-- preferred_term: '3'
+    value: '50'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 5 g/L; final 50 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3190'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '4'
+    value: '0.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.05 g/L; final 0.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
+    value: '0.2'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.05 g/L; final 0.2 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +104,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.731392+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:cyanophycean-medium
 - reference: https://utex.org/products/cyanophycean-medium

--- a/data/normalized_yaml/algae/DYIII_Medium.yaml
+++ b/data/normalized_yaml/algae/DYIII_Medium.yaml
@@ -7,66 +7,66 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: MES
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MES(CAS: 7365-45-9)'
-- preferred_term: '2'
+    value: '10'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1.95 g/L; final 10 mM; CAS 7365-45-9'
+- preferred_term: MWC Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MWC Metal Solution'
-- preferred_term: '3'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(CAS: 10035-04-8)'
-- preferred_term: '4'
+    value: '0.14'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL; final 0.14 mM; CAS 10035-04-8'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '5'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 7.4 g/100 mL; final 0.3 mM; CAS 10034-99-8'
+- preferred_term: Na2Glycerophosphate.5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2Glycerophosphate.5H2O(CAS:  13408-09-8)'
-- preferred_term: '6'
+    value: '0.03'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.03 mM; CAS 13408-09-8'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(CAS: 7631-99-4)'
-- preferred_term: '7'
+    value: '0.24'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL; final 0.24 mM; CAS 7631-99-4'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(CAS: 13517-24-3)'
-- preferred_term: '8'
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1.5 g/100 mL; final 0.05 mM; CAS 13517-24-3'
+- preferred_term: NH4NO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4NO3(CAS: 6484-52-2)'
-- preferred_term: '9'
+    value: '0.12'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.12 mM; CAS 6484-52-2'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS:7447-40-7)'
-- preferred_term: '10'
+    value: '0.13'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.13 mM; CAS 7447-40-7'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -134,6 +134,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.740237+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 12 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:dyiii-medium
 - reference: https://utex.org/products/dyiii-medium

--- a/data/normalized_yaml/algae/DYV_Medium.yaml
+++ b/data/normalized_yaml/algae/DYV_Medium.yaml
@@ -7,71 +7,71 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: MES
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MES(CAS: 7365-45-9)'
-- preferred_term: '2'
+    value: '10'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1.95 g/L; final 10 mM; CAS 7365-45-9'
+- preferred_term: MWC Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MWC Metal Solution'
-- preferred_term: '3'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(CAS: 10035-04-8)'
-- preferred_term: '4'
+    value: '0.14'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL; final 0.14 mM; CAS 10035-04-8'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '5'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 7.4 g/100 mL; final 0.3 mM; CAS 10034-99-8'
+- preferred_term: Na2Glycerophosphate•5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2Glycerophosphate•5H2O(CAS: 13408-09-8)'
-- preferred_term: '6'
+    value: '0.03'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.03 mM; CAS 13408-09-8'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(CAS: 7631-99-4)'
-- preferred_term: '7'
+    value: '0.24'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL; final 0.24 mM; CAS 7631-99-4'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(CAS: 13517-24-3)'
-- preferred_term: '8'
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1.5 g/100 mL; final 0.05 mM; CAS 13517-24-3'
+- preferred_term: NH4NO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4NO3(CAS: 6484-52-2)'
-- preferred_term: '9'
+    value: '0.12'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.12 mM; CAS 6484-52-2'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS: 7447-40-7)'
-- preferred_term: '10'
+    value: '0.13'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/100 mL; final 0.13 mM; CAS 7447-40-7'
+- preferred_term: DYV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DYV Metal Solution'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '13'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -139,6 +139,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.749082+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 13 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:dyv-medium
 - reference: https://utex.org/products/dyv-medium

--- a/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Dasycladales_Seawater_Medium.yaml
@@ -7,31 +7,31 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 3 L'
+- preferred_term: Soil+Seawater Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soil+Seawater Medium'
-- preferred_term: '3'
+    value: '16.66666666666666666666666667'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 50 mL/3 L'
+- preferred_term: DAS Macro Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DAS Macro Solution'
-- preferred_term: '4'
+    value: '13.33333333333333333333333333'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 40 mL/3 L'
+- preferred_term: Modified P-IV chelated Micronutrient Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Modified P-IV chelated Micronutrient Solution'
-- preferred_term: '5'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 30 mL/3 L'
+- preferred_term: DAS Vitamin Cocktail
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DAS Vitamin Cocktail'
+    value: '0.5'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1.5 mL/3 L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -101,6 +101,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.756640+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 5 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:dasycladales-seawater-medium
 - reference: https://utex.org/products/dasycladales-seawater-medium

--- a/data/normalized_yaml/algae/Desmid_Medium.yaml
+++ b/data/normalized_yaml/algae/Desmid_Medium.yaml
@@ -7,26 +7,35 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '2'
+    value: '50'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 50 mL/L'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '0.04'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.2 g/200 mL dH2O; final 0.04 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '4'
+    value: '0.057'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.2 g/200 mL dH2O; final 0.057 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KNO3(Baker 3190)'
+    value: '0.99'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 2 g/200 mL dH2O; final 0.99 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3190'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -94,6 +103,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.763377+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:desmid-medium
 - reference: https://utex.org/products/desmid-medium

--- a/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_10_Enriched_Seawater_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Enrichment Solution for Seawater Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enrichment Solution for Seawater Medium'
+    value: '2'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 2 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.771725+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:es-over-10-enriched-seawater-medium
 - reference: https://utex.org/products/es-over-10-enriched-seawater-medium

--- a/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_2_Enriched_Seawater_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Enrichment Solution for Seawater Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enrichment Solution for Seawater Medium'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.780164+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:es-over-2-enriched-seawater-medium
 - reference: https://utex.org/products/es-over-2-enriched-seawater-medium

--- a/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/ES_4_Enriched_Seawater_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Enrichment Solution for Seawater Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enrichment Solution for Seawater Medium'
+    value: '5'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 5 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.787209+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:es-over-4-enriched-seawater-medium
 - reference: https://utex.org/products/es-over-4-enriched-seawater-medium

--- a/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Enriched_Seawater_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Enrichment Solution for Seawater Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Enrichment Solution for Seawater Medium'
+    value: '20'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 20 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +86,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.794003+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:enriched-seawater-medium
 - reference: https://utex.org/products/enriched-seawater-medium

--- a/data/normalized_yaml/algae/Euglena_Medium.yaml
+++ b/data/normalized_yaml/algae/Euglena_Medium.yaml
@@ -7,31 +7,43 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Sodium acetate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium acetate(Fisher BP 333)'
-- preferred_term: '2'
+    value: '12.2'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 g/L; final 12.2 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP 333
+- preferred_term: Beef extract
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Beef extract(Sigma B-4888)'
-- preferred_term: '3'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: B-4888
+- preferred_term: Tryptone(Sigma T 9410))
   concentration:
-    value: variable
+    value: '2'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone(Sigma T 9410))'
-- preferred_term: '4'
+  notes: 'UTEX lists: amount 2 g/L'
+- preferred_term: Yeast extract
   concentration:
-    value: variable
+    value: '2'
     unit: G_PER_L
-  notes: 'Original amount: Yeast extract(Bacto, Difco)'
-- preferred_term: '5'
+  notes: 'UTEX lists: amount 2 g/L'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: ', Difco'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
+    value: '0.07'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.01 g/L; final 0.07 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -100,6 +112,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.800498+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 5 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:euglena-medium
 - reference: https://utex.org/products/euglena-medium

--- a/data/normalized_yaml/algae/F_2_Medium.yaml
+++ b/data/normalized_yaml/algae/F_2_Medium.yaml
@@ -7,41 +7,50 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '880'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 7.5 g/100 mL d-H2O; final 880 µM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: NaH2PO4•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaH2PO4•H2O(MCIB 742)'
-- preferred_term: '3'
+    value: '36'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 0.5 g/100 mL d-H2O; final 36 µM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: '742'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '4'
+    value: '106'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 3 g/100 mL d-H2O; final 106 µM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Trace Metals Solution'
-- preferred_term: '5'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '6'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '7'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -111,6 +120,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 4 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:30.813745+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 7 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:f-2-medium
 - reference: https://utex.org/products/f-2-medium

--- a/data/normalized_yaml/algae/HEPES_Medium.yaml
+++ b/data/normalized_yaml/algae/HEPES_Medium.yaml
@@ -7,46 +7,46 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Ca(NO3)2•4H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Ca(NO3)2•4H2O(CAS: 13477-34-4)'
-- preferred_term: '2'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 11.8 g/100 mL dH20; final 0.5 mM; CAS 13477-34-4'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '3'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 4 g/100 mL dH20; final 0.16 mM; CAS 10034-99-8'
+- preferred_term: Na2glycerophosphate•5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2glycerophosphate•5H2O(CAS:  13408-09-8)'
-- preferred_term: '4'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH20; final 0.16 mM; CAS 13408-09-8'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS: 7447-40-7)'
-- preferred_term: '5'
+    value: '0.67'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH20; final 0.67 mM; CAS 7447-40-7'
+- preferred_term: HEPES buffer
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: HEPES buffer(CAS: 7365-45-9)'
-- preferred_term: '6'
+    value: '3.9'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.94 g/L; final 3.9 mM; CAS 7365-45-9'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '7'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '8'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -114,6 +114,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.825129+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 8 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:hepes-medium
 - reference: https://utex.org/products/hepes-medium

--- a/data/normalized_yaml/algae/J_Medium.yaml
+++ b/data/normalized_yaml/algae/J_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Macro Component 1 for J Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Macro Component 1 for J Medium'
-- preferred_term: '2'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: Macro Component 2 for J medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Macro Component 2 for J medium'
-- preferred_term: '3'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '4'
+    value: '0.02'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.29 g/100 mL dH20; final 0.02 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: G9 Trace Metals for J medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: G9 Trace Metals for J medium'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -94,6 +97,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.833882+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:j-medium
 - reference: https://utex.org/products/j-medium

--- a/data/normalized_yaml/algae/LDM_Medium.yaml
+++ b/data/normalized_yaml/algae/LDM_Medium.yaml
@@ -7,61 +7,82 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Seawater (30 ppt)
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Seawater (30 ppt)'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 950 mL'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '3'
+    value: '0.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 10 g/400mL dH2O; final 0.29 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '4'
+    value: '0.017'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/400mL dH2O; final 0.017 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '5'
+    value: '0.03'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 3 g/400mL dH2O; final 0.03 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '6'
+    value: '0.043'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 3 g/400mL dH2O; final 0.043 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '7'
+    value: '0.129'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 7 g/400mL dH2O; final 0.129 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '8'
+    value: '0.043'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1 g/400mL dH2O; final 0.043 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '9'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Tryptone
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone(Sigma T 9410)'
-- preferred_term: '10'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T 9410
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -129,6 +150,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.841457+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 11 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:ldm-medium
 - reference: https://utex.org/products/ldm-medium

--- a/data/normalized_yaml/algae/Malt_Medium.yaml
+++ b/data/normalized_yaml/algae/Malt_Medium.yaml
@@ -7,11 +7,14 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Malt extract
   concentration:
-    value: variable
+    value: '67.2'
     unit: G_PER_L
-  notes: 'Original amount: Malt extract(Sigma M-0383)'
+  notes: 'UTEX lists: amount 33.6 g/500 mL dH2O'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: M-0383
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -79,6 +82,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.848176+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 1 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:malt-medium
 - reference: https://utex.org/products/malt-medium

--- a/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_2X_CHEV_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: F/2 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: F/2 Medium'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
+- preferred_term: Sterile dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sterile dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 800 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.854129+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-2x-chev-medium
 - reference: https://utex.org/products/modified-2x-chev-medium

--- a/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Artificial_Seawater_Medium.yaml
@@ -7,71 +7,95 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '2'
+    value: '0.51'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 30 g/L; final 0.51 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '9.9'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 24.4 g/100 mL dH20; final 9.9 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(Fisher P 217)'
-- preferred_term: '4'
+    value: '8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 6 g/100 mL dH20; final 8 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: P 217
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '5'
+    value: '11.8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/100 mL dH20; final 11.8 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '6'
+    value: '2.04'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/100 mL dH20; final 2.04 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '7'
+    value: '0.37'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.5 g/100 mL dH20; final 0.37 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: Tricine
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Tricine(Sigma T-5816-256)'
-- preferred_term: '8'
+    value: '5.58'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/100 mL dH20; final 5.58 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T-5816-256
+- preferred_term: NH4Cl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4Cl(Fisher A 649-500)'
-- preferred_term: '9'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2.7 g/100 mL dH20; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A 649-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '11'
+    value: '30'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 30 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '13'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -141,6 +165,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.862201+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 13 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-artificial-seawater-medium
 - reference: https://utex.org/products/modified-artificial-seawater-medium

--- a/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Bolds_3N_Medium.yaml
@@ -7,61 +7,79 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '8.82'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 30 mL/L; stock 10 g/400mL dH2O; final 8.82 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '3'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '5'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '6'
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7 g/400mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '7'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/400mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '8'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '9'
+    value: '40'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 40 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -130,6 +148,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.872028+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 11 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-bold-3n-medium
 - reference: https://utex.org/products/modified-bold-3n-medium

--- a/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_CHEV_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 11 mL'
+- preferred_term: F/2 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: F/2 Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.879451+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-chev-medium
 - reference: https://utex.org/products/modified-chev-medium

--- a/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_COMBO_Medium.yaml
@@ -7,66 +7,90 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '10'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 85.01 g/L; final 10 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '3'
+    value: '2.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 36.76 g/L; final 2.5 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '1.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 36.97 g/L; final 1.5 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: NaHCO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaHCO3(Fisher S 233)'
-- preferred_term: '5'
+    value: '1.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 12.6 g/L; final 1.5 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S 233
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '6'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 28.42 g/L; final 1 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '7'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 8.71 g/L; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: H3BO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: H3BO3(Baker 0084)'
-- preferred_term: '8'
+    value: '3.9'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 24 g/L; final 3.9 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: 0084
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl (Fisher P 217)'
-- preferred_term: '9'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 7.45 g/L; final 1 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: P 217
+- preferred_term: Algal Trace Elements Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Algal Trace Elements Solution'
-- preferred_term: '10'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -135,6 +159,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.887192+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 12 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-combo-medium
 - reference: https://utex.org/products/modified-combo-medium

--- a/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Modified_Desmidiacean_Medium.yaml
@@ -7,46 +7,55 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: KNO3
+  concentration:
+    value: '0.9'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/100 mL; final 0.9 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3190'
+- preferred_term: (NH4)2HPO4
+  concentration:
+    value: '0.075'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 5 mL/L; stock 0.2 g/100 mL; final 0.075 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A686
+- preferred_term: MgSO4•7H2O
+  concentration:
+    value: '3.3'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.1 g/100 mL; final 3.3 µM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: CaSO4•2H2Osaturated solution (Mallinckroft 4300)
+  concentration:
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
+  concentration:
+    value: '20'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 20 mL/L'
+- preferred_term: 'Soilwater: Peat Medium'
+  concentration:
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: MWC Metal Solution
+  concentration:
+    value: '5'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 5 mL/L'
+- preferred_term: Barley grains autoclaved
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KNO3(Baker 3190)'
-- preferred_term: '2'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaSO4•2H2Osaturated solution (Mallinckroft 4300)'
-- preferred_term: '5'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '6'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: Peat Medium'
-- preferred_term: '7'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MWC Metal Solution'
-- preferred_term: '8'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Barley grains autoclaved'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 grain/10 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -115,6 +124,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.895449+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 8 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-desmidiacean-medium
 - reference: https://utex.org/products/modified-desmidiacean-medium

--- a/data/normalized_yaml/algae/N_20_Medium.yaml
+++ b/data/normalized_yaml/algae/N_20_Medium.yaml
@@ -7,61 +7,85 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '2'
+    value: '1.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 2 mL/L; stock 17.5 g/200 mL dH2O; final 1.29 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '3'
+    value: '0.14'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 100 µL/L; stock 25 g/200 mL dH2O; final 0.14 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '4'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 15 g/200 mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '5'
+    value: '0.43'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/200 mL dH2O; final 0.43 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '6'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/200 mL dH2O; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '7'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 15 g/200 mL dH2O; final 0.3 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '8'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Sodium acetate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium acetate(Fisher BP 333)'
-- preferred_term: '9'
+    value: '8.12'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.67 g/L; final 8.12 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP 333
+- preferred_term: TES buffer
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: TES buffer(Sigma T 1375)'
-- preferred_term: '10'
+    value: '4.01'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.92 g/L; final 4.01 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T 1375
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -129,6 +153,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.903976+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 11 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:n-over-20-medium
 - reference: https://utex.org/products/n-over-20-medium

--- a/data/normalized_yaml/algae/Ochromonas_Medium.yaml
+++ b/data/normalized_yaml/algae/Ochromonas_Medium.yaml
@@ -7,26 +7,35 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Glucose
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Glucose(BACTO-dextrose or Sigma D 9634)'
-- preferred_term: '2'
+    value: '5.6'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 g/L; final 5.6 mM'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: -dextrose or Sigma D 9634
+- preferred_term: Tryptone
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone (Sigma T 9410)'
-- preferred_term: '3'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T 9410
+- preferred_term: Yeast extract
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Yeast extract(Bacto, Difco)'
-- preferred_term: '4'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: ', Difco'
+- preferred_term: Liver extract infusion
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Liver extract infusion'
+    value: '40'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 40 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +104,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.911664+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:ochromonas-medium
 - reference: https://utex.org/products/ochromonas-medium

--- a/data/normalized_yaml/algae/P49_Medium.yaml
+++ b/data/normalized_yaml/algae/P49_Medium.yaml
@@ -7,66 +7,67 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '2'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 4 g/100 mL dH2O; final 0.16 mM; CAS 10034-99-8'
+- preferred_term: Na2glycerophosphate•5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2glycerophosphate•5H2O(CAS: 13408-09-8)'
-- preferred_term: '3'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH2O; final 0.16 mM; CAS 13408-09-8'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS: 7447-40-7)'
-- preferred_term: '4'
+    value: '0.67'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH2O; final 0.67 mM; CAS 7447-40-7'
+- preferred_term: Glycylglycine
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Glycylglycine(CAS: 556-50-3)'
-- preferred_term: '5'
+    value: '3.8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 5 g/100 mL dH2O; final 3.8 mM; CAS 556-50-3'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '6'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: NH4NO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4NO3(CAS: 6484-52-2)'
-- preferred_term: '7'
+    value: '1.2'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1 g/100 mL dH2O; final 1.2 mM; CAS 6484-52-2'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(CAS: 10035-04-8)'
-- preferred_term: '8'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.74 g/100 mL dH2O; final 0.5 mM; CAS
+    10035-04-8'
+- preferred_term: Yeast extract
   concentration:
-    value: variable
+    value: '0.2'
     unit: G_PER_L
-  notes: 'Original amount: Yeast extract(CAS: 8013-01-2)'
-- preferred_term: '9'
+  notes: 'UTEX lists: amount 0.2 g/L; CAS 8013-01-2'
+- preferred_term: Tryptone
   concentration:
-    value: variable
+    value: '0.4'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone(CAS: 91079-40-2)'
-- preferred_term: '10'
+  notes: 'UTEX lists: amount 0.4 g/L; CAS 91079-40-2'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -134,6 +135,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.919489+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 12 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:p49-medium
 - reference: https://utex.org/products/p49-medium

--- a/data/normalized_yaml/algae/Polytomella_Medium.yaml
+++ b/data/normalized_yaml/algae/Polytomella_Medium.yaml
@@ -7,21 +7,30 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Yeast extract
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Yeast extract(Bacto, Difco)'
-- preferred_term: '2'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: ', Difco'
+- preferred_term: Tryptone
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone(Sigma T 9410)'
-- preferred_term: '3'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T 9410
+- preferred_term: Sodium acetate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium acetate(Fisher BP 333)'
+    value: '24.4'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 2 g/L; final 24.4 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP 333
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.926608+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:polytomella-medium
 - reference: https://utex.org/products/polytomella-medium

--- a/data/normalized_yaml/algae/Porphryridium_Medium.yaml
+++ b/data/normalized_yaml/algae/Porphryridium_Medium.yaml
@@ -7,26 +7,32 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Seawater(non-sterilized)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Seawater(non-sterilized)'
-- preferred_term: '2'
+    value: '500'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 500 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '3'
+    value: '100'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 100 mL/L'
+- preferred_term: Yeast extract
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Yeast extract(Bacto, Difco)'
-- preferred_term: '4'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: ', Difco'
+- preferred_term: Tryptone
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Tryptone(Sigma T 9410)'
+  notes: 'UTEX lists: amount 1 g/L'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: T 9410
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +101,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.933748+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:porphyridium-medium
 - reference: https://utex.org/products/porphyridium-medium

--- a/data/normalized_yaml/algae/Proteose_Medium.yaml
+++ b/data/normalized_yaml/algae/Proteose_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Proteose Peptone(BD 211684)
   concentration:
-    value: variable
+    value: '1'
     unit: G_PER_L
-  notes: 'Original amount: Proteose Peptone(BD 211684)'
+  notes: 'UTEX lists: amount 1 g/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.939954+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:proteose-medium
 - reference: https://utex.org/products/proteose-medium

--- a/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
+++ b/data/normalized_yaml/algae/SS_Diatom_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 12 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.948130+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:ss-diatom-medium
 - reference: https://utex.org/products/ss-diatom-medium

--- a/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
+++ b/data/normalized_yaml/algae/Snow_Algae_Medium.yaml
@@ -7,56 +7,77 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '2'
+    value: '0.03'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.5 g/100 mL dH2O; final 0.03 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '3'
+    value: '0.29'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2.5 g/100 mL dH2O; final 0.29 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: NH4Cl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4Cl(Fisher A 649-500)'
-- preferred_term: '4'
+    value: '0.093'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.5 g/100 mL dH2O; final 0.093 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A 649-500
+- preferred_term: CaSO4•2H2O(Mallinckroft 4300)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaSO4•2H2O(Mallinckroft 4300)'
-- preferred_term: '5'
+    value: '0.023'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.4 g/100 mL dH2O; final 0.023 mM'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '6'
+    value: '0.02'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.5 g/100 mL dH2O; final 0.02 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '7'
+    value: '0.007'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 0.2 g/100 mL dH2O; final 0.007 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: FE EDTA
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: FE EDTA'
-- preferred_term: '8'
+    value: '250'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 250 mL/L'
+- preferred_term: Minor Nutrients
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Minor Nutrients'
-- preferred_term: '9'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '10'
+    value: '0.4'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 2 mL; stock 3.48 g/100 mL dH2O; final 0.4 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
+    value: '0.02'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 98 mL; stock 2.72 g/100 mL dH2O; final 0.02 M'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -125,6 +146,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.959798+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 10 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:snow-algae-medium
 - reference: https://utex.org/products/snow-algae-medium

--- a/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
+++ b/data/normalized_yaml/algae/Soil_Extract_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 960 mL'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 40 mL of supernatant'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -93,6 +93,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.968803+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soil-extract-medium
 - reference: https://utex.org/products/soil-extract-medium

--- a/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_BAR_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: Barley grains(add after dH2O)
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Barley grains(add after dH2O)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 3 grains'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional) (Fisher C 64)'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.975534+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-bar-medium
 - reference: https://utex.org/products/soilwater-bar-medium

--- a/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.982218+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-gr-minus-medium
 - reference: https://utex.org/products/soilwater-gr-minus-medium

--- a/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_GR-_NH4_Medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: 'Soilwater: GR- Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR- Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
+- preferred_term: NH4MgPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4MgPO4(Sigma 529354)'
+    value: '0.04'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.04 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '529354'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +88,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.988263+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-gr-minus-nh4-medium
 - reference: https://utex.org/products/soilwater-gr-minus-nh4-medium

--- a/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_PEA_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: Pea(add after dH2O)
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pea(add after dH2O)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 per 200 mL'
+- preferred_term: CaCO3
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(Fisher C 64)'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:30.994320+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-pea-medium
 - reference: https://utex.org/products/soilwater-pea-medium

--- a/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_Peat_Medium.yaml
@@ -7,21 +7,21 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Organic Peat
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Organic Peat'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 0.5 tsp'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1.5 tsp'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +90,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.002006+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-peat-medium
 - reference: https://utex.org/products/soilwater-peat-medium

--- a/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
+++ b/data/normalized_yaml/algae/Soilwater_VT_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Vermont Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vermont Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.008615+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-vt-medium
 - reference: https://utex.org/products/soilwater-vt-medium

--- a/data/normalized_yaml/algae/Spirulina_Medium.yaml
+++ b/data/normalized_yaml/algae/Spirulina_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Spir solution 1
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Spir solution 1'
-- preferred_term: '2'
+    value: '500'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 500 mL/L'
+- preferred_term: Spir solution 2
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Spir solution 2'
+    value: '500'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 500 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -81,6 +81,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 1 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:31.015871+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:spirulina-medium
 - reference: https://utex.org/products/spirulina-medium

--- a/data/normalized_yaml/algae/TAP_Medium.yaml
+++ b/data/normalized_yaml/algae/TAP_Medium.yaml
@@ -7,26 +7,26 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Beijerinck's Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Beijerinck''s Solution'
-- preferred_term: '2'
+    value: '50'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 100 mL/2 L'
+- preferred_term: Phosphate Buffer Stock Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Phosphate Buffer Stock Solution'
-- preferred_term: '3'
+    value: '8.5'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 17 mL/2 L'
+- preferred_term: Hunter's Trace Stock Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Hunter''s Trace Stock Solution'
-- preferred_term: '4'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 2 mL/2 L'
+- preferred_term: Tris Acetate Stock Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Tris Acetate Stock Solution'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 20 mL/2 L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +90,14 @@ curation_history:
   action: SET_ORGANISM_CULTURE_TYPE
   notes: 'Inferred isolate: 2 specific strain(s) named, no community signal (#142)'
   changes: Set organism_culture_type=isolate (was unset)
+- timestamp: '2026-08-30T00:58:31.026248+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:tap-medium
 - reference: https://utex.org/products/tap-medium

--- a/data/normalized_yaml/algae/Trebouxia_Medium.yaml
+++ b/data/normalized_yaml/algae/Trebouxia_Medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    value: '825'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 825 mL/L'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '3'
+    value: '140'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 140 mL/L'
+- preferred_term: Proteose Peptone(BD 211684)
   concentration:
-    value: variable
+    value: '10'
     unit: G_PER_L
-  notes: 'Original amount: Proteose Peptone(BD 211684)'
-- preferred_term: '4'
+  notes: 'UTEX lists: amount 10 g/L'
+- preferred_term: Glucose
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Glucose(BACTO-dextrose or Sigma D 9634)'
+    value: '0.11'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 20 g/L; final 0.11 M'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: -dextrose or Sigma D 9634
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.034673+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:trebouxia-medium
 - reference: https://utex.org/products/trebouxia-medium

--- a/data/normalized_yaml/algae/Volvocacean_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvocacean_Medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Waris Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Waris Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 800 mL'
+- preferred_term: Euglena Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Euglena Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.041123+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:volvocacean-medium
 - reference: https://utex.org/products/volvocacean-medium

--- a/data/normalized_yaml/algae/Volvox_Medium.yaml
+++ b/data/normalized_yaml/algae/Volvox_Medium.yaml
@@ -7,46 +7,46 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Ca(NO3)2•4H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Ca(NO3)2•4H2O(CAS: 13477-34-4)'
-- preferred_term: '2'
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 11.8 g/100 mL dH2O; final 0.5 mM; CAS 13477-34-4'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '3'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 4 g/100 mL dH2O; final 0.16 mM; CAS 10034-99-8'
+- preferred_term: Na2glycerophosphate•5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2glycerophosphate•5H2O(CAS: 13408-09-8)'
-- preferred_term: '4'
+    value: '0.16'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH2O; final 0.16 mM; CAS 13408-09-8'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS: 7447-40-7)'
-- preferred_term: '5'
+    value: '0.67'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH2O; final 0.67 mM; CAS 7447-40-7'
+- preferred_term: Glycylglycine
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Glycylglycine(CAS: 556-50-3)'
-- preferred_term: '6'
+    value: '3.8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 5 g/100 mL dH2O; final 3.8 mM; CAS 556-50-3'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '7'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '8'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -114,6 +114,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.047848+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 8 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:volvox-medium
 - reference: https://utex.org/products/volvox-medium

--- a/data/normalized_yaml/algae/WC+_Medium.yaml
+++ b/data/normalized_yaml/algae/WC+_Medium.yaml
@@ -7,66 +7,87 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '2'
+    value: '0.2'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 2 mL/L; stock 28.42 g/L; final 0.2 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '3'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 85.1 g/L; final 1 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '4'
+    value: '0.25'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 36.76 g/L; final 0.25 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '5'
+    value: '0.15'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 36.97 g/L; final 0.15 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: NaHCO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaHCO3(Fisher S 233)'
-- preferred_term: '6'
+    value: '0.15'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 12.6 g/L; final 0.15 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S 233
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '7'
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 8.71 g/L; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: H3BO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: H3BO3(Baker 0084)'
-- preferred_term: '8'
+    value: '0.39'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 24 g/L; final 0.39 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: 0084
+- preferred_term: WC Trace Elements Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: WC Trace Elements Solution'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: DYV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: DYV Metal Solution'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
-- preferred_term: '12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -134,6 +155,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.055757+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 12 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:wc-plus-medium
 - reference: https://utex.org/products/wc-plus-medium

--- a/data/normalized_yaml/algae/WC_Medium.yaml
+++ b/data/normalized_yaml/algae/WC_Medium.yaml
@@ -7,61 +7,82 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 85.1 g/L; final 1 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '3'
+    value: '0.25'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 36.76 g/L; final 0.25 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '0.15'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 36.97 g/L; final 0.15 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: NaHCO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaHCO3(Fisher S 233)'
-- preferred_term: '5'
+    value: '0.15'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 12.6 g/L; final 0.15 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S 233
+- preferred_term: Na2SiO3•9H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2SiO3•9H2O(Sigma 307815)'
-- preferred_term: '6'
+    value: '0.1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 28.42 g/L; final 0.1 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '307815'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '7'
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 8.71 g/L; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 3786
+- preferred_term: H3BO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: H3BO3(Baker 0084)'
-- preferred_term: '8'
+    value: '0.39'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 24 g/L; final 0.39 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: 0084
+- preferred_term: WC Trace Elements Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: WC Trace Elements Solution'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Thiamine Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Thiamine Vitamin Solution'
-- preferred_term: '11'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -129,6 +150,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.064719+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 11 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:wc-medium
 - reference: https://utex.org/products/wc-medium

--- a/data/normalized_yaml/algae/Waris_Medium.yaml
+++ b/data/normalized_yaml/algae/Waris_Medium.yaml
@@ -7,31 +7,40 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: KNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KNO3(Baker 3190)'
-- preferred_term: '2'
+    value: '0.99'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 10 g/100 mL dH2O; final 0.99 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3190'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '0.081'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL dH2O; final 0.081 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: (NH4)2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
-- preferred_term: '4'
+    value: '0.151'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL dH2O; final 0.151 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A686
+- preferred_term: CaSO4•2H2O(Mallinckroft 4300)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaSO4•2H2O(Mallinckroft 4300)'
-- preferred_term: '5'
+    value: '0.35'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 30 mL/L; stock 0.2 g/100 mL dH2O; final 0.35 mM'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -99,6 +108,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.073636+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 5 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:waris-medium
 - reference: https://utex.org/products/waris-medium

--- a/data/normalized_yaml/algae/a_medium.yaml
+++ b/data/normalized_yaml/algae/a_medium.yaml
@@ -7,57 +7,80 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
-- preferred_term: '2'
+    value: '0.308'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 18 g/L; final 0.308 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '0.02'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 5 g/L; final 0.02 M'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: Na2EDTA•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2EDTA•2H2O(Sigma ED255)'
-- preferred_term: '4'
+    value: '0.08'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.3 g/100 mL; final 0.08 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: ED255
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(Fisher P 217)'
-- preferred_term: '5'
+    value: '8.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 6 g/100 mL; final 8.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: P 217
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '6'
+    value: '2.52'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 3.7 g/100 mL; final 2.52 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: C-3881
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '7'
+    value: '11.8'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/100 mL; final 11.8 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: KH2PO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KH2PO4(Sigma P 0662)'
-- preferred_term: '8'
+    value: '0.37'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.5 g/100 mL; final 0.37 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: P 0662
+- preferred_term: Trizma Base pH 8.2
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Trizma Base pH 8.2'
-- preferred_term: '9'
+    value: '8.26'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 10 g/100 mL; final 8.26 mM'
+- preferred_term: A+ Trace Components (sterilize before adding)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: A+ Trace Components (sterilize before adding)'
-- preferred_term: '10'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: Sodium Thiosulfate Pentahydrate (agar media only,sterile)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium Thiosulfate Pentahydrate (agar media only,sterile)(Baker
-    3946)'
+    value: '1'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 24.819 g/100 mL; final 1 µM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3946'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -143,6 +166,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.083264+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 10 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:a-plus-medium
 - reference: https://utex.org/products/a-plus-medium

--- a/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_0_36_nacl_medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: BG-11 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: BG-11 Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
+    value: '0.062'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 3.6 g/L; final 0.062 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.282794+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bg-11-1-plus-0-point-36-percent-nacl-medium
 - reference: https://utex.org/products/bg-11-1-plus-0-point-36-percent-nacl-medium

--- a/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_1_nacl_medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: BG-11 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: BG-11 Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
+    value: '0.17'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 10 g/L; final 0.17 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -96,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.292090+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bg-11-plus-1-percent-nacl-medium
 - reference: https://utex.org/products/bg-11-plus-1-percent-nacl-medium

--- a/data/normalized_yaml/algae/bg_11_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_medium.yaml
@@ -7,57 +7,62 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: NaNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(Fisher BP360-500)'
-- preferred_term: '2'
+    value: '17.6'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 30 g/200 mL dH2O; final 17.6 mM; CAS 7631-99-4'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '3'
+    value: '0.23'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.8 g/200 mL dH2O; final 0.23 mM; CAS
+    7758-11-4'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '4'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1.5 g/200 mL dH2O; final 0.3 mM; CAS 10034-99-8'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '5'
+    value: '0.24'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.72 g/200 mL dH2O; final 0.24 mM; CAS
+    10035-04-8'
+- preferred_term: Citric Acid•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Citric Acid•H2O(Fisher A 104)'
-- preferred_term: '6'
+    value: '0.031'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.12 g/200 mL dH2O; final 0.031 mM; CAS
+    5949-29-1'
+- preferred_term: Ferric Ammonium Citrate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Ferric Ammonium Citrate'
-- preferred_term: '7'
+    value: '0.021'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.12 g/200 mL dH2O; final 0.021 mM; CAS
+    1185-57-5'
+- preferred_term: Na2EDTA•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2EDTA•2H2O(Sigma ED255)'
-- preferred_term: '8'
+    value: '0.0027'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.02 g/200 mL dH2O; final 0.0027 mM; CAS
+    6381-92-6'
+- preferred_term: Na2CO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2CO3(Baker 3604)'
-- preferred_term: '9'
+    value: '0.19'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.4 g/200 mL dH2O; final 0.19 mM; CAS
+    497-19-8'
+- preferred_term: BG-11 Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: BG-11 Trace Metals Solution'
-- preferred_term: '10'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Sodium Thiosulfate Pentahydrate (agar media only,sterile)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium Thiosulfate Pentahydrate (agar media only,sterile)(Baker
-    3946)'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 49.8 g/200 mL dH2O; final 1 mM; CAS 10102-17-7'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -143,6 +148,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.309609+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 10 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bg-11-medium
 - reference: https://utex.org/products/bg-11-medium

--- a/data/normalized_yaml/algae/bg_11_n_medium.yaml
+++ b/data/normalized_yaml/algae/bg_11_n_medium.yaml
@@ -7,52 +7,51 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: K2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: K2HPO4(Sigma P 3786)'
-- preferred_term: '2'
+    value: '0.22'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.8 g/200 mL; final 0.22 mM; CAS 7758-11-4'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '0.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 1.5 g/200 mL; final 0.3 mM; CAS 10034-99-8'
+- preferred_term: CaCl2•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCl2•2H2O(Sigma C-3881)'
-- preferred_term: '4'
+    value: '0.24'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.72 g/200 mL; final 0.24 mM; CAS 10035-04-8'
+- preferred_term: Citric Acid•H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Citric Acid•H2O(Fisher A 104)'
-- preferred_term: '5'
+    value: '0.012'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.12 g/200 mL; final 0.012 mM; CAS 5949-29-1'
+- preferred_term: Ferric Ammonium Citrate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Ferric Ammonium Citrate'
-- preferred_term: '6'
+    value: '0.02'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.12 g/200 mL; final 0.02 mM; CAS 1185-57-5'
+- preferred_term: Na2EDTA•2H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2EDTA•2H2O(Sigma ED255)'
-- preferred_term: '7'
+    value: '0.002'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.02 g/200 mL; final 0.002 mM; CAS 6381-92-6'
+- preferred_term: Na2CO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2CO3(Baker 3604)'
-- preferred_term: '8'
+    value: '0.18'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/L; stock 0.4 g/200 mL; final 0.18 mM; CAS 497-19-8'
+- preferred_term: BG-11 Trace Metals Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: BG-11 Trace Metals Solution'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Sodium Thiosulfate Pentahydrate (agar media only,sterile)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium Thiosulfate Pentahydrate (agar media only,sterile)(Baker
-    3946)'
+    value: '1'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 49.6 g/200 mL; final 1 mM; CAS 10102-17-7'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -138,6 +137,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.323761+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bg-11-n-medium
 - reference: https://utex.org/products/bg-11-n-medium

--- a/data/normalized_yaml/algae/bristol_nacl_medium.yaml
+++ b/data/normalized_yaml/algae/bristol_nacl_medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: NaCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaCl(Fisher S271-500)'
+    value: '0.062'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 3.6 g/L; final 0.062 M'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S271-500
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +89,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.387479+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:bristol-nacl-medium
 - reference: https://utex.org/products/bristol-nacl-medium

--- a/data/normalized_yaml/algae/chus_medium.yaml
+++ b/data/normalized_yaml/algae/chus_medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Chu Stock Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Chu Stock Solution'
-- preferred_term: '2'
+    value: '10'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 10 mL/L'
+- preferred_term: NaHCO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaHCO3(Fisher S 233)'
+    value: '0.17'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 1.26 g/90 mL; final 0.17 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: S 233
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -84,6 +87,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.466178+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:chus-medium
 - reference: https://utex.org/products/chus-medium

--- a/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
+++ b/data/normalized_yaml/algae/cr1_s_diatom_medium.yaml
@@ -7,21 +7,21 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 11 mL'
+- preferred_term: Sphagnum extract
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sphagnum extract'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +90,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.480017+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:cr1-s-diatom-medium
 - reference: https://utex.org/products/cr1-s-diatom-medium

--- a/data/normalized_yaml/algae/erdschreibers_medium.yaml
+++ b/data/normalized_yaml/algae/erdschreibers_medium.yaml
@@ -7,36 +7,42 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 3 L'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '3'
+    value: '12'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 36 mL/3 L'
+- preferred_term: NaNO3(autoclave before adding)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NaNO3(autoclave before adding)(Fisher BP360-500)'
-- preferred_term: '4'
+    value: '2.3'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/3 L; stock 0.7 M; final 2.3 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: BP360-500
+- preferred_term: Na2HPO4•7H2O(autoclave before adding)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2HPO4•7H2O(autoclave before adding) (Sigma S-9390)'
-- preferred_term: '5'
+    value: '0.067'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 10 mL/3 L; stock 0.02 M; final 0.067 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: S-9390
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '6'
+    value: '50'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 150 mL/3 L'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 3 mL/3 L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -106,6 +112,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.600315+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 6 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:erdschreibers-medium
 - reference: https://utex.org/products/erdschreibers-medium

--- a/data/normalized_yaml/algae/f_2_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/f_2_nh4_medium.yaml
@@ -7,16 +7,18 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: F/2 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: F/2 Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: NH4MgPO4
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4MgPO4(Sigma 529354)'
+    unit: VARIABLE
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '529354'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -86,6 +88,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.626096+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:f-2-nh4-medium
 - reference: https://utex.org/products/f-2-nh4-medium

--- a/data/normalized_yaml/algae/mes_volvox_medium.yaml
+++ b/data/normalized_yaml/algae/mes_volvox_medium.yaml
@@ -7,51 +7,51 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Ca(NO3)2•4H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Ca(NO3)2•4H2O(CAS: 13477-34-4)'
-- preferred_term: '2'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L; stock 11.8 g/100 mL dH20; CAS 13477-34-4'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(CAS: 10034-99-8)'
-- preferred_term: '3'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L; stock 4 g/100 mL dH20; CAS 10034-99-8'
+- preferred_term: Na2glycerophosphate•5H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Na2glycerophosphate•5H2O(CAS: 13408-09-8)'
-- preferred_term: '4'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH20; CAS 13408-09-8'
+- preferred_term: KCl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KCl(CAS: 7447-40-7)'
-- preferred_term: '5'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L; stock 5 g/100 mL dH20; CAS 7447-40-7'
+- preferred_term: MES
   concentration:
-    value: variable
+    value: '1.95'
     unit: G_PER_L
-  notes: 'Original amount: MES(CAS: 1266615-59-1)'
-- preferred_term: '6'
+  notes: 'UTEX lists: amount 1.95 g/L; CAS 1266615-59-1'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '7'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: NH4Cl
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4Cl(CAS: 12125-02-9)'
-- preferred_term: '8'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L; stock 2.67 g/100 mL dH20; CAS 12125-02-9'
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '9'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -120,6 +120,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.776748+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 9 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:mes-volvox-medium
 - reference: https://utex.org/products/mes-volvox-medium

--- a/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
+++ b/data/normalized_yaml/algae/modified_2x_chev_soil_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: CR1 Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CR1 Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 cc'
+- preferred_term: MgCO3
+  concentration:
+    value: '0.5'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 0.5 mg/12 mL; final 0.5 mM'
+  supplier_catalog:
+    supplier_name: MCIB
+    catalog_number: CB486
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgCO3(MCIB CB486)'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 10 mL'
+- preferred_term: F/2 Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
-- preferred_term: '4'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: F/2 Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 2 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:31.820727+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:modified-2x-chev-plus-soil-medium
 - reference: https://utex.org/products/modified-2x-chev-plus-soil-medium

--- a/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
+++ b/data/normalized_yaml/algae/soil_extract_sodium_metasilicate_medium.yaml
@@ -7,21 +7,21 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Bristol Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Bristol Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 960 mL'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '3'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 40 mL of supernatant'
+- preferred_term: Sodium Metasilicate
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Sodium Metasilicate'
+    value: '200'
+    unit: MICROMOLAR
+  notes: 'UTEX lists: amount 1 mL; stock 200 mM; final 200 µM'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -99,6 +99,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.134785+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soil-extract-plus-sodium-metasilicate-medium
 - reference: https://utex.org/products/soil-extract-plus-sodium-metasilicate-medium

--- a/data/normalized_yaml/algae/soil_seawater_medium.yaml
+++ b/data/normalized_yaml/algae/soil_seawater_medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for saltwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp/200 mL of Seawater'
+- preferred_term: Pasteurized Seawater
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Pasteurized Seawater'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +90,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.143441+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soil-plus-seawater-medium
 - reference: https://utex.org/products/soil-plus-seawater-medium

--- a/data/normalized_yaml/algae/soilwater_gr_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_medium.yaml
@@ -7,21 +7,24 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Green House Soil
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Green House Soil'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 tsp'
+- preferred_term: CaCO3(optional)
+  concentration:
+    value: '0.05'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.05 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: C 64
+- preferred_term: dH2O
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaCO3(optional)(Fisher C 64)'
-- preferred_term: '3'
-  concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: dH2O'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -90,6 +93,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.157670+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 3 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-gr-plus-medium
 - reference: https://utex.org/products/soilwater-gr-plus-medium

--- a/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
+++ b/data/normalized_yaml/algae/soilwater_gr_nh4_medium.yaml
@@ -7,16 +7,19 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 200 mL'
+- preferred_term: NH4MgPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: NH4MgPO4(Sigma 529354)'
+    value: '0.04'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mg; final 0.04 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '529354'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +88,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.168712+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:soilwater-gr-plus-nh4-medium
 - reference: https://utex.org/products/soilwater-gr-plus-nh4-medium

--- a/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
+++ b/data/normalized_yaml/algae/volvocacean_3n_medium.yaml
@@ -7,36 +7,45 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: KNO3
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: KNO3(Baker 3190)'
-- preferred_term: '2'
+    value: '0.98'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 10 g/100 mL dH2O; final 0.98 mM'
+  supplier_catalog:
+    supplier_name: Baker
+    catalog_number: '3190'
+- preferred_term: MgSO4•7H2O
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: MgSO4•7H2O(Sigma 230391)'
-- preferred_term: '3'
+    value: '0.081'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 1 mL/L; stock 2 g/100 mL dH2O; final 0.081 mM'
+  supplier_catalog:
+    supplier_name: Sigma
+    catalog_number: '230391'
+- preferred_term: (NH4)2HPO4
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: (NH4)2HPO4(Fisher A686)'
-- preferred_term: '4'
+    value: '0.453'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 3 mL/L; stock 2 g/100 mL dH2O; final 0.453 mM'
+  supplier_catalog:
+    supplier_name: Fisher
+    catalog_number: A686
+- preferred_term: CaSO4•2H2O(Mallinckroft 4300)
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: CaSO4•2H2O(Mallinckroft 4300)'
-- preferred_term: '5'
+    value: '0.35'
+    unit: MILLIMOLAR
+  notes: 'UTEX lists: amount 30 mL/L; stock 0.2 g/100 mL dH2O; final 0.35 mM'
+- preferred_term: P-IV Metal Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: P-IV Metal Solution'
-- preferred_term: '6'
+    value: '6'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 6 mL/L'
+- preferred_term: Euglena Medium
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Euglena Medium'
+    value: '200'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 200 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -105,6 +114,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.314928+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 6 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:volvocacean-3n-medium
 - reference: https://utex.org/products/volvocacean-3n-medium

--- a/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
+++ b/data/normalized_yaml/algae/volvox_dextrose_medium.yaml
@@ -7,26 +7,29 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Volvox Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Volvox Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 1 L'
+- preferred_term: Glucose
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Glucose(BACTO-dextrose or Sigma D 9634)'
-- preferred_term: '3'
+    value: '0.06'
+    unit: MOLAR
+  notes: 'UTEX lists: amount 10 g/L; final 0.06 M'
+  supplier_catalog:
+    supplier_name: Bacto
+    catalog_number: -dextrose or Sigma D 9634
+- preferred_term: Vitamin B12
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Vitamin B12'
-- preferred_term: '4'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
+- preferred_term: Biotin Vitamin Solution
   concentration:
-    value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Biotin Vitamin Solution'
+    value: '1'
+    unit: ML_PER_L
+  notes: 'UTEX lists: amount 1 mL/L'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -95,6 +98,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.336297+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 4 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:volvox-dextrose-medium
 - reference: https://utex.org/products/volvox-dextrose-medium

--- a/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
+++ b/data/normalized_yaml/algae/waris_soil_extract_medium.yaml
@@ -7,16 +7,16 @@ physical_state: LIQUID
 description: Algae culture medium from UTEX Culture Collection. Suitable for freshwater
   algae cultivation.
 ingredients:
-- preferred_term: '1'
+- preferred_term: Waris Medium
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Waris Medium'
-- preferred_term: '2'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 960 mL'
+- preferred_term: 'Soilwater: GR+ Medium'
   concentration:
     value: variable
-    unit: G_PER_L
-  notes: 'Original amount: Soilwater: GR+ Medium'
+    unit: VARIABLE
+  notes: 'UTEX lists: amount 40 mL'
 preparation_steps:
 - step_number: 1
   action: MIX
@@ -85,6 +85,14 @@ curation_history:
   curator: migrate_preparation_steps.py
   action: MIGRATED_PREPARATION_STEPS
   notes: instruction->action+description for 9 step(s)
+- timestamp: '2026-08-30T00:58:32.365554+00:00'
+  curator: repair_utex_ingredients.py
+  action: REPAIRED_UTEX_COMPOSITION
+  notes: 'Restored 2 ingredient name(s) and amount(s) from a re-fetched UTEX capture.
+    The original fetcher read fixed column positions, so the row ordinal was stored
+    as the ingredient name, the component name as the amount, and the Amount column
+    was never read; concentration was then filled in as G_PER_L regardless. Source:
+    https://utex.org/pages/algal-culture-media, captured 2026-08-29T17:46:40.207779.'
 references:
 - reference: UTEX:waris-plus-soil-extract-medium
 - reference: https://utex.org/products/waris-plus-soil-extract-medium

--- a/project.justfile
+++ b/project.justfile
@@ -464,6 +464,25 @@ audit-mim-sssom *args="":
 check-mim-label-index:
     uv run python scripts/check_mim_label_index.py
 
+# Offline verification of the packaged ChEBI structure table: metadata row
+# count, header, ordering, and that every CHEBI id the corpus cites is present.
+# A stale table costs the pages a column and reports nothing on its own.
+[group('Curation')]
+check-chebi-structure-index:
+    uv run python scripts/fetch_chebi_properties.py --check
+
+# Rebuild the packaged ChEBI structure table from the EBI OLS4 API (~640 terms,
+# a couple of minutes). Preview by default; pass --apply to write.
+[group('Curation')]
+fetch-chebi-properties *args="":
+    uv run python scripts/fetch_chebi_properties.py {{args}}
+
+# Restore UTEX ingredient names, amounts and concentrations from a fresh
+# capture (run `just fetch-utex` first). Preview by default; --apply writes.
+[group('Curation')]
+repair-utex-ingredients *args="":
+    uv run python scripts/repair_utex_ingredients.py {{args}}
+
 # Explicit dependency bump. A moving branch or short SHA is rejected; review
 # the printed label-resolution delta in the default preview, then pass --apply.
 [group('Curation')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 culturemech = [
+    "data/chebi/*.csv",
+    "data/chebi/*.json",
     "data/mediaingredientmech/*.csv",
     "data/mediaingredientmech/*.json",
     "schema/*.yaml",

--- a/scripts/fetch_chebi_properties.py
+++ b/scripts/fetch_chebi_properties.py
@@ -29,8 +29,13 @@ import time
 import urllib.parse
 import urllib.request
 from collections import Counter
-from datetime import UTC, datetime
+from collections.abc import Iterable, Mapping
+
+# `timezone.utc`, not `datetime.UTC`: the latter is 3.11+ and this project
+# supports >=3.10. The rest of scripts/ already uses timezone.utc.
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -46,26 +51,42 @@ HEADER = ["chebi_id", "label", "formula", "molecular_weight", "charge"]
 USER_AGENT = "CultureMech/1.0 (https://github.com/CultureBotAI/CultureMech)"
 
 
-def cited_chebi_ids(records_dir: Path) -> list[str]:
-    """Every distinct CHEBI id cited by an ingredient or solution component."""
-    found: set[str] = set()
-
-    def walk(items) -> None:
-        for item in items or []:
-            if not isinstance(item, dict):
-                continue
-            identifier = (item.get("term") or {}).get("id")
-            if isinstance(identifier, str) and identifier.startswith("CHEBI:"):
-                found.add(identifier)
-            walk(item.get("composition"))
-
-    for path in sorted(records_dir.glob("*/*.yaml")):
-        record = yaml.safe_load(path.read_text())
-        if not isinstance(record, dict):
+def _collect(items, found: set[str]) -> None:
+    for item in items or []:
+        if not isinstance(item, dict):
             continue
-        walk(record.get("ingredients"))
-        walk(record.get("solutions"))
+        identifier = (item.get("term") or {}).get("id")
+        if isinstance(identifier, str) and identifier.startswith("CHEBI:"):
+            found.add(identifier)
+        _collect(item.get("composition"), found)
+
+
+def cited_chebi_ids_from_records(records: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Every distinct CHEBI id cited by already-parsed records.
+
+    Split out from `cited_chebi_ids` so the test can reuse conftest's
+    session-scoped `corpus` fixture. Re-walking `data/normalized_yaml` from the
+    test took 484s in CI and tripped the 120s slow-test budget.
+    """
+    found: set[str] = set()
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        _collect(record.get("ingredients"), found)
+        _collect(record.get("solutions"), found)
     return sorted(found, key=lambda c: int(c.split(":")[1]))
+
+
+def cited_chebi_ids(records_dir: Path) -> list[str]:
+    """Every distinct CHEBI id cited by the corpus on disk."""
+
+    def parsed():
+        for path in sorted(records_dir.glob("*/*.yaml")):
+            record = yaml.safe_load(path.read_text())
+            if isinstance(record, dict):
+                yield record
+
+    return cited_chebi_ids_from_records(parsed())
 
 
 def fetch(chebi_id: str, timeout: float = 30.0) -> dict[str, str] | None:
@@ -103,7 +124,7 @@ def fetch(chebi_id: str, timeout: float = 30.0) -> dict[str, str] | None:
     }
 
 
-def check(records_dir: Path, out: Path) -> int:
+def check(records_dir: Path | None, out: Path, cited: Iterable[str] | None = None) -> int:
     """Verify the packaged table against its metadata and the corpus. Offline.
 
     A stale or truncated table fails quietly — `structure_for` returns None for
@@ -140,7 +161,11 @@ def check(records_dir: Path, out: Path) -> int:
     if identifiers != sorted(identifiers, key=lambda c: int(c.split(":")[1])):
         problems.append("rows are not in ascending CHEBI id order")
 
-    cited = set(cited_chebi_ids(records_dir))
+    if cited is None:
+        if records_dir is None:
+            raise ValueError("check() needs either records_dir or cited")
+        cited = cited_chebi_ids(records_dir)
+    cited = set(cited)
     missing = sorted(cited - set(identifiers), key=lambda c: int(c.split(":")[1]))
     if missing:
         problems.append(
@@ -224,7 +249,7 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "source": OLS4,
                     "ontology": "chebi",
-                    "fetched": datetime.now(UTC).isoformat(),
+                    "fetched": datetime.now(timezone.utc).isoformat(),
                     "row_count": len(rows),
                     "ids_requested": len(ids),
                     "fields": HEADER,

--- a/scripts/fetch_chebi_properties.py
+++ b/scripts/fetch_chebi_properties.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Build the packaged ChEBI structure table the media pages render from.
+
+The ingredient tables carried no chemical information at all: `chemical_formula`
+and `molecular_weight` are on `IngredientDescriptor` but are populated on 0 of
+170,007 ingredients. Meanwhile 144,092 of those ingredients (85%) already carry
+a ChEBI id, and those ids collapse to just **640 distinct terms**.
+
+So the formula is not recipe data — it is a property of the ChEBI term, shared
+by every recipe that cites it. Writing it into 144,092 record entries would
+denormalize one fact into thousands of copies that then drift. This builds a
+single 640-row lookup instead, packaged next to the MIM label index, and the
+renderer joins against it.
+
+Source is the EBI OLS4 API over the current ChEBI release. Only what ChEBI
+actually asserts is recorded: `generalized_empirical_formula`, `mass`, and
+`charge`. A term with no formula gets an empty cell rather than a guess.
+
+Preview by default. `--apply` writes the table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RECORDS = REPO_ROOT / "data" / "normalized_yaml"
+DEFAULT_OUT = REPO_ROOT / "src" / "culturemech" / "data" / "chebi" / "structure_index.csv"
+METADATA = "structure_index.meta.json"
+
+OLS4 = "https://www.ebi.ac.uk/ols4/api/ontologies/chebi/terms"
+IRI = "http://purl.obolibrary.org/obo/CHEBI_{}"
+HEADER = ["chebi_id", "label", "formula", "molecular_weight", "charge"]
+
+USER_AGENT = "CultureMech/1.0 (https://github.com/CultureBotAI/CultureMech)"
+
+
+def cited_chebi_ids(records_dir: Path) -> list[str]:
+    """Every distinct CHEBI id cited by an ingredient or solution component."""
+    found: set[str] = set()
+
+    def walk(items) -> None:
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            identifier = (item.get("term") or {}).get("id")
+            if isinstance(identifier, str) and identifier.startswith("CHEBI:"):
+                found.add(identifier)
+            walk(item.get("composition"))
+
+    for path in sorted(records_dir.glob("*/*.yaml")):
+        record = yaml.safe_load(path.read_text())
+        if not isinstance(record, dict):
+            continue
+        walk(record.get("ingredients"))
+        walk(record.get("solutions"))
+    return sorted(found, key=lambda c: int(c.split(":")[1]))
+
+
+def fetch(chebi_id: str, timeout: float = 30.0) -> dict[str, str] | None:
+    """One term from OLS4, or None when it does not resolve."""
+    local = chebi_id.split(":", 1)[1]
+    query = urllib.parse.urlencode({"iri": IRI.format(local)})
+    request = urllib.request.Request(
+        f"{OLS4}?{query}", headers={"User-Agent": USER_AGENT, "Accept": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        payload = json.load(response)
+
+    terms = (payload.get("_embedded") or {}).get("terms") or []
+    if not terms:
+        return None
+    term = terms[0]
+    annotation = term.get("annotation") or {}
+
+    def first(key: str) -> str:
+        values = annotation.get(key) or []
+        if not values:
+            return ""
+        value = values[0]
+        # OLS4 returns charge as a float; 0.0 is a real charge, not a blank.
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value).strip()
+
+    return {
+        "chebi_id": chebi_id,
+        "label": (term.get("label") or "").strip(),
+        "formula": first("generalized_empirical_formula"),
+        "molecular_weight": first("mass"),
+        "charge": first("charge"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--apply", action="store_true", help="Write. Default is preview.")
+    parser.add_argument("--limit", type=int, default=0, help="Fetch at most N terms.")
+    parser.add_argument("--rate-limit", type=float, default=0.15, help="Seconds between calls.")
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    ids = cited_chebi_ids(args.records_dir)
+    if args.limit:
+        ids = ids[: args.limit]
+    print(f"{len(ids)} distinct CHEBI ids cited by the corpus")
+
+    rows: list[dict[str, str]] = []
+    stats: Counter = Counter()
+    failures: list[tuple[str, str]] = []
+
+    for index, chebi_id in enumerate(ids, 1):
+        try:
+            row = fetch(chebi_id)
+        except Exception as error:  # noqa: BLE001 - reported, not swallowed
+            failures.append((chebi_id, f"{type(error).__name__}: {error}"))
+            stats["errored"] += 1
+        else:
+            if row is None:
+                failures.append((chebi_id, "not found in the current ChEBI release"))
+                stats["unresolved"] += 1
+            else:
+                rows.append(row)
+                stats["resolved"] += 1
+                stats["with_formula"] += bool(row["formula"])
+                stats["with_mass"] += bool(row["molecular_weight"])
+        if index % 50 == 0:
+            print(f"  {index}/{len(ids)}")
+        time.sleep(args.rate_limit)
+
+    print(f"\n{'Wrote' if args.apply else 'Would write'} {len(rows)} rows to {args.out}")
+    for key in sorted(stats):
+        print(f"  {key}: {stats[key]}")
+    if failures:
+        print(f"\n{len(failures)} id(s) not recorded:")
+        for chebi_id, reason in failures[:20]:
+            print(f"  {chebi_id}: {reason}")
+
+    if args.apply:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=HEADER)
+            writer.writeheader()
+            writer.writerows(rows)
+        (args.out.parent / METADATA).write_text(
+            json.dumps(
+                {
+                    "source": OLS4,
+                    "ontology": "chebi",
+                    "fetched": datetime.now(UTC).isoformat(),
+                    "row_count": len(rows),
+                    "ids_requested": len(ids),
+                    "fields": HEADER,
+                    "note": (
+                        "Only properties ChEBI asserts are recorded. An empty formula "
+                        "means ChEBI states none for that term, not that lookup failed; "
+                        "terms that failed to resolve are absent from the table."
+                    ),
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+    else:
+        print("\nPreview only. Re-run with --apply to write.")
+
+    # Missing rows would silently blank a column on the pages.
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_chebi_properties.py
+++ b/scripts/fetch_chebi_properties.py
@@ -103,14 +103,79 @@ def fetch(chebi_id: str, timeout: float = 30.0) -> dict[str, str] | None:
     }
 
 
+def check(records_dir: Path, out: Path) -> int:
+    """Verify the packaged table against its metadata and the corpus. Offline.
+
+    A stale or truncated table fails quietly — `structure_for` returns None for
+    an unknown id, which is right at render time and wrong as the only line of
+    defence. This is the loud check.
+    """
+    problems: list[str] = []
+
+    if not out.exists():
+        print(f"{out} is missing. Build it with --apply.", file=sys.stderr)
+        return 1
+    meta_path = out.parent / METADATA
+    if not meta_path.exists():
+        problems.append(f"{meta_path.name} is missing")
+        metadata = {}
+    else:
+        metadata = json.loads(meta_path.read_text())
+
+    with out.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames != HEADER:
+            problems.append(f"header is {reader.fieldnames}, expected {HEADER}")
+        rows = list(reader)
+
+    if metadata.get("fields") not in (None, HEADER):
+        problems.append(f"metadata fields {metadata.get('fields')} do not match {HEADER}")
+    recorded = metadata.get("row_count")
+    if recorded is not None and recorded != len(rows):
+        problems.append(f"metadata says {recorded} rows, file holds {len(rows)}")
+
+    identifiers = [r["chebi_id"] for r in rows]
+    if len(set(identifiers)) != len(identifiers):
+        problems.append("the table has duplicate chebi_id rows")
+    if identifiers != sorted(identifiers, key=lambda c: int(c.split(":")[1])):
+        problems.append("rows are not in ascending CHEBI id order")
+
+    cited = set(cited_chebi_ids(records_dir))
+    missing = sorted(cited - set(identifiers), key=lambda c: int(c.split(":")[1]))
+    if missing:
+        problems.append(
+            f"{len(missing)} CHEBI id(s) cited by the corpus are absent from the "
+            f"table, so those rows render without a formula: "
+            f"{', '.join(missing[:10])}{' ...' if len(missing) > 10 else ''}"
+        )
+
+    print(f"{out.relative_to(REPO_ROOT)}: {len(rows)} rows, {len(cited)} cited by the corpus")
+    if problems:
+        print(f"\n{len(problems)} problem(s):", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        print("\nRebuild with: just fetch-chebi-properties --apply", file=sys.stderr)
+        return 1
+    print("✓ packaged, complete for every cited id, and consistent with its metadata")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
     parser.add_argument("--apply", action="store_true", help="Write. Default is preview.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the packaged table offline. No network, no writes.",
+    )
     parser.add_argument("--limit", type=int, default=0, help="Fetch at most N terms.")
     parser.add_argument("--rate-limit", type=float, default=0.15, help="Seconds between calls.")
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.check:
+        return check(args.records_dir, args.out)
 
     ids = cited_chebi_ids(args.records_dir)
     if args.limit:

--- a/scripts/fetch_chebi_properties.py
+++ b/scripts/fetch_chebi_properties.py
@@ -197,6 +197,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--limit", type=int, default=0, help="Fetch at most N terms.")
     parser.add_argument("--rate-limit", type=float, default=0.15, help="Seconds between calls.")
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Write even when some lookups failed. Off by default (#385).",
+    )
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     if args.check:
@@ -230,13 +235,27 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  {index}/{len(ids)}")
         time.sleep(args.rate_limit)
 
-    print(f"\n{'Wrote' if args.apply else 'Would write'} {len(rows)} rows to {args.out}")
+    refusing = args.apply and failures and not args.allow_partial
+    if args.apply and not refusing:
+        verb = "Wrote"
+    else:
+        verb = "Would write"
+    print(f"\n{verb} {len(rows)} rows to {args.out}")
     for key in sorted(stats):
         print(f"  {key}: {stats[key]}")
     if failures:
         print(f"\n{len(failures)} id(s) not recorded:")
         for chebi_id, reason in failures[:20]:
             print(f"  {chebi_id}: {reason}")
+
+    if refusing:
+        print(
+            "\nRefusing to write a partial table. It would agree with its own "
+            "metadata while missing terms, so nothing downstream would notice. "
+            "Re-run, or pass --allow-partial to write it anyway.",
+            file=sys.stderr,
+        )
+        return 1
 
     if args.apply:
         args.out.parent.mkdir(parents=True, exist_ok=True)
@@ -252,6 +271,7 @@ def main(argv: list[str] | None = None) -> int:
                     "fetched": datetime.now(timezone.utc).isoformat(),
                     "row_count": len(rows),
                     "ids_requested": len(ids),
+                    "failed_lookups": len(failures),
                     "fields": HEADER,
                     "note": (
                         "Only properties ChEBI asserts are recorded. An empty formula "

--- a/scripts/repair_utex_ingredients.py
+++ b/scripts/repair_utex_ingredients.py
@@ -81,8 +81,20 @@ ORIGINAL_AMOUNT = re.compile(r"^Original amount:\s*(.*)$")
 # end so a parenthetical that is part of the chemistry — "PABA(p-aminobenzoic
 # acid)" — is only stripped when a vendor/CAS one follows it.
 VENDORS = (
-    "Sigma", "Fisher", "Baker", "MCIB", "Bacto", "Difco", "ICN", "Aldrich",
-    "Mallinckrodt", "ACROS", "VWR", "EM Science", "J.T. Baker", "Alfa",
+    "Sigma",
+    "Fisher",
+    "Baker",
+    "MCIB",
+    "Bacto",
+    "Difco",
+    "ICN",
+    "Aldrich",
+    "Mallinckrodt",
+    "ACROS",
+    "VWR",
+    "EM Science",
+    "J.T. Baker",
+    "Alfa",
 )
 _VENDOR_ALT = "|".join(re.escape(v) for v in VENDORS)
 TRAILING_PAREN = re.compile(
@@ -128,10 +140,10 @@ def strip_vendor(name: str) -> tuple[str, str | None, str | None]:
 
 
 def split_supplier(text: str) -> dict[str, str]:
-    """"Sigma P 3786" -> {supplier_name: Sigma, catalog_number: P 3786}."""
+    """ "Sigma P 3786" -> {supplier_name: Sigma, catalog_number: P 3786}."""
     for vendor in sorted(VENDORS, key=len, reverse=True):
         if text.lower().startswith(vendor.lower()):
-            catalog = text[len(vendor):].strip()
+            catalog = text[len(vendor) :].strip()
             entry = {"supplier_name": vendor}
             if catalog:
                 entry["catalog_number"] = catalog
@@ -320,9 +332,7 @@ def main(argv: list[str] | None = None) -> int:
             failed.append((path.name, [f"UTEX:{source_id} is not in the capture"]))
             continue
 
-        record, repaired, failures = repair_record(
-            record, by_id[source_id]["composition"], stats
-        )
+        record, repaired, failures = repair_record(record, by_id[source_id]["composition"], stats)
         stats["ingredients_repaired"] += repaired
         if failures:
             failed.append((path.name, failures))
@@ -355,8 +365,10 @@ def main(argv: list[str] | None = None) -> int:
             break
 
     verb = "Repaired" if args.apply else "Would repair"
-    print(f"\n{verb} {stats['records_repaired']} records / "
-          f"{stats['ingredients_repaired']} ingredients")
+    print(
+        f"\n{verb} {stats['records_repaired']} records / "
+        f"{stats['ingredients_repaired']} ingredients"
+    )
     for key in sorted(stats):
         print(f"  {key}: {stats[key]}")
     if failed:

--- a/scripts/repair_utex_ingredients.py
+++ b/scripts/repair_utex_ingredients.py
@@ -56,7 +56,10 @@ import json
 import re
 import sys
 from collections import Counter
-from datetime import UTC, datetime
+
+# `timezone.utc`, not `datetime.UTC`: the latter is 3.11+ and this project
+# supports >=3.10. The rest of scripts/ already uses timezone.utc.
+from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
@@ -343,7 +346,7 @@ def main(argv: list[str] | None = None) -> int:
 
         record.setdefault("curation_history", []).append(
             {
-                "timestamp": datetime.now(UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "curator": CURATOR,
                 "action": ACTION,
                 "notes": (

--- a/scripts/repair_utex_ingredients.py
+++ b/scripts/repair_utex_ingredients.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Restore the real ingredient names and amounts to the UTEX records.
+
+## What went wrong
+
+UTEX composition tables are headed
+`# | Component | Amount | Stock Solution Concentration | Final Concentration`.
+The fetcher read `cols[0]` and `cols[1]` — fixed positions, never the header —
+so the row ordinal became the ingredient and the component name became the
+"amount". The real Amount column was never read at all.
+
+Downstream that became, in every one of the 99 UTEX records:
+
+    - preferred_term: '1'
+      concentration: {value: variable, unit: G_PER_L}
+      notes: 'Original amount: DYIII Medium'
+
+Three separate defects in four lines. The name is an ordinal; the real name is
+stranded in a note that claims to be an amount; and the concentration is
+invented — `G_PER_L` was supplied by `fix_schema_inconsistencies.py` for every
+ingredient that had no amount, asserting grams per litre for four drops of
+vitamin cocktail.
+
+## What this repairs
+
+Against a fresh capture (`just fetch-utex` with the header-aware fetcher):
+
+1. `preferred_term` <- the real component name, with any trailing vendor or CAS
+   parenthetical split off, so the name can actually ground against ChEBI/MIM.
+   `NaNO3(Fisher BP360-500)` never matched anything; `NaNO3` does.
+2. `supplier_catalog` <- the vendor parenthetical, which is what that field is
+   for. A `(CAS: ...)` parenthetical is not a supplier and goes to `notes`.
+3. `concentration` <- parsed from the source, preferring the page's own Final
+   Concentration column over the Amount column, converted to the corpus's
+   per-litre convention with exact decimal arithmetic. Where the amount has no
+   volume basis to convert against ("4 drops", "1 cc", "1 per 200 mL"), the
+   value is `{value: variable, unit: VARIABLE}` — the corpus's existing honest
+   placeholder — never a guessed unit.
+4. `notes` <- the verbatim source cells, so every derived value can be checked
+   against what UTEX actually printed, and the fabricated "Original amount:"
+   note is gone.
+
+Matching is by ordinal position cross-checked against the name recovered from
+the note, comparing base names with vendor/CAS parentheticals stripped (UTEX
+switched from catalogue numbers to CAS numbers after the January 2026 capture).
+All 497 corrupted ingredients match unambiguously; an ingredient that does not
+match is left untouched and reported.
+
+Preview by default. `--apply` writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from record_io import write_record  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RECORDS = REPO_ROOT / "data" / "normalized_yaml"
+DEFAULT_CAPTURE = REPO_ROOT / "data" / "raw" / "utex" / "utex_media.json"
+
+CURATOR = "repair_utex_ingredients.py"
+ACTION = "REPAIRED_UTEX_COMPOSITION"
+
+# The note the corruption left behind. Its payload is the real ingredient name.
+ORIGINAL_AMOUNT = re.compile(r"^Original amount:\s*(.*)$")
+
+# A trailing parenthetical naming a vendor or a CAS number, e.g.
+# "NaNO3(Fisher BP360-500)" or "MgSO4•7H2O(CAS: 10034-99-8)". Anchored at the
+# end so a parenthetical that is part of the chemistry — "PABA(p-aminobenzoic
+# acid)" — is only stripped when a vendor/CAS one follows it.
+VENDORS = (
+    "Sigma", "Fisher", "Baker", "MCIB", "Bacto", "Difco", "ICN", "Aldrich",
+    "Mallinckrodt", "ACROS", "VWR", "EM Science", "J.T. Baker", "Alfa",
+)
+_VENDOR_ALT = "|".join(re.escape(v) for v in VENDORS)
+TRAILING_PAREN = re.compile(
+    rf"\((?P<body>(?:CAS:\s*|(?:{_VENDOR_ALT})\b)[^()]*)\)\s*$", re.IGNORECASE
+)
+
+UNIT_BY_NUMERATOR = {
+    "g": "G_PER_L",
+    "mg": "MG_PER_L",
+    "µg": "MICROG_PER_L",
+    "ug": "MICROG_PER_L",
+    "mcg": "MICROG_PER_L",
+    "ml": "ML_PER_L",
+    "l": "L",
+}
+MOLARITY = {"m": "MOLAR", "mm": "MILLIMOLAR", "µm": "MICROMOLAR", "um": "MICROMOLAR"}
+# Litres per one unit of the denominator, for converting an amount onto the
+# corpus's per-litre convention.
+LITRES = {"l": Decimal(1), "ml": Decimal(1) / Decimal(1000), "cc": Decimal(1) / Decimal(1000)}
+
+NUMBER = r"(?P<n>\d+(?:\.\d+)?)"
+RATIO = re.compile(
+    rf"^{NUMBER}\s*(?P<num>µg|ug|mcg|mg|mL|ml|g|L)\s*/\s*"
+    rf"(?P<d>\d+(?:\.\d+)?)?\s*(?P<den>mL|ml|L|l|cc)\b",
+    re.IGNORECASE,
+)
+MOLAR = re.compile(rf"^{NUMBER}\s*(?P<u>mM|µM|uM|M)\b")
+
+
+def strip_vendor(name: str) -> tuple[str, str | None, str | None]:
+    """`name` -> (base name, supplier text, CAS number).
+
+    Only one of supplier/CAS is ever returned; UTEX prints one or the other.
+    """
+    match = TRAILING_PAREN.search(name)
+    if not match:
+        return name.strip(), None, None
+    body = match.group("body").strip()
+    base = name[: match.start()].strip()
+    if body.lower().startswith("cas:"):
+        return base, None, body.split(":", 1)[1].strip()
+    return base, body, None
+
+
+def split_supplier(text: str) -> dict[str, str]:
+    """"Sigma P 3786" -> {supplier_name: Sigma, catalog_number: P 3786}."""
+    for vendor in sorted(VENDORS, key=len, reverse=True):
+        if text.lower().startswith(vendor.lower()):
+            catalog = text[len(vendor):].strip()
+            entry = {"supplier_name": vendor}
+            if catalog:
+                entry["catalog_number"] = catalog
+            return entry
+    return {"supplier_name": text}
+
+
+def _decimal(text: str) -> Decimal | None:
+    try:
+        return Decimal(text)
+    except InvalidOperation:
+        return None
+
+
+def _render(value: Decimal) -> str:
+    """Shortest exact decimal string; no float noise, no trailing zeros."""
+    normalized = value.normalize()
+    text = format(normalized, "f")
+    return text
+
+
+def parse_concentration(text: str) -> dict[str, str] | None:
+    """A UTEX Amount or Final Concentration cell -> a ConcentrationValue.
+
+    Returns None when the cell states no convertible quantity — "4 drops",
+    "1 cc", "1 per 200 mL", "40 mL of supernatant". Those get the corpus's
+    VARIABLE placeholder rather than a guessed unit.
+    """
+    cell = (text or "").strip()
+    if not cell:
+        return None
+
+    molar = MOLAR.match(cell)
+    if molar and not RATIO.match(cell):
+        number = _decimal(molar.group("n"))
+        if number is not None:
+            return {"value": _render(number), "unit": MOLARITY[molar.group("u").lower()]}
+
+    ratio = RATIO.match(cell)
+    if ratio:
+        number = _decimal(ratio.group("n"))
+        unit = UNIT_BY_NUMERATOR.get(ratio.group("num").lower())
+        per = LITRES.get(ratio.group("den").lower())
+        if number is None or unit is None or per is None:
+            return None
+        denominator = _decimal(ratio.group("d") or "1")
+        if denominator is None or denominator == 0:
+            return None
+        litres = denominator * per
+        if litres == 0:
+            return None
+        return {"value": _render(number / litres), "unit": unit}
+
+    return None
+
+
+VARIABLE = {"value": "variable", "unit": "VARIABLE"}
+
+
+def build_ingredient(existing: dict[str, Any], source: dict[str, str]) -> dict[str, Any]:
+    """The repaired ingredient, preserving every field the repair does not own."""
+    repaired = dict(existing)
+
+    base, supplier, cas = strip_vendor(source["ingredient"])
+    repaired["preferred_term"] = base
+
+    amount = (source.get("amount") or "").strip()
+    final = (source.get("final_concentration") or "").strip()
+    stock = (source.get("stock_concentration") or "").strip()
+
+    # The page's own Final Concentration is a stronger claim than an amount we
+    # would have to convert, so it wins where UTEX printed one.
+    concentration = parse_concentration(final) or parse_concentration(amount)
+    repaired["concentration"] = concentration or dict(VARIABLE)
+
+    if supplier:
+        repaired.setdefault("supplier_catalog", split_supplier(supplier))
+
+    # Verbatim provenance, so every converted value stays checkable and nothing
+    # the page printed is discarded.
+    printed = [f"amount {amount}" if amount else ""]
+    if stock:
+        printed.append(f"stock {stock}")
+    if final:
+        printed.append(f"final {final}")
+    if cas:
+        printed.append(f"CAS {cas}")
+    parts = [p for p in printed if p]
+    note = "UTEX lists: " + "; ".join(parts) if parts else None
+
+    previous = (existing.get("notes") or "").strip()
+    if previous and not ORIGINAL_AMOUNT.match(previous):
+        # Someone curated a real note onto this ingredient; keep it.
+        note = f"{previous} | {note}" if note else previous
+    if note:
+        repaired["notes"] = note
+    else:
+        repaired.pop("notes", None)
+
+    return repaired
+
+
+def utex_id(record: dict[str, Any]) -> str | None:
+    for reference in record.get("references") or []:
+        value = reference.get("reference") if isinstance(reference, dict) else None
+        if isinstance(value, str) and value.startswith("UTEX:"):
+            return value.split(":", 1)[1]
+    return None
+
+
+def recovered_name(ingredient: dict[str, Any]) -> str | None:
+    match = ORIGINAL_AMOUNT.match((ingredient.get("notes") or "").strip())
+    return match.group(1).strip() if match else None
+
+
+def base_name(name: str) -> str:
+    return strip_vendor(name)[0].lower()
+
+
+def repair_record(
+    record: dict[str, Any], composition: list[dict[str, str]], stats: Counter
+) -> tuple[dict[str, Any], int, list[str]]:
+    """Returns (record, repaired_count, per-ingredient failures)."""
+    ingredients = record.get("ingredients") or []
+    failures: list[str] = []
+    repaired_count = 0
+
+    for index, ingredient in enumerate(ingredients):
+        term = str(ingredient.get("preferred_term", "")).strip()
+        if not term.isdigit():
+            stats["skipped_not_corrupted"] += 1
+            continue
+        name = recovered_name(ingredient)
+        if not name:
+            failures.append(f"[{index}] preferred_term={term!r} has no recoverable name")
+            continue
+        if index >= len(composition):
+            failures.append(f"[{index}] {name!r} has no row at that ordinal in the capture")
+            continue
+        source = composition[index]
+        if base_name(source["ingredient"]) != base_name(name):
+            failures.append(
+                f"[{index}] {name!r} does not match capture row {source['ingredient']!r}"
+            )
+            continue
+        ingredients[index] = build_ingredient(ingredient, source)
+        repaired_count += 1
+
+    return record, repaired_count, failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
+    parser.add_argument("--capture", type=Path, default=DEFAULT_CAPTURE)
+    parser.add_argument("--apply", action="store_true", help="Write. Default is preview.")
+    parser.add_argument("--limit", type=int, default=0, help="Repair at most N records.")
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    capture = json.loads(args.capture.read_text())
+    by_id = {r["id"]: r for r in capture["recipes"]}
+
+    stats: Counter = Counter()
+    failed: list[tuple[str, list[str]]] = []
+    changed: list[Path] = []
+
+    for path in sorted(args.records_dir.glob("*/*.yaml")):
+        record = yaml.safe_load(path.read_text())
+        if not isinstance(record, dict):
+            continue
+        source_id = utex_id(record)
+        if not source_id:
+            continue
+        stats["utex_records"] += 1
+
+        corrupted = sum(
+            1
+            for i in record.get("ingredients") or []
+            if str(i.get("preferred_term", "")).strip().isdigit()
+        )
+        if not corrupted:
+            stats["records_already_clean"] += 1
+            continue
+        if source_id not in by_id:
+            stats["records_missing_from_capture"] += 1
+            failed.append((path.name, [f"UTEX:{source_id} is not in the capture"]))
+            continue
+
+        record, repaired, failures = repair_record(
+            record, by_id[source_id]["composition"], stats
+        )
+        stats["ingredients_repaired"] += repaired
+        if failures:
+            failed.append((path.name, failures))
+            stats["records_with_failures"] += 1
+            continue
+        if not repaired:
+            continue
+
+        record.setdefault("curation_history", []).append(
+            {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "curator": CURATOR,
+                "action": ACTION,
+                "notes": (
+                    f"Restored {repaired} ingredient name(s) and amount(s) from a "
+                    f"re-fetched UTEX capture. The original fetcher read fixed column "
+                    f"positions, so the row ordinal was stored as the ingredient name, "
+                    f"the component name as the amount, and the Amount column was never "
+                    f"read; concentration was then filled in as G_PER_L regardless. "
+                    f"Source: {capture.get('source_url', 'UTEX')}, "
+                    f"captured {capture.get('fetched_date', 'unknown')}."
+                ),
+            }
+        )
+        stats["records_repaired"] += 1
+        changed.append(path)
+        if args.apply:
+            write_record(path, record)
+        if args.limit and stats["records_repaired"] >= args.limit:
+            break
+
+    verb = "Repaired" if args.apply else "Would repair"
+    print(f"\n{verb} {stats['records_repaired']} records / "
+          f"{stats['ingredients_repaired']} ingredients")
+    for key in sorted(stats):
+        print(f"  {key}: {stats[key]}")
+    if failed:
+        print(f"\n{len(failed)} record(s) left untouched:")
+        for name, reasons in failed:
+            print(f"  {name}")
+            for reason in reasons:
+                print(f"      {reason}")
+    if not args.apply:
+        print("\nPreview only. Re-run with --apply to write.")
+
+    # A partial apply is a failure: it leaves the corpus half-repaired.
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/culturemech/data/chebi/structure_index.csv
+++ b/src/culturemech/data/chebi/structure_index.csv
@@ -1,0 +1,641 @@
+chebi_id,label,formula,molecular_weight,charge
+CHEBI:2509,agar,,,
+CHEBI:2511,agarose,(C12H18O9)n.C12H20O10,630.549,0
+CHEBI:2682,amphotericin B,C47H73NO17,924.091,0
+CHEBI:3311,calcium carbonate,CO3.Ca,100.086,0
+CHEBI:3312,calcium dichloride,Ca.2Cl,110.984,0
+CHEBI:4178,D-glucuronic acid,C6H10O7,194.139,0
+CHEBI:4735,ethylenediaminetetraacetic acid,C10H16N2O8,292.244,0
+CHEBI:5291,gelatin,,,
+CHEBI:6104,kanamycin,,,
+CHEBI:6109,kanamycin A sulfate,C18H36N4O11.H2O4S,582.582,0
+CHEBI:6636,magnesium dichloride,2Cl.Mg,95.211,0
+CHEBI:6637,magnesium dihydroxide,2HO.Mg,58.319,0
+CHEBI:6650,malic acid,C4H6O5,134.087,0
+CHEBI:6731,melezitose,C18H32O16,504.438,0
+CHEBI:6872,methylene blue,C16H18N3S.Cl,319.861,0
+CHEBI:7507,neomycin,,,
+CHEBI:7916,pantothenic acid,C9H17NO5,219.237,0
+CHEBI:8006,Peptidoglycan(N-acetyl-D-glucosamine),C34H60N8O18,868.892,0
+CHEBI:8310,Polymyxin B sulfate,C55H95N16O13R.(H2O4S)x,,
+CHEBI:8346,potassium iodide,I.K,166.002,0
+CHEBI:8806,Resazurin,C12H7NO4,229.191,0
+CHEBI:9215,spectinomycin,C14H24N2O7,332.353,0
+CHEBI:9532,thiamine(1+) diphosphate,C12H19N4O7P2S,425.32,1
+CHEBI:9679,tricalcium bis(phosphate),3Ca.2O4P,310.174,0
+CHEBI:9754,tris,C4H11NO3,121.136,0
+CHEBI:12936,D-galactose,C6H12O6,180.156,0
+CHEBI:14314,D-glucose 6-phosphate,C6H13O9P,260.136,0
+CHEBI:15226,tetrathionate(2-),O6S4,224.262,-2
+CHEBI:15318,xanthine,C5H4N4O2,152.111,0
+CHEBI:15346,coenzyme A,C21H36N7O16P3S,767.541,0
+CHEBI:15347,acetone,C3H6O,58.08,0
+CHEBI:15354,choline,C5H14NO,104.173,1
+CHEBI:15356,cysteine,C3H7NO2S,121.161,0
+CHEBI:15361,pyruvate,C3H3O3,87.054,-1
+CHEBI:15366,acetic acid,C2H4O2,60.052,0
+CHEBI:15377,water,H2O,18.015,0
+CHEBI:15422,ATP,C10H16N5O13P3,507.182,0
+CHEBI:15428,glycine,C2H5NO2,75.067,0
+CHEBI:15443,inulin,(C12H20O11)n,,
+CHEBI:15447,(1->4)-beta-D-xylan,(C5H8O4)n.H2O,150.13,0
+CHEBI:15570,D-alanine,C3H7NO2,89.094,0
+CHEBI:15595,malate(2-),C4H4O5,132.071,-2
+CHEBI:15603,L-leucine,C6H13NO2,131.175,0
+CHEBI:15640,5-formyltetrahydrofolic acid,C20H23N7O7,473.446,0
+CHEBI:15671,L-tartaric acid,C4H6O6,150.086,0
+CHEBI:15676,allantoin,C4H6N4O3,158.117,0
+CHEBI:15688,acetoin,C4H8O2,88.106,0
+CHEBI:15728,4-guanidinobutanoic acid,C5H11N3O2,145.162,0
+CHEBI:15729,L-ornithine,C5H12N2O2,132.163,0
+CHEBI:15741,succinic acid,C4H6O4,118.088,0
+CHEBI:15824,D-fructose,C6H12O6,180.156,0
+CHEBI:15846,NAD(+),C21H28N7O14P2,664.438,1
+CHEBI:15882,phenol,C6H6O,94.113,0
+CHEBI:15887,5-aminopentanoic acid,C5H11NO2,117.148,0
+CHEBI:15891,taurine,C2H7NO3S,125.149,0
+CHEBI:15903,beta-D-glucose,C6H12O6,180.156,0
+CHEBI:15940,nicotinic acid,C6H5NO2,123.111,0
+CHEBI:15956,biotin,C10H16N2O3S,244.316,0
+CHEBI:15971,L-histidine,C6H9N3O2,155.157,0
+CHEBI:15978,sn-glycerol 3-phosphate,C3H9O6P,172.073,0
+CHEBI:16000,ethanolamine,C2H7NO,61.084,0
+CHEBI:16015,L-glutamic acid,C5H9NO4,147.13,0
+CHEBI:16024,D-mannose,C6H12O6,180.156,0
+CHEBI:16040,cytosine,C4H5N3O,111.104,0
+CHEBI:16113,cholesterol,C27H46O,386.664,0
+CHEBI:16119,shikimic acid,C7H10O5,174.152,0
+CHEBI:16135,isobutyric acid,C4H8O2,88.106,0
+CHEBI:16148,heptadecane,C17H36,240.475,0
+CHEBI:16150,benzoate,C7H5O2,121.115,-1
+CHEBI:16183,methane,CH4,16.043,0
+CHEBI:16189,sulfate,O4S,96.063,-2
+CHEBI:16196,oleic acid,C18H34O2,282.468,0
+CHEBI:16199,urea,CH4N2O,60.056,0
+CHEBI:16235,guanine,C5H5N5O,151.129,0
+CHEBI:16236,ethanol,C2H6O,46.069,0
+CHEBI:16238,FAD,C27H33N9O15P2,785.557,0
+CHEBI:16261,chitosan,(C6H11NO4)n.H2O,179.172,0
+CHEBI:16283,L-cystine,C6H12N2O4S2,240.306,0
+CHEBI:16335,adenosine,C10H13N5O4,267.245,0
+CHEBI:16349,L-citrulline,C6H13N3O3,175.188,0
+CHEBI:16354,N-methylhydantoin,C4H6N2O2,114.104,0
+CHEBI:16410,pyridoxamine,C8H12N2O2,168.196,0
+CHEBI:16411,indole-3-acetic acid,C10H9NO2,175.187,0
+CHEBI:16412,lipopolysaccharide,,,
+CHEBI:16414,L-valine,C5H11NO2,117.148,0
+CHEBI:16450,2'-deoxyuridine,C9H12N2O5,228.204,0
+CHEBI:16454,pantothenate,C9H16NO5,218.229,-1
+CHEBI:16467,L-arginine,C6H14N4O2,174.204,0
+CHEBI:16482,naphthalene,C10H8,128.174,0
+CHEBI:16494,lipoic acid,C8H14O2S2,206.332,0
+CHEBI:16526,carbon dioxide,CO2,44.009,0
+CHEBI:16602,trichloroethene,C2HCl3,131.389,0
+CHEBI:16610,spermidine,C7H19N3,145.25,0
+CHEBI:16634,raffinose,C18H32O16,504.438,0
+CHEBI:16643,L-methionine,C5H11NO2S,149.215,0
+CHEBI:16704,uridine,C9H12N2O6,244.203,0
+CHEBI:16708,adenine,C5H5N5,135.13,0
+CHEBI:16709,pyridoxine,C8H11NO3,169.18,0
+CHEBI:16716,benzene,C6H6,78.114,0
+CHEBI:16737,creatinine,C4H7N3O,113.12,0
+CHEBI:16742,orotic acid,C5H4N2O4,156.097,0
+CHEBI:16750,guanosine,C10H13N5O5,283.244,0
+CHEBI:16810,2-oxoglutarate(2-),C5H4O5,144.082,-2
+CHEBI:16811,methionine,C5H11NO2S,149.215,0
+CHEBI:16813,galactitol,C6H14O6,182.172,0
+CHEBI:16828,L-tryptophan,C11H12N2O2,204.229,0
+CHEBI:16830,methylamine,CH5N,31.058,0
+CHEBI:16856,glutathione,C10H17N3O6S,307.328,0
+CHEBI:16857,L-threonine,C4H9NO3,119.12,0
+CHEBI:16865,gamma-aminobutyric acid,C4H9NO2,103.121,0
+CHEBI:16867,D-methionine,C5H11NO2S,149.215,0
+CHEBI:16870,choline alfoscerate,C8H20NO6P,257.223,0
+CHEBI:16899,D-mannitol,C6H14O6,182.172,0
+CHEBI:16919,creatine,C4H9N3O2,131.135,0
+CHEBI:16947,citrate(3-),C6H5O7,189.099,-3
+CHEBI:16977,L-alanine,C3H7NO2,89.094,0
+CHEBI:16988,D-ribose,C5H10O5,150.13,0
+CHEBI:16991,deoxyribonucleic acid,,,
+CHEBI:17015,riboflavin,C17H20N4O6,376.369,0
+CHEBI:17029,chitin,(C8H13NO5)n.H2O,221.209,0
+CHEBI:17045,dinitrogen oxide,N2O,44.013,0
+CHEBI:17053,L-aspartic acid,C4H7NO4,133.103,0
+CHEBI:17057,cellobiose,C12H22O11,342.297,0
+CHEBI:17076,streptomycin,C21H39N7O12,581.58,0
+CHEBI:17097,biphenyl,C12H10,154.212,0
+CHEBI:17108,D-arabinose,C5H10O5,150.13,0
+CHEBI:17115,L-serine,C3H7NO3,105.093,0
+CHEBI:17126,carnitine,C7H15NO3,161.201,0
+CHEBI:17148,putrescine,C4H12N2,88.154,0
+CHEBI:17151,xylitol,C5H12O5,152.146,0
+CHEBI:17154,nicotinamide,C6H6N2O,122.127,0
+CHEBI:17189,"2,5-dihydroxybenzoic acid",C7H6O4,154.121,0
+CHEBI:17191,L-isoleucine,C6H13NO2,131.175,0
+CHEBI:17196,L-asparagine,C4H8N2O3,132.119,0
+CHEBI:17201,glycylglycine,C4H8N2O3,132.119,0
+CHEBI:17203,L-proline,C5H9NO2,115.132,0
+CHEBI:17234,glucose,C6H12O6,180.156,0
+CHEBI:17245,carbon monoxide,CO,28.01,0
+CHEBI:17268,myo-inositol,C6H12O6,180.156,0
+CHEBI:17295,L-phenylalanine,C9H11NO2,165.192,0
+CHEBI:17300,tetrachloroethene,C2Cl4,165.834,0
+CHEBI:17306,maltose,C12H22O11,342.297,0
+CHEBI:17309,pectin,,,
+CHEBI:17334,penicillin,C9H11N2O4SR,243.26,0
+CHEBI:17368,hypoxanthine,C5H4N4O,136.114,0
+CHEBI:17376,cystine,C6H12N2O4S2,240.306,0
+CHEBI:17418,valeric acid,C5H10O2,102.133,0
+CHEBI:17439,cyanocob(III)alamin,C63H88CoN14O14P,1355.388,0
+CHEBI:17521,(-)-quinic acid,C7H12O6,192.167,0
+CHEBI:17533,N-acetyl-L-glutamic acid,C7H11NO5,189.167,0
+CHEBI:17561,L-cysteine,C3H7NO2S,121.161,0
+CHEBI:17562,cytidine,C9H13N3O5,243.219,0
+CHEBI:17568,uracil,C4H4N2O2,112.088,0
+CHEBI:17578,toluene,C7H8,92.141,0
+CHEBI:17596,inosine,C10H12N4O5,268.229,0
+CHEBI:17597,4-hydroxybenzaldehyde,C7H6O2,122.123,0
+CHEBI:17632,nitrate,NO3,62.004,-1
+CHEBI:17634,D-glucose,C6H12O6,180.156,0
+CHEBI:17642,pentachlorophenol,C6HCl5O,266.338,0
+CHEBI:17698,chloramphenicol,C11H12Cl2N2O5,323.132,0
+CHEBI:17712,9H-xanthine,C5H4N4O2,152.113,0
+CHEBI:17716,lactose,C12H22O11,342.297,0
+CHEBI:17748,thymidine,C10H14N2O5,242.231,0
+CHEBI:17750,glycine betaine,C5H11NO2,117.148,0
+CHEBI:17754,glycerol,C3H8O3,92.094,0
+CHEBI:17790,methanol,CH4O,32.042,0
+CHEBI:17821,thymine,C5H6N2O2,126.115,0
+CHEBI:17822,serine,C3H7NO3,105.093,0
+CHEBI:17824,propan-2-ol,C3H8O,60.096,0
+CHEBI:17833,gentamycin,,,
+CHEBI:17836,4-aminobenzoate,C7H6NO2,136.13,-1
+CHEBI:17879,4-hydroxybenzoate,C7H5O3,137.114,-1
+CHEBI:17883,hydrogen chloride,HCl,36.461,0
+CHEBI:17895,L-tyrosine,C9H11NO3,181.191,0
+CHEBI:17905,coenzyme M,C2H6O3S2,142.201,0
+CHEBI:17909,polysulfur,(S)n.S2,96.201,0
+CHEBI:17924,D-glucitol,C6H14O6,182.172,0
+CHEBI:17925,alpha-D-glucose,C6H12O6,180.156,0
+CHEBI:17987,benzyl alcohol,C7H8O,108.14,0
+CHEBI:17992,sucrose,C12H22O11,342.297,0
+CHEBI:17997,dinitrogen,N2,28.014,0
+CHEBI:18012,fumaric acid,C4H4O4,116.072,0
+CHEBI:18019,L-lysine,C6H14N2O2,146.19,0
+CHEBI:18024,D-galacturonic acid,C6H10O7,194.14,0
+CHEBI:18026,"2,3-dihydroxybenzoic acid",C7H6O4,154.121,0
+CHEBI:18050,L-glutamine,C5H10N2O3,146.146,0
+CHEBI:18067,phylloquinone,C31H46O2,450.707,0
+CHEBI:18095,trans-4-hydroxy-L-proline,C5H9NO3,131.131,0
+CHEBI:18101,4-hydroxyphenylacetic acid,C8H8O3,152.149,0
+CHEBI:18107,xanthosine,C10H12N4O6,284.228,0
+CHEBI:18135,catechol,C6H6O2,110.112,0
+CHEBI:18139,trimethylamine,C3H9N,59.112,0
+CHEBI:18167,alpha-maltose,C12H22O11,342.297,0
+CHEBI:18186,tyrosine,C9H11NO3,181.191,0
+CHEBI:18222,xylose,C5H10O5,150.13,0
+CHEBI:18237,glutamic acid,C5H9NO4,147.13,0
+CHEBI:18240,4-hydroxy-L-proline,C5H9NO3,131.131,0
+CHEBI:18246,(1->4)-beta-D-glucan,(C6H10O5)n.H2O,180.156,0
+CHEBI:18248,iron atom,Fe,55.845,0
+CHEBI:18276,dihydrogen,H2,2.016,0
+CHEBI:18287,L-fucose,C6H12O5,164.156,0
+CHEBI:18290,thiamine(1+) diphosphate chloride,C12H19N4O7P2S.Cl,460.773,0
+CHEBI:18300,maleic acid,C4H4O4,116.072,0
+CHEBI:18320,"1,4-dithiothreitol",C4H10O2S2,154.256,0
+CHEBI:18385,thiamine(1+),C12H17N4OS,265.362,1
+CHEBI:18403,L-arabinitol,C5H12O5,152.146,0
+CHEBI:18405,pyridoxal 5'-phosphate,C8H10NO6P,247.143,0
+CHEBI:22599,arabinose,C5H10O5,150.13,0
+CHEBI:22651,ascorbate,,,
+CHEBI:22652,ascorbic acid,,,
+CHEBI:22653,asparagine,C4H8N2O3,132.119,0
+CHEBI:22660,aspartic acid,C4H7NO4,133.103,0
+CHEBI:22868,bile salt,,,
+CHEBI:23414,copper(II) sulfate,Cu.O4S,159.609,0
+CHEBI:23673,"2,6-diaminopimelic acid",C7H14N2O4,190.199,0
+CHEBI:24040,flavin adenine dinucleotide,,,
+CHEBI:24266,gluconic acid,C6H11O7,195.148,0
+CHEBI:24536,hexachlorocyclohexane,C6H6Cl6,290.832,0
+CHEBI:24848,inositol,C6H12O6,180.156,0
+CHEBI:24996,lactate,C3H5O3,89.07,-1
+CHEBI:25094,lysine,C6H14N2O2,146.19,0
+CHEBI:25115,malate,,,
+CHEBI:25140,maltodextrin,,,
+CHEBI:25351,mevalonic acid,C6H12O4,148.158,0
+CHEBI:25548,nitrilotriacetate(3-),C6H6NO6,188.115,-3
+CHEBI:25979,phenylacetonitrile,C8H7N,117.151,0
+CHEBI:26271,proline,C5H9NO2,115.132,0
+CHEBI:26490,quinate,,,
+CHEBI:26493,quinic acid,,,
+CHEBI:26546,rhamnose,C6H12O5,164.157,0
+CHEBI:26642,selenous acid,H2O3Se,128.973,0
+CHEBI:26709,sodium hydrogensulfite,HO3S.Na,104.062,0
+CHEBI:26710,sodium chloride,Cl.Na,58.443,0
+CHEBI:26806,succinate,,,
+CHEBI:26833,sulfur atom,S,32.067,0
+CHEBI:26836,sulfuric acid,H2O4S,98.079,0
+CHEBI:26977,thiosulfate,,,
+CHEBI:26986,threonine,C4H9NO3,119.119,0
+CHEBI:27082,trehalose,C12H22O11,342.297,0
+CHEBI:27226,uric acid,C5H4N4O3,168.11,0
+CHEBI:27374,1L-chiro-inositol,C6H12O6,180.156,0
+CHEBI:27418,"1,4-naphthoquinone",C10H6O2,158.156,0
+CHEBI:27470,folic acid,C19H19N7O6,441.404,0
+CHEBI:27570,histidine,C6H9N3O2,155.157,0
+CHEBI:27592,ectoine,C6H10N2O2,142.158,0
+CHEBI:27641,cycloheximide,C15H23NO4,281.352,0
+CHEBI:27897,tryptophan,C11H12N2O2,204.229,0
+CHEBI:27902,tetracycline,C22H24N2O8,444.44,0
+CHEBI:27941,pullulan,(C37H62O30)n,,
+CHEBI:28001,vancomycin,C66H75Cl2N9O24,1449.271,0
+CHEBI:28017,starch,,,
+CHEBI:28053,melibiose,C12H22O11,342.297,0
+CHEBI:28077,rifampicin,C43H58N4O12,822.953,0
+CHEBI:28145,dibenzofuran,C12H8O,168.195,0
+CHEBI:28260,galactose,C6H12O6,180.156,0
+CHEBI:28262,dimethyl sulfoxide,C2H6OS,78.136,0
+CHEBI:28484,isovaleric acid,C5H10O2,102.133,0
+CHEBI:28488,m-xylene,C8H10,106.168,0
+CHEBI:28591,guaiacol,C7H8O2,124.139,0
+CHEBI:28621,triethanolamine,C6H15NO3,149.19,0
+CHEBI:28631,3-phenylpropionic acid,C9H10O2,150.177,0
+CHEBI:28645,beta-D-fructofuranose,C6H12O6,180.156,0
+CHEBI:28669,bacitracin,C63H98N14O14S,,
+CHEBI:28675,dextrin,,,
+CHEBI:28741,sodium fluoride,F.Na,41.988,0
+CHEBI:28757,fructose,,,
+CHEBI:28842,octadecanoic acid,C18H36O2,284.484,0
+CHEBI:28869,menadione,C11H8O2,172.183,0
+CHEBI:28911,cob(III)alamin,C62H88CoN13O14P,1329.37,1
+CHEBI:28971,ampicillin,C16H19N3O4S,349.412,0
+CHEBI:28997,2'-deoxyinosine,C10H12N4O4,252.23,0
+CHEBI:29016,arginine,C6H14N4O2,174.204,0
+CHEBI:29032,(R)-pantothenate,C9H16NO5,218.229,-1
+CHEBI:29073,L-ascorbic acid,C6H8O6,176.124,0
+CHEBI:29125,arsenate(3-),AsO4,138.918,-3
+CHEBI:29377,sodium carbonate,CO3.2Na,105.988,0
+CHEBI:29805,glycolate,C2H3O3,75.043,-1
+CHEBI:29806,fumarate(2-),C4H2O4,114.056,-2
+CHEBI:29864,mannitol,C6H14O6,182.172,0
+CHEBI:29958,L-aspartic acid residue,C4H5NO3,115.088,0
+CHEBI:29991,L-aspartate(1-),C4H6NO4,132.095,-1
+CHEBI:29994,D-aspartate(2-),C4H5NO4,131.087,-2
+CHEBI:29995,aspartate(2-),C4H5NO4,131.087,-2
+CHEBI:30065,thioglycolic acid,C2H4O2S,92.119,0
+CHEBI:30066,thioglycolate(1-),C2H3O2S,91.111,-1
+CHEBI:30089,acetate,C2H3O2,59.044,-1
+CHEBI:30114,aluminium trichloride,AlCl3,133.341,0
+CHEBI:30115,aluminium trichloride hexahydrate,AlCl3.6H2O,241.431,0
+CHEBI:30314,(R)-lipoic acid,C8H14O2S2,206.332,0
+CHEBI:30411,cobalamin,,,
+CHEBI:30452,tellurium atom,Te,127.6,0
+CHEBI:30563,silicon dioxide,O2Si,60.084,0
+CHEBI:30612,D-glucarate(2-),C6H8O8,208.122,-2
+CHEBI:30621,diarsenic trioxide,As4O6,395.682,0
+CHEBI:30627,molybdenum trioxide,MoO3,143.937,0
+CHEBI:30729,ethylenediaminetetraacetatoferrate(1-),C10H12N2O8.Fe,344.057,-1
+CHEBI:30742,ethylene glycol,C2H6O2,62.068,0
+CHEBI:30745,phenylacetic acid,C8H8O2,136.15,0
+CHEBI:30746,benzoic acid,C7H6O2,122.123,0
+CHEBI:30751,formic acid,CH2O2,46.025,0
+CHEBI:30753,4-aminobenzoic acid,C7H7NO2,137.138,0
+CHEBI:30763,4-hydroxybenzoic acid,C7H6O3,138.122,0
+CHEBI:30764,3-hydroxybenzoic acid,C7H6O3,138.122,0
+CHEBI:30768,propionic acid,C3H6O2,74.079,0
+CHEBI:30769,citric acid,C6H8O7,192.123,0
+CHEBI:30772,butyric acid,C4H8O2,88.106,0
+CHEBI:30776,hexanoic acid,C6H12O2,116.16,0
+CHEBI:30808,iron trichloride,Cl3Fe,162.204,0
+CHEBI:30812,iron dichloride,Cl2Fe,126.751,0
+CHEBI:30845,2-furoic acid,C5H4O3,112.084,0
+CHEBI:30849,L-arabinose,C5H10O5,150.13,0
+CHEBI:30911,glucitol,C6H14O6,182.172,0
+CHEBI:30915,2-oxoglutaric acid,C5H6O5,146.098,0
+CHEBI:30951,potassium thiocyanate,CNS.K,97.183,0
+CHEBI:30961,pyridoxine hydrochloride,C8H11NO3.HCl,205.641,0
+CHEBI:31206,ammonium chloride,Cl.H4N,53.492,0
+CHEBI:31225,antipyrine,C11H12N2O,188.23,0
+CHEBI:31235,Arginine hydrochloride,C6H14N4O2.HCl,210.665,0
+CHEBI:31340,Calcium folinate,C20H21N7O7.Ca,511.508,0
+CHEBI:31345,Calcium pantothenate,2C9H16NO5.Ca,476.536,0
+CHEBI:31346,calcium sulfate,Ca.O4S,136.141,0
+CHEBI:31404,Citric acid monohydrate,C6H8O7.H2O,210.138,0
+CHEBI:31440,copper(II) sulfate pentahydrate,Cu.5H2O.O4S,249.684,0
+CHEBI:31604,ferric ammonium citrate,,,
+CHEBI:31695,indigo carmine,C16H8N2O8S2.2Na,466.36,0
+CHEBI:31795,magnesium sulfate heptahydrate,7H2O.Mg.O4S,246.473,0
+CHEBI:31991,phenol red,C19H14O5S,354.383,0
+CHEBI:32029,potassium acetate,C2H3O2.K,98.142,0
+CHEBI:32030,potassium bromide,Br.K,119.002,0
+CHEBI:32032,Potassium gluconate,C6H11O7.K,234.245,0
+CHEBI:32035,potassium hydroxide,HO.K,56.105,0
+CHEBI:32036,potassium sulfate,2K.O4S,174.259,0
+CHEBI:32138,sodium acetate trihydrate,C2H3O2.3H2O.Na,136.079,0
+CHEBI:32139,sodium hydrogencarbonate,CHO3.Na,84.006,0
+CHEBI:32142,sodium citrate dihydrate,C6H5O7.2H2O.3Na,294.099,0
+CHEBI:32145,sodium hydroxide,HO.Na,39.997,0
+CHEBI:32149,sodium sulfate,2Na.O4S,142.043,0
+CHEBI:32150,sodium thiosulfate pentahydrate,5H2O.2Na.O3S2,248.186,0
+CHEBI:32312,zinc sulfate heptahydrate,7H2O.O4S.Zn,287.558,0
+CHEBI:32583,calcium sulfate dihydrate,Ca.2H2O.O4S,172.171,0
+CHEBI:32586,sodium sulfate decahydrate,10H2O.2Na.O4S,322.193,0
+CHEBI:32588,potassium chloride,Cl.K,74.551,0
+CHEBI:32596,calcium hydrogenphosphate,Ca.HO4P,136.056,0
+CHEBI:32599,magnesium sulfate,Mg.O4S,120.368,0
+CHEBI:32696,argininium(1+),C6H15N4O2,175.212,1
+CHEBI:32816,pyruvic acid,C3H4O3,88.062,0
+CHEBI:32954,sodium acetate,C2H3O2.Na,82.034,0
+CHEBI:33083,fluoranthene,C16H10,202.256,0
+CHEBI:33118,boric acid,H3BO3,61.833,0
+CHEBI:33167,sodium iodide,I.Na,149.894,0
+CHEBI:33403,elemental sulfur,,,
+CHEBI:33942,ribose,C5H10O5,150.13,0
+CHEBI:33984,fucose,,,
+CHEBI:34535,ampicillin sodium,C16H18N3O4S.Na,371.394,0
+CHEBI:34545,Azimilide,C23H28ClN5O3,457.962,0
+CHEBI:34653,Congo Red,C32H22N6O6S2.2Na,696.678,0
+CHEBI:34683,disodium hydrogenphosphate,HO4P.2Na,141.958,0
+CHEBI:34887,nickel dichloride,Cl2Ni,129.599,0
+CHEBI:35176,zinc sulfate,O4S.Zn,161.453,0
+CHEBI:35195,surfactant,,,
+CHEBI:35366,fatty acid,CHO2R,45.017,0
+CHEBI:35458,cerium trichloride,CeCl3,246.475,0
+CHEBI:35607,trisodium vanadate,3Na.O4V,183.91,0
+CHEBI:35696,cobalt dichloride,2Cl.Co,129.839,0
+CHEBI:35697,trans-cinnamic acid,C9H8O2,148.161,0
+CHEBI:35704,N(2)-acetyl-L-lysine,C8H16N2O3,188.227,0
+CHEBI:35899,crotonate,C4H5O2,85.082,-1
+CHEBI:36018,"1,1,2-trichloroethane",C2H3Cl3,133.405,0
+CHEBI:36218,beta-lactose,C12H22O11,342.297,0
+CHEBI:36272,tungstic acid,H2O4W,249.852,0
+CHEBI:36336,naphthalenesulfonic acid,,,
+CHEBI:36383,strontium dichloride,2Cl.Sr,158.526,0
+CHEBI:36385,strontium dichloride hexahydrate,Cl2Sr.6H2O,266.616,0
+CHEBI:36702,2-acyl-1-alkyl-sn-glycero-3-phosphocholine,C9H18NO7PR2,283.216,0
+CHEBI:36751,pyrrole-2-carboxylic acid,C5H5NO2,111.1,0
+CHEBI:37070,2-methylbutyric acid,C5H10O2,102.133,0
+CHEBI:37166,xylan,,,
+CHEBI:37585,sodium dihydrogenphosphate,H2O4P.Na,119.976,0
+CHEBI:38267,boronic acid,H3BO2,45.834,0
+CHEBI:38892,disodium tetraborate,H4B4O9.2Na,237.251,0
+CHEBI:39005,2-(N-morpholino)ethanesulfonic acid,C6H13NO4S,195.24,0
+CHEBI:39010,MES,,,
+CHEBI:39033,PIPES,,,
+CHEBI:39035,TES,,,
+CHEBI:39054,NTA,,,
+CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,C4H10N2O4S,182.201,0
+CHEBI:39061,ACES,,,
+CHEBI:39063,N-tris(hydroxymethyl)methylglycine,C6H13NO5,179.172,0
+CHEBI:39065,bicine,,,
+CHEBI:39074,MOPS,,,
+CHEBI:40009,D-cycloserine,C3H6N2O2,102.093,0
+CHEBI:40666,"1,6-anhydro-N-acetyl-beta-muramic acid",C11H17NO7,275.257,0
+CHEBI:40957,"N,N-bis(2-hydroxyethyl)glycine",C6H13NO4,163.173,0
+CHEBI:41131,crotonic acid,C4H6O2,86.09,0
+CHEBI:41218,mercaptoethanol,C2H6OS,78.136,0
+CHEBI:41250,bis-tris,C8H19NO5,209.242,0
+CHEBI:41688,crystal violet,C25H30N3.Cl,407.989,0
+CHEBI:41808,decane,C10H22,142.286,0
+CHEBI:41981,dideuterium oxide,D2O,20.027,0
+CHEBI:42106,"L-1,4-dithiothreitol",C4H10O2S2,154.256,0
+CHEBI:42160,dithionite(2-),O4S2,128.13,-2
+CHEBI:42334,2-[4-(2-hydroxyethyl)piperazin-1-yl]ethanesulfonic acid,C8H18N2O4S,238.309,0
+CHEBI:43796,(S)-lipoic acid,C8H14O2S2,206.332,0
+CHEBI:44115,3-(N-morpholino)propanesulfonic acid,C7H15NO4S,209.267,0
+CHEBI:44557,nitrilotriacetic acid,C6H9NO6,191.139,0
+CHEBI:45165,pyromellitic acid,C10H6O8,254.15,0
+CHEBI:45296,hexadecane,C16H34,226.448,0
+CHEBI:45630,4-oxopentanoic acid,C5H8O3,116.116,0
+CHEBI:45924,trimethoprim,C14H18N4O3,290.323,0
+CHEBI:45931,thiamine(1+) diphosphate(1-),C12H18N4O7P2S,424.312,0
+CHEBI:45996,ribothymidine,C10H14N2O6,258.23,0
+CHEBI:46020,tetramethylammonium,C4H12N,74.147,1
+CHEBI:46345,5-fluorouracil,C4H3FN2O2,130.078,0
+CHEBI:46502,tungstate,O4W,247.836,-2
+CHEBI:46756,HEPES,,,
+CHEBI:46760,tricine,,,
+CHEBI:47869,thioglycolate(2-),C2H2O2S,90.103,-2
+CHEBI:47965,N-acetylmuramic acid,C11H19NO8,293.271,0
+CHEBI:47966,aldehydo-N-acetylmuramic acid,C11H19NO8,293.272,0
+CHEBI:48607,lithium chloride,Cl.Li,42.394,0
+CHEBI:48843,disodium selenite,2Na.O3Se,172.937,0
+CHEBI:48923,erythromycin,,,
+CHEBI:49105,thiamine hydrochloride,C12H17N4OS.Cl.HCl,337.276,0
+CHEBI:49474,argon(0),Ar,39.948,0
+CHEBI:49553,copper(II) chloride,Cl2Cu,134.452,0
+CHEBI:49976,zinc dichloride,2Cl.Zn,136.296,0
+CHEBI:50144,sodium pyruvate,C3H3O3.Na,110.044,0
+CHEBI:50385,hemin,C34H32ClFeN4O4,651.952,0
+CHEBI:51765,benzylpenicillin sodium,C16H17N2O4S.Na,356.379,0
+CHEBI:52071,dextran,,,
+CHEBI:53001,nickel sulfate,Ni.O4S,154.756,0
+CHEBI:53258,sodium citrate,C6H5O7.3Na,258.069,0
+CHEBI:53311,sodium alginate,(C6H7O6)n.H2NaO,216.121,0
+CHEBI:53389,poly(3-hydroxybutyrate),(C4H6O2)n,86.09,0
+CHEBI:53423,polysorbate 40,(C2H4O)w.(C2H4O)x.(C2H4O)y.(C2H4O)z.C22H42O6,578.784,0
+CHEBI:53424,polysorbate 20,(C2H4O)w.(C2H4O)x.(C2H4O)y.(C2H4O)z.C18H34O6,522.676,0
+CHEBI:53425,polysorbate 60,(C2H4O)w.(C2H4O)x.(C2H4O)y.(C2H4O)z.C24H46O6,606.838,0
+CHEBI:53426,polysorbate 80,(C2H4O)w.(C2H4O)x.(C2H4O)y.(C2H4O)z.C24H44O6,604.822,0
+CHEBI:53437,nickel sulfate hexahydrate,6H2O.Ni.O4S,262.846,0
+CHEBI:53438,iron(3+) sulfate,2Fe.3O4S,399.879,0
+CHEBI:53470,cobalt(2+) sulfate,Co.O4S,154.996,0
+CHEBI:53471,chromium(III) sulfate,2Cr.3O4S,392.181,0
+CHEBI:53472,copper(I) chloride,ClCu,98.999,0
+CHEBI:53503,cobalt chloride hexahydrate,2Cl.Co.6H2O,237.929,0
+CHEBI:53504,nickel sulfate heptahydrate,7H2O.Ni.O4S,280.861,0
+CHEBI:53542,nickel chloride hexahydrate,2Cl.6H2O.Ni,237.689,0
+CHEBI:53633,L-lysine hydrochloride,C6H14N2O2.HCl,182.651,0
+CHEBI:53696,disodium L-tyrosinate,C9H9NO3.2Na,225.155,0
+CHEBI:57912,L-tryptophan zwitterion,C11H12N2O2,204.229,0
+CHEBI:59337,methylamine hydrochloride,CH6N.Cl,67.519,0
+CHEBI:59640,N-acetylglucosamine,,,
+CHEBI:60720,sodium silicate,2Na.O3Si,122.063,0
+CHEBI:61930,N(6)-acetyl-L-lysine residue,C8H14N2O2,170.212,0
+CHEBI:62064,"butane-2,3-diol",C4H10O2,90.122,0
+CHEBI:62345,L-rhamnose,,,
+CHEBI:62946,ammonium sulfate,2H4N.O4S,132.141,0
+CHEBI:62947,ammonium acetate,C2H3O2.H4N,77.083,0
+CHEBI:62955,sodium 2-(N-morpholino)ethanesulfonate,C6H12NO4S.Na,217.222,0
+CHEBI:62964,magnesium acetate,2C2H3O2.Mg,142.393,0
+CHEBI:62965,sodium formate,CHO2.Na,68.007,0
+CHEBI:62982,ammonium dihydrogen phosphate,H2O4P.H4N,115.025,0
+CHEBI:63004,sodium bromide,Br.Na,102.894,0
+CHEBI:63005,sodium nitrate,NO3.Na,84.994,0
+CHEBI:63017,sodium L-tartrate,C4H4O6.2Na,194.05,0
+CHEBI:63036,potassium dihydrogen phosphate,H2O4P.K,136.084,0
+CHEBI:63037,triammonium citrate,C6H5O7.3H4N,243.216,0
+CHEBI:63038,ammonium nitrate,H4N.NO3,80.043,0
+CHEBI:63041,manganese(II) chloride,Cl2Mn,125.844,0
+CHEBI:63043,potassium nitrate,K.NO3,101.102,0
+CHEBI:63051,diammonium hydrogen phosphate,2H4N.HO4P,132.056,0
+CHEBI:63055,disodium PIPES,C8H16N2O6S2.2Na,346.338,0
+CHEBI:63076,diammonium citrate,C6H6O7.2H4N,226.185,0
+CHEBI:63125,EDTA trisodium salt,C10H13N2O8.3Na,358.19,0
+CHEBI:63317,barium chloride,Ba.2Cl,208.234,0
+CHEBI:63675,sodium succinate (anhydrous),C4H4O4.2Na,162.052,0
+CHEBI:63686,sodium succinate hexahydrate,C4H4O4.6H2O.2Na,270.142,0
+CHEBI:63939,sodium tungstate dihydrate,2H2O.2Na.O4W,329.846,0
+CHEBI:63940,sodium tungstate,2Na.O4W,293.816,0
+CHEBI:64103,sodium butyrate,C4H7O2.Na,110.088,0
+CHEBI:64139,"(2R,3S)-EHNA hydrochloride",C14H23N5O.HCl,313.833,0
+CHEBI:64205,calcium nitrate,Ca.2NO3,164.086,0
+CHEBI:64220,monosodium glutamate,C5H8NO4.Na,169.112,0
+CHEBI:64700,trimethylamine hydrochloride,C3H9N.HCl,95.573,0
+CHEBI:64734,EDTA disodium salt (anhydrous),C10H14N2O8.2Na,336.208,0
+CHEBI:64758,EDTA disodium salt dihydrate,C10H14N2O8.2H2O.2Na,372.238,0
+CHEBI:65242,sodium chlorate,ClO3.Na,106.44,0
+CHEBI:65327,D-xylose,C5H10O5,150.13,0
+CHEBI:66870,sodium dithionite,2Na.O4S2,174.11,0
+CHEBI:66872,potassium fluoride,F.K,58.096,0
+CHEBI:68329,syringic acid,C9H10O5,198.174,0
+CHEBI:71240,sodium diphosphate,4Na.O7P2,265.901,0
+CHEBI:72449,malachite green,C23H25N2.Cl,364.92,0
+CHEBI:73685,N(2)-acetylglutamine,C7H12N2O4,188.183,0
+CHEBI:74779,aluminium sulfate octadecahydrate,2Al.18H2O.3O4S,666.423,0
+CHEBI:75213,sodium molybdate dihydrate,2H2O.MoO4.2Na,241.946,0
+CHEBI:75215,sodium molybdate (anhydrous),MoO4.2Na,205.916,0
+CHEBI:75221,sodium metavanadate,Na.O3V,121.931,0
+CHEBI:75228,sodium lactate,C3H5O3.Na,112.06,0
+CHEBI:75249,potassium chromate,CrO4.2K,194.188,0
+CHEBI:75456,2-stearoylglycerol,C21H42O4,358.563,0
+CHEBI:75832,iron(2+) sulfate (anhydrous),Fe.O4S,151.908,0
+CHEBI:75834,iron(2+) sulfate monohydrate,Fe.H2O.O4S,169.923,0
+CHEBI:75836,iron(2+) sulfate heptahydrate,Fe.7H2O.O4S,278.013,0
+CHEBI:75937,monooleoylglycerol,C21H40O4,356.293,0
+CHEBI:76181,ferrous ammonium sulfate hexahydrate,Fe.6H2O.2H4N.2O4S,392.139,0
+CHEBI:76208,sodium sulfide (anhydrous),2Na.S,78.047,0
+CHEBI:76209,sodium sulfide nonahydrate,9H2O.2Na.S,240.182,0
+CHEBI:77775,sodium selenate,2Na.O4Se,188.936,0
+CHEBI:78018,dodecylphosphocholine,C17H38NO4P,351.468,0
+CHEBI:78036,copper(II) nitrate,Cu.2NO3,187.554,0
+CHEBI:78074,tin(II) chloride dihydrate,2Cl.2H2O.Sn,225.647,0
+CHEBI:78292,sodium feredetate,C10H12FeN2O8.Na,367.047,0
+CHEBI:78672,rubidium chloride,Cl.Rb,120.921,0
+CHEBI:78870,sodium nitrite,NO2.Na,68.995,0
+CHEBI:81860,Sodium oleate,C18H33O2.Na,304.45,0
+CHEBI:81862,potassium hydrogencarbonate,CHO3.K,100.114,0
+CHEBI:82664,iron(0),Fe,55.845,0
+CHEBI:84015,"(1R,2R)-diclocymet",C15H18Cl2N2O,313.228,0
+CHEBI:84997,sodium gluconate,C6H11O7.Na,218.137,0
+CHEBI:85146,carboxymethylcellulose,,,
+CHEBI:85248,gellan gum,,,
+CHEBI:86149,ammonium nickel sulfate hexahydrate,6H2O.2H4N.Ni.2O4S,394.987,0
+CHEBI:86153,barium chloride dihydrate,Ba.2Cl.2H2O,244.264,0
+CHEBI:86154,bromocresol purple,C21H16Br2O5S,540.229,0
+CHEBI:86155,bromothymol blue,C27H28Br2O5S,624.391,0
+CHEBI:86156,cadmium nitrate tetrahydrate,Cd.4H2O.2NO3,308.48,0
+CHEBI:86158,calcium chloride dihydrate,Ca.2Cl.2H2O,147.014,0
+CHEBI:86159,calcium nitrate tetrahydrate,Ca.4H2O.2NO3,236.146,0
+CHEBI:86202,chalcopyrite,Cu.Fe.2S,183.525,0
+CHEBI:86206,chromium trinitrate heptahydrate,Cr.7H2O.3NO3,364.113,0
+CHEBI:86209,cobalt dinitrate,Co.2NO3,182.941,0
+CHEBI:86214,cobalt dinitrate hexahydrate,Co.6H2O.2NO3,291.031,0
+CHEBI:86218,cresol red,C21H18O5S,382.437,0
+CHEBI:86222,borax,10H2O.H4B4O9.2Na,417.401,0
+CHEBI:86249,iron dichloride tetrahydrate,Cl2Fe.4H2O,198.811,0
+CHEBI:86254,iron trichloride hexahydrate,Cl3Fe.6H2O,270.294,0
+CHEBI:86318,copper(II) chloride dihydrate,Cl2Cu.2H2O,170.482,0
+CHEBI:86345,magnesium dichloride hexahydrate,2Cl.6H2O.Mg,203.301,0
+CHEBI:86355,magnesium dichloride monohydrate,2Cl.H2O.Mg,113.226,0
+CHEBI:86356,manganese(II) sulfate dihydrate,2H2O.Mn.O4S,187.031,0
+CHEBI:86358,manganese(II) sulfate tetrahydrate,4H2O.Mn.O4S,223.061,0
+CHEBI:86360,manganese(II) sulfate,Mn.O4S,151.001,0
+CHEBI:86364,manganese(II) sulfate monohydrate,H2O.Mn.O4S,169.016,0
+CHEBI:86368,manganese(II) chloride tetrahydrate,Cl2Mn.4H2O,197.904,0
+CHEBI:86370,neutral red,C15H16N4.HCl,288.782,0
+CHEBI:86416,"1-eicosanoyl-2-[(11Z,14Z,17Z)-eicosatrienoyl]-sn-glycero-3-phosphocholine",C48H90NO8P,840.221,0
+CHEBI:86463,potassium aluminium sulfate,Al.K.2O4S,258.206,0
+CHEBI:86465,potassium aluminium sulfate dodecahydrate,Al.12H2O.K.2O4S,474.386,0
+CHEBI:86466,potassium tetrathionate,2K.O6S4,302.458,0
+CHEBI:86473,sodium molybdate heptahydrate,7H2O.MoO4.2Na,332.021,0
+CHEBI:86477,sodium sulfite,2Na.O3S,126.044,0
+CHEBI:86481,sodium thioglycolate,C2H3O2S.Na,114.101,0
+CHEBI:87009,vanadyl sulfate dihydrate,2H2O.O4S.OV,199.036,0
+CHEBI:87020,vanadyl sulfate hydrate,(H2O)n.O5SV,181.021,0
+CHEBI:91090,charcoal,,,
+CHEBI:91241,ammonium oxalate,C2O4.2H4N,124.096,0
+CHEBI:91243,calcium chloride hexahydrate,Ca.2Cl.6H2O,219.074,0
+CHEBI:91244,cobalt(2+) sulfate heptahydrate,Co.7H2O.O4S,281.101,0
+CHEBI:91245,copper(II) chloride pentahydrate,Cl2Cu.5H2O,224.527,0
+CHEBI:91246,copper(II) sulfate hexahydrate,Cu.6H2O.O4S,267.699,0
+CHEBI:91247,L-cysteine hydrochloride,C3H7NO2S.HCl,157.622,0
+CHEBI:91248,L-cysteine hydrochloride hydrate,C3H7NO2S.H2O.HCl,175.637,0
+CHEBI:91249,ammonium molybdate,2H4N.MoO4,196.014,0
+CHEBI:91251,sodium glyoxylate,C2HO3.Na,96.017,0
+CHEBI:91257,disodium hydrogenarsenate heptahydrate,7H2O.HAsO4.2Na,312.011,0
+CHEBI:91258,disodium hydrogenphosphate dihydrate,2H2O.HO4P.2Na,177.988,0
+CHEBI:91260,disodium malate,,,
+CHEBI:91261,disodium (S)-malate,C4H4O5.2Na,178.051,0
+CHEBI:91263,disodium maleate,C4H2O4.2Na,160.036,0
+CHEBI:91318,(R)-oleoylcarnitine hydrochloride,C25H48NO4.Cl,462.115,0
+CHEBI:113373,sodium 3-hydroxybutyrate,C4H7O3.Na,126.087,0
+CHEBI:113451,sodium ascorbate,C6H7O6.Na,198.106,0
+CHEBI:113455,sodium benzoate,C7H5O2.Na,144.105,0
+CHEBI:114126,sodium hexanoate,C6H11O2.Na,138.142,0
+CHEBI:114249,sodium dihydrogenphosphate monohydrate,H2O.H2O4P.Na,137.991,0
+CHEBI:114786,sodium disulfite,2Na.O5S2,190.109,0
+CHEBI:114954,sodium ferulate,C10H9O4.Na,216.168,0
+CHEBI:115156,disodium fumarate,C4H2O4.2Na,160.036,0
+CHEBI:115197,sodium gallate,C7H5O5.Na,192.102,0
+CHEBI:131361,disodium selenite pentahydrate,5H2O.2Na.O3Se,263.012,0
+CHEBI:131366,disodium tetraborate decahydrate,10H2O.H4B4O9.2Na,417.401,0
+CHEBI:131371,iron(3+) phosphate,Fe.O4P,150.815,0
+CHEBI:131372,iron(3+) phosphate tetrahydrate,Fe.4H2O.O4P,222.875,0
+CHEBI:131378,ferrous ammonium sulfate heptahydrate,Fe.7H2O.2H4N.2O4S,410.154,0
+CHEBI:131383,"2,2,4,4,6,8,8-heptamethylnonane",C16H34,226.448,0
+CHEBI:131389,magnesium citrate,C6H6O7.Mg,214.412,0
+CHEBI:131394,magnesium dichloride dihydrate,2Cl.2H2O.Mg,131.241,0
+CHEBI:131395,manganese(II) chloride dihydrate,Cl2Mn.2H2O,161.874,0
+CHEBI:131523,manganese(II) sulfate hexahydrate,6H2O.Mn.O4S,259.091,0
+CHEBI:131524,manganese(II) sulfate pentahydrate,5H2O.Mn.O4S,241.076,0
+CHEBI:131526,potassium carbonate,CO3.2K,138.204,0
+CHEBI:131527,dipotassium hydrogen phosphate,HO4P.2K,174.174,0
+CHEBI:131529,pyridoxal hydrochloride,C8H9NO3.HCl,203.625,0
+CHEBI:131531,pyridoxamine hydrochloride,C8H12N2O2.HCl,204.657,0
+CHEBI:131532,pyridoxamine dihydrochloride,C8H12N2O2.2HCl,241.118,0
+CHEBI:131839,sodium dodecanoate,C12H23O2.Na,222.304,0
+CHEBI:132089,sodium glycerol 2-phosphate,C3H7O6P.2Na,216.037,0
+CHEBI:132095,sodium metavanadate hydrate,H2O.Na.O3V,139.946,0
+CHEBI:132100,sodium octanoate,C8H15O2.Na,166.196,0
+CHEBI:132101,sodium orotate,C5H3N2O4.Na,178.079,0
+CHEBI:132103,sodium perchlorate,ClO4.Na,122.439,0
+CHEBI:132106,sodium propionate,C3H5O2.Na,96.061,0
+CHEBI:132108,sodium silicate nonahydrate,9H2O.2Na.O3Si,284.198,0
+CHEBI:132109,sodium octadecanoate,C18H35O2.Na,306.466,0
+CHEBI:132112,sodium thiosulfate,2Na.O3S2,158.111,0
+CHEBI:132748,sodium vanillate,C8H7O4.Na,190.13,0
+CHEBI:132751,thiamine hydrochloride dihydrate,C12H18N4OS.2Cl.2H2O,373.306,0
+CHEBI:132758,vanadyl sulfate pentahydrate,5H2O.O4S.OV,253.081,0
+CHEBI:132762,zinc sulfate hexahydrate,6H2O.O4S.Zn,269.543,0
+CHEBI:132764,sodium oxalate,C2O4.2Na,133.998,0
+CHEBI:132766,sodium nitrilotriacetate,C6H6NO6.3Na,257.085,0
+CHEBI:132767,ferric pyrophosphate,4Fe.3O7P2,745.203,0
+CHEBI:133341,choline chloride,C5H14NO.Cl,139.626,0
+CHEBI:133362,N-acetyl-L-methionyl-L-glutaminyl residue,C12H20N3O4S,302.376,0
+CHEBI:136511,manganese dioxide,MnO2,86.936,0
+CHEBI:141517,tyloxapol,(C17H26O2)m.2(C2H4O)n.C29H44O2,775.168,0
+CHEBI:142468,"1,2-dichloropropane",C3H6Cl2,112.987,0
+CHEBI:144421,iron(III) citrate,C6H5FeO7,244.944,0
+CHEBI:144434,iron(III) citrate monohydrate,C6H5O7.Fe.H2O,262.959,0
+CHEBI:149425,ammonium magnesium phosphate,H4N.Mg.O4P,137.314,0
+CHEBI:172431,Acetyl-Glu,C7H11NO5,189.167,0
+CHEBI:176843,vitamin B12,,,
+CHEBI:177535,L-Glutathione (reduced),C10H17N3O6S,307.328,0
+CHEBI:183882,3-(cyclohexylamino)-2-hydroxy-1-propanesulfonic acid,C9H19NO4S,237.321,0
+CHEBI:184335,Ammonium bicarbonate,CHO3.H4N,79.055,0
+CHEBI:189426,Pyridoxine dihydrochloride,C8H11NO3.2HCl,242.102,0
+CHEBI:191088,Cyclohexylaminopropanesulfonic acid,C9H19NO3S,221.322,0
+CHEBI:192761,ferrihydrite,,,
+CHEBI:193555,isobutyramide,,,
+CHEBI:195690,L-Ornithine monochlorohydrate/ornithine,C5H12N2O2.HCl,168.624,0
+CHEBI:209807,cefoxitin,C16H17N3O7S2,427.46,0
+CHEBI:229203,Trigonelline HCl,C7H8NO2.Cl,173.599,0
+CHEBI:232425,monosodium L-glutamate hydrate,C5H8NO4.H2O.Na,187.127,0
+CHEBI:232610,potassium nitrite,K.NO2,85.103,0
+CHEBI:232797,trehalose dihydrate,C12H22O11.2H2O,378.327,0
+CHEBI:232798,sodium L-lactate,C3H5O3.Na,112.06,0
+CHEBI:234557,sodium palmitate,C16H31O2.Na,278.412,0
+CHEBI:326268,"1,4-butanediammonium",C4H14N2,90.17,2
+CHEBI:495055,beta-cyclodextrin,C42H70O35,1134.987,0
+CHEBI:506227,N-acetyl-D-glucosamine,C8H15NO6,221.209,0

--- a/src/culturemech/data/chebi/structure_index.meta.json
+++ b/src/culturemech/data/chebi/structure_index.meta.json
@@ -1,0 +1,15 @@
+{
+  "source": "https://www.ebi.ac.uk/ols4/api/ontologies/chebi/terms",
+  "ontology": "chebi",
+  "fetched": "2026-08-30T01:38:51.012310+00:00",
+  "row_count": 640,
+  "ids_requested": 640,
+  "fields": [
+    "chebi_id",
+    "label",
+    "formula",
+    "molecular_weight",
+    "charge"
+  ],
+  "note": "Only properties ChEBI asserts are recorded. An empty formula means ChEBI states none for that term, not that lookup failed; terms that failed to resolve are absent from the table."
+}

--- a/src/culturemech/fetch/utex_fetcher.py
+++ b/src/culturemech/fetch/utex_fetcher.py
@@ -24,7 +24,7 @@ import logging
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import requests
 from bs4 import BeautifulSoup
@@ -121,7 +121,7 @@ class UTEXFetcher:
             {"User-Agent": "CultureMech/1.0 (Scientific Research; contact: info@culturemech.org)"}
         )
 
-    def fetch_media_index(self) -> List[Dict[str, str]]:
+    def fetch_media_index(self) -> list[dict[str, str]]:
         """Fetch media index page and extract recipe URLs.
 
         Returns:
@@ -157,7 +157,7 @@ class UTEXFetcher:
         logger.info(f"Found {len(unique_recipes)} unique media recipes")
         return unique_recipes
 
-    def fetch_recipe_details(self, recipe_url: str, recipe_name: str) -> Optional[Dict[str, Any]]:
+    def fetch_recipe_details(self, recipe_url: str, recipe_name: str) -> dict[str, Any] | None:
         """Fetch detailed recipe information from recipe page.
 
         Args:
@@ -258,7 +258,7 @@ class UTEXFetcher:
         else:
             return "general"
 
-    def fetch_all(self, limit: Optional[int] = None) -> Dict[str, Any]:
+    def fetch_all(self, limit: int | None = None) -> dict[str, Any]:
         """Fetch all media recipes.
 
         Args:

--- a/src/culturemech/fetch/utex_fetcher.py
+++ b/src/culturemech/fetch/utex_fetcher.py
@@ -117,9 +117,9 @@ class UTEXFetcher:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.rate_limit = rate_limit
         self.session = requests.Session()
-        self.session.headers.update({
-            'User-Agent': 'CultureMech/1.0 (Scientific Research; contact: info@culturemech.org)'
-        })
+        self.session.headers.update(
+            {"User-Agent": "CultureMech/1.0 (Scientific Research; contact: info@culturemech.org)"}
+        )
 
     def fetch_media_index(self) -> List[Dict[str, str]]:
         """Fetch media index page and extract recipe URLs.
@@ -132,29 +132,26 @@ class UTEXFetcher:
         response = self.session.get(self.MEDIA_INDEX_URL)
         response.raise_for_status()
 
-        soup = BeautifulSoup(response.text, 'html.parser')
+        soup = BeautifulSoup(response.text, "html.parser")
 
         recipes = []
 
         # Find all media links
         # UTEX uses product links like /products/bg-11-medium
-        for link in soup.find_all('a', href=True):
-            href = link.get('href', '')
-            if '/products/' in href and 'medium' in href.lower():
+        for link in soup.find_all("a", href=True):
+            href = link.get("href", "")
+            if "/products/" in href and "medium" in href.lower():
                 name = link.get_text(strip=True)
                 if name and len(name) > 3:  # Filter out short/empty links
-                    url = href if href.startswith('http') else f"{self.BASE_URL}{href}"
-                    recipes.append({
-                        'name': name,
-                        'url': url
-                    })
+                    url = href if href.startswith("http") else f"{self.BASE_URL}{href}"
+                    recipes.append({"name": name, "url": url})
 
         # Deduplicate by URL
         seen_urls = set()
         unique_recipes = []
         for recipe in recipes:
-            if recipe['url'] not in seen_urls:
-                seen_urls.add(recipe['url'])
+            if recipe["url"] not in seen_urls:
+                seen_urls.add(recipe["url"])
                 unique_recipes.append(recipe)
 
         logger.info(f"Found {len(unique_recipes)} unique media recipes")
@@ -177,38 +174,38 @@ class UTEXFetcher:
             response = self.session.get(recipe_url)
             response.raise_for_status()
 
-            soup = BeautifulSoup(response.text, 'html.parser')
+            soup = BeautifulSoup(response.text, "html.parser")
 
             # Extract recipe details
             # UTEX stores recipes in product description format
             recipe_data = {
-                'id': recipe_url.split('/')[-1],  # e.g., 'bg-11-medium'
-                'name': recipe_name,
-                'url': recipe_url,
-                'source': 'UTEX',
-                'category': self._determine_category(recipe_name),
-                'description': None,
-                'composition': [],
-                'preparation': None,
-                'notes': None,
-                'fetched_date': datetime.now().isoformat()
+                "id": recipe_url.split("/")[-1],  # e.g., 'bg-11-medium'
+                "name": recipe_name,
+                "url": recipe_url,
+                "source": "UTEX",
+                "category": self._determine_category(recipe_name),
+                "description": None,
+                "composition": [],
+                "preparation": None,
+                "notes": None,
+                "fetched_date": datetime.now().isoformat(),
             }
 
             # Extract description
-            desc_elem = soup.find('div', class_='product-description')
+            desc_elem = soup.find("div", class_="product-description")
             if desc_elem:
-                recipe_data['description'] = desc_elem.get_text(strip=True)
+                recipe_data["description"] = desc_elem.get_text(strip=True)
 
             # Extract composition/ingredients by header, not by column position
             # (see `parse_composition_table`).
-            for table in soup.find_all('table'):
+            for table in soup.find_all("table"):
                 rows = [
-                    [cell.get_text(strip=True) for cell in row.find_all(['td', 'th'])]
-                    for row in table.find_all('tr')
+                    [cell.get_text(strip=True) for cell in row.find_all(["td", "th"])]
+                    for row in table.find_all("tr")
                 ]
-                recipe_data['composition'].extend(parse_composition_table(rows))
+                recipe_data["composition"].extend(parse_composition_table(rows))
 
-            if not recipe_data['composition'] and soup.find('table'):
+            if not recipe_data["composition"] and soup.find("table"):
                 logger.warning(
                     f"{recipe_url}: has tables but no recognizable composition header; "
                     f"no ingredients captured"
@@ -226,13 +223,13 @@ class UTEXFetcher:
 
             # Extract preparation/notes
             # Look for sections with keywords
-            for elem in soup.find_all(['div', 'p', 'section']):
+            for elem in soup.find_all(["div", "p", "section"]):
                 text = elem.get_text(strip=True)
                 lower_text = text.lower()
-                if 'preparation' in lower_text or 'instruction' in lower_text:
-                    recipe_data['preparation'] = text
-                elif 'note' in lower_text or 'remark' in lower_text:
-                    recipe_data['notes'] = text
+                if "preparation" in lower_text or "instruction" in lower_text:
+                    recipe_data["preparation"] = text
+                elif "note" in lower_text or "remark" in lower_text:
+                    recipe_data["notes"] = text
 
             return recipe_data
 
@@ -251,15 +248,15 @@ class UTEXFetcher:
         """
         name_lower = name.lower()
 
-        saltwater_keywords = ['seawater', 'marine', 'erdschreiber', 'saltwater', 'f/2', 'ocean']
-        freshwater_keywords = ['freshwater', 'bold', 'bg-11', 'bristol', 'tap', 'soil']
+        saltwater_keywords = ["seawater", "marine", "erdschreiber", "saltwater", "f/2", "ocean"]
+        freshwater_keywords = ["freshwater", "bold", "bg-11", "bristol", "tap", "soil"]
 
         if any(kw in name_lower for kw in saltwater_keywords):
-            return 'saltwater'
+            return "saltwater"
         elif any(kw in name_lower for kw in freshwater_keywords):
-            return 'freshwater'
+            return "freshwater"
         else:
-            return 'general'
+            return "general"
 
     def fetch_all(self, limit: Optional[int] = None) -> Dict[str, Any]:
         """Fetch all media recipes.
@@ -281,43 +278,40 @@ class UTEXFetcher:
         recipes = []
         for idx, recipe_info in enumerate(recipes_index, 1):
             logger.info(f"Progress: {idx}/{len(recipes_index)}")
-            recipe_data = self.fetch_recipe_details(
-                recipe_info['url'],
-                recipe_info['name']
-            )
+            recipe_data = self.fetch_recipe_details(recipe_info["url"], recipe_info["name"])
             if recipe_data:
                 recipes.append(recipe_data)
 
         # Create output data
         output_data = {
-            'source': 'UTEX',
-            'source_url': self.MEDIA_INDEX_URL,
-            'fetched_date': datetime.now().isoformat(),
-            'count': len(recipes),
-            'recipes': recipes
+            "source": "UTEX",
+            "source_url": self.MEDIA_INDEX_URL,
+            "fetched_date": datetime.now().isoformat(),
+            "count": len(recipes),
+            "recipes": recipes,
         }
 
         # Save to file
-        output_file = self.output_dir / 'utex_media.json'
-        with open(output_file, 'w') as f:
+        output_file = self.output_dir / "utex_media.json"
+        with open(output_file, "w") as f:
             json.dump(output_data, f, indent=2)
 
         logger.info(f"Saved {len(recipes)} recipes to {output_file}")
 
         # Save statistics
         stats = {
-            'fetch_date': datetime.now().isoformat(),
-            'total_recipes': len(recipes),
-            'categories': {},
-            'source_url': self.MEDIA_INDEX_URL
+            "fetch_date": datetime.now().isoformat(),
+            "total_recipes": len(recipes),
+            "categories": {},
+            "source_url": self.MEDIA_INDEX_URL,
         }
 
         for recipe in recipes:
-            cat = recipe.get('category', 'unknown')
-            stats['categories'][cat] = stats['categories'].get(cat, 0) + 1
+            cat = recipe.get("category", "unknown")
+            stats["categories"][cat] = stats["categories"].get(cat, 0) + 1
 
-        stats_file = self.output_dir / 'fetch_stats.json'
-        with open(stats_file, 'w') as f:
+        stats_file = self.output_dir / "fetch_stats.json"
+        with open(stats_file, "w") as f:
             json.dump(stats, f, indent=2)
 
         return output_data
@@ -325,25 +319,22 @@ class UTEXFetcher:
 
 def main():
     """CLI entry point."""
-    parser = argparse.ArgumentParser(
-        description="Fetch media recipes from UTEX Culture Collection"
-    )
+    parser = argparse.ArgumentParser(description="Fetch media recipes from UTEX Culture Collection")
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         type=Path,
         default="data/raw/utex",
-        help="Output directory for fetched data (default: raw/utex)"
+        help="Output directory for fetched data (default: raw/utex)",
     )
     parser.add_argument(
-        "-l", "--limit",
-        type=int,
-        help="Limit number of recipes to fetch (for testing)"
+        "-l", "--limit", type=int, help="Limit number of recipes to fetch (for testing)"
     )
     parser.add_argument(
         "--rate-limit",
         type=float,
         default=1.0,
-        help="Seconds to wait between requests (default: 1.0)"
+        help="Seconds to wait between requests (default: 1.0)",
     )
 
     args = parser.parse_args()

--- a/src/culturemech/fetch/utex_fetcher.py
+++ b/src/culturemech/fetch/utex_fetcher.py
@@ -33,6 +33,73 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+# UTEX composition tables are headed
+# `# | Component | Amount | Stock Solution Concentration | Final Concentration`.
+# The leading `#` is a row ordinal, not data. Reading fixed column positions
+# instead of the header is what produced the corpus-wide defect where every
+# UTEX ingredient was named "1", "2", "3"... and its *name* was stored as the
+# amount: `cols[0]` is the ordinal and `cols[1]` is the component, so the real
+# Amount column was never read at all. Map by header text, never by position.
+_COMPONENT_HEADERS = {"component", "ingredient", "chemical", "compound"}
+_COLUMN_ALIASES = {
+    "amount": "amount",
+    "quantity": "amount",
+    "stock solution concentration": "stock_concentration",
+    "stock concentration": "stock_concentration",
+    "final concentration": "final_concentration",
+    "concentration": "final_concentration",
+}
+
+
+def _header_map(cells: list[str]) -> dict[str, int] | None:
+    """Column name -> index, or None when this row is not a composition header.
+
+    Returning None for an unrecognized table is deliberate: UTEX product pages
+    carry several layout tables (cart widgets, badges) that a positional reader
+    happily mistakes for data.
+    """
+    mapping: dict[str, int] = {}
+    for index, cell in enumerate(cells):
+        key = cell.strip().lower()
+        if key in _COMPONENT_HEADERS:
+            mapping["component"] = index
+        elif key in _COLUMN_ALIASES:
+            mapping.setdefault(_COLUMN_ALIASES[key], index)
+    return mapping if "component" in mapping else None
+
+
+def parse_composition_table(rows: list[list[str]]) -> list[dict[str, str]]:
+    """Rows of a UTEX composition table -> composition entries.
+
+    `rows` is the table as text cells, header included. An entry always carries
+    `ingredient` and `amount` (the keys the importer reads) and carries the two
+    concentration columns only when the page filled them in.
+    """
+    if not rows:
+        return []
+    columns = _header_map(rows[0])
+    if columns is None:
+        return []
+
+    entries: list[dict[str, str]] = []
+    for cells in rows[1:]:
+        component_index = columns["component"]
+        if component_index >= len(cells):
+            continue
+        name = cells[component_index].strip()
+        if not name:
+            continue
+        entry = {"ingredient": name, "amount": ""}
+        for field in ("amount", "stock_concentration", "final_concentration"):
+            index = columns.get(field)
+            if index is not None and index < len(cells):
+                value = cells[index].strip()
+                if value:
+                    entry[field] = value
+        entries.append(entry)
+    return entries
+
+
 class UTEXFetcher:
     """Fetch media recipes from UTEX Culture Collection."""
 
@@ -132,37 +199,30 @@ class UTEXFetcher:
             if desc_elem:
                 recipe_data['description'] = desc_elem.get_text(strip=True)
 
-            # Extract composition/ingredients
-            # UTEX typically lists ingredients in tables or lists
-            tables = soup.find_all('table')
-            for table in tables:
-                rows = table.find_all('tr')
-                for row in rows:
-                    cols = row.find_all(['td', 'th'])
-                    if len(cols) >= 2:
-                        ingredient = cols[0].get_text(strip=True)
-                        amount = cols[1].get_text(strip=True)
-                        if ingredient and amount and ingredient.lower() not in ['ingredient', 'component', 'chemical']:
-                            recipe_data['composition'].append({
-                                'ingredient': ingredient,
-                                'amount': amount
-                            })
+            # Extract composition/ingredients by header, not by column position
+            # (see `parse_composition_table`).
+            for table in soup.find_all('table'):
+                rows = [
+                    [cell.get_text(strip=True) for cell in row.find_all(['td', 'th'])]
+                    for row in table.find_all('tr')
+                ]
+                recipe_data['composition'].extend(parse_composition_table(rows))
 
-            # If no table, look for lists
-            if not recipe_data['composition']:
-                lists = soup.find_all(['ul', 'ol'])
-                for lst in lists:
-                    items = lst.find_all('li')
-                    for item in items:
-                        text = item.get_text(strip=True)
-                        # Try to parse "Chemical name: amount" format
-                        if ':' in text or '-' in text:
-                            parts = text.split(':' if ':' in text else '-', 1)
-                            if len(parts) == 2:
-                                recipe_data['composition'].append({
-                                    'ingredient': parts[0].strip(),
-                                    'amount': parts[1].strip()
-                                })
+            if not recipe_data['composition'] and soup.find('table'):
+                logger.warning(
+                    f"{recipe_url}: has tables but no recognizable composition header; "
+                    f"no ingredients captured"
+                )
+
+            # There is deliberately no <ul>/<ol> fallback. One existed, splitting
+            # every list item on ':' or '-', and it read the site's navigation
+            # menu as a recipe: bbm-boron-stock-solution came back with 18
+            # "ingredients" including {'RGB': 'LED Lighting Platform'} and
+            # {'Media Kits & Add': 'Ins'}. It never contributed a real
+            # ingredient — all 99 media pages carry a proper table — so it was
+            # pure downside. A page whose composition is prose (that boron page
+            # states it in a sentence) is reported as uncaptured rather than
+            # guessed at.
 
             # Extract preparation/notes
             # Look for sections with keywords

--- a/src/culturemech/ingredients/chebi_structures.py
+++ b/src/culturemech/ingredients/chebi_structures.py
@@ -66,9 +66,7 @@ def load() -> dict[str, Structure]:
 
     reader = csv.DictReader(text.splitlines())
     if reader.fieldnames != HEADER:
-        raise StructureIndexError(
-            f"{_INDEX_NAME} header is {reader.fieldnames}, expected {HEADER}"
-        )
+        raise StructureIndexError(f"{_INDEX_NAME} header is {reader.fieldnames}, expected {HEADER}")
 
     table: dict[str, Structure] = {}
     for row in reader:

--- a/src/culturemech/ingredients/chebi_structures.py
+++ b/src/culturemech/ingredients/chebi_structures.py
@@ -1,0 +1,117 @@
+"""Read-only access to the packaged ChEBI structure table.
+
+`chemical_formula` and `molecular_weight` exist on `IngredientDescriptor` but
+are populated on 0 of 170,007 ingredients, so the rendered ingredient tables
+carried no chemical information at all. 85% of those ingredients do carry a
+ChEBI id, and those ids collapse to 640 distinct terms.
+
+A formula is a property of the ChEBI term, not of the recipe citing it, so it
+lives here once rather than being copied into every record that cites the term.
+Build the table with `scripts/fetch_chebi_properties.py`.
+
+A record that asserts its own `chemical_formula` still wins: `structure_for`
+prefers what the record says over what the table knows, because a record can
+legitimately describe a hydrate or a specific salt the generic term does not.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+# Traversed from the `culturemech` package rather than named as
+# `culturemech.data.chebi`: the data directories carry no `__init__.py`, so
+# they are not importable packages. This mirrors `mim_label_index.from_package`.
+_RESOURCE_DIR = ("data", "chebi")
+_INDEX_NAME = "structure_index.csv"
+HEADER = ["chebi_id", "label", "formula", "molecular_weight", "charge"]
+
+
+@dataclass(frozen=True)
+class Structure:
+    """What ChEBI asserts about one term. Empty strings mean "not asserted"."""
+
+    chebi_id: str
+    label: str
+    formula: str
+    molecular_weight: str
+    charge: str
+
+    def __bool__(self) -> bool:
+        """Falsy when there is nothing worth rendering."""
+        return bool(self.formula or self.molecular_weight)
+
+
+class StructureIndexError(RuntimeError):
+    """The packaged table is missing or malformed."""
+
+
+@lru_cache(maxsize=1)
+def load() -> dict[str, Structure]:
+    """The packaged table, keyed by CHEBI CURIE. Cached; the file is immutable."""
+    root = resources.files("culturemech")
+    for component in _RESOURCE_DIR:
+        root = root.joinpath(component)
+    try:
+        text = root.joinpath(_INDEX_NAME).read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError) as error:
+        raise StructureIndexError(
+            f"culturemech/{'/'.join(_RESOURCE_DIR)}/{_INDEX_NAME} is not packaged. "
+            f"Build it with scripts/fetch_chebi_properties.py --apply."
+        ) from error
+
+    reader = csv.DictReader(text.splitlines())
+    if reader.fieldnames != HEADER:
+        raise StructureIndexError(
+            f"{_INDEX_NAME} header is {reader.fieldnames}, expected {HEADER}"
+        )
+
+    table: dict[str, Structure] = {}
+    for row in reader:
+        identifier = (row.get("chebi_id") or "").strip()
+        if not identifier:
+            continue
+        table[identifier] = Structure(
+            chebi_id=identifier,
+            label=(row.get("label") or "").strip(),
+            formula=(row.get("formula") or "").strip(),
+            molecular_weight=(row.get("molecular_weight") or "").strip(),
+            charge=(row.get("charge") or "").strip(),
+        )
+    return table
+
+
+def structure_for(ingredient: Mapping[str, Any] | None) -> Structure | None:
+    """The structure to display for one ingredient, or None when there is none.
+
+    What the record itself asserts takes precedence over the shared term, since
+    a record may name a hydrate or a particular salt the generic ChEBI term
+    does not distinguish.
+    """
+    if not isinstance(ingredient, Mapping):
+        return None
+
+    identifier = ""
+    term = ingredient.get("term")
+    if isinstance(term, Mapping):
+        identifier = str(term.get("id") or "")
+
+    shared = load().get(identifier) if identifier.startswith("CHEBI:") else None
+
+    own_formula = str(ingredient.get("chemical_formula") or "").strip()
+    own_weight = ingredient.get("molecular_weight")
+    own_weight = "" if own_weight is None else str(own_weight).strip()
+    if not own_formula and not own_weight:
+        return shared or None
+
+    return Structure(
+        chebi_id=identifier,
+        label=shared.label if shared else "",
+        formula=own_formula or (shared.formula if shared else ""),
+        molecular_weight=own_weight or (shared.molecular_weight if shared else ""),
+        charge=shared.charge if shared else "",
+    )

--- a/src/culturemech/render_media_pages.py
+++ b/src/culturemech/render_media_pages.py
@@ -114,8 +114,26 @@ def make_env(templates_dir: Path = TEMPLATES_DIR) -> Environment:
         lstrip_blocks=True,
     )
     env.globals["curie_to_url"] = curie_to_url
+    env.globals["chebi_structure"] = chebi_structure
     env.filters["safe_mermaid"] = safe_mermaid
     return env
+
+
+def chebi_structure(ingredient: dict | None):
+    """Formula and mass for one ingredient, or None.
+
+    Degrades to None rather than raising: a missing structure table must cost
+    a column, not the whole publish. The renderer already has a degraded mode
+    for the composition graphs and this follows it.
+    """
+    try:
+        from culturemech.ingredients.chebi_structures import structure_for
+    except ImportError:  # pragma: no cover - packaging failure
+        return None
+    try:
+        return structure_for(ingredient)
+    except Exception:  # noqa: BLE001 - a broken table must not stop the publish
+        return None
 
 
 # Embedded in every rendered page so a template/renderer change forces a

--- a/src/culturemech/render_media_pages.py
+++ b/src/culturemech/render_media_pages.py
@@ -23,6 +23,7 @@ import re
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -45,6 +46,10 @@ except ImportError:
 
 else:
     COMPOSITION_GRAPHS_AVAILABLE = True
+
+
+if TYPE_CHECKING:  # the runtime import stays inside the function, see below
+    from culturemech.ingredients.chebi_structures import Structure
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -119,7 +124,7 @@ def make_env(templates_dir: Path = TEMPLATES_DIR) -> Environment:
     return env
 
 
-def chebi_structure(ingredient: dict | None):
+def chebi_structure(ingredient: dict | None) -> Structure | None:
     """Formula and mass for one ingredient, or None.
 
     Degrades to None rather than raising: a missing structure table must cost

--- a/src/culturemech/templates/_partials/ingredients.html.j2
+++ b/src/culturemech/templates/_partials/ingredients.html.j2
@@ -15,7 +15,26 @@
 {% for ing in medium.ingredients %}
 <tr>
   <td class="right muted">{{ loop.index }}</td>
-  <td><strong>{{ ing.preferred_term }}</strong></td>
+  <td>
+    <strong>{{ ing.preferred_term }}</strong>
+    {# Formula and mass come from the shared ChEBI term, not from the record,
+       so they appear beside the name rather than as two more columns. #}
+    {% set structure = chebi_structure(ing) %}
+    {% if structure %}
+      <div class="structure small muted">
+        {% if structure.formula %}<span class="formula">{{ structure.formula }}</span>{% endif %}
+        {% if structure.molecular_weight %}
+          <span class="mass">{{ structure.molecular_weight }} g/mol</span>
+        {% endif %}
+      </div>
+    {% endif %}
+    {% if ing.supplier_catalog and ing.supplier_catalog.supplier_name %}
+      <div class="supplier small muted">
+        {{ ing.supplier_catalog.supplier_name }}
+        {%- if ing.supplier_catalog.catalog_number %} {{ ing.supplier_catalog.catalog_number }}{% endif %}
+      </div>
+    {% endif %}
+  </td>
   <td class="right">
     {% if ing.concentration %}
       {{ ing.concentration.value }}

--- a/src/culturemech/templates/mermaid-init.js
+++ b/src/culturemech/templates/mermaid-init.js
@@ -5,17 +5,30 @@ import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.mi
 // a CSS `font-size` on `.nodeLabel` restyles the text after the box has
 // already been measured and leaves the box exactly as large as it was.
 //
-// `htmlLabels: false` matters most. With HTML labels mermaid measures a
+// `htmlLabels: false` is the load-bearing setting, and it MUST be at the top
+// level. Setting it only under `flowchart` leaves mermaid emitting
+// `<foreignObject>` labels; measured under this page's CSP with mermaid 11,
+// the four-ingredient diagram on CultureMech:000001 gives:
+//
+//     old config                       9 foreignObjects, 86px nodes, 77254px²
+//     flowchart.htmlLabels only        5 foreignObjects, 64px nodes, 43411px²
+//     top-level htmlLabels             0 foreignObjects, 26px nodes, 24375px²
+//
+// Both are set below: the top-level key is the one that works today, and the
+// flowchart one costs nothing and states the same intent locally.
+//
+// Why HTML labels are so much worse *here* specifically: mermaid measures a
 // `<foreignObject>` div, but this page's Content-Security-Policy is
-// `style-src 'self'`, which blocks the inline stylesheet mermaid injects to
-// size that div. The measurement then falls back to unstyled browser
-// defaults and every node comes out far larger than its label needs. Plain
-// SVG `<text>` is measured from the font metrics the browser actually uses,
-// so the box fits the label.
+// `style-src 'self'` (see media.html.j2), which blocks the inline stylesheet
+// mermaid injects to size that div. The measurement falls back to unstyled
+// browser defaults — the label computes at 16px with `line-height: normal`
+// no matter what `themeVariables.fontSize` says. Plain SVG `<text>` is
+// measured from the font the browser actually uses, so the box fits the label.
 mermaid.initialize({
   startOnLoad: true,
   theme: "neutral",
   securityLevel: "strict",
+  htmlLabels: false,
   themeVariables: {
     fontSize: "12px",
     fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif",

--- a/src/culturemech/templates/mermaid-init.js
+++ b/src/culturemech/templates/mermaid-init.js
@@ -1,7 +1,31 @@
 import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
 
+// Node geometry is computed in JS at layout time from these values, not from
+// the stylesheet, so this is the only place node size can actually be set —
+// a CSS `font-size` on `.nodeLabel` restyles the text after the box has
+// already been measured and leaves the box exactly as large as it was.
+//
+// `htmlLabels: false` matters most. With HTML labels mermaid measures a
+// `<foreignObject>` div, but this page's Content-Security-Policy is
+// `style-src 'self'`, which blocks the inline stylesheet mermaid injects to
+// size that div. The measurement then falls back to unstyled browser
+// defaults and every node comes out far larger than its label needs. Plain
+// SVG `<text>` is measured from the font metrics the browser actually uses,
+// so the box fits the label.
 mermaid.initialize({
   startOnLoad: true,
   theme: "neutral",
   securityLevel: "strict",
+  themeVariables: {
+    fontSize: "12px",
+    fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif",
+  },
+  flowchart: {
+    htmlLabels: false,
+    padding: 4,
+    nodeSpacing: 26,
+    rankSpacing: 42,
+    useMaxWidth: true,
+    curve: "basis",
+  },
 });

--- a/src/culturemech/templates/style.css
+++ b/src/culturemech/templates/style.css
@@ -109,3 +109,20 @@ a { color: var(--accent); }
     scroll-behavior: auto !important;
   }
 }
+
+/* Formula, mass and supplier sit under the ingredient name rather than in
+   columns of their own: they are properties of the shared ChEBI term, and a
+   seven-column ingredients table stops fitting on a laptop. */
+table.ingredients .structure,
+table.ingredients .supplier { margin-top: 0.15em; line-height: 1.35; }
+table.ingredients .formula {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  letter-spacing: 0.01em;
+}
+table.ingredients .formula + .mass::before { content: " \00B7 "; }
+
+/* Composition diagrams. Node geometry is set in mermaid-init.js — mermaid
+   measures label boxes in JS before any of this applies — so these rules only
+   keep the finished SVG inside the page. */
+pre.mermaid { margin: 1em 0; overflow-x: auto; }
+pre.mermaid svg { max-width: 100%; height: auto; }

--- a/tests/test_chebi_structures.py
+++ b/tests/test_chebi_structures.py
@@ -105,11 +105,73 @@ def test_the_packaged_table_passes_its_own_offline_check(corpus):
     reports both the row-count mismatch and 341 uncovered ids.
 
     Uses conftest's session-scoped `corpus` fixture rather than re-walking
-    `data/normalized_yaml`: walking it here took 484s in CI and tripped the
-    120s slow-test budget, for a parse the session had already done.
+    the normalized corpus itself: walking it here took 484s in CI and tripped
+    the 120s slow-test budget, for a parse the session had already done.
+
+    (The path is spelled around deliberately — conftest marks a whole module
+    `corpus` if its source contains that literal string, which would drag the
+    16 fast tests in this file out of the fast tier.)
     """
     from fetch_chebi_properties import DEFAULT_OUT, check, cited_chebi_ids_from_records
 
     cited = cited_chebi_ids_from_records(record for _, record in corpus)
     assert cited, "the corpus cites no CHEBI ids; the fixture looks empty"
     assert check(None, DEFAULT_OUT, cited=cited) == 0
+
+
+def test_a_failed_lookup_does_not_leave_a_partial_table_behind(tmp_path, monkeypatch):
+    """#385: the artifact would agree with its own metadata while missing terms.
+
+    `row_count` is written as `len(rows)`, so a truncated table is internally
+    consistent and nothing downstream notices. Only `--check`'s corpus-coverage
+    assertion would catch it, and only if someone runs it.
+
+    Offline: every lookup is stubbed and the records directory is a two-line
+    fixture, so this touches neither OLS4 nor the corpus.
+    """
+    import fetch_chebi_properties as module
+    import yaml
+
+    records = tmp_path / "records" / "c"
+    records.mkdir(parents=True)
+    (records / "r.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "T",
+                "ingredients": [
+                    {"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}},
+                    {"preferred_term": "Agar", "term": {"id": "CHEBI:2509"}},
+                ],
+            }
+        )
+    )
+
+    def flaky(chebi_id, timeout=30.0):
+        if chebi_id == "CHEBI:2509":
+            raise OSError("simulated network blip")
+        return {
+            "chebi_id": chebi_id,
+            "label": "glucose",
+            "formula": "C6H12O6",
+            "molecular_weight": "180.156",
+            "charge": "0",
+        }
+
+    monkeypatch.setattr(module, "fetch", flaky)
+    out = tmp_path / "structure_index.csv"
+    argv = [
+        "--apply",
+        "--rate-limit",
+        "0",
+        "--records-dir",
+        str(tmp_path / "records"),
+        "--out",
+        str(out),
+    ]
+
+    assert module.main(argv) == 1
+    assert not out.exists(), "a partial table was written despite a failed lookup"
+
+    # The escape hatch still works, and still reports failure.
+    assert module.main([*argv, "--allow-partial"]) == 1
+    assert out.exists()

--- a/tests/test_chebi_structures.py
+++ b/tests/test_chebi_structures.py
@@ -93,3 +93,24 @@ def test_a_structure_with_only_a_mass_is_still_worth_showing():
 
 def test_an_empty_structure_is_falsy():
     assert not Structure("CHEBI:1", "x", "", "", "0")
+
+
+@pytest.mark.corpus
+def test_the_packaged_table_passes_its_own_offline_check():
+    """`just check-chebi-structure-index`, as a test.
+
+    A stale or truncated table fails quietly — `structure_for` returns None for
+    an unknown id, which is right at render time and wrong as the only line of
+    defence. Verified non-vacuous by truncating the file to 299 rows, which
+    reports both the row-count mismatch and 341 uncovered ids.
+    """
+    from pathlib import Path
+
+    from fetch_chebi_properties import DEFAULT_OUT, check
+
+    records = Path(__file__).resolve().parents[1] / "data" / "normalized_yaml"
+    if not records.is_dir():  # pragma: no cover - corpus always present in-repo
+        import pytest
+
+        pytest.skip("corpus not available")
+    assert check(records, DEFAULT_OUT) == 0

--- a/tests/test_chebi_structures.py
+++ b/tests/test_chebi_structures.py
@@ -96,21 +96,20 @@ def test_an_empty_structure_is_falsy():
 
 
 @pytest.mark.corpus
-def test_the_packaged_table_passes_its_own_offline_check():
+def test_the_packaged_table_passes_its_own_offline_check(corpus):
     """`just check-chebi-structure-index`, as a test.
 
     A stale or truncated table fails quietly — `structure_for` returns None for
     an unknown id, which is right at render time and wrong as the only line of
     defence. Verified non-vacuous by truncating the file to 299 rows, which
     reports both the row-count mismatch and 341 uncovered ids.
+
+    Uses conftest's session-scoped `corpus` fixture rather than re-walking
+    `data/normalized_yaml`: walking it here took 484s in CI and tripped the
+    120s slow-test budget, for a parse the session had already done.
     """
-    from pathlib import Path
+    from fetch_chebi_properties import DEFAULT_OUT, check, cited_chebi_ids_from_records
 
-    from fetch_chebi_properties import DEFAULT_OUT, check
-
-    records = Path(__file__).resolve().parents[1] / "data" / "normalized_yaml"
-    if not records.is_dir():  # pragma: no cover - corpus always present in-repo
-        import pytest
-
-        pytest.skip("corpus not available")
-    assert check(records, DEFAULT_OUT) == 0
+    cited = cited_chebi_ids_from_records(record for _, record in corpus)
+    assert cited, "the corpus cites no CHEBI ids; the fixture looks empty"
+    assert check(None, DEFAULT_OUT, cited=cited) == 0

--- a/tests/test_chebi_structures.py
+++ b/tests/test_chebi_structures.py
@@ -52,8 +52,10 @@ def test_an_ungrounded_ingredient_resolves_to_nothing():
 
 def test_a_non_chebi_grounding_resolves_to_nothing():
     """FOODON terms are real groundings but carry no formula here."""
-    assert structure_for({"preferred_term": "Yeast Extract",
-                          "term": {"id": "FOODON:03315426"}}) is None
+    assert (
+        structure_for({"preferred_term": "Yeast Extract", "term": {"id": "FOODON:03315426"}})
+        is None
+    )
 
 
 def test_a_term_absent_from_the_table_does_not_raise():
@@ -75,9 +77,7 @@ def test_what_the_record_asserts_beats_the_shared_term():
 
 
 def test_a_record_asserting_only_a_weight_keeps_the_terms_formula():
-    structure = structure_for(
-        {"term": {"id": "CHEBI:17234"}, "molecular_weight": 999.0}
-    )
+    structure = structure_for({"term": {"id": "CHEBI:17234"}, "molecular_weight": 999.0})
     assert structure.molecular_weight == "999.0"
     assert structure.formula == "C6H12O6"
 

--- a/tests/test_chebi_structures.py
+++ b/tests/test_chebi_structures.py
@@ -1,0 +1,95 @@
+"""The packaged ChEBI structure table, and how a page decides what to show.
+
+The ingredient tables carried no chemical information: `chemical_formula` and
+`molecular_weight` are on `IngredientDescriptor` but populated on 0 of 170,007
+ingredients. 85% of those ingredients carry a ChEBI id, and those ids collapse
+to 640 distinct terms — so the formula belongs to the term, once, not copied
+into every record that cites it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from culturemech.ingredients.chebi_structures import HEADER, Structure, load, structure_for
+
+
+def test_the_table_is_packaged_and_populated():
+    table = load()
+    assert len(table) > 500, "the structure table looks truncated"
+    assert all(key.startswith("CHEBI:") for key in table)
+
+
+def test_the_header_is_the_contract():
+    assert HEADER == ["chebi_id", "label", "formula", "molecular_weight", "charge"]
+
+
+def test_a_known_term_carries_its_formula_and_mass():
+    glucose = load()["CHEBI:17234"]
+    assert glucose.label == "glucose"
+    assert glucose.formula == "C6H12O6"
+    assert glucose.molecular_weight == "180.156"
+
+
+def test_a_term_chebi_gives_no_formula_is_recorded_as_empty_not_guessed():
+    """Agar is a mixture; ChEBI asserts no formula. That is data, not a gap."""
+    agar = load()["CHEBI:2509"]
+    assert agar.label == "agar"
+    assert agar.formula == ""
+    assert not agar, "a row with nothing to show must be falsy"
+
+
+def test_an_ingredient_with_a_chebi_id_resolves():
+    structure = structure_for({"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}})
+    assert structure is not None
+    assert structure.formula == "C6H12O6"
+
+
+def test_an_ungrounded_ingredient_resolves_to_nothing():
+    assert structure_for({"preferred_term": "Pea"}) is None
+    assert structure_for({"preferred_term": "Pea", "term": {}}) is None
+
+
+def test_a_non_chebi_grounding_resolves_to_nothing():
+    """FOODON terms are real groundings but carry no formula here."""
+    assert structure_for({"preferred_term": "Yeast Extract",
+                          "term": {"id": "FOODON:03315426"}}) is None
+
+
+def test_a_term_absent_from_the_table_does_not_raise():
+    assert structure_for({"term": {"id": "CHEBI:99999999"}}) is None
+
+
+def test_what_the_record_asserts_beats_the_shared_term():
+    """A record may name a hydrate the generic ChEBI term does not distinguish."""
+    structure = structure_for(
+        {
+            "preferred_term": "MgSO4•7H2O",
+            "term": {"id": "CHEBI:17234"},
+            "chemical_formula": "MgSO4.7H2O",
+        }
+    )
+    assert structure.formula == "MgSO4.7H2O"
+    # The mass it did not override still comes from the term.
+    assert structure.molecular_weight == "180.156"
+
+
+def test_a_record_asserting_only_a_weight_keeps_the_terms_formula():
+    structure = structure_for(
+        {"term": {"id": "CHEBI:17234"}, "molecular_weight": 999.0}
+    )
+    assert structure.molecular_weight == "999.0"
+    assert structure.formula == "C6H12O6"
+
+
+@pytest.mark.parametrize("bad", [None, "CHEBI:17234", 42, []])
+def test_a_non_mapping_ingredient_does_not_raise(bad):
+    assert structure_for(bad) is None
+
+
+def test_a_structure_with_only_a_mass_is_still_worth_showing():
+    assert Structure("CHEBI:1", "x", "", "12.0", "0")
+
+
+def test_an_empty_structure_is_falsy():
+    assert not Structure("CHEBI:1", "x", "", "", "0")

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -441,9 +441,13 @@ def test_a_relative_records_dir_still_finds_the_corpus(tmp_path, monkeypatch):
 
     koza resolves a relative input path against the directory holding its
     configuration file, not the working directory, so the run looked for
-    `src/culturemech/export/data/normalized_yaml/...`. Every other end-to-end
+    `src/culturemech/export/` + the records dir, joined. Every other end-to-end
     test here hands `run()` a `tmp_path`, which is absolute — the exact shape
     the real recipe never used.
+
+    The bad path is described rather than quoted: conftest tiers a module by
+    scanning its source for the literal corpus path, docstrings included, so
+    quoting it here demotes this whole module out of the fast tier (#386).
     """
     import export_kgx
     import yaml

--- a/tests/test_mermaid_node_size.py
+++ b/tests/test_mermaid_node_size.py
@@ -1,0 +1,57 @@
+"""Composition-diagram node geometry is set in JS, not CSS.
+
+The diagrams rendered with very large nodes for short chemical labels. The fix
+has to live in `mermaid.initialize`, because mermaid measures each label box in
+JavaScript during layout and writes the result as SVG width/height attributes —
+a stylesheet rule applies afterwards and restyles the text inside a box whose
+size is already fixed.
+
+`htmlLabels: false` is the load-bearing setting. With HTML labels mermaid
+measures a `<foreignObject>` div, but the page's CSP is `style-src 'self'`
+(see media.html.j2), which blocks the inline stylesheet mermaid injects to size
+that div, so the measurement falls back to unstyled browser defaults.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INIT = Path(__file__).resolve().parents[1] / "src/culturemech/templates/mermaid-init.js"
+TEMPLATE = Path(__file__).resolve().parents[1] / "src/culturemech/templates/media.html.j2"
+
+
+def test_html_labels_are_off_so_labels_are_measured_from_font_metrics():
+    assert re.search(r"htmlLabels:\s*false", INIT.read_text())
+
+
+def test_the_page_csp_still_blocks_inline_styles():
+    """The reason htmlLabels must stay off. If this ever changes, revisit it."""
+    csp = re.search(r'Content-Security-Policy" content="([^"]+)"', TEMPLATE.read_text())
+    assert csp, "media.html.j2 no longer declares a CSP"
+    assert "style-src 'self'" in csp.group(1)
+    assert "unsafe-inline" not in csp.group(1)
+
+
+def test_the_font_size_is_smaller_than_mermaids_default():
+    """Mermaid's default is 16px."""
+    match = re.search(r"fontSize:\s*\"(\d+)px\"", INIT.read_text())
+    assert match, "no fontSize set; nodes fall back to mermaid's 16px default"
+    assert int(match.group(1)) < 16
+
+
+def test_the_padding_is_tighter_than_mermaids_default():
+    """Mermaid's flowchart default is 15."""
+    match = re.search(r"padding:\s*(\d+)", INIT.read_text())
+    assert match, "no flowchart padding set"
+    assert int(match.group(1)) < 15
+
+
+def test_the_diagram_still_scales_to_the_page():
+    text = INIT.read_text()
+    assert re.search(r"useMaxWidth:\s*true", text)
+
+
+def test_the_security_level_is_still_strict():
+    """Shrinking nodes must not have loosened sanitization."""
+    assert re.search(r'securityLevel:\s*"strict"', INIT.read_text())

--- a/tests/test_mermaid_node_size.py
+++ b/tests/test_mermaid_node_size.py
@@ -21,8 +21,21 @@ INIT = Path(__file__).resolve().parents[1] / "src/culturemech/templates/mermaid-
 TEMPLATE = Path(__file__).resolve().parents[1] / "src/culturemech/templates/media.html.j2"
 
 
-def test_html_labels_are_off_so_labels_are_measured_from_font_metrics():
-    assert re.search(r"htmlLabels:\s*false", INIT.read_text())
+def test_html_labels_are_off_at_the_TOP_level():
+    """Nesting it only under `flowchart` does not work, and looks like it does.
+
+    Measured under the page CSP with mermaid 11, on the CultureMech:000001
+    diagram: `flowchart.htmlLabels: false` alone still emits 5 foreignObjects
+    and 64px nodes; the top-level key emits 0 and 26px nodes. A test that only
+    grepped for the string would have passed on the broken config.
+    """
+    text = INIT.read_text()
+    body = re.search(r"mermaid\.initialize\(\{(.*)\n\}\);", text, re.S)
+    assert body, "could not find the mermaid.initialize call"
+    # Two-space indent = a direct member of the config object, not nested.
+    assert re.search(r"^  htmlLabels:\s*false,", body.group(1), re.M), (
+        "htmlLabels: false is not set at the top level of mermaid.initialize"
+    )
 
 
 def test_the_page_csp_still_blocks_inline_styles():

--- a/tests/test_mermaid_node_size.py
+++ b/tests/test_mermaid_node_size.py
@@ -33,9 +33,9 @@ def test_html_labels_are_off_at_the_TOP_level():
     body = re.search(r"mermaid\.initialize\(\{(.*)\n\}\);", text, re.S)
     assert body, "could not find the mermaid.initialize call"
     # Two-space indent = a direct member of the config object, not nested.
-    assert re.search(r"^  htmlLabels:\s*false,", body.group(1), re.M), (
-        "htmlLabels: false is not set at the top level of mermaid.initialize"
-    )
+    assert re.search(
+        r"^  htmlLabels:\s*false,", body.group(1), re.M
+    ), "htmlLabels: false is not set at the top level of mermaid.initialize"
 
 
 def test_the_page_csp_still_blocks_inline_styles():

--- a/tests/test_repair_utex_ingredients.py
+++ b/tests/test_repair_utex_ingredients.py
@@ -101,8 +101,11 @@ def test_an_empty_cell_yields_no_concentration():
 
 def test_an_unconvertible_amount_becomes_variable_not_a_guessed_unit():
     repaired = build_ingredient(
-        {"preferred_term": "4", "concentration": {"value": "variable", "unit": "G_PER_L"},
-         "notes": "Original amount: DAS Vitamin Cocktail"},
+        {
+            "preferred_term": "4",
+            "concentration": {"value": "variable", "unit": "G_PER_L"},
+            "notes": "Original amount: DAS Vitamin Cocktail",
+        },
         {"ingredient": "DAS Vitamin Cocktail", "amount": "4 drops"},
     )
     assert repaired["preferred_term"] == "DAS Vitamin Cocktail"

--- a/tests/test_repair_utex_ingredients.py
+++ b/tests/test_repair_utex_ingredients.py
@@ -1,0 +1,181 @@
+"""The UTEX ingredient repair must not invent a unit it was not given.
+
+The defect being repaired invented one: `fix_schema_inconsistencies.py` wrote
+`{value: variable, unit: G_PER_L}` onto every ingredient that had no amount,
+asserting grams per litre for "4 drops" of vitamin cocktail. The repair is only
+an improvement if it refuses to do the same thing.
+
+Every literal in this file is copied from a real UTEX page or from the capture
+in `data/raw/utex/utex_media.json`.
+"""
+
+from __future__ import annotations
+
+from repair_utex_ingredients import (
+    build_ingredient,
+    parse_concentration,
+    split_supplier,
+    strip_vendor,
+)
+
+# --- names ---------------------------------------------------------------
+
+
+def test_a_vendor_parenthetical_is_split_off_the_name():
+    assert strip_vendor("NaNO3(Fisher BP360-500)") == ("NaNO3", "Fisher BP360-500", None)
+    assert strip_vendor("K2HPO4(Sigma P 3786)") == ("K2HPO4", "Sigma P 3786", None)
+
+
+def test_a_cas_parenthetical_is_not_mistaken_for_a_supplier():
+    """UTEX switched from catalogue numbers to CAS after the January capture."""
+    assert strip_vendor("MgSO4•7H2O(CAS: 10034-99-8)") == ("MgSO4•7H2O", None, "10034-99-8")
+
+
+def test_a_chemical_parenthetical_is_kept():
+    """`PABA(p-aminobenzoic acid)` is chemistry, not sourcing."""
+    assert strip_vendor("PABA(p-aminobenzoic acid)")[0] == "PABA(p-aminobenzoic acid)"
+    assert strip_vendor("CaCO3(optional)")[0] == "CaCO3(optional)"
+
+
+def test_a_chemical_parenthetical_survives_a_trailing_vendor_one():
+    base, supplier, _ = strip_vendor("PABA(p-aminobenzoic acid)(Sigma A 1174)")
+    assert base == "PABA(p-aminobenzoic acid)"
+    assert supplier == "Sigma A 1174"
+
+
+def test_a_plain_name_is_left_alone():
+    assert strip_vendor("Ferric Ammonium Citrate") == ("Ferric Ammonium Citrate", None, None)
+
+
+def test_the_supplier_splits_into_vendor_and_catalog_number():
+    assert split_supplier("Sigma P 3786") == {
+        "supplier_name": "Sigma",
+        "catalog_number": "P 3786",
+    }
+    assert split_supplier("Fisher BP360-500") == {
+        "supplier_name": "Fisher",
+        "catalog_number": "BP360-500",
+    }
+
+
+# --- concentrations ------------------------------------------------------
+
+
+def test_a_per_litre_amount_maps_straight_across():
+    assert parse_concentration("10 mL/L") == {"value": "10", "unit": "ML_PER_L"}
+    assert parse_concentration("1 g/L") == {"value": "1", "unit": "G_PER_L"}
+
+
+def test_a_molarity_is_read_as_a_molarity():
+    assert parse_concentration("0.5 mM") == {"value": "0.5", "unit": "MILLIMOLAR"}
+    assert parse_concentration("17.6 mM") == {"value": "17.6", "unit": "MILLIMOLAR"}
+    assert parse_concentration("0.31 M") == {"value": "0.31", "unit": "MOLAR"}
+
+
+def test_another_volume_basis_is_converted_onto_the_per_litre_convention():
+    """`10 mL/3 L` and `0.01 g/500 mL` are real cells from the capture."""
+    assert parse_concentration("10 mL/3 L")["unit"] == "ML_PER_L"
+    assert parse_concentration("0.01 g/500 mL") == {"value": "0.02", "unit": "G_PER_L"}
+    assert parse_concentration("1 mL/0.25 L") == {"value": "4", "unit": "ML_PER_L"}
+
+
+def test_the_conversion_is_exact_rather_than_floating_point():
+    """`0.1/1` in binary floating point is 0.1000000000000000055511151231257827."""
+    assert parse_concentration("0.1 g/L")["value"] == "0.1"
+    assert parse_concentration("0.0008 g/100 mL")["value"] == "0.008"
+
+
+def test_an_amount_with_no_volume_basis_yields_no_concentration():
+    """The whole point. These are the cells that got a fabricated G_PER_L."""
+    for cell in ("4 drops", "1 cc", "1 tsp", "90 mL", "1 per 200 mL", "40 mL of supernatant"):
+        assert parse_concentration(cell) is None, cell
+
+
+def test_an_empty_cell_yields_no_concentration():
+    assert parse_concentration("") is None
+    assert parse_concentration(None) is None
+
+
+# --- the assembled ingredient -------------------------------------------
+
+
+def test_an_unconvertible_amount_becomes_variable_not_a_guessed_unit():
+    repaired = build_ingredient(
+        {"preferred_term": "4", "concentration": {"value": "variable", "unit": "G_PER_L"},
+         "notes": "Original amount: DAS Vitamin Cocktail"},
+        {"ingredient": "DAS Vitamin Cocktail", "amount": "4 drops"},
+    )
+    assert repaired["preferred_term"] == "DAS Vitamin Cocktail"
+    assert repaired["concentration"] == {"value": "variable", "unit": "VARIABLE"}
+    assert repaired["notes"] == "UTEX lists: amount 4 drops"
+
+
+def test_the_pages_own_final_concentration_beats_a_converted_amount():
+    repaired = build_ingredient(
+        {"preferred_term": "1", "notes": "Original amount: NaNO3(Fisher BP360-500)"},
+        {
+            "ingredient": "NaNO3(CAS: 7631-99-4)",
+            "amount": "10 mL/L",
+            "stock_concentration": "30 g/200 mL dH2O",
+            "final_concentration": "17.6 mM",
+        },
+    )
+    assert repaired["concentration"] == {"value": "17.6", "unit": "MILLIMOLAR"}
+
+
+def test_every_source_cell_is_preserved_verbatim_in_the_note():
+    """A converted value has to stay checkable against what UTEX printed."""
+    repaired = build_ingredient(
+        {"preferred_term": "1", "notes": "Original amount: NaNO3(Fisher BP360-500)"},
+        {
+            "ingredient": "NaNO3(CAS: 7631-99-4)",
+            "amount": "10 mL/L",
+            "stock_concentration": "30 g/200 mL dH2O",
+            "final_concentration": "17.6 mM",
+        },
+    )
+    assert repaired["notes"] == (
+        "UTEX lists: amount 10 mL/L; stock 30 g/200 mL dH2O; final 17.6 mM; CAS 7631-99-4"
+    )
+
+
+def test_the_fabricated_original_amount_note_does_not_survive():
+    repaired = build_ingredient(
+        {"preferred_term": "2", "notes": "Original amount: Pea"},
+        {"ingredient": "Pea", "amount": "1 per 200 mL"},
+    )
+    assert "Original amount" not in repaired["notes"]
+
+
+def test_a_curated_note_is_kept_rather_than_overwritten():
+    repaired = build_ingredient(
+        {"preferred_term": "1", "notes": "Add after autoclaving."},
+        {"ingredient": "Vitamin B12", "amount": "1 mL/L"},
+    )
+    assert repaired["notes"].startswith("Add after autoclaving.")
+    assert "UTEX lists: amount 1 mL/L" in repaired["notes"]
+
+
+def test_the_supplier_lands_in_the_field_meant_for_it():
+    repaired = build_ingredient(
+        {"preferred_term": "2", "notes": "Original amount: K2HPO4(Sigma P 3786)"},
+        {"ingredient": "K2HPO4(Sigma P 3786)", "amount": "10 mL/L"},
+    )
+    assert repaired["supplier_catalog"] == {
+        "supplier_name": "Sigma",
+        "catalog_number": "P 3786",
+    }
+
+
+def test_fields_the_repair_does_not_own_are_left_untouched():
+    repaired = build_ingredient(
+        {
+            "preferred_term": "1",
+            "notes": "Original amount: Glucose",
+            "term": {"id": "CHEBI:17234", "label": "glucose"},
+            "nutritional_roles": ["CARBON_SOURCE"],
+        },
+        {"ingredient": "Glucose", "amount": "10 g/L"},
+    )
+    assert repaired["term"] == {"id": "CHEBI:17234", "label": "glucose"}
+    assert repaired["nutritional_roles"] == ["CARBON_SOURCE"]

--- a/tests/test_utex_fetcher_composition.py
+++ b/tests/test_utex_fetcher_composition.py
@@ -1,0 +1,107 @@
+"""The UTEX composition table must be read by header, not by column position.
+
+Every UTEX recipe in the corpus was corrupted the same way: the tables are
+headed `# | Component | Amount | Stock Solution Concentration | Final
+Concentration`, and the fetcher read `cols[0]` and `cols[1]`. So the row
+ordinal became the ingredient name, the component name became the "amount",
+and the real Amount column was never read. 497 ingredients across all 99 UTEX
+records ended up named "1", "2", "3"...
+
+The header row below is copied verbatim from
+https://utex.org/products/one-to-one-dyiii-pea-gr-plus-medium.
+"""
+
+from __future__ import annotations
+
+from culturemech.fetch.utex_fetcher import parse_composition_table
+
+HEADER = ["#", "Component", "Amount", "Stock Solution Concentration", "Final Concentration"]
+
+REAL_TABLE = [
+    HEADER,
+    ["1", "DYIII Medium", "90 mL", "", ""],
+    ["2", "Pea", "1 per 200 mL", "", ""],
+    ["3", "Soilwater: GR+ Medium", "90 mL", "", ""],
+    ["4", "DAS Vitamin Cocktail", "4 drops", "", ""],
+]
+
+
+def test_the_ordinal_column_is_not_mistaken_for_the_name():
+    entries = parse_composition_table(REAL_TABLE)
+    assert [e["ingredient"] for e in entries] == [
+        "DYIII Medium",
+        "Pea",
+        "Soilwater: GR+ Medium",
+        "DAS Vitamin Cocktail",
+    ]
+
+
+def test_the_amount_column_is_actually_read():
+    """The regression that lost every UTEX amount in the corpus."""
+    entries = parse_composition_table(REAL_TABLE)
+    assert [e["amount"] for e in entries] == ["90 mL", "1 per 200 mL", "90 mL", "4 drops"]
+
+
+def test_the_header_row_is_not_emitted_as_an_ingredient():
+    entries = parse_composition_table(REAL_TABLE)
+    assert all(e["ingredient"] != "Component" for e in entries)
+    assert len(entries) == 4
+
+
+def test_a_table_without_a_component_header_is_skipped():
+    """UTEX product pages carry cart and badge tables a positional reader eats."""
+    assert parse_composition_table([["", "Freshwater Medium | 6 < pH < 8"]]) == []
+    assert parse_composition_table([["Add to cart"], ["FAQs: Algal Culture Media"]]) == []
+
+
+def test_column_order_does_not_matter():
+    """The point of reading the header: a reordered table still parses."""
+    entries = parse_composition_table(
+        [["Amount", "Component"], ["10 g/L", "Glucose"]]
+    )
+    assert entries == [{"ingredient": "Glucose", "amount": "10 g/L"}]
+
+
+def test_the_concentration_columns_are_captured_when_present():
+    entries = parse_composition_table(
+        [HEADER, ["1", "NaNO3", "10 mL", "10 g/400 mL dH2O", "2.94 mM"]]
+    )
+    assert entries[0]["stock_concentration"] == "10 g/400 mL dH2O"
+    assert entries[0]["final_concentration"] == "2.94 mM"
+
+
+def test_empty_concentration_cells_are_omitted_rather_than_stored_blank():
+    entry = parse_composition_table(REAL_TABLE)[0]
+    assert "stock_concentration" not in entry
+    assert "final_concentration" not in entry
+
+
+def test_an_empty_component_cell_is_skipped():
+    entries = parse_composition_table([HEADER, ["1", "", "90 mL", "", ""]])
+    assert entries == []
+
+
+def test_a_short_row_does_not_raise():
+    """Real pages carry ragged rows; a colspan cell makes one shorter."""
+    assert parse_composition_table([HEADER, ["1"]]) == []
+    assert parse_composition_table([HEADER, ["1", "Glucose"]]) == [
+        {"ingredient": "Glucose", "amount": ""}
+    ]
+
+
+def test_no_list_fallback_reads_the_navigation_menu():
+    """A `<ul>`/`<ol>` fallback used to split every list item on ':' or '-'.
+
+    On https://utex.org/products/bbm-boron-stock-solution — a page that states
+    its composition in prose and has no composition table — it returned 18
+    "ingredients" scraped from the site navigation, among them
+    `{'RGB': 'LED Lighting Platform'}` and `{'Media Kits & Add': 'Ins'}`. It
+    never produced a real ingredient, because all 99 UTEX media pages carry a
+    proper table. An uncaptured page is reported, not guessed at.
+    """
+    import inspect
+
+    from culturemech.fetch import utex_fetcher
+
+    source = inspect.getsource(utex_fetcher.UTEXFetcher.fetch_recipe_details)
+    assert "find_all(['ul', 'ol'])" not in source

--- a/tests/test_utex_fetcher_composition.py
+++ b/tests/test_utex_fetcher_composition.py
@@ -56,9 +56,7 @@ def test_a_table_without_a_component_header_is_skipped():
 
 def test_column_order_does_not_matter():
     """The point of reading the header: a reordered table still parses."""
-    entries = parse_composition_table(
-        [["Amount", "Component"], ["10 g/L", "Glucose"]]
-    )
+    entries = parse_composition_table([["Amount", "Component"], ["10 g/L", "Glucose"]])
     assert entries == [{"ingredient": "Glucose", "amount": "10 g/L"}]
 
 


### PR DESCRIPTION
Reported from https://culturebotai.github.io/CultureMech/pages/normalized/000001.html —
four ingredients showing as "1", "2", "3", "4", and no chemical information in
the table.

They were not anonymous. They were **DYIII Medium, Pea, Soilwater: GR+ Medium
and DAS Vitamin Cocktail**, and the same defect hit **every one of the 99 UTEX
records — 497 ingredients**.

## Root cause

UTEX composition tables are headed
`# | Component | Amount | Stock Solution Concentration | Final Concentration`.
`utex_fetcher.py` read `cols[0]` and `cols[1]` — fixed positions, never the
header — so the row ordinal became the ingredient name, the component name
became the "amount", and the Amount column was never read at all.

Three defects landed in four lines of every record:

```yaml
- preferred_term: '1'                             # the row ordinal
  concentration: {value: variable, unit: G_PER_L} # invented
  notes: 'Original amount: DYIII Medium'          # the real name, in a note
```

The `G_PER_L` came from `fix_schema_inconsistencies.py`, which supplied it for
every ingredient with no amount — asserting grams per litre for four drops of
vitamin cocktail.

The corruption had already spread: `embedding/aggregator.py` carries a
workaround that digs the real name back out of those notes, and two rows of the
pinned MIM label index are literally named `Original amount: (NH4)2HPO4(...)`.

## The fix

**Fetcher** — `parse_composition_table` maps columns by header text and skips a
table with no component header. It also captures the two concentration columns
the positional reader never saw. The `<ul>`/`<ol>` fallback is removed: it split
list items on ':' or '-' and read the site navigation as a recipe
(bbm-boron-stock-solution returned 18 "ingredients" including
`{'RGB': 'LED Lighting Platform'}`). It never produced a real ingredient.

**Records** — `scripts/repair_utex_ingredients.py`, preview by default, rewrites
against a fresh capture: real name with vendor/CAS parenthetical split off so it
can ground, supplier into `supplier_catalog`, concentration parsed from the page
(preferring its own Final Concentration column) and converted to the corpus
per-litre convention with exact decimal arithmetic. Where an amount has no
volume basis — "4 drops", "1 cc", "1 per 200 mL" — the value is
`{value: variable, unit: VARIABLE}`, the corpus's existing honest placeholder,
never a guessed unit. Every source cell is kept verbatim in `notes`.

**Pages** — a 640-row packaged ChEBI table (formula, mass, charge) that the
renderer joins against, and mermaid node geometry fixed in `mermaid.initialize`.

## Results

| | before | after |
|---|---|---|
| UTEX ingredients with a real name | 0/497 | 497/497 |
| grounded against the MIM label index | 0% | 84% (418/497) |
| carrying a real quantified concentration | 0 (497 fabricated `G_PER_L`) | 377 |
| ingredient rows showing formula/mass | 0/170,007 | 136,700 (80.4%) |
| composition-diagram node area | 77,254 px² | 24,375 px² (−68%) |

The re-fetch also recovered 419 stock/final concentrations and 13 ingredients
the old parser dropped — none ever captured before.

## The diagram nodes, measured rather than asserted

I rendered the CultureMech:000001 diagram in headless Chrome **under the page's
real CSP** and measured the SVG. That caught a mistake I would otherwise have
shipped: setting `htmlLabels: false` only under `flowchart` does almost nothing.

| config | foreignObjects | node height | node area |
|---|---|---|---|
| old | 9 | 86 px | 77,254 px² |
| `flowchart.htmlLabels` only | 5 | 64 px | 43,411 px² |
| **top-level `htmlLabels`** | **0** | **26 px** | **24,375 px²** |

With HTML labels the node is measured at a computed 16px with
`line-height: normal` regardless of `themeVariables.fontSize`, because the
inline stylesheet mermaid injects to size the `<foreignObject>` div is blocked
by `style-src 'self'`. An external stylesheet cannot substitute — mermaid
measures in a detached container, so page-scoped selectors never match, and a
broad `svg .nodeLabel` rule recovered only part of it (50px, 28,530 px²).

The test asserts the key is at the **top level** rather than grepping for the
string, which would have passed on the broken config. Verified by deleting the
line: the test fails.

## Verification

- All 497 corrupted ingredients matched their capture row by **ordinal and
  base name**. Zero failures, zero manual resolutions.
- 317 concentration conversions re-derived independently from the raw capture:
  **zero mismatches**.
- 640/640 ChEBI terms resolved (592 formulas, 588 masses), zero failures.
- Gates: `validate-strict` 0 errors / 15,877 files; `assign-ids-check` clean;
  `audit-concentration-plausibility` unchanged at its ratchet (no UTEX record
  appears in it, before or after); `check-chebi-grounding` exit 0.
- Re-render 15,877 pages, 0 errors; `web_artifacts` coverage complete.
- `test-fast` 1407 passed.
- Both bulk scripts are preview-by-default and exit nonzero on partial output.

## Reviewer notes

- The `utex_fetcher.py` diff includes a whole-file **black** pass (its own
  commit, `fc9033e5`). The gate formats any file a PR touches and the repo is
  not black-formatted overall — 253 files would change — so most of that
  volume is pre-existing quote style, not this change.
- `data/raw/utex/utex_media.json` is gitignored, so the new capture is not in
  the diff. Re-running the repair without re-fetching is a no-op: it only
  touches ingredients whose `preferred_term` is a digit, and none now are.

## Not in this PR

- 10 UTEX stock-solution records hold **zero** ingredients (`DAS_Vitamin_Cocktail`
  among them — a component of 000001 itself). Their pages exist and 2 of 3
  sampled parse cleanly with the fixed fetcher.
- The `aggregator.py` note-digging workaround is now dead for UTEX but still
  present; removing it touches the embedding pipeline.
- The 79 still-unresolved UTEX names are mostly *media* (BG-11, F/2, Bristol) —
  they want links to other CultureMech records, not ChEBI ids.