### PR TITLE
Restore MediaDB ingredient names truncated at a parenthesis (#387 part 2)

### DIFF
--- a/data/normalized_yaml/bacterial/MEDIADB_109_M9_gupta.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_109_M9_gupta.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:006995
 name: m9_gupta
-original_name: '''M9 (gupta'
+original_name: M9 (gupta) with lactose
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -112,11 +112,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:16:27.995078+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 109
   term:
     id: MEDIADB:109
-    label: '''M9 (gupta'
+    label: M9 (gupta) with lactose
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_416_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_416_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007317
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,18 +317,27 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.850177+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.680650+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (audit G22)
   notes: 'G22 phosphate speciation split (see reports/chebi_grounding_audit.md): re-grounded
     Sodium dihydrogen phosphate from CHEBI:37583 (trisodium phosphate) to CHEBI:37585
     (sodium dihydrogenphosphate) on its term and mediaingredientmech_chebi_term references.'
+- timestamp: '2026-08-31T06:17:07.097048+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 416
   term:
     id: MEDIADB:416
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_417_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_417_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007318
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 250 mM Fe2O3 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.865933+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.698785+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.117488+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 417
   term:
     id: MEDIADB:417
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 250 mM Fe2O3 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_418_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_418_Defined_freshwater_medium_CoSO4.yaml
@@ -105,7 +105,7 @@ ingredients:
   term:
     id: CHEBI:3312
     label: calcium dichloride
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '20.0'
     unit: MILLIMOLAR
@@ -322,11 +322,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.881852+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.714805+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:05.656281+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:418's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 418
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_418_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_418_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007319
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 20 mM Iron citrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -339,11 +339,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:418's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.136113+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 418
   term:
     id: MEDIADB:418
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 20 mM Iron citrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_419_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_419_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007320
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 5 mM nitrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -337,11 +337,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.163143+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 419
   term:
     id: MEDIADB:419
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 5 mM nitrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_420_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_420_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007322
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 50 mM Iron citrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -335,11 +335,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:420's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.183318+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 420
   term:
     id: MEDIADB:420
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 50 mM Iron citrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_420_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_420_Defined_freshwater_medium_CoSO4.yaml
@@ -101,7 +101,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17836
     label: 4-aminobenzoate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '50.0'
     unit: MILLIMOLAR
@@ -318,11 +318,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.913029+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.746660+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:55.414624+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:420's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 420
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_421_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_421_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007323
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 20 mM nitrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -337,11 +337,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.202370+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 421
   term:
     id: MEDIADB:421
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 20 mM nitrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_422_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_422_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007324
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 15 mM MnO2 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -338,11 +338,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:422's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.221518+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 422
   term:
     id: MEDIADB:422
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 15 mM MnO2 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_422_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_422_Defined_freshwater_medium_CoSO4.yaml
@@ -111,7 +111,7 @@ ingredients:
   term:
     id: CHEBI:3312
     label: calcium dichloride
-- preferred_term: '''Manganese(IV'
+- preferred_term: Manganese(IV) oxide
   concentration:
     value: '15.0'
     unit: MILLIMOLAR
@@ -321,11 +321,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.945122+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.778335+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:55.446025+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:422's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 422
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_423_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_423_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007325
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.961447+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.794081+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.241012+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 423
   term:
     id: MEDIADB:423
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_424_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_424_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007326
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 50 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.977430+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.809886+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.262135+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 424
   term:
     id: MEDIADB:424
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 50 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_425_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_425_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007327
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Ethanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:28.994210+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.825750+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.279868+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 425
   term:
     id: MEDIADB:425
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Ethanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_426_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_426_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007328
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Propionate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -311,16 +311,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.009541+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.840766+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.299137+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 426
   term:
     id: MEDIADB:426
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Propionate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_427_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_427_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007329
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Butyrate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -314,16 +314,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.025532+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.856075+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.319632+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 427
   term:
     id: MEDIADB:427
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 20 mM Butyrate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_428_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_428_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007330
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Isobutyrate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.040620+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.871473+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.337023+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 428
   term:
     id: MEDIADB:428
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Isobutyrate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_429_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_429_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007331
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Valerate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.055769+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.886508+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.378989+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 429
   term:
     id: MEDIADB:429
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Valerate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_430_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007333
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Isovalerate
 category: bacterial
 medium_type: COMPLEX
 composition_type: UNDEFINED
@@ -359,16 +359,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.072626+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.903372+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.408194+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 430
   term:
     id: MEDIADB:430
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Isovalerate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/
 

--- a/data/normalized_yaml/bacterial/MEDIADB_431_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_431_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007334
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Pyruvate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.089069+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.919937+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.428421+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 431
   term:
     id: MEDIADB:431
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Pyruvate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_432_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_432_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007335
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Propanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.104658+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.935987+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.446224+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 432
   term:
     id: MEDIADB:432
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Propanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_433_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_433_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007336
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Butanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.120444+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.951138+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.464023+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 433
   term:
     id: MEDIADB:433
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Butanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_434_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_434_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007337
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Toluene
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.137840+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.966847+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.484868+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 434
   term:
     id: MEDIADB:434
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 10 mM Toluene
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_435_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_435_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007338
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 1 mM Toluene
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.153833+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:15.982735+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.504794+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 435
   term:
     id: MEDIADB:435
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 1 mM Toluene
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_436_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_436_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007339
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 1 mM Benzoate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.524959+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 436
   term:
     id: MEDIADB:436
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 1 mM Benzoate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_437_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_437_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007340
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Benzaldehyde
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -311,16 +311,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.185211+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.013694+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.546586+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 437
   term:
     id: MEDIADB:437
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Benzaldehyde
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_438_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_438_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007341
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Benzyl alcohol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.565524+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 438
   term:
     id: MEDIADB:438
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Benzyl alcohol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_439_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_439_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007342
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzoate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -314,16 +314,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.216389+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.045423+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.586700+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 439
   term:
     id: MEDIADB:439
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzoate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_440_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_440_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007344
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzaldehyde
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.609010+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 440
   term:
     id: MEDIADB:440
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzaldehyde
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_441_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_441_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,7 @@
 id: CultureMech:007345
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzyl
+  alcohol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +311,29 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.246975+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.075880+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.626363+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 441
   term:
     id: MEDIADB:441
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzyl
+      alcohol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_442_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_442_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007346
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Phenol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -316,16 +316,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.262602+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.091036+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.643990+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 442
   term:
     id: MEDIADB:442
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM Phenol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_443_Defined_freshwater_medium_CoSO4.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_443_Defined_freshwater_medium_CoSO4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007347
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Cresol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.277948+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.106088+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.661484+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 443
   term:
     id: MEDIADB:443
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + 100 mM Fe2O3 + 0.5 mM p-Cresol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_444_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_444_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007348
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.294009+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.122096+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.681833+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 444
   term:
     id: MEDIADB:444
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_445_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_445_Defined_freshwater_medium_CoCl2.yaml
@@ -91,7 +91,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17836
     label: 4-aminobenzoate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '50.0'
     unit: MILLIMOLAR
@@ -318,11 +318,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.309997+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.138127+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:55.740550+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:445's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 445
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_445_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_445_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007349
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 50 mM Iron citrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -335,11 +335,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:445's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.700685+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 445
   term:
     id: MEDIADB:445
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 50 mM Iron citrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_446_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_446_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007350
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 5 mM nitrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -337,11 +337,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.722020+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 446
   term:
     id: MEDIADB:446
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 5 mM nitrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_447_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_447_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007351
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 250 mM Fe2O3 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.342202+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.169547+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.742489+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 447
   term:
     id: MEDIADB:447
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 250 mM Fe2O3 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_448_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_448_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007352
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 20 mM nitrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -337,11 +337,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:07.763852+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 448
   term:
     id: MEDIADB:448
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 20 mM nitrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_449_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_449_Defined_freshwater_medium_CoCl2.yaml
@@ -101,7 +101,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17836
     label: 4-aminobenzoate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '20.0'
     unit: MILLIMOLAR
@@ -322,11 +322,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.374315+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.202168+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:55.793474+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:449's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 449
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_449_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_449_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007353
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 20 mM Iron citrate + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -339,11 +339,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:449's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.784843+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 449
   term:
     id: MEDIADB:449
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 20 mM Iron citrate + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_450_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_450_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007355
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 15 mM MnO2 + 113.2 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -338,11 +338,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:450's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:07.802997+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 450
   term:
     id: MEDIADB:450
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 15 mM MnO2 + 113.2 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_450_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_450_Defined_freshwater_medium_CoCl2.yaml
@@ -111,7 +111,7 @@ ingredients:
   term:
     id: CHEBI:3312
     label: calcium dichloride
-- preferred_term: '''Manganese(IV'
+- preferred_term: Manganese(IV) oxide
   concentration:
     value: '15.0'
     unit: MILLIMOLAR
@@ -321,11 +321,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.390178+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.217974+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:55.811622+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:450's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 450
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_451_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_451_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007356
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 50 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.406835+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.233581+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.823712+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 451
   term:
     id: MEDIADB:451
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 50 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_452_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_452_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007357
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Propionate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -311,16 +311,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.423282+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.248746+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.843277+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 452
   term:
     id: MEDIADB:452
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Propionate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_453_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_453_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007358
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Ethanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.438982+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.264116+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.867732+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 453
   term:
     id: MEDIADB:453
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Ethanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_454_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_454_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007359
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Butyrate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -314,16 +314,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.454766+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.279952+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.885424+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 454
   term:
     id: MEDIADB:454
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 20 mM Butyrate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_455_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_455_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007360
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Acetate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.472801+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.295555+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.903380+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 455
   term:
     id: MEDIADB:455
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Acetate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_456_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_456_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007361
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Valerate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.488430+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.310994+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.922743+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 456
   term:
     id: MEDIADB:456
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Valerate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_457_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_457_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007362
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Toluene
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.509241+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.326441+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.943215+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 457
   term:
     id: MEDIADB:457
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Toluene
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_458_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_458_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007363
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Pyruvate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.525485+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.341840+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.961513+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 458
   term:
     id: MEDIADB:458
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Pyruvate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_459_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_459_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007364
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Propanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.540906+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.357199+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:07.990314+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 459
   term:
     id: MEDIADB:459
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Propanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_460_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007366
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Isovalerate
 category: bacterial
 medium_type: COMPLEX
 composition_type: UNDEFINED
@@ -359,16 +359,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.557683+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.374012+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.025060+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 460
   term:
     id: MEDIADB:460
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Isovalerate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/
 

--- a/data/normalized_yaml/bacterial/MEDIADB_461_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_461_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007367
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Isobutyrate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.574638+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.390888+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.045696+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 461
   term:
     id: MEDIADB:461
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Isobutyrate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_462_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_462_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007368
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Butanol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.589883+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.406204+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.095218+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 462
   term:
     id: MEDIADB:462
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 10 mM Butanol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_463_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_463_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007369
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 1 mM Toluene
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -317,16 +317,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.607794+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.421637+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.123950+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 463
   term:
     id: MEDIADB:463
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 1 mM Toluene
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_464_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_464_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007370
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 1 mM Benzoate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:08.146475+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 464
   term:
     id: MEDIADB:464
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 1 mM Benzoate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_465_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_465_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007371
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Phenol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -316,16 +316,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.638532+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.452293+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.166072+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 465
   term:
     id: MEDIADB:465
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Phenol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_466_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_466_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,7 @@
 id: CultureMech:007372
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzyl
+  alcohol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +311,29 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.654494+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.467580+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.192613+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 466
   term:
     id: MEDIADB:466
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzyl
+      alcohol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_467_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_467_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007373
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzoate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -314,16 +314,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.669627+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.482766+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.218665+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 467
   term:
     id: MEDIADB:467
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzoate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_468_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_468_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007374
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzaldehyde
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:08.241559+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 468
   term:
     id: MEDIADB:468
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Hydroxybenzaldehyde
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_469_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_469_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007375
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Cresol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -310,16 +310,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.701083+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.513745+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.262609+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 469
   term:
     id: MEDIADB:469
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM p-Cresol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_470_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_470_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007377
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Benzyl alcohol
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -330,11 +330,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:08.281629+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 470
   term:
     id: MEDIADB:470
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Benzyl alcohol
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_471_Defined_freshwater_medium_CoCl2.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_471_Defined_freshwater_medium_CoCl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007378
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Benzaldehyde
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -311,16 +311,28 @@ curation_history:
 - timestamp: '2026-06-08T23:19:29.742994+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:16.545780+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T06:17:08.305427+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 471
   term:
     id: MEDIADB:471
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + 100 mM Fe2O3 + 0.5 mM Benzaldehyde
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_476_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_476_AMS1_Pyruvate_Glycine.yaml
@@ -182,7 +182,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:35176
     label: zinc sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -228,7 +228,16 @@ curation_history:
 - timestamp: '2026-06-09T01:42:16.558815+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:56.081460+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:476's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 476
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_476_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_476_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007383
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -238,11 +238,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:476's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.320146+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 476
   term:
     id: MEDIADB:476
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_478_AMS1_Pyruvate_Serine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_478_AMS1_Pyruvate_Serine.yaml
@@ -182,7 +182,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:35176
     label: zinc sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -228,7 +228,16 @@ curation_history:
 - timestamp: '2026-06-09T01:42:16.570287+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:05:56.095906+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:478's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 478
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_478_AMS1_Pyruvate_Serine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_478_AMS1_Pyruvate_Serine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007385
 name: ams1_pyruvate_serine
-original_name: '''AMS1 (Pyruvate+Serine'
+original_name: AMS1 (Pyruvate+Serine) + Thiamin
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -238,11 +238,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:478's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.342035+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 478
   term:
     id: MEDIADB:478
-    label: '''AMS1 (Pyruvate+Serine'
+    label: AMS1 (Pyruvate+Serine) + Thiamin
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_479_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_479_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007386
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + Phosphite
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -225,11 +225,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:479's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.357932+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 479
   term:
     id: MEDIADB:479
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + Phosphite
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_479_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_479_AMS1_Pyruvate_Glycine.yaml
@@ -101,7 +101,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -219,6 +219,12 @@ curation_history:
   notes: 'Replaced 11 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:05:56.109733+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:479's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 479
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_480_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_480_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007388
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + Glucose 6-Phosphate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -233,11 +233,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:480's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.371370+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 480
   term:
     id: MEDIADB:480
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + Glucose 6-Phosphate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_480_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_480_AMS1_Pyruvate_Glycine.yaml
@@ -179,7 +179,7 @@ ingredients:
   term:
     id: CHEBI:35696
     label: cobalt dichloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -227,6 +227,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:05:56.123781+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:480's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 480
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_481_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_481_AMS1_Pyruvate_Glycine.yaml
@@ -106,7 +106,7 @@ ingredients:
     value: '0.001'
     unit: MILLIMOLAR
   notes: 'Cross-references: KEGG:r5p'
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -220,6 +220,12 @@ curation_history:
   notes: 'Replaced 11 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:05:56.137489+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:481's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 481
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_481_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_481_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007389
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + Ribose 5-Phosphate
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -226,11 +226,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:481's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.392026+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 481
   term:
     id: MEDIADB:481
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + Ribose 5-Phosphate
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_482_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_482_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007390
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + Methylphosphonic acid
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -225,11 +225,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:482's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.404745+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 482
   term:
     id: MEDIADB:482
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + Methylphosphonic acid
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_482_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_482_AMS1_Pyruvate_Glycine.yaml
@@ -105,7 +105,7 @@ ingredients:
   concentration:
     value: '0.001'
     unit: MILLIMOLAR
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -219,6 +219,12 @@ curation_history:
   notes: 'Replaced 11 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:05:56.152160+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:482's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 482
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_483_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_483_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007391
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + 2-aminoethylphosphonic acid
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -226,11 +226,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:483's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.421657+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 483
   term:
     id: MEDIADB:483
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + 2-aminoethylphosphonic acid
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/MEDIADB_483_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_483_AMS1_Pyruvate_Glycine.yaml
@@ -91,7 +91,7 @@ ingredients:
   term:
     id: CHEBI:75215
     label: sodium molybdate (anhydrous)
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -220,6 +220,12 @@ curation_history:
   notes: 'Replaced 11 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:05:56.167674+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:483's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 483
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_484_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_484_AMS1_Pyruvate_Glycine.yaml
@@ -140,7 +140,7 @@ ingredients:
     value: '0.001'
     unit: MILLIMOLAR
   notes: 'Cross-references: KEGG:pser-L'
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -220,6 +220,12 @@ curation_history:
   notes: 'Replaced 11 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:05:56.181201+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:484's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 484
   term:

--- a/data/normalized_yaml/bacterial/MEDIADB_484_AMS1_Pyruvate_Glycine.yaml
+++ b/data/normalized_yaml/bacterial/MEDIADB_484_AMS1_Pyruvate_Glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007392
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine) + Thiamin + Phosphoserine
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -226,11 +226,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:484's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:08.434626+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 484
   term:
     id: MEDIADB:484
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine) + Thiamin + Phosphoserine
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/a_b_salts_medium_jensen_et_al.yaml
+++ b/data/normalized_yaml/bacterial/a_b_salts_medium_jensen_et_al.yaml
@@ -89,7 +89,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:62946
     label: ammonium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.00184979'
     unit: MILLIMOLAR
@@ -132,6 +132,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:06.861664+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:142's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 142
   term:

--- a/data/normalized_yaml/bacterial/a_b_salts_medium_with_uracil_jensen_et_al.yaml
+++ b/data/normalized_yaml/bacterial/a_b_salts_medium_with_uracil_jensen_et_al.yaml
@@ -100,7 +100,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:62946
     label: ammonium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.00184979'
     unit: MILLIMOLAR
@@ -143,6 +143,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:06.870125+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:143's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 143
   term:

--- a/data/normalized_yaml/bacterial/acetate_minimal_media_zhao.yaml
+++ b/data/normalized_yaml/bacterial/acetate_minimal_media_zhao.yaml
@@ -106,7 +106,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.06165'
     unit: MILLIMOLAR
@@ -152,6 +152,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:06.983360+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:129's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 129
   term:

--- a/data/normalized_yaml/bacterial/acetate_minimal_media_zhao.yaml
+++ b/data/normalized_yaml/bacterial/acetate_minimal_media_zhao.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007017
 name: acetate_minimal_media_zhao
-original_name: '''acetate minimal media (zhao'
+original_name: acetate minimal media (zhao)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -158,11 +158,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:129's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:19.138774+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 129
   term:
     id: MEDIADB:129
-    label: '''acetate minimal media (zhao'
+    label: acetate minimal media (zhao)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ams1_pyruvate_glycine.yaml
+++ b/data/normalized_yaml/bacterial/ams1_pyruvate_glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007382
 name: ams1_pyruvate_glycine
-original_name: '''AMS1 (Pyruvate+Glycine'
+original_name: AMS1 (Pyruvate+Glycine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -232,11 +232,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:475's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:20.391941+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 475
   term:
     id: MEDIADB:475
-    label: '''AMS1 (Pyruvate+Glycine'
+    label: AMS1 (Pyruvate+Glycine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ams1_pyruvate_glycine.yaml
+++ b/data/normalized_yaml/bacterial/ams1_pyruvate_glycine.yaml
@@ -98,7 +98,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32588
     label: potassium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -222,7 +222,16 @@ curation_history:
 - timestamp: '2026-06-09T01:42:18.116828+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:06:08.268780+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:475's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 475
   term:

--- a/data/normalized_yaml/bacterial/ams1_pyruvate_serine.yaml
+++ b/data/normalized_yaml/bacterial/ams1_pyruvate_serine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007384
 name: ams1_pyruvate_serine
-original_name: '''AMS1 (Pyruvate+Serine'
+original_name: AMS1 (Pyruvate+Serine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -232,11 +232,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:477's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:20.404920+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 477
   term:
     id: MEDIADB:477
-    label: '''AMS1 (Pyruvate+Serine'
+    label: AMS1 (Pyruvate+Serine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ams1_pyruvate_serine.yaml
+++ b/data/normalized_yaml/bacterial/ams1_pyruvate_serine.yaml
@@ -176,7 +176,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:35176
     label: zinc sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000117'
     unit: MILLIMOLAR
@@ -222,7 +222,16 @@ curation_history:
 - timestamp: '2026-06-09T01:42:18.129559+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:06:08.281558+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:477's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 477
   term:

--- a/data/normalized_yaml/bacterial/asp2.yaml
+++ b/data/normalized_yaml/bacterial/asp2.yaml
@@ -87,7 +87,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:4735
     label: ethylenediaminetetraacetic acid
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.00493'
     unit: MILLIMOLAR
@@ -263,6 +263,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:09.085365+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:295's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 295
   term:

--- a/data/normalized_yaml/bacterial/batch_cultivation_medium_for_a28.yaml
+++ b/data/normalized_yaml/bacterial/batch_cultivation_medium_for_a28.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007247
 name: batch_cultivation_medium_for_a28
-original_name: '''Batch Cultivation Medium (for A28'
+original_name: Batch Cultivation Medium (for A28)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:21.669521+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 346
   term:
     id: MEDIADB:346
-    label: '''Batch Cultivation Medium (for A28'
+    label: Batch Cultivation Medium (for A28)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/batch_cultivation_medium_for_ta1.yaml
+++ b/data/normalized_yaml/bacterial/batch_cultivation_medium_for_ta1.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007209
 name: batch_cultivation_medium_for_ta1
-original_name: '''Batch Cultivation Medium (for TA1'
+original_name: Batch Cultivation Medium (for TA1)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -126,11 +126,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:21.677836+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 310
   term:
     id: MEDIADB:310
-    label: '''Batch Cultivation Medium (for TA1'
+    label: Batch Cultivation Medium (for TA1)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/bg11_0_015_mm_iron_shcolnick_2006.yaml
+++ b/data/normalized_yaml/bacterial/bg11_0_015_mm_iron_shcolnick_2006.yaml
@@ -64,7 +64,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:35176
     label: zinc sulfate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.015'
     unit: MILLIMOLAR
@@ -170,6 +170,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:09.746297+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:385's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 385
   term:

--- a/data/normalized_yaml/bacterial/bg11_0_015_mm_iron_shcolnick_2006.yaml
+++ b/data/normalized_yaml/bacterial/bg11_0_015_mm_iron_shcolnick_2006.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007289
 name: bg11_0_015_mm_iron_shcolnick_2006
-original_name: '''BG11, 0.015 mM Iron (Shcolnick 2006'
+original_name: BG11, 0.015 mM Iron (Shcolnick 2006)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -176,11 +176,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:385's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:21.826287+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 385
   term:
     id: MEDIADB:385
-    label: '''BG11, 0.015 mM Iron (Shcolnick 2006'
+    label: BG11, 0.015 mM Iron (Shcolnick 2006)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/cdm_lp.yaml
+++ b/data/normalized_yaml/bacterial/cdm_lp.yaml
@@ -384,7 +384,7 @@ ingredients:
     value: 1e-05
     unit: MILLIMOLAR
   notes: 'Cross-references: KEGG:avite1'
-- preferred_term: '''Cyanocob(III'
+- preferred_term: Cyanocob(III)alamin
   concentration:
     value: '0.004'
     unit: MILLIMOLAR
@@ -640,6 +640,12 @@ curation_history:
   action: RESTORED_CORRUPT_SOURCE_COMPOUND
   notes: Restored C00002 as ATP (CHEBI:15422) from the MediaDB row sequence; resolves
     the 2026-08-24 EMPTY_INGREDIENT_NAME review finding.
+- timestamp: '2026-08-31T04:06:11.218057+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:33's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 33
   term:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_ethanol_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_ethanol_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007227
 name: chemically_defined_fermentation_medium_20g_ethanol_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g ethanol + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g ethanol + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -149,11 +149,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.370043+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 328
   term:
     id: MEDIADB:328
-    label: '''Chemically Defined Fermentation Medium (20g ethanol + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (20g ethanol + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007223
 name: chemically_defined_fermentation_medium_20g_glucose_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g glucose + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g glucose + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.379108+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 324
   term:
     id: MEDIADB:324
-    label: '''Chemically Defined Fermentation Medium (20g glucose + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (20g glucose + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_ethanol_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_ethanol_12_5g_msg.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007231
 name: chemically_defined_fermentation_medium_20g_glucose_20g_ethanol_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g glucose + 20g ethanol
-  +12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g glucose + 20g ethanol +12.5g
+  MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -160,12 +160,18 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.388055+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 331
   term:
     id: MEDIADB:331
-    label: '''Chemically Defined Fermentation Medium (20g glucose + 20g ethanol +12.5g
-      MSG'
+    label: Chemically Defined Fermentation Medium (20g glucose + 20g ethanol +12.5g
+      MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_glycerol_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_glycerol_12_5g_msg.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007230
 name: chemically_defined_fermentation_medium_20g_glucose_20g_glycerol_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g glucose + 20g glycerol
-  +12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g glucose + 20g glycerol
+  +12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -160,12 +160,18 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.397066+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 330
   term:
     id: MEDIADB:330
-    label: '''Chemically Defined Fermentation Medium (20g glucose + 20g glycerol +12.5g
-      MSG'
+    label: Chemically Defined Fermentation Medium (20g glucose + 20g glycerol +12.5g
+      MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_lactose_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glucose_20g_lactose_12_5g_msg.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007228
 name: chemically_defined_fermentation_medium_20g_glucose_20g_lactose_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g glucose + 20g lactose
-  +12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g glucose + 20g lactose +12.5g
+  MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -160,12 +160,18 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.406100+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 329
   term:
     id: MEDIADB:329
-    label: '''Chemically Defined Fermentation Medium (20g glucose + 20g lactose +12.5g
-      MSG'
+    label: Chemically Defined Fermentation Medium (20g glucose + 20g lactose +12.5g
+      MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glycerol_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_20g_glycerol_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007226
 name: chemically_defined_fermentation_medium_20g_glycerol_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (20g glycerol + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (20g glycerol + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -149,11 +149,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.414808+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 327
   term:
     id: MEDIADB:327
-    label: '''Chemically Defined Fermentation Medium (20g glycerol + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (20g glycerol + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_11g_ammonium_acetate.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_11g_ammonium_acetate.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007234
 name: chemically_defined_fermentation_medium_45g_glucose_11g_ammonium_acetate
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 11g ammonium
-  acetate'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 11g ammonium
+  acetate)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +145,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.423133+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 334
   term:
     id: MEDIADB:334
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 11g ammonium acetate'
+    label: Chemically Defined Fermentation Medium (45g glucose + 11g ammonium acetate)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_arginine.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_arginine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007242
 name: chemically_defined_fermentation_medium_45g_glucose_12_5g_arginine
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g arginine'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 12.5g arginine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.431629+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 341
   term:
     id: MEDIADB:341
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g arginine'
+    label: Chemically Defined Fermentation Medium (45g glucose + 12.5g arginine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_glycine.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007241
 name: chemically_defined_fermentation_medium_45g_glucose_12_5g_glycine
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g glycine'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 12.5g glycine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +145,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.439892+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 340
   term:
     id: MEDIADB:340
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g glycine'
+    label: Chemically Defined Fermentation Medium (45g glucose + 12.5g glycine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_histidine.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_histidine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007239
 name: chemically_defined_fermentation_medium_45g_glucose_12_5g_histidine
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g histidine'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 12.5g histidine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.449451+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 339
   term:
     id: MEDIADB:339
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g histidine'
+    label: Chemically Defined Fermentation Medium (45g glucose + 12.5g histidine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_isoleucine.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_isoleucine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007243
 name: chemically_defined_fermentation_medium_45g_glucose_12_5g_isoleucine
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g isoleucine'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 12.5g isoleucine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -141,11 +141,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.458185+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 342
   term:
     id: MEDIADB:342
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g isoleucine'
+    label: Chemically Defined Fermentation Medium (45g glucose + 12.5g isoleucine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007217
 name: chemically_defined_fermentation_medium_45g_glucose_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.466685+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 318
   term:
     id: MEDIADB:318
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (45g glucose + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_13_7g_diammonium_tartrate.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_13_7g_diammonium_tartrate.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007232
 name: chemically_defined_fermentation_medium_45g_glucose_13_7g_diammonium_tartrate
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 13.7g diammonium
-  tartrate'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 13.7g diammonium
+  tartrate)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -139,12 +139,18 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.475071+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 332
   term:
     id: MEDIADB:332
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 13.7g diammonium
-      tartrate'
+    label: Chemically Defined Fermentation Medium (45g glucose + 13.7g diammonium
+      tartrate)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_18g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_18g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007238
 name: chemically_defined_fermentation_medium_45g_glucose_18g_msg
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 18g MSG'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 18g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.483322+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 338
   term:
     id: MEDIADB:338
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 18g MSG'
+    label: Chemically Defined Fermentation Medium (45g glucose + 18g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4_5g_urea.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4_5g_urea.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007236
 name: chemically_defined_fermentation_medium_45g_glucose_4_5g_urea
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 4.5g urea'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 4.5g urea)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +145,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.491582+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 336
   term:
     id: MEDIADB:336
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 4.5g urea'
+    label: Chemically Defined Fermentation Medium (45g glucose + 4.5g urea)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4g_ammonium_nitrate.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4g_ammonium_nitrate.yaml
@@ -1,7 +1,6 @@
 id: CultureMech:007233
 name: chemically_defined_fermentation_medium_45g_glucose_4g_ammonium_nitrate
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 4g ammonium
-  nitrate'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 4g ammonium nitrate)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +144,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.499703+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 333
   term:
     id: MEDIADB:333
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 4g ammonium nitrate'
+    label: Chemically Defined Fermentation Medium (45g glucose + 4g ammonium nitrate)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4g_sodium_nitrate.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_4g_sodium_nitrate.yaml
@@ -1,7 +1,6 @@
 id: CultureMech:007235
 name: chemically_defined_fermentation_medium_45g_glucose_4g_sodium_nitrate
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 4g sodium
-  nitrate'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 4g sodium nitrate)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +144,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.508016+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 335
   term:
     id: MEDIADB:335
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 4g sodium nitrate'
+    label: Chemically Defined Fermentation Medium (45g glucose + 4g sodium nitrate)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_7g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_glucose_7g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007237
 name: chemically_defined_fermentation_medium_45g_glucose_7g_msg
-original_name: '''Chemically Defined Fermentation Medium (45g glucose + 7g MSG'
+original_name: Chemically Defined Fermentation Medium (45g glucose + 7g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.516338+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 337
   term:
     id: MEDIADB:337
-    label: '''Chemically Defined Fermentation Medium (45g glucose + 7g MSG'
+    label: Chemically Defined Fermentation Medium (45g glucose + 7g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_lactose_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_45g_lactose_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007225
 name: chemically_defined_fermentation_medium_45g_lactose_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (45g lactose + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (45g lactose + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -149,11 +149,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.524594+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 326
   term:
     id: MEDIADB:326
-    label: '''Chemically Defined Fermentation Medium (45g lactose + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (45g lactose + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_70g_glucose_12_5g_msg.yaml
+++ b/data/normalized_yaml/bacterial/chemically_defined_fermentation_medium_70g_glucose_12_5g_msg.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007224
 name: chemically_defined_fermentation_medium_70g_glucose_12_5g_msg
-original_name: '''Chemically Defined Fermentation Medium (70g glucose + 12.5g MSG'
+original_name: Chemically Defined Fermentation Medium (70g glucose + 12.5g MSG)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -148,11 +148,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:23.533137+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 325
   term:
     id: MEDIADB:325
-    label: '''Chemically Defined Fermentation Medium (70g glucose + 12.5g MSG'
+    label: Chemically Defined Fermentation Medium (70g glucose + 12.5g MSG)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/complete_seed_medium_liu_2004.yaml
+++ b/data/normalized_yaml/bacterial/complete_seed_medium_liu_2004.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007282
 name: complete_seed_medium_liu_2004
-original_name: '''Complete Seed Medium (Liu 2004'
+original_name: Complete Seed Medium (Liu 2004)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -153,11 +153,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:24.617524+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 379
   term:
     id: MEDIADB:379
-    label: '''Complete Seed Medium (Liu 2004'
+    label: Complete Seed Medium (Liu 2004)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/dawes_and_mandelstam_medium_from_leitch_et_al.yaml
+++ b/data/normalized_yaml/bacterial/dawes_and_mandelstam_medium_from_leitch_et_al.yaml
@@ -98,7 +98,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0039955'
     unit: MILLIMOLAR
@@ -151,6 +151,12 @@ curation_history:
   notes: 'Replaced 8 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:13.045066+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:177's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 177
   term:

--- a/data/normalized_yaml/bacterial/defined_freshwater_medium_cocl2.yaml
+++ b/data/normalized_yaml/bacterial/defined_freshwater_medium_cocl2.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007294
 name: defined_freshwater_medium_cocl2
-original_name: '''Defined freshwater medium (CoCl2'
+original_name: Defined freshwater medium (CoCl2) + Electron Donors/Acceptors
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -428,11 +428,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:390's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:25.136498+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 390
   term:
     id: MEDIADB:390
-    label: '''Defined freshwater medium (CoCl2'
+    label: Defined freshwater medium (CoCl2) + Electron Donors/Acceptors
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/defined_freshwater_medium_cocl2.yaml
+++ b/data/normalized_yaml/bacterial/defined_freshwater_medium_cocl2.yaml
@@ -44,7 +44,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:176843
     label: vitamin B12
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '56.0'
     unit: MILLIMOLAR
@@ -422,6 +422,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:13.196655+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:390's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 390
   term:

--- a/data/normalized_yaml/bacterial/defined_freshwater_medium_coso4.yaml
+++ b/data/normalized_yaml/bacterial/defined_freshwater_medium_coso4.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007293
 name: defined_freshwater_medium_coso4
-original_name: '''Defined freshwater medium (CoSO4'
+original_name: Defined freshwater medium (CoSO4) + Electron Donors/Acceptors
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -428,11 +428,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:389's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:25.158277+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 389
   term:
     id: MEDIADB:389
-    label: '''Defined freshwater medium (CoSO4'
+    label: Defined freshwater medium (CoSO4) + Electron Donors/Acceptors
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/defined_freshwater_medium_coso4.yaml
+++ b/data/normalized_yaml/bacterial/defined_freshwater_medium_coso4.yaml
@@ -38,7 +38,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:16024
     label: D-mannose
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '56.0'
     unit: MILLIMOLAR
@@ -422,6 +422,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:13.219304+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:389's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 389
   term:

--- a/data/normalized_yaml/bacterial/deshpande_medium_fang_et_al.yaml
+++ b/data/normalized_yaml/bacterial/deshpande_medium_fang_et_al.yaml
@@ -68,7 +68,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000123305'
     unit: MILLIMOLAR
@@ -118,6 +118,12 @@ curation_history:
   notes: 'Replaced 2 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:13.378834+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:205's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 205
   term:

--- a/data/normalized_yaml/bacterial/deshpande_medium_with_met_asp_fang_et_al.yaml
+++ b/data/normalized_yaml/bacterial/deshpande_medium_with_met_asp_fang_et_al.yaml
@@ -87,7 +87,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000123305'
     unit: MILLIMOLAR
@@ -142,6 +142,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:13.387518+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:206's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 206
   term:

--- a/data/normalized_yaml/bacterial/deshpande_medium_with_met_asp_gly_arg_fang_et_al.yaml
+++ b/data/normalized_yaml/bacterial/deshpande_medium_with_met_asp_gly_arg_fang_et_al.yaml
@@ -108,7 +108,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.000123305'
     unit: MILLIMOLAR
@@ -163,6 +163,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:13.397305+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:207's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 207
   term:

--- a/data/normalized_yaml/bacterial/ecoli_bl21_medium_park_et_al.yaml
+++ b/data/normalized_yaml/bacterial/ecoli_bl21_medium_park_et_al.yaml
@@ -21,7 +21,7 @@ ingredients:
   term:
     id: CHEBI:15903
     label: beta-D-glucose
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.24496'
     unit: MILLIMOLAR
@@ -143,6 +143,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:16.221557+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:277's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 277
   term:

--- a/data/normalized_yaml/bacterial/fermentation_medium_acetate_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_acetate_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007263
 name: fermentation_medium_acetate_nh4cl
-original_name: '''Fermentation Medium (Acetate+NH4Cl'
+original_name: Fermentation Medium (Acetate+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.323180+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 361
   term:
     id: MEDIADB:361
-    label: '''Fermentation Medium (Acetate+NH4Cl'
+    label: Fermentation Medium (Acetate+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_ethanol_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_ethanol_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007254
 name: fermentation_medium_ethanol_nh4cl
-original_name: '''Fermentation Medium (Ethanol+NH4Cl'
+original_name: Fermentation Medium (Ethanol+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.332095+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 353
   term:
     id: MEDIADB:353
-    label: '''Fermentation Medium (Ethanol+NH4Cl'
+    label: Fermentation Medium (Ethanol+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_fructose_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_fructose_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007249
 name: fermentation_medium_fructose_nh4cl
-original_name: '''Fermentation Medium (Fructose+NH4Cl'
+original_name: Fermentation Medium (Fructose+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -140,11 +140,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.340855+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 349
   term:
     id: MEDIADB:349
-    label: '''Fermentation Medium (Fructose+NH4Cl'
+    label: Fermentation Medium (Fructose+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_alanine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_alanine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007274
 name: fermentation_medium_glucose_alanine
-original_name: '''Fermentation Medium (Glucose+Alanine'
+original_name: Fermentation Medium (Glucose+Alanine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.349456+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 371
   term:
     id: MEDIADB:371
-    label: '''Fermentation Medium (Glucose+Alanine'
+    label: Fermentation Medium (Glucose+Alanine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_arginine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_arginine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007271
 name: fermentation_medium_glucose_arginine
-original_name: '''Fermentation Medium (Glucose+Arginine'
+original_name: Fermentation Medium (Glucose+Arginine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.358267+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 369
   term:
     id: MEDIADB:369
-    label: '''Fermentation Medium (Glucose+Arginine'
+    label: Fermentation Medium (Glucose+Arginine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_aspartic_acid.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_aspartic_acid.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007268
 name: fermentation_medium_glucose_aspartic_acid
-original_name: '''Fermentation Medium (Glucose+Aspartic acid'
+original_name: Fermentation Medium (Glucose+Aspartic acid)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:28.367058+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 366
   term:
     id: MEDIADB:366
-    label: '''Fermentation Medium (Glucose+Aspartic acid'
+    label: Fermentation Medium (Glucose+Aspartic acid)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_glutamic_acid.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_glutamic_acid.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007266
 name: fermentation_medium_glucose_glutamic_acid
-original_name: '''Fermentation Medium (Glucose+Glutamic acid'
+original_name: Fermentation Medium (Glucose+Glutamic acid)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -141,11 +141,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.375885+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 364
   term:
     id: MEDIADB:364
-    label: '''Fermentation Medium (Glucose+Glutamic acid'
+    label: Fermentation Medium (Glucose+Glutamic acid)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_glutamine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_glutamine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007267
 name: fermentation_medium_glucose_glutamine
-original_name: '''Fermentation Medium (Glucose+Glutamine'
+original_name: Fermentation Medium (Glucose+Glutamine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -137,11 +137,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.384270+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 365
   term:
     id: MEDIADB:365
-    label: '''Fermentation Medium (Glucose+Glutamine'
+    label: Fermentation Medium (Glucose+Glutamine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_glycine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_glycine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007280
 name: fermentation_medium_glucose_glycine
-original_name: '''Fermentation Medium (Glucose+Glycine'
+original_name: Fermentation Medium (Glucose+Glycine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.392695+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 377
   term:
     id: MEDIADB:377
-    label: '''Fermentation Medium (Glucose+Glycine'
+    label: Fermentation Medium (Glucose+Glycine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_histidine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_histidine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007281
 name: fermentation_medium_glucose_histidine
-original_name: '''Fermentation Medium (Glucose+Histidine'
+original_name: Fermentation Medium (Glucose+Histidine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -143,11 +143,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.401441+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 378
   term:
     id: MEDIADB:378
-    label: '''Fermentation Medium (Glucose+Histidine'
+    label: Fermentation Medium (Glucose+Histidine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_isoleucine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_isoleucine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007277
 name: fermentation_medium_glucose_isoleucine
-original_name: '''Fermentation Medium (Glucose+Isoleucine'
+original_name: Fermentation Medium (Glucose+Isoleucine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -140,11 +140,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.409766+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 374
   term:
     id: MEDIADB:374
-    label: '''Fermentation Medium (Glucose+Isoleucine'
+    label: Fermentation Medium (Glucose+Isoleucine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_leucine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_leucine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007276
 name: fermentation_medium_glucose_leucine
-original_name: '''Fermentation Medium (Glucose+Leucine'
+original_name: Fermentation Medium (Glucose+Leucine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -140,11 +140,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.417966+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 373
   term:
     id: MEDIADB:373
-    label: '''Fermentation Medium (Glucose+Leucine'
+    label: Fermentation Medium (Glucose+Leucine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007218
 name: fermentation_medium_glucose_nh4cl
-original_name: '''Fermentation Medium (Glucose+NH4Cl'
+original_name: Fermentation Medium (Glucose+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -143,11 +143,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.426318+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 319
   term:
     id: MEDIADB:319
-    label: '''Fermentation Medium (Glucose+NH4Cl'
+    label: Fermentation Medium (Glucose+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_phenylalanine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_phenylalanine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007270
 name: fermentation_medium_glucose_phenylalanine
-original_name: '''Fermentation Medium (Glucose+Phenylalanine'
+original_name: Fermentation Medium (Glucose+Phenylalanine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -140,11 +140,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.434527+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 368
   term:
     id: MEDIADB:368
-    label: '''Fermentation Medium (Glucose+Phenylalanine'
+    label: Fermentation Medium (Glucose+Phenylalanine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_proline.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_proline.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007273
 name: fermentation_medium_glucose_proline
-original_name: '''Fermentation Medium (Glucose+Proline'
+original_name: Fermentation Medium (Glucose+Proline)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.443069+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 370
   term:
     id: MEDIADB:370
-    label: '''Fermentation Medium (Glucose+Proline'
+    label: Fermentation Medium (Glucose+Proline)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_serine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_serine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007278
 name: fermentation_medium_glucose_serine
-original_name: '''Fermentation Medium (Glucose+Serine'
+original_name: Fermentation Medium (Glucose+Serine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -137,11 +137,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.451352+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 375
   term:
     id: MEDIADB:375
-    label: '''Fermentation Medium (Glucose+Serine'
+    label: Fermentation Medium (Glucose+Serine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_threonine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_threonine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007275
 name: fermentation_medium_glucose_threonine
-original_name: '''Fermentation Medium (Glucose+Threonine'
+original_name: Fermentation Medium (Glucose+Threonine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -145,11 +145,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:28.460295+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 372
   term:
     id: MEDIADB:372
-    label: '''Fermentation Medium (Glucose+Threonine'
+    label: Fermentation Medium (Glucose+Threonine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_tyrosine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_tyrosine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007269
 name: fermentation_medium_glucose_tyrosine
-original_name: '''Fermentation Medium (Glucose+Tyrosine'
+original_name: Fermentation Medium (Glucose+Tyrosine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -143,11 +143,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.468852+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 367
   term:
     id: MEDIADB:367
-    label: '''Fermentation Medium (Glucose+Tyrosine'
+    label: Fermentation Medium (Glucose+Tyrosine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_urea.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_urea.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007265
 name: fermentation_medium_glucose_urea
-original_name: '''Fermentation Medium (Glucose+Urea'
+original_name: Fermentation Medium (Glucose+Urea)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.477768+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 363
   term:
     id: MEDIADB:363
-    label: '''Fermentation Medium (Glucose+Urea'
+    label: Fermentation Medium (Glucose+Urea)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glucose_valine.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glucose_valine.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007279
 name: fermentation_medium_glucose_valine
-original_name: '''Fermentation Medium (Glucose+Valine'
+original_name: Fermentation Medium (Glucose+Valine)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -140,11 +140,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.485920+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 376
   term:
     id: MEDIADB:376
-    label: '''Fermentation Medium (Glucose+Valine'
+    label: Fermentation Medium (Glucose+Valine)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_glycerol_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_glycerol_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007252
 name: fermentation_medium_glycerol_nh4cl
-original_name: '''Fermentation Medium (Glycerol+NH4Cl'
+original_name: Fermentation Medium (Glycerol+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.494438+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 351
   term:
     id: MEDIADB:351
-    label: '''Fermentation Medium (Glycerol+NH4Cl'
+    label: Fermentation Medium (Glycerol+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_l_alanine_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_l_alanine_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007255
 name: fermentation_medium_l_alanine_nh4cl
-original_name: '''Fermentation Medium (L-alanine+NH4Cl'
+original_name: Fermentation Medium (L-alanine+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.503056+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 354
   term:
     id: MEDIADB:354
-    label: '''Fermentation Medium (L-alanine+NH4Cl'
+    label: Fermentation Medium (L-alanine+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_l_arginine_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_l_arginine_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007258
 name: fermentation_medium_l_arginine_nh4cl
-original_name: '''Fermentation Medium (L-arginine+NH4Cl'
+original_name: Fermentation Medium (L-arginine+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.511500+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 357
   term:
     id: MEDIADB:357
-    label: '''Fermentation Medium (L-arginine+NH4Cl'
+    label: Fermentation Medium (L-arginine+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_l_aspartate_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_l_aspartate_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007257
 name: fermentation_medium_l_aspartate_nh4cl
-original_name: '''Fermentation Medium (L-aspartate+NH4Cl'
+original_name: Fermentation Medium (L-aspartate+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:28.519879+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 356
   term:
     id: MEDIADB:356
-    label: '''Fermentation Medium (L-aspartate+NH4Cl'
+    label: Fermentation Medium (L-aspartate+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_l_glutamate_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_l_glutamate_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007256
 name: fermentation_medium_l_glutamate_nh4cl
-original_name: '''Fermentation Medium (L-glutamate+NH4Cl'
+original_name: Fermentation Medium (L-glutamate+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -141,11 +141,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.528282+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 355
   term:
     id: MEDIADB:355
-    label: '''Fermentation Medium (L-glutamate+NH4Cl'
+    label: Fermentation Medium (L-glutamate+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_l_proline_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_l_proline_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007259
 name: fermentation_medium_l_proline_nh4cl
-original_name: '''Fermentation Medium (L-proline+NH4Cl'
+original_name: Fermentation Medium (L-proline+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.536522+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 358
   term:
     id: MEDIADB:358
-    label: '''Fermentation Medium (L-proline+NH4Cl'
+    label: Fermentation Medium (L-proline+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_lactate_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_lactate_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007262
 name: fermentation_medium_lactate_nh4cl
-original_name: '''Fermentation Medium (Lactate+NH4Cl'
+original_name: Fermentation Medium (Lactate+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -143,11 +143,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.544983+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 360
   term:
     id: MEDIADB:360
-    label: '''Fermentation Medium (Lactate+NH4Cl'
+    label: Fermentation Medium (Lactate+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_mannose_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_mannose_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007251
 name: fermentation_medium_mannose_nh4cl
-original_name: '''Fermentation Medium (Mannose+NH4Cl'
+original_name: Fermentation Medium (Mannose+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.553282+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 350
   term:
     id: MEDIADB:350
-    label: '''Fermentation Medium (Mannose+NH4Cl'
+    label: Fermentation Medium (Mannose+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_methanol_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_methanol_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007253
 name: fermentation_medium_methanol_nh4cl
-original_name: '''Fermentation Medium (Methanol+NH4Cl'
+original_name: Fermentation Medium (Methanol+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.561833+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 352
   term:
     id: MEDIADB:352
-    label: '''Fermentation Medium (Methanol+NH4Cl'
+    label: Fermentation Medium (Methanol+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_oleic_acid_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_oleic_acid_nh4cl.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(9Z'
+- preferred_term: (9Z)-Octadecenoic acid
   concentration:
     value: '111.0'
     unit: MILLIMOLAR
@@ -137,6 +137,12 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T04:06:16.840917+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:362's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 362
   term:

--- a/data/normalized_yaml/bacterial/fermentation_medium_oleic_acid_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_oleic_acid_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007264
 name: fermentation_medium_oleic_acid_nh4cl
-original_name: '''Fermentation Medium (Oleic acid+NH4Cl'
+original_name: Fermentation Medium (Oleic acid+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -143,11 +143,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:362's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:28.570634+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 362
   term:
     id: MEDIADB:362
-    label: '''Fermentation Medium (Oleic acid+NH4Cl'
+    label: Fermentation Medium (Oleic acid+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_pyruvate_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_pyruvate_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007260
 name: fermentation_medium_pyruvate_nh4cl
-original_name: '''Fermentation Medium (Pyruvate+NH4Cl'
+original_name: Fermentation Medium (Pyruvate+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -144,11 +144,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.579457+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 359
   term:
     id: MEDIADB:359
-    label: '''Fermentation Medium (Pyruvate+NH4Cl'
+    label: Fermentation Medium (Pyruvate+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fermentation_medium_trehalose_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/fermentation_medium_trehalose_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007248
 name: fermentation_medium_trehalose_nh4cl
-original_name: '''Fermentation Medium (Trehalose+NH4Cl'
+original_name: Fermentation Medium (Trehalose+NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -138,11 +138,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:17:28.588143+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 348
   term:
     id: MEDIADB:348
-    label: '''Fermentation Medium (Trehalose+NH4Cl'
+    label: Fermentation Medium (Trehalose+NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/fry_et_al.yaml
+++ b/data/normalized_yaml/bacterial/fry_et_al.yaml
@@ -95,7 +95,7 @@ ingredients:
   term:
     id: CHEBI:63041
     label: manganese(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.00799112'
     unit: MILLIMOLAR
@@ -147,6 +147,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:20.731804+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:220's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 220
   term:

--- a/data/normalized_yaml/bacterial/fwafc.yaml
+++ b/data/normalized_yaml/bacterial/fwafc.yaml
@@ -84,7 +84,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:176843
     label: vitamin B12
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '57.1057'
     unit: MILLIMOLAR
@@ -324,11 +324,23 @@ curation_history:
 - timestamp: '2026-06-08T23:19:39.257539+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
 - timestamp: '2026-06-09T01:42:20.574706+00:00'
   curator: chebi-regrounding-v1.0
   action: Corrected CHEBI ingredient grounding (shared-id regrounding audit, G21/G22/G24)
-  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more ingredient groundings on this record that had been collapsed onto a chemically non-specific or shared CHEBI id were re-grounded to the correct chemically-specific term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+  notes: 'Part of the shared-id CHEBI regrounding audit (G21/G22/G24): one or more
+    ingredient groundings on this record that had been collapsed onto a chemically
+    non-specific or shared CHEBI id were re-grounded to the correct chemically-specific
+    term, verified against OAK chebi.db rdfs:label. See reports/chebi_grounding_audit.md.'
+- timestamp: '2026-08-31T04:06:20.878903+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:3's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 3
   term:

--- a/data/normalized_yaml/bacterial/glucose_limiting_minimal_media_hassan_et_al.yaml
+++ b/data/normalized_yaml/bacterial/glucose_limiting_minimal_media_hassan_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007003
 name: glucose_limiting_minimal_media_hassan_et_al
-original_name: '''glucose limiting minimal media (Hassan et al'
+original_name: glucose limiting minimal media (Hassan et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -102,11 +102,17 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:32.811844+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 116
   term:
     id: MEDIADB:116
-    label: '''glucose limiting minimal media (Hassan et al'
+    label: glucose limiting minimal media (Hassan et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/glucose_m9_medium_peng_zhao.yaml
+++ b/data/normalized_yaml/bacterial/glucose_m9_medium_peng_zhao.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007019
 name: glucose_m9_medium_peng_zhao
-original_name: '''glucose m9 medium (peng/zhao'
+original_name: glucose m9 medium (peng/zhao)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -159,11 +159,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:130's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:32.820627+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 130
   term:
     id: MEDIADB:130
-    label: '''glucose m9 medium (peng/zhao'
+    label: glucose m9 medium (peng/zhao)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/glucose_m9_medium_peng_zhao.yaml
+++ b/data/normalized_yaml/bacterial/glucose_m9_medium_peng_zhao.yaml
@@ -102,7 +102,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.06165'
     unit: MILLIMOLAR
@@ -153,6 +153,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:21.338604+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:130's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 130
   term:

--- a/data/normalized_yaml/bacterial/glucose_minimal_media_hassan_et_al.yaml
+++ b/data/normalized_yaml/bacterial/glucose_minimal_media_hassan_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007002
 name: glucose_minimal_media_hassan_et_al
-original_name: '''glucose minimal media (Hassan et al'
+original_name: glucose minimal media (Hassan et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -102,11 +102,17 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:32.838190+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 115
   term:
     id: MEDIADB:115
-    label: '''glucose minimal media (Hassan et al'
+    label: glucose minimal media (Hassan et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/glucose_minimal_media_zhao_zhu.yaml
+++ b/data/normalized_yaml/bacterial/glucose_minimal_media_zhao_zhu.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007021
 name: glucose_minimal_media_zhao_zhu
-original_name: '''glucose minimal media (zhao/zhu'
+original_name: glucose minimal media (zhao/zhu)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -171,11 +171,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:132's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:32.852402+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 132
   term:
     id: MEDIADB:132
-    label: '''glucose minimal media (zhao/zhu'
+    label: glucose minimal media (zhao/zhu)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/glucose_minimal_media_zhao_zhu.yaml
+++ b/data/normalized_yaml/bacterial/glucose_minimal_media_zhao_zhu.yaml
@@ -111,7 +111,7 @@ ingredients:
   term:
     id: CHEBI:23414
     label: copper(II) sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.18535'
     unit: MILLIMOLAR
@@ -165,6 +165,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:21.367779+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:132's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 132
   term:

--- a/data/normalized_yaml/bacterial/glucose_minmal_media_zhao.yaml
+++ b/data/normalized_yaml/bacterial/glucose_minmal_media_zhao.yaml
@@ -102,7 +102,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.06165'
     unit: MILLIMOLAR
@@ -153,6 +153,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:21.377489+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:128's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 128
   term:

--- a/data/normalized_yaml/bacterial/glucose_minmal_media_zhao.yaml
+++ b/data/normalized_yaml/bacterial/glucose_minmal_media_zhao.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007016
 name: glucose_minmal_media_zhao
-original_name: '''Glucose minmal media (zhao'
+original_name: Glucose minmal media (zhao)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -159,11 +159,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:128's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:32.862015+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 128
   term:
     id: MEDIADB:128
-    label: '''Glucose minmal media (zhao'
+    label: Glucose minmal media (zhao)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/glucose_salt_medium_k.yaml
+++ b/data/normalized_yaml/bacterial/glucose_salt_medium_k.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007123
 name: glucose_salt_medium_k
-original_name: '''Glucose salt (Medium K'
+original_name: Glucose salt (Medium K); Schaechter et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -95,11 +95,17 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:32.875689+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 228
   term:
     id: MEDIADB:228
-    label: '''Glucose salt (Medium K'
+    label: Glucose salt (Medium K); Schaechter et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/gotz_minimal_medium_with_malate.yaml
+++ b/data/normalized_yaml/bacterial/gotz_minimal_medium_with_malate.yaml
@@ -17,7 +17,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:15956
     label: biotin
-- preferred_term: '''(S'
+- preferred_term: (S)-Malate
   concentration:
     value: '27.0'
     unit: MILLIMOLAR
@@ -175,6 +175,12 @@ curation_history:
   notes: 'Replaced 9 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:21.490241+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:224's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 224
   term:

--- a/data/normalized_yaml/bacterial/histidine_limiting_minimal_media_hassan_et_al.yaml
+++ b/data/normalized_yaml/bacterial/histidine_limiting_minimal_media_hassan_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007005
 name: histidine_limiting_minimal_media_hassan_et_al
-original_name: '''histidine limiting minimal media (Hassan et al'
+original_name: histidine limiting minimal media (Hassan et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -102,11 +102,17 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:34.058739+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 118
   term:
     id: MEDIADB:118
-    label: '''histidine limiting minimal media (Hassan et al'
+    label: histidine limiting minimal media (Hassan et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/hmm_with_0_5_g_l_junlon_pw_110_hobbs_et_al.yaml
+++ b/data/normalized_yaml/bacterial/hmm_with_0_5_g_l_junlon_pw_110_hobbs_et_al.yaml
@@ -114,7 +114,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0540999'
     unit: MILLIMOLAR
@@ -182,6 +182,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:22.626637+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:253's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 253
   term:

--- a/data/normalized_yaml/bacterial/hmm_with_1_5_g_l_junlon_pw_110_hobbs_et_al.yaml
+++ b/data/normalized_yaml/bacterial/hmm_with_1_5_g_l_junlon_pw_110_hobbs_et_al.yaml
@@ -114,7 +114,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0540999'
     unit: MILLIMOLAR
@@ -182,6 +182,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:22.638379+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:255's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 255
   term:

--- a/data/normalized_yaml/bacterial/hmm_with_1_g_l_junlon_pw_110_hobbs_et_al.yaml
+++ b/data/normalized_yaml/bacterial/hmm_with_1_g_l_junlon_pw_110_hobbs_et_al.yaml
@@ -114,7 +114,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0540999'
     unit: MILLIMOLAR
@@ -182,6 +182,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:22.651053+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:254's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 254
   term:

--- a/data/normalized_yaml/bacterial/hmm_with_2_g_l_junlon_pw_110_hobbs_et_al.yaml
+++ b/data/normalized_yaml/bacterial/hmm_with_2_g_l_junlon_pw_110_hobbs_et_al.yaml
@@ -114,7 +114,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0540999'
     unit: MILLIMOLAR
@@ -182,6 +182,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:22.662541+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:256's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 256
   term:

--- a/data/normalized_yaml/bacterial/hs_medium_methanol_acetate.yaml
+++ b/data/normalized_yaml/bacterial/hs_medium_methanol_acetate.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007379
 name: hs_medium_methanol_acetate
-original_name: '''HS Medium (Methanol-Acetate'
+original_name: HS Medium (Methanol-Acetate)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -161,11 +161,17 @@ curation_history:
   notes: 'Replaced 8 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:34.205559+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 472
   term:
     id: MEDIADB:472
-    label: '''HS Medium (Methanol-Acetate'
+    label: HS Medium (Methanol-Acetate)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/labarre_modified_bg11.yaml
+++ b/data/normalized_yaml/bacterial/labarre_modified_bg11.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007221
 name: labarre_modified_bg11
-original_name: '''Labarre (Modified BG11'
+original_name: Labarre (Modified BG11)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -186,11 +186,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:321's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:17:35.464974+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 321
   term:
     id: MEDIADB:321
-    label: '''Labarre (Modified BG11'
+    label: Labarre (Modified BG11)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/labarre_modified_bg11.yaml
+++ b/data/normalized_yaml/bacterial/labarre_modified_bg11.yaml
@@ -136,7 +136,7 @@ ingredients:
   term:
     id: CHEBI:131527
     label: dipotassium hydrogen phosphate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.0245'
     unit: MILLIMOLAR
@@ -180,6 +180,12 @@ curation_history:
   notes: 'Replaced 8 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.112486+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:321's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 321
   term:

--- a/data/normalized_yaml/bacterial/lactate_salt_schaechter_et_al.yaml
+++ b/data/normalized_yaml/bacterial/lactate_salt_schaechter_et_al.yaml
@@ -14,7 +14,7 @@ ingredients:
   term:
     id: CHEBI:16947
     label: citrate(3-)
-- preferred_term: '''(R'
+- preferred_term: (R)-Lactate
   concentration:
     value: '22.4543'
     unit: MILLIMOLAR
@@ -89,6 +89,12 @@ curation_history:
   notes: 'Replaced 2 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.144879+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:230's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 230
   term:

--- a/data/normalized_yaml/bacterial/leitch_et_al.yaml
+++ b/data/normalized_yaml/bacterial/leitch_et_al.yaml
@@ -98,7 +98,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0039955'
     unit: MILLIMOLAR
@@ -150,6 +150,12 @@ curation_history:
   notes: 'Replaced 8 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.471834+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:176's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 176
   term:

--- a/data/normalized_yaml/bacterial/lg_medium.yaml
+++ b/data/normalized_yaml/bacterial/lg_medium.yaml
@@ -116,7 +116,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.01'
     unit: MILLIMOLAR
@@ -166,6 +166,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:24.530604+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:186's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 186
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_acetate.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_acetate.yaml
@@ -120,7 +120,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -131,7 +131,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -170,6 +170,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.631181+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:18's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 18
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_beta_d_glucose.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_beta_d_glucose.yaml
@@ -120,7 +120,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -131,7 +131,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -170,6 +170,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.641882+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:22's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 22
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_d_2_3_butanediol.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_d_2_3_butanediol.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(R,R'
+- preferred_term: (R,R)-Butane-2,3-diol
   concentration:
     value: '25.0'
     unit: MILLIMOLAR
@@ -113,7 +113,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -124,7 +124,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -163,6 +163,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.652675+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 3 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:20's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 20
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_d_glucarate.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_d_glucarate.yaml
@@ -117,7 +117,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -128,7 +128,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -172,6 +172,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:24.662622+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:21's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 21
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_l_asparagine.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_l_asparagine.yaml
@@ -120,7 +120,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -131,7 +131,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -170,6 +170,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.672876+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:19's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 19
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_l_lactate.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_l_lactate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(S'
+- preferred_term: (S)-Lactate
   concentration:
     value: '25.0'
     unit: MILLIMOLAR
@@ -114,7 +114,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -125,7 +125,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -164,6 +164,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.682373+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 3 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:23's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 23
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_quinate.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_quinate.yaml
@@ -117,7 +117,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -128,7 +128,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -172,6 +172,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:24.691957+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:24's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 24
   term:

--- a/data/normalized_yaml/bacterial/liquid_ma_minimal_media_succinate_urea_ammonia.yaml
+++ b/data/normalized_yaml/bacterial/liquid_ma_minimal_media_succinate_urea_ammonia.yaml
@@ -121,7 +121,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.003'
     unit: MILLIMOLAR
@@ -132,7 +132,7 @@ ingredients:
   term:
     id: CHEBI:49976
     label: zinc dichloride
-- preferred_term: '''Chromium(III'
+- preferred_term: Chromium(III) Chloride
   concentration:
     value: '0.0003'
     unit: MILLIMOLAR
@@ -171,6 +171,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:24.701830+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 2 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:25's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 25
   term:

--- a/data/normalized_yaml/bacterial/lsg_medium.yaml
+++ b/data/normalized_yaml/bacterial/lsg_medium.yaml
@@ -127,7 +127,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.01'
     unit: MILLIMOLAR
@@ -177,6 +177,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:06:24.821144+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:187's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 187
   term:

--- a/data/normalized_yaml/bacterial/m9_durso_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_durso_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:006990
 name: m9_durso_et_al
-original_name: '''M9 (Durso et al'
+original_name: M9 (Durso et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -113,11 +113,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.457494+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 103
   term:
     id: MEDIADB:103
-    label: '''M9 (Durso et al'
+    label: M9 (Durso et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_farewell.yaml
+++ b/data/normalized_yaml/bacterial/m9_farewell.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(9Z'
+- preferred_term: (9Z)-Octadecenoic acid
   concentration:
     value: '5.0'
     unit: MILLIMOLAR
@@ -95,6 +95,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.223367+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:161's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 161
   term:

--- a/data/normalized_yaml/bacterial/m9_farmer_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_farmer_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007010
 name: m9_farmer_et_al
-original_name: '''M9 (farmer et al'
+original_name: M9 (farmer et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -103,11 +103,17 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.473393+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 122
   term:
     id: MEDIADB:122
-    label: '''M9 (farmer et al'
+    label: M9 (farmer et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_gupta.yaml
+++ b/data/normalized_yaml/bacterial/m9_gupta.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:006994
 name: m9_gupta
-original_name: '''M9 (Gupta'
+original_name: M9 (Gupta) with glucose
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -112,11 +112,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.480175+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 108
   term:
     id: MEDIADB:108
-    label: '''M9 (Gupta'
+    label: M9 (Gupta) with glucose
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_medium_fischer_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_medium_fischer_et_al.yaml
@@ -112,7 +112,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.616722'
     unit: MILLIMOLAR
@@ -155,6 +155,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.252072+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:147's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 147
   term:

--- a/data/normalized_yaml/bacterial/m9_minimal_medium_with_l_lactate.yaml
+++ b/data/normalized_yaml/bacterial/m9_minimal_medium_with_l_lactate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(S'
+- preferred_term: (S)-Lactate
   concentration:
     value: '22.0'
     unit: MILLIMOLAR
@@ -97,6 +97,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.299503+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:78's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 78
   term:

--- a/data/normalized_yaml/bacterial/m9_minimal_medium_with_l_malate.yaml
+++ b/data/normalized_yaml/bacterial/m9_minimal_medium_with_l_malate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(S'
+- preferred_term: (S)-Malate
   concentration:
     value: '15.0'
     unit: MILLIMOLAR
@@ -97,6 +97,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.305988+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:79's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 79
   term:

--- a/data/normalized_yaml/bacterial/m9_oh.yaml
+++ b/data/normalized_yaml/bacterial/m9_oh.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007008
 name: m9_oh
-original_name: '''M9 (oh'
+original_name: M9 (oh)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -113,11 +113,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.552148+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 120
   term:
     id: MEDIADB:120
-    label: '''M9 (oh'
+    label: M9 (oh)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_seo.yaml
+++ b/data/normalized_yaml/bacterial/m9_seo.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:006991
 name: m9_seo
-original_name: '''M9 (Seo'
+original_name: M9 (Seo)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -130,11 +130,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.574456+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 104
   term:
     id: MEDIADB:104
-    label: '''M9 (Seo'
+    label: M9 (Seo)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_tomaras.yaml
+++ b/data/normalized_yaml/bacterial/m9_tomaras.yaml
@@ -70,7 +70,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.2'
     unit: MILLIMOLAR
@@ -116,6 +116,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.348870+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:294's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 294
   term:

--- a/data/normalized_yaml/bacterial/m9_with_0_4_glucose_prachaiyo_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_0_4_glucose_prachaiyo_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007441
 name: m9_with_0_4_glucose_prachaiyo_et_al
-original_name: '''M9 with 0.4% glucose (prachaiyo et al'
+original_name: M9 with 0.4% glucose (prachaiyo et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -103,11 +103,17 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.608488+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 93
   term:
     id: MEDIADB:93
-    label: '''M9 with 0.4% glucose (prachaiyo et al'
+    label: M9 with 0.4% glucose (prachaiyo et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_0_7_glucose_prachaiyo_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_0_7_glucose_prachaiyo_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007446
 name: m9_with_0_7_glucose_prachaiyo_et_al
-original_name: '''M9 with 0.7% glucose (prachaiyo et al'
+original_name: M9 with 0.7% glucose (prachaiyo et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -103,11 +103,17 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.638708+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 98
   term:
     id: MEDIADB:98
-    label: '''M9 with 0.7% glucose (prachaiyo et al'
+    label: M9 with 0.7% glucose (prachaiyo et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_16_g_l_glucose_kazan.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_16_g_l_glucose_kazan.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007014
 name: m9_with_16_g_l_glucose_kazan
-original_name: '''M9 with 16 g/l glucose (kazan'
+original_name: M9 with 16 g/l glucose (kazan)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.646961+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 126
   term:
     id: MEDIADB:126
-    label: '''M9 with 16 g/l glucose (kazan'
+    label: M9 with 16 g/l glucose (kazan)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_1_0_glucose_prachaiyo_et_al.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_1_0_glucose_prachaiyo_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007447
 name: m9_with_1_0_glucose_prachaiyo_et_al
-original_name: '''M9 with 1.0% glucose (prachaiyo et al'
+original_name: M9 with 1.0% glucose (prachaiyo et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -103,11 +103,17 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:17:36.659230+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 99
   term:
     id: MEDIADB:99
-    label: '''M9 with 1.0% glucose (prachaiyo et al'
+    label: M9 with 1.0% glucose (prachaiyo et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_2_g_l_glucose_kazan.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_2_g_l_glucose_kazan.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007011
 name: m9_with_2_g_l_glucose_kazan
-original_name: '''M9 with 2 g/l glucose (kazan'
+original_name: M9 with 2 g/l glucose (kazan)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.668292+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 123
   term:
     id: MEDIADB:123
-    label: '''M9 with 2 g/l glucose (kazan'
+    label: M9 with 2 g/l glucose (kazan)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_32_g_l_glucose_kazan.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_32_g_l_glucose_kazan.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007015
 name: m9_with_32_g_l_glucose_kazan
-original_name: '''M9 with 32 g/l glucose (kazan'
+original_name: M9 with 32 g/l glucose (kazan)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.679225+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 127
   term:
     id: MEDIADB:127
-    label: '''M9 with 32 g/l glucose (kazan'
+    label: M9 with 32 g/l glucose (kazan)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_4_g_l_glucose_kazan.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_4_g_l_glucose_kazan.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007012
 name: m9_with_4_g_l_glucose_kazan
-original_name: '''M9 with 4 g/l glucose (kazan'
+original_name: M9 with 4 g/l glucose (kazan)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.706163+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 124
   term:
     id: MEDIADB:124
-    label: '''M9 with 4 g/l glucose (kazan'
+    label: M9 with 4 g/l glucose (kazan)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_8_g_l_glucose_kazan.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_8_g_l_glucose_kazan.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007013
 name: m9_with_8_g_l_glucose_kazan
-original_name: '''M9 with 8 g/l glucose (kazan'
+original_name: M9 with 8 g/l glucose (kazan)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -146,11 +146,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.733459+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 125
   term:
     id: MEDIADB:125
-    label: '''M9 with 8 g/l glucose (kazan'
+    label: M9 with 8 g/l glucose (kazan)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9_with_iptg_oh.yaml
+++ b/data/normalized_yaml/bacterial/m9_with_iptg_oh.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007009
 name: m9_with_iptg_oh
-original_name: '''M9 with iptg (oh'
+original_name: M9 with iptg (oh)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -118,11 +118,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:17:36.741442+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 121
   term:
     id: MEDIADB:121
-    label: '''M9 with iptg (oh'
+    label: M9 with iptg (oh)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/m9zb_with_malate.yaml
+++ b/data/normalized_yaml/bacterial/m9zb_with_malate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(S'
+- preferred_term: (S)-Malate
   concentration:
     value: '30.0'
     unit: MILLIMOLAR
@@ -97,6 +97,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:06:25.521531+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:113's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 113
   term:

--- a/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
+++ b/data/normalized_yaml/bacterial/mcn_medium_whitman.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007380
 name: mcn_medium_whitman
-original_name: '''McN Medium (Whitman'
+original_name: McN Medium (Whitman)
 category: bacterial
 medium_type: COMPLEX
 composition_type: UNDEFINED
@@ -304,11 +304,17 @@ curation_history:
     row in this record, which made the recipe read as double-strength in those components
     (#263): Sodium chloride, Tryptone, Yeast extract.'
   changes: ingredients 30 -> 27
+- timestamp: '2026-08-31T06:17:37.792230+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 473
   term:
     id: MEDIADB:473
-    label: '''McN Medium (Whitman'
+    label: McN Medium (Whitman)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/
 

--- a/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
+++ b/data/normalized_yaml/bacterial/mcna_medium_lupa.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007381
 name: mcna_medium_lupa
-original_name: '''McNA Medium (Lupa'
+original_name: McNA Medium (Lupa)
 category: bacterial
 medium_type: COMPLEX
 composition_type: UNDEFINED
@@ -315,11 +315,17 @@ curation_history:
     row in this record, which made the recipe read as double-strength in those components
     (#263): Sodium chloride, Tryptone, Yeast extract.'
   changes: ingredients 31 -> 28
+- timestamp: '2026-08-31T06:17:37.813611+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 474
   term:
     id: MEDIADB:474
-    label: '''McNA Medium (Lupa'
+    label: McNA Medium (Lupa)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/
 

--- a/data/normalized_yaml/bacterial/minimal_chemically_defined_medium_his_pro_letort_2001.yaml
+++ b/data/normalized_yaml/bacterial/minimal_chemically_defined_medium_his_pro_letort_2001.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007297
 name: minimal_chemically_defined_medium_his_pro_letort_2001
-original_name: '''Minimal chemically-defined medium + His +Pro (letort 2001'
+original_name: Minimal chemically-defined medium + His +Pro (letort 2001)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -235,11 +235,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:15.538004+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 393
   term:
     id: MEDIADB:393
-    label: '''Minimal chemically-defined medium + His +Pro (letort 2001'
+    label: Minimal chemically-defined medium + His +Pro (letort 2001)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_chemically_defined_medium_letort_2001.yaml
+++ b/data/normalized_yaml/bacterial/minimal_chemically_defined_medium_letort_2001.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007296
 name: minimal_chemically_defined_medium_letort_2001
-original_name: '''Minimal chemically-defined medium (letort 2001'
+original_name: Minimal chemically-defined medium (letort 2001)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -214,11 +214,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:15.550287+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 392
   term:
     id: MEDIADB:392
-    label: '''Minimal chemically-defined medium (letort 2001'
+    label: Minimal chemically-defined medium (letort 2001)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_medium_frustaci.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_frustaci.yaml
@@ -110,7 +110,7 @@ ingredients:
   term:
     id: CHEBI:23414
     label: copper(II) sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0037'
     unit: MILLIMOLAR
@@ -149,6 +149,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:02.594708+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:225's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 225
   term:

--- a/data/normalized_yaml/bacterial/minimal_medium_jyssum_1959.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_jyssum_1959.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007299
 name: minimal_medium_jyssum_1959
-original_name: '''Minimal medium (Jyssum 1959'
+original_name: Minimal medium (Jyssum 1959)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -119,11 +119,17 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:15.589708+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 395
   term:
     id: MEDIADB:395
-    label: '''Minimal medium (Jyssum 1959'
+    label: Minimal medium (Jyssum 1959)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_medium_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_tang_et_al_2009.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007073
 name: minimal_medium_tang_et_al_2009
-original_name: '''Minimal medium (tang et al 2009'
+original_name: Minimal medium (tang et al 2009)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -157,7 +157,8 @@ curation_history:
 - timestamp: '2026-06-14T05:58:58.561437+00:00'
   curator: idnf-grounding-fix-v1.0
   action: Fixed ID_NOT_FOUND term groundings
-  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
+  notes: Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI,
+    0 de-grounded (mixture or unverifiable).
 - timestamp: '2026-01-27T07:21:44.226667Z'
   curator: mediadb-import
   action: Imported from MediaDB
@@ -186,11 +187,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:15.605374+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 182
   term:
     id: MEDIADB:182
-    label: '''Minimal medium (tang et al 2009'
+    label: Minimal medium (tang et al 2009)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_and_salt_stress_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_and_salt_stress_tang_et_al_2009.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007076
 name: minimal_medium_w_amino_acids_and_salt_stress_tang_et_al_2009
-original_name: '''Minimal Medium w/amino acids and salt stress (Tang et al 2009'
+original_name: Minimal Medium w/amino acids and salt stress (Tang et al 2009)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -343,11 +343,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:15.630120+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 185
   term:
     id: MEDIADB:185
-    label: '''Minimal Medium w/amino acids and salt stress (Tang et al 2009'
+    label: Minimal Medium w/amino acids and salt stress (Tang et al 2009)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_w_amino_acids_tang_et_al_2009.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007075
 name: minimal_medium_w_amino_acids_tang_et_al_2009
-original_name: '''Minimal Medium w/amino acids (Tang et al 2009'
+original_name: Minimal Medium w/amino acids (Tang et al 2009)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -332,11 +332,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:15.647633+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 184
   term:
     id: MEDIADB:184
-    label: '''Minimal Medium w/amino acids (Tang et al 2009'
+    label: Minimal Medium w/amino acids (Tang et al 2009)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_medium_whitchurch_et_al.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_whitchurch_et_al.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.001'
     unit: MILLIMOLAR
@@ -175,6 +175,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:02.657128+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:35's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 35
   term:

--- a/data/normalized_yaml/bacterial/minimal_medium_with_salt_stress_tang_et_al_2009.yaml
+++ b/data/normalized_yaml/bacterial/minimal_medium_with_salt_stress_tang_et_al_2009.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007074
 name: minimal_medium_with_salt_stress_tang_et_al_2009
-original_name: '''Minimal medium with salt stress (tang et al 2009'
+original_name: Minimal medium with salt stress (tang et al 2009)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -167,7 +167,8 @@ curation_history:
 - timestamp: '2026-06-14T05:58:58.561437+00:00'
   curator: idnf-grounding-fix-v1.0
   action: Fixed ID_NOT_FOUND term groundings
-  notes: 'Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI, 0 de-grounded (mixture or unverifiable).'
+  notes: Absent/obsolete CHEBI term ids fixed - 2 re-grounded to the correct CHEBI,
+    0 de-grounded (mixture or unverifiable).
 - timestamp: '2026-01-27T07:21:44.237020Z'
   curator: mediadb-import
   action: Imported from MediaDB
@@ -196,11 +197,17 @@ curation_history:
   notes: 'Replaced 8 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:15.666983+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 183
   term:
     id: MEDIADB:183
-    label: '''Minimal medium with salt stress (tang et al 2009'
+    label: Minimal medium with salt stress (tang et al 2009)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/minimal_seed_medium_liu_2004.yaml
+++ b/data/normalized_yaml/bacterial/minimal_seed_medium_liu_2004.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007284
 name: minimal_seed_medium_liu_2004
-original_name: '''Minimal Seed Medium (Liu 2004'
+original_name: Minimal Seed Medium (Liu 2004)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -133,11 +133,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:15.690274+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 380
   term:
     id: MEDIADB:380
-    label: '''Minimal Seed Medium (Liu 2004'
+    label: Minimal Seed Medium (Liu 2004)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/mm_biotin_and_thiamine_villasenor_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_biotin_and_thiamine_villasenor_et_al.yaml
@@ -73,7 +73,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31206
     label: ammonium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0184'
     unit: MILLIMOLAR
@@ -112,6 +112,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:02.995691+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:171's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 171
   term:

--- a/data/normalized_yaml/bacterial/mm_causey.yaml
+++ b/data/normalized_yaml/bacterial/mm_causey.yaml
@@ -90,7 +90,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.01'
     unit: MILLIMOLAR
@@ -139,6 +139,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.004250+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:167's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 167
   term:

--- a/data/normalized_yaml/bacterial/mm_glucose_dunn_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_glucose_dunn_et_al.yaml
@@ -62,7 +62,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32599
     label: magnesium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.123304'
     unit: MILLIMOLAR
@@ -115,6 +115,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.012320+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:150's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 150
   term:

--- a/data/normalized_yaml/bacterial/mm_pyruvate_dunn_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_pyruvate_dunn_et_al.yaml
@@ -62,7 +62,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32599
     label: magnesium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.123304'
     unit: MILLIMOLAR
@@ -115,6 +115,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.024440+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:148's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 148
   term:

--- a/data/normalized_yaml/bacterial/mm_pyruvate_with_aspartate_dunn_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_pyruvate_with_aspartate_dunn_et_al.yaml
@@ -70,7 +70,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32599
     label: magnesium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.123304'
     unit: MILLIMOLAR
@@ -128,6 +128,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:03.032691+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:149's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 149
   term:

--- a/data/normalized_yaml/bacterial/mm_succinate_with_biotin_dunn_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_succinate_with_biotin_dunn_et_al.yaml
@@ -62,7 +62,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32599
     label: magnesium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.123304'
     unit: MILLIMOLAR
@@ -115,6 +115,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.050363+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:152's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 152
   term:

--- a/data/normalized_yaml/bacterial/mm_succinate_with_nh4cl_encarnacion_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_succinate_with_nh4cl_encarnacion_et_al.yaml
@@ -51,7 +51,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31206
     label: ammonium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0184'
     unit: MILLIMOLAR
@@ -90,6 +90,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.057047+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:165's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 165
   term:

--- a/data/normalized_yaml/bacterial/mm_succinate_without_biotin_dunn_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mm_succinate_without_biotin_dunn_et_al.yaml
@@ -51,7 +51,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:32599
     label: magnesium sulfate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.123304'
     unit: MILLIMOLAR
@@ -104,6 +104,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.063952+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:151's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 151
   term:

--- a/data/normalized_yaml/bacterial/mmb_succinate_with_nh4cl_and_biotin_taboada_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mmb_succinate_with_nh4cl_and_biotin_taboada_et_al.yaml
@@ -62,7 +62,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31206
     label: ammonium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0184'
     unit: MILLIMOLAR
@@ -101,6 +101,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.129812+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:169's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 169
   term:

--- a/data/normalized_yaml/bacterial/mmp_biotin_thiamine_and_ca_pantothenate_villasenor_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mmp_biotin_thiamine_and_ca_pantothenate_villasenor_et_al.yaml
@@ -83,7 +83,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31206
     label: ammonium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0184'
     unit: MILLIMOLAR
@@ -123,6 +123,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.381565+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:172's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 172
   term:

--- a/data/normalized_yaml/bacterial/mms_medium_huber_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mms_medium_huber_et_al.yaml
@@ -185,7 +185,7 @@ ingredients:
   term:
     id: CHEBI:76208
     label: sodium sulfide (anhydrous)
-- preferred_term: '''Nickel(II'
+- preferred_term: Nickel(II) ammonium sulfate
   concentration:
     value: '0.00697114'
     unit: MILLIMOLAR
@@ -235,6 +235,12 @@ curation_history:
   notes: 'Replaced 12 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.392862+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:144's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 144
   term:

--- a/data/normalized_yaml/bacterial/mmt_succinate_with_nh4cl_and_thiamine_taboada_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mmt_succinate_with_nh4cl_and_thiamine_taboada_et_al.yaml
@@ -62,7 +62,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:31206
     label: ammonium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0184'
     unit: MILLIMOLAR
@@ -101,6 +101,12 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.407562+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:170's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 170
   term:

--- a/data/normalized_yaml/bacterial/model_designed_medium_baart_2007.yaml
+++ b/data/normalized_yaml/bacterial/model_designed_medium_baart_2007.yaml
@@ -109,7 +109,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:26710
     label: sodium chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.3'
     unit: MILLIMOLAR
@@ -155,6 +155,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:03.523312+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:394's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 394
   term:

--- a/data/normalized_yaml/bacterial/model_designed_medium_baart_2007.yaml
+++ b/data/normalized_yaml/bacterial/model_designed_medium_baart_2007.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007298
 name: model_designed_medium_baart_2007
-original_name: '''Model-designed medium (Baart 2007'
+original_name: Model-designed medium (Baart 2007)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -161,11 +161,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:394's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:18:16.460950+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 394
   term:
     id: MEDIADB:394
-    label: '''Model-designed medium (Baart 2007'
+    label: Model-designed medium (Baart 2007)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/modified_hmm_ozergin_ulgen_et_al.yaml
+++ b/data/normalized_yaml/bacterial/modified_hmm_ozergin_ulgen_et_al.yaml
@@ -109,7 +109,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0540999'
     unit: MILLIMOLAR
@@ -177,6 +177,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:04.074393+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:257's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 257
   term:

--- a/data/normalized_yaml/bacterial/modified_labarre_medium_56_mm_glucose.yaml
+++ b/data/normalized_yaml/bacterial/modified_labarre_medium_56_mm_glucose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007290
 name: modified_labarre_medium_56_mm_glucose
-original_name: '''Modified Labarre Medium (56 mM Glucose'
+original_name: Modified Labarre Medium (56 mM Glucose)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -196,11 +196,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:386's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:18:16.996489+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 386
   term:
     id: MEDIADB:386
-    label: '''Modified Labarre Medium (56 mM Glucose'
+    label: Modified Labarre Medium (56 mM Glucose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/modified_labarre_medium_56_mm_glucose.yaml
+++ b/data/normalized_yaml/bacterial/modified_labarre_medium_56_mm_glucose.yaml
@@ -21,7 +21,7 @@ ingredients:
   term:
     id: CHEBI:16947
     label: citrate(3-)
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.0245'
     unit: MILLIMOLAR
@@ -190,6 +190,12 @@ curation_history:
   notes: 'Replaced 9 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:04.118592+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:386's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 386
   term:

--- a/data/normalized_yaml/bacterial/modified_m1_medium_with_lactate_and_glycine_no_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/modified_m1_medium_with_lactate_and_glycine_no_nh4cl.yaml
@@ -1,6 +1,7 @@
 id: CultureMech:007071
 name: modified_m1_medium_with_lactate_and_glycine_no_nh4cl
-original_name: '''Modified M1 Medium with Lactate and Glycine (no NH4Cl'
+original_name: Modified M1 Medium with Lactate and Glycine (no NH4Cl); Pinchuk et
+  al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -323,11 +324,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:17.089287+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 180
   term:
     id: MEDIADB:180
-    label: '''Modified M1 Medium with Lactate and Glycine (no NH4Cl'
+    label: Modified M1 Medium with Lactate and Glycine (no NH4Cl); Pinchuk et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/modified_vogel_medium_maltose.yaml
+++ b/data/normalized_yaml/bacterial/modified_vogel_medium_maltose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007245
 name: modified_vogel_medium_maltose
-original_name: '''Modified Vogel Medium (maltose'
+original_name: Modified Vogel Medium (maltose)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -160,11 +160,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:17.803325+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 344
   term:
     id: MEDIADB:344
-    label: '''Modified Vogel Medium (maltose'
+    label: Modified Vogel Medium (maltose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/modified_vogel_medium_xylose.yaml
+++ b/data/normalized_yaml/bacterial/modified_vogel_medium_xylose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007210
 name: modified_vogel_medium_xylose
-original_name: '''Modified Vogel Medium (xylose'
+original_name: Modified Vogel Medium (xylose)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -159,11 +159,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:17.812635+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 311
   term:
     id: MEDIADB:311
-    label: '''Modified Vogel Medium (xylose'
+    label: Modified Vogel Medium (xylose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/mogensen_minimal_medium_ethanol.yaml
+++ b/data/normalized_yaml/bacterial/mogensen_minimal_medium_ethanol.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007246
 name: mogensen_minimal_medium_ethanol
-original_name: '''Mogensen Minimal Medium (Ethanol'
+original_name: Mogensen Minimal Medium (Ethanol)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -170,11 +170,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:17.910969+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 345
   term:
     id: MEDIADB:345
-    label: '''Mogensen Minimal Medium (Ethanol'
+    label: Mogensen Minimal Medium (Ethanol)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/mogensen_minimal_medium_glucose.yaml
+++ b/data/normalized_yaml/bacterial/mogensen_minimal_medium_glucose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007207
 name: mogensen_minimal_medium_glucose
-original_name: '''Mogensen Minimal Medium (Glucose'
+original_name: Mogensen Minimal Medium (Glucose)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -169,11 +169,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:17.920734+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 309
   term:
     id: MEDIADB:309
-    label: '''Mogensen Minimal Medium (Glucose'
+    label: Mogensen Minimal Medium (Glucose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/mops_minimal_medium_bergholz_et_al.yaml
+++ b/data/normalized_yaml/bacterial/mops_minimal_medium_bergholz_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:006989
 name: mops_minimal_medium_bergholz_et_al
-original_name: '''MOPS minimal medium (Bergholz et al'
+original_name: MOPS minimal medium (Bergholz et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -179,11 +179,17 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:18.038653+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 102
   term:
     id: MEDIADB:102
-    label: '''MOPS minimal medium (Bergholz et al'
+    label: MOPS minimal medium (Bergholz et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ms10_medium_supplements_for_batch_cultivation_modified.yaml
+++ b/data/normalized_yaml/bacterial/ms10_medium_supplements_for_batch_cultivation_modified.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007316
 name: ms10_medium_supplements_for_batch_cultivation_modified
-original_name: '''MS10 Medium + Supplements for Batch Cultivation (Modified'
+original_name: MS10 Medium + Supplements for Batch Cultivation (Modified)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -312,11 +312,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:18.362571+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 415
   term:
     id: MEDIADB:415
-    label: '''MS10 Medium + Supplements for Batch Cultivation (Modified'
+    label: MS10 Medium + Supplements for Batch Cultivation (Modified)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/nmm_with_lactate.yaml
+++ b/data/normalized_yaml/bacterial/nmm_with_lactate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(R'
+- preferred_term: (R)-Lactate
   concentration:
     value: '56.0'
     unit: MILLIMOLAR
@@ -125,6 +125,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:06.387353+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:157's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 157
   term:

--- a/data/normalized_yaml/bacterial/nmm_with_malate.yaml
+++ b/data/normalized_yaml/bacterial/nmm_with_malate.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''(S'
+- preferred_term: (S)-Malate
   concentration:
     value: '38.0'
     unit: MILLIMOLAR
@@ -125,6 +125,12 @@ curation_history:
   notes: 'Replaced 4 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:06.395292+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:158's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 158
   term:

--- a/data/normalized_yaml/bacterial/pa_5052.yaml
+++ b/data/normalized_yaml/bacterial/pa_5052.yaml
@@ -320,7 +320,7 @@ ingredients:
   term:
     id: CHEBI:48843
     label: disodium selenite
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.01'
     unit: MILLIMOLAR
@@ -370,6 +370,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 2 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:06.991296+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:189's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 189
   term:

--- a/data/normalized_yaml/bacterial/pyruvate_minimal_media.yaml
+++ b/data/normalized_yaml/bacterial/pyruvate_minimal_media.yaml
@@ -106,7 +106,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.06165'
     unit: MILLIMOLAR
@@ -152,6 +152,12 @@ curation_history:
   notes: 'Replaced 5 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:08.727506+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:131's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 131
   term:

--- a/data/normalized_yaml/bacterial/rdm.yaml
+++ b/data/normalized_yaml/bacterial/rdm.yaml
@@ -387,7 +387,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17115
     label: L-serine
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.02'
     unit: MILLIMOLAR
@@ -449,6 +449,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:09.085639+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:296's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 296
   term:

--- a/data/normalized_yaml/bacterial/rdm_10_mm_nacl.yaml
+++ b/data/normalized_yaml/bacterial/rdm_10_mm_nacl.yaml
@@ -387,7 +387,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17115
     label: L-serine
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.02'
     unit: MILLIMOLAR
@@ -460,6 +460,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:09.109369+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:297's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 297
   term:

--- a/data/normalized_yaml/bacterial/rdm_20_mm_nacl.yaml
+++ b/data/normalized_yaml/bacterial/rdm_20_mm_nacl.yaml
@@ -387,7 +387,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17115
     label: L-serine
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.02'
     unit: MILLIMOLAR
@@ -460,6 +460,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:09.134256+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:298's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 298
   term:

--- a/data/normalized_yaml/bacterial/rdm_50_mm_nacl.yaml
+++ b/data/normalized_yaml/bacterial/rdm_50_mm_nacl.yaml
@@ -387,7 +387,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:17115
     label: L-serine
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.02'
     unit: MILLIMOLAR
@@ -460,6 +460,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:09.161644+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:299's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 299
   term:

--- a/data/normalized_yaml/bacterial/rdm_base_medium_vitamins_maltose_0_5_g_l_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/rdm_base_medium_vitamins_maltose_0_5_g_l_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007286
 name: rdm_base_medium_vitamins_maltose_0_5_g_l_nh4cl
-original_name: '''RDM Base Medium + Vitamins + Maltose (0.5 g/L NH4Cl'
+original_name: RDM Base Medium + Vitamins + Maltose (0.5 g/L NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -289,11 +289,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:22.068399+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 382
   term:
     id: MEDIADB:382
-    label: '''RDM Base Medium + Vitamins + Maltose (0.5 g/L NH4Cl'
+    label: RDM Base Medium + Vitamins + Maltose (0.5 g/L NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/rdm_base_medium_vitamins_maltose_1_g_l_nh4cl.yaml
+++ b/data/normalized_yaml/bacterial/rdm_base_medium_vitamins_maltose_1_g_l_nh4cl.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007285
 name: rdm_base_medium_vitamins_maltose_1_g_l_nh4cl
-original_name: '''RDM Base Medium + Vitamins + Maltose (1 g/L NH4Cl'
+original_name: RDM Base Medium + Vitamins + Maltose (1 g/L NH4Cl)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -289,11 +289,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:22.088719+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 381
   term:
     id: MEDIADB:381
-    label: '''RDM Base Medium + Vitamins + Maltose (1 g/L NH4Cl'
+    label: RDM Base Medium + Vitamins + Maltose (1 g/L NH4Cl)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_0_2_kno3_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -187,6 +187,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.163149+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:210's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 210
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_0_2_kno3_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007104
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_0_2_kno3_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glucose + 0.2% KNO3; Nakano et al','N
+  and phenylalanine + 1% glucose + 0.2% KNO3; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -193,12 +193,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:210's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.155442+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 210
   term:
     id: MEDIADB:210
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glucose + 0.2% KNO3; Nakano et al','N
+      and phenylalanine + 1% glucose + 0.2% KNO3; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_1_pyruvate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_1_pyruvate_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -190,6 +190,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.176708+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:212's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 212
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_1_pyruvate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_1_pyruvate_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007106
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_1_pyruvate_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glucose + 1% pyruvate; Nakano et al','N
+  and phenylalanine + 1% glucose + 1% pyruvate; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -196,12 +196,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:212's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.167684+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 212
   term:
     id: MEDIADB:212
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glucose + 1% pyruvate; Nakano et al','N
+      and phenylalanine + 1% glucose + 1% pyruvate; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -179,6 +179,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.187706+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:208's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 208
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007101
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glucose_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glucose; Nakano et al','N
+  and phenylalanine + 1% glucose; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -185,12 +185,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:208's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.178306+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 208
   term:
     id: MEDIADB:208
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glucose; Nakano et al','N
+      and phenylalanine + 1% glucose; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -190,6 +190,12 @@ curation_history:
   notes: 'Replaced 7 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.198538+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:213's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 213
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007107
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_fumarate_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glycerol + 0.2% fumarate; Nakano et al','N
+  and phenylalanine + 1% glycerol + 0.2% fumarate; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -196,12 +196,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:213's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.189015+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 213
   term:
     id: MEDIADB:213
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glycerol + 0.2% fumarate; Nakano et al','N
+      and phenylalanine + 1% glycerol + 0.2% fumarate; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007105
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_kno3_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glycerol + 0.2% KNO3; Nakano et al','N
+  and phenylalanine + 1% glycerol + 0.2% KNO3; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -193,12 +193,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:211's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.199551+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 211
   term:
     id: MEDIADB:211
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glycerol + 0.2% KNO3; Nakano et al','N
+      and phenylalanine + 1% glycerol + 0.2% KNO3; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -187,6 +187,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.209152+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:211's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 211
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_nakano_et_al_n.yaml
@@ -132,7 +132,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -179,6 +179,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:11.219821+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:209's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 209
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007102
 name: spizizens_medium_trace_elements_0_2_glutamate_50_ug_ml_tryptophan_and_phenylalanine_1_glycerol_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-  and phenylalanine + 1% glycerol; Nakano et al','N
+  and phenylalanine + 1% glycerol; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -185,12 +185,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:209's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.210435+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 209
   term:
     id: MEDIADB:209
     label: Spizizen's medium + trace elements + 0.2% glutamate + 50 ug/mL tryptophan
-      and phenylalanine + 1% glycerol; Nakano et al','N
+      and phenylalanine + 1% glycerol; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_0_2_kno3_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -330,6 +330,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.235807+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:216's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 216
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_0_2_kno3_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007110
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glucose_0_2_kno3_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glucose +
-  0.2% KNO3; Nakano et al','N
+  0.2% KNO3; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -336,12 +336,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:216's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.224736+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 216
   term:
     id: MEDIADB:216
     label: Spizizen's medium + trace elements + amino acids sln + 1% glucose + 0.2%
-      KNO3; Nakano et al','N
+      KNO3; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_1_pyruvate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_1_pyruvate_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007112
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glucose_1_pyruvate_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glucose +
-  1% pyruvate; Nakano et al','N
+  1% pyruvate; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -339,12 +339,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:218's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.242195+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 218
   term:
     id: MEDIADB:218
     label: Spizizen's medium + trace elements + amino acids sln + 1% glucose + 1%
-      pyruvate; Nakano et al','N
+      pyruvate; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_1_pyruvate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_1_pyruvate_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -333,6 +333,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.253931+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:218's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 218
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -323,6 +323,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.276428+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:214's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 214
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glucose_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007108
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glucose_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glucose;
-  Nakano et al','N
+  Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -329,12 +329,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:214's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.259050+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 214
   term:
     id: MEDIADB:214
     label: Spizizen's medium + trace elements + amino acids sln + 1% glucose; Nakano
-      et al','N
+      et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007113
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_fumarate_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glycerol
-  + 0.2% fumarate; Nakano et al','N
+  + 0.2% fumarate; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -339,12 +339,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:219's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.275572+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 219
   term:
     id: MEDIADB:219
     label: Spizizen's medium + trace elements + amino acids sln + 1% glycerol + 0.2%
-      fumarate; Nakano et al','N
+      fumarate; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_fumarate_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -333,6 +333,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.294872+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:219's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 219
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007111
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_kno3_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glycerol
-  + 0.2% KNO3; Nakano et al','N
+  + 0.2% KNO3; Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -336,12 +336,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:217's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.292905+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 217
   term:
     id: MEDIADB:217
     label: Spizizen's medium + trace elements + amino acids sln + 1% glycerol + 0.2%
-      KNO3; Nakano et al','N
+      KNO3; Nakano et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_0_2_kno3_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -330,6 +330,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.313049+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:217's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 217
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_nakano_et_al_n.yaml
@@ -264,7 +264,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:53258
     label: sodium citrate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.04994'
     unit: MILLIMOLAR
@@ -323,6 +323,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 3 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:11.330843+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:215's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 215
   term:

--- a/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_nakano_et_al_n.yaml
+++ b/data/normalized_yaml/bacterial/spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_nakano_et_al_n.yaml
@@ -1,7 +1,7 @@
 id: CultureMech:007109
 name: spizizens_medium_trace_elements_amino_acids_sln_1_glycerol_nakano_et_al_n
 original_name: Spizizen's medium + trace elements + amino acids sln + 1% glycerol;
-  Nakano et al','N
+  Nakano et al
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -329,12 +329,18 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:215's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:27:07.309355+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 215
   term:
     id: MEDIADB:215
     label: Spizizen's medium + trace elements + amino acids sln + 1% glycerol; Nakano
-      et al','N
+      et al
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/supplemented_bg11_glucose.yaml
+++ b/data/normalized_yaml/bacterial/supplemented_bg11_glucose.yaml
@@ -6,7 +6,7 @@ medium_type: DEFINED
 composition_type: DEFINED
 physical_state: LIQUID
 ingredients:
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.0245'
     unit: MILLIMOLAR
@@ -190,6 +190,12 @@ curation_history:
   notes: 'Replaced 9 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:12.325091+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:387's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 387
   term:

--- a/data/normalized_yaml/bacterial/supplemented_bg11_mutant.yaml
+++ b/data/normalized_yaml/bacterial/supplemented_bg11_mutant.yaml
@@ -35,7 +35,7 @@ ingredients:
   term:
     id: CHEBI:131527
     label: dipotassium hydrogen phosphate
-- preferred_term: '''Fe(III'
+- preferred_term: Fe(III)dicitrate
   concentration:
     value: '0.0245'
     unit: MILLIMOLAR
@@ -219,6 +219,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 4 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:12.337085+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:388's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 388
   term:

--- a/data/normalized_yaml/bacterial/supplemented_bg11_mutant.yaml
+++ b/data/normalized_yaml/bacterial/supplemented_bg11_mutant.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007292
 name: supplemented_bg11_mutant
-original_name: '''Supplemented BG11 (Mutant'
+original_name: Supplemented BG11 (Mutant)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -225,11 +225,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:388's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:18:24.912416+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 388
   term:
     id: MEDIADB:388
-    label: '''Supplemented BG11 (Mutant'
+    label: Supplemented BG11 (Mutant)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/supplemented_m9_rhee.yaml
+++ b/data/normalized_yaml/bacterial/supplemented_m9_rhee.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007006
 name: supplemented_m9_rhee
-original_name: '''Supplemented m9 (rhee'
+original_name: Supplemented m9 (rhee)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -179,11 +179,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:119's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:18:24.923577+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 119
   term:
     id: MEDIADB:119
-    label: '''Supplemented m9 (rhee'
+    label: Supplemented m9 (rhee)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/supplemented_m9_rhee.yaml
+++ b/data/normalized_yaml/bacterial/supplemented_m9_rhee.yaml
@@ -129,7 +129,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.01998'
     unit: MILLIMOLAR
@@ -173,6 +173,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:12.348776+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:119's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 119
   term:

--- a/data/normalized_yaml/bacterial/synthetic_medium_c.yaml
+++ b/data/normalized_yaml/bacterial/synthetic_medium_c.yaml
@@ -186,7 +186,7 @@ ingredients:
   term:
     id: CHEBI:49553
     label: copper(II) chloride
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.0284'
     unit: MILLIMOLAR
@@ -314,6 +314,12 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 2 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T04:07:12.510575+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:315's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 315
   term:

--- a/data/normalized_yaml/bacterial/tap_auto.yaml
+++ b/data/normalized_yaml/bacterial/tap_auto.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007283
 name: tap_auto
-original_name: '''TAP (auto'
+original_name: TAP (auto)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -137,11 +137,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:25.470287+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 37
   term:
     id: MEDIADB:37
-    label: '''TAP (auto'
+    label: TAP (auto)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/tap_hetero_mixo.yaml
+++ b/data/normalized_yaml/bacterial/tap_hetero_mixo.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007272
 name: tap_hetero_mixo
-original_name: '''TAP (hetero/mixo'
+original_name: TAP (hetero/mixo)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -149,11 +149,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:25.479801+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 36
   term:
     id: MEDIADB:36
-    label: '''TAP (hetero/mixo'
+    label: TAP (hetero/mixo)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/thiamine_limiting_minimal_media_hassan_et_al.yaml
+++ b/data/normalized_yaml/bacterial/thiamine_limiting_minimal_media_hassan_et_al.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007004
 name: thiamine_limiting_minimal_media_hassan_et_al
-original_name: '''thiamine limiting minimal media (Hassan et al'
+original_name: thiamine limiting minimal media (Hassan et al)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -102,11 +102,17 @@ curation_history:
   notes: 'Replaced 3 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:26.869860+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 117
   term:
     id: MEDIADB:117
-    label: '''thiamine limiting minimal media (Hassan et al'
+    label: thiamine limiting minimal media (Hassan et al)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ybg11_0_fecl3_shcolnick_2006.yaml
+++ b/data/normalized_yaml/bacterial/ybg11_0_fecl3_shcolnick_2006.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007288
 name: ybg11_0_fecl3_shcolnick_2006
-original_name: '''YBG11, 0 FeCl3 (Shcolnick 2006'
+original_name: YBG11, 0 FeCl3 (Shcolnick 2006)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -159,11 +159,17 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T06:18:31.756346+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 384
   term:
     id: MEDIADB:384
-    label: '''YBG11, 0 FeCl3 (Shcolnick 2006'
+    label: YBG11, 0 FeCl3 (Shcolnick 2006)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/bacterial/ybg11_shcolnick_2006.yaml
+++ b/data/normalized_yaml/bacterial/ybg11_shcolnick_2006.yaml
@@ -99,7 +99,7 @@ ingredients:
   mediaingredientmech_chebi_term:
     id: CHEBI:29377
     label: sodium carbonate
-- preferred_term: '''Iron(III'
+- preferred_term: Iron(III) chloride
   concentration:
     value: '0.006'
     unit: MILLIMOLAR
@@ -163,6 +163,12 @@ curation_history:
   notes: 'Replaced 6 legacy mediaingredientmech_term link(s) with mediaingredientmech_chebi_term
     (id-safe: ingredient''s own CHEBI + label). MIM deprecated the MediaIngredientMech:NNNNNN
     id scheme.'
+- timestamp: '2026-08-31T04:07:19.249244+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
+    parser. Resolved against MEDIADB:383's own compound list in media_database.07Oct2015.sql,
+    requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
 media_term:
   preferred_term: MediaDB Medium 383
   term:

--- a/data/normalized_yaml/bacterial/ybg11_shcolnick_2006.yaml
+++ b/data/normalized_yaml/bacterial/ybg11_shcolnick_2006.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:007287
 name: ybg11_shcolnick_2006
-original_name: '''YBG11 (Shcolnick 2006'
+original_name: YBG11 (Shcolnick 2006)
 category: bacterial
 medium_type: DEFINED
 composition_type: DEFINED
@@ -169,11 +169,17 @@ curation_history:
   notes: Restored 1 ingredient name(s) truncated at a parenthesis by the MediaDB SQL
     parser. Resolved against MEDIADB:383's own compound list in media_database.07Oct2015.sql,
     requiring a unique prefix match and, where more than one matched, an equal Amount_mM.
+- timestamp: '2026-08-31T06:18:31.766086+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 383
   term:
     id: MEDIADB:383
-    label: '''YBG11 (Shcolnick 2006'
+    label: YBG11 (Shcolnick 2006)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/fungal/yeast_mineral_medium_10_g_l_glucose.yaml
+++ b/data/normalized_yaml/fungal/yeast_mineral_medium_10_g_l_glucose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:010555
 name: yeast_mineral_medium_10_g_l_glucose
-original_name: '''Yeast Mineral Medium (10 g/L Glucose'
+original_name: Yeast Mineral Medium (10 g/L Glucose)
 category: fungal
 medium_type: DEFINED
 composition_type: DEFINED
@@ -246,11 +246,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:33.053733+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 397
   term:
     id: MEDIADB:397
-    label: '''Yeast Mineral Medium (10 g/L Glucose'
+    label: Yeast Mineral Medium (10 g/L Glucose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/fungal/yeast_mineral_medium_25_g_l_glucose.yaml
+++ b/data/normalized_yaml/fungal/yeast_mineral_medium_25_g_l_glucose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:010557
 name: yeast_mineral_medium_25_g_l_glucose
-original_name: '''Yeast Mineral Medium (25 g/L Glucose'
+original_name: Yeast Mineral Medium (25 g/L Glucose)
 category: fungal
 medium_type: DEFINED
 composition_type: DEFINED
@@ -246,11 +246,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:33.066985+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 399
   term:
     id: MEDIADB:399
-    label: '''Yeast Mineral Medium (25 g/L Glucose'
+    label: Yeast Mineral Medium (25 g/L Glucose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/fungal/yeast_mineral_medium_7_5_g_l_ethanol.yaml
+++ b/data/normalized_yaml/fungal/yeast_mineral_medium_7_5_g_l_ethanol.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:010556
 name: yeast_mineral_medium_7_5_g_l_ethanol
-original_name: '''Yeast Mineral Medium (7.5 g/L Ethanol'
+original_name: Yeast Mineral Medium (7.5 g/L Ethanol)
 category: fungal
 medium_type: DEFINED
 composition_type: DEFINED
@@ -247,11 +247,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:33.083161+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 398
   term:
     id: MEDIADB:398
-    label: '''Yeast Mineral Medium (7.5 g/L Ethanol'
+    label: Yeast Mineral Medium (7.5 g/L Ethanol)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/fungal/yeast_mineral_medium_7_9_g_l_ethanol.yaml
+++ b/data/normalized_yaml/fungal/yeast_mineral_medium_7_9_g_l_ethanol.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:010558
 name: yeast_mineral_medium_7_9_g_l_ethanol
-original_name: '''Yeast Mineral Medium (7.9 g/L Ethanol'
+original_name: Yeast Mineral Medium (7.9 g/L Ethanol)
 category: fungal
 medium_type: DEFINED
 composition_type: DEFINED
@@ -247,11 +247,17 @@ curation_history:
   notes: Re-grounded 2 term reference(s) to the correct CHEBI (see reports/chebi_grounding_audit.md).
     Label-conditional fixes for pyridoxine/pyridoxamine, glycerol, MnSO4, Ca(NO3)2,
     selenate; casamino acids de-grounded (mixture, no single CHEBI).
+- timestamp: '2026-08-31T06:18:33.098163+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 400
   term:
     id: MEDIADB:400
-    label: '''Yeast Mineral Medium (7.9 g/L Ethanol'
+    label: Yeast Mineral Medium (7.9 g/L Ethanol)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/data/normalized_yaml/fungal/yeast_optimized_defined_medium_glucose.yaml
+++ b/data/normalized_yaml/fungal/yeast_optimized_defined_medium_glucose.yaml
@@ -1,6 +1,6 @@
 id: CultureMech:010554
 name: yeast_optimized_defined_medium_glucose
-original_name: '''Yeast Optimized Defined Medium (Glucose'
+original_name: Yeast Optimized Defined Medium (Glucose)
 category: fungal
 medium_type: DEFINED
 composition_type: DEFINED
@@ -308,11 +308,17 @@ curation_history:
   action: Adopted MIM published grounding
   notes: Grounded 1 ingredient(s) from MIM's ingredient_mappings.sssom.tsv (2026-08-18),
     exactMatch only, where this record carried no CHEBI term (#308).
+- timestamp: '2026-08-31T06:18:33.116933+00:00'
+  curator: repair_mediadb_names.py
+  action: REPAIRED_MEDIADB_TRUNCATED_NAME
+  notes: Restored the medium's own name in media_term.term.label, original_name. The
+    MediaDB SQL parser truncated every value containing a parenthesis at that parenthesis;
+    recovered from media_database.07Oct2015.sql.
 media_term:
   preferred_term: MediaDB Medium 396
   term:
     id: MEDIADB:396
-    label: '''Yeast Optimized Defined Medium (Glucose'
+    label: Yeast Optimized Defined Medium (Glucose)
 notes: 'Source: MediaDB (Chemically-defined media for genome-sequenced organisms)
   Reference: https://mediadb.systemsbiology.net/'
 applications:

--- a/scripts/repair_mediadb_names.py
+++ b/scripts/repair_mediadb_names.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Restore MediaDB ingredient names truncated at a parenthesis (#387).
+
+## What went wrong
+
+`mediadb_fetcher.py` split SQL INSERT rows with `re.findall(r'\\(([^)]+)\\)', ...)`.
+`[^)]+` stops at the FIRST closing paren, so
+
+    (16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')
+
+parsed as the four fields `16413, NULL, NULL, 'Iron(III` — and that fragment,
+leading quote and all, became the ingredient's `preferred_term` in 75 recipes.
+Chemical names carry parentheses constantly (oxidation states, stereo
+descriptors), so the bug hit precisely the compounds hardest to guess back.
+
+## Why the fragment alone is not enough
+
+`'(S` is `(S)-Malate` in four recipes and `(S)-Lactate` in two others. A global
+prefix->name table would silently pick one and be wrong about the rest, so
+resolution is per record:
+
+1. the record's `media_term.term.id` gives its MediaDB medium id;
+2. `media_compounds` gives that medium's actual compound list;
+3. the fragment must prefix exactly one of those compounds' real names;
+4. where the fragment still matches more than one, the recorded concentration
+   must equal that compound's `Amount_mM` in the dump.
+
+An ingredient that does not resolve to exactly one compound is left untouched
+and reported. Names are read through the fixed fetcher rather than a second
+parser, so there is one implementation of the SQL grammar, not two.
+
+Preview by default. `--apply` writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+
+# `timezone.utc`, not `datetime.UTC`: the latter is 3.11+ and this project
+# supports >=3.10.
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from record_io import write_record  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from culturemech.fetch.mediadb_fetcher import MediaDBFetcher  # noqa: E402
+
+DEFAULT_RECORDS = REPO_ROOT / "data" / "normalized_yaml"
+DEFAULT_DUMP = REPO_ROOT / "data" / "raw" / "mediadb" / "media_database.07Oct2015.sql"
+
+CURATOR = "repair_mediadb_names.py"
+ACTION = "REPAIRED_MEDIADB_TRUNCATED_NAME"
+
+
+def looks_truncated(name: str) -> bool:
+    """A `preferred_term` that is a parse fragment rather than a chemical name.
+
+    The tell is the leading apostrophe: it is the SQL string's opening quote,
+    kept because the closing one was never reached. Names that merely *end* in
+    a prime are real — `Premithramycin A2'`, `Nebramycin factor 5'` — so only
+    the leading quote counts.
+    """
+    return name.startswith("'")
+
+
+def load_mediadb(dump: Path) -> tuple[dict[str, dict[str, str]], dict[str, list[tuple[str, str]]]]:
+    """(compounds by id, medium id -> [(compound id, amount_mM)]) from the dump."""
+    fetcher = MediaDBFetcher(output_dir=dump.parent)
+    if not fetcher.parse_sql_dump(dump):
+        raise SystemExit(f"Could not parse {dump}")
+
+    compositions: dict[str, list[tuple[str, str]]] = {}
+    for medium_id, entries in fetcher.media_compositions.items():
+        compositions[medium_id] = [
+            (str(entry.get("compound_id") or ""), str(entry.get("concentration") or ""))
+            for entry in entries
+        ]
+    return fetcher.compounds, compositions
+
+
+def medium_id(record: dict[str, Any]) -> str | None:
+    identifier = ((record.get("media_term") or {}).get("term") or {}).get("id") or ""
+    return identifier.split(":", 1)[1] if identifier.startswith("MEDIADB:") else None
+
+
+def _same_amount(recorded: Any, dump_amount: str) -> bool:
+    try:
+        return abs(float(recorded) - float(dump_amount)) < 1e-9
+    except (TypeError, ValueError):
+        return False
+
+
+def resolve(
+    fragment: str,
+    concentration: Any,
+    pool: list[tuple[str, str]],
+    compounds: dict[str, dict[str, str]],
+) -> tuple[str | None, str]:
+    """The one compound name this fragment can mean, or (None, why not)."""
+    prefix = fragment.lstrip("'")
+    if not prefix:
+        return None, "fragment is only a quote"
+
+    matches = [
+        (compound_id, compounds[compound_id]["name"], amount)
+        for compound_id, amount in pool
+        if compound_id in compounds and compounds[compound_id]["name"].startswith(prefix)
+    ]
+    if not matches:
+        return None, f"no compound in this medium starts with {prefix!r}"
+
+    names = {name for _, name, _ in matches}
+    if len(names) == 1:
+        return names.pop(), ""
+
+    narrowed = {name for _, name, amount in matches if _same_amount(concentration, amount)}
+    if len(narrowed) == 1:
+        return narrowed.pop(), ""
+    return None, f"{len(names)} candidates at this medium: {sorted(names)[:4]}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
+    parser.add_argument("--dump", type=Path, default=DEFAULT_DUMP)
+    parser.add_argument("--apply", action="store_true", help="Write. Default is preview.")
+    parser.add_argument("--limit", type=int, default=0, help="Stop after N records (0 = all).")
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not args.dump.exists():
+        print(
+            f"{args.dump} is not present. It is a gitignored raw capture; "
+            f"restore it before repairing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    compounds, compositions = load_mediadb(args.dump)
+    print(f"{len(compounds)} compounds, {len(compositions)} media from {args.dump.name}")
+
+    stats: Counter = Counter()
+    renames: Counter = Counter()
+    failures: list[tuple[str, str, str]] = []
+
+    for path in sorted(args.records_dir.glob("*/*.yaml")):
+        record = yaml.safe_load(path.read_text())
+        if not isinstance(record, dict):
+            continue
+
+        damaged = [
+            ingredient
+            for ingredient in record.get("ingredients") or []
+            if isinstance(ingredient, dict)
+            and looks_truncated(str(ingredient.get("preferred_term", "")))
+        ]
+        if not damaged:
+            continue
+        stats["records_with_damage"] += 1
+
+        source_id = medium_id(record)
+        if not source_id:
+            for ingredient in damaged:
+                failures.append((path.name, str(ingredient["preferred_term"]), "no MEDIADB:<id>"))
+            continue
+
+        pool = compositions.get(source_id, [])
+        repaired = 0
+        for ingredient in damaged:
+            fragment = str(ingredient["preferred_term"])
+            concentration = (ingredient.get("concentration") or {}).get("value")
+            name, reason = resolve(fragment, concentration, pool, compounds)
+            if not name:
+                failures.append((path.name, fragment, reason))
+                continue
+            ingredient["preferred_term"] = name
+            renames[(fragment, name)] += 1
+            repaired += 1
+
+        if not repaired:
+            continue
+        stats["ingredients_repaired"] += repaired
+        record.setdefault("curation_history", []).append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "curator": CURATOR,
+                "action": ACTION,
+                "notes": (
+                    f"Restored {repaired} ingredient name(s) truncated at a parenthesis by "
+                    f"the MediaDB SQL parser. Resolved against MEDIADB:{source_id}'s own "
+                    f"compound list in {args.dump.name}, requiring a unique prefix match "
+                    f"and, where more than one matched, an equal Amount_mM."
+                ),
+            }
+        )
+        stats["records_repaired"] += 1
+        if args.apply:
+            write_record(path, record)
+        if args.limit and stats["records_repaired"] >= args.limit:
+            break
+
+    verb = "Repaired" if args.apply else "Would repair"
+    print(f"\n{verb} {stats['records_repaired']} records / {stats['ingredients_repaired']} names")
+    for key in sorted(stats):
+        print(f"  {key}: {stats[key]}")
+    if renames:
+        print("\nresolutions:")
+        for (fragment, name), count in renames.most_common():
+            print(f"  {count:4d}  {fragment!r} -> {name!r}")
+    if failures:
+        print(f"\n{len(failures)} left untouched:")
+        for name, fragment, reason in failures:
+            print(f"  {name}: {fragment!r} — {reason}")
+    if not args.apply:
+        print("\nPreview only. Re-run with --apply to write.")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repair_mediadb_names.py
+++ b/scripts/repair_mediadb_names.py
@@ -71,8 +71,10 @@ def looks_truncated(name: str) -> bool:
     return name.startswith("'")
 
 
-def load_mediadb(dump: Path) -> tuple[dict[str, dict[str, str]], dict[str, list[tuple[str, str]]]]:
-    """(compounds by id, medium id -> [(compound id, amount_mM)]) from the dump."""
+def load_mediadb(
+    dump: Path,
+) -> tuple[dict[str, dict[str, str]], dict[str, list[tuple[str, str]]], dict[str, str]]:
+    """(compounds by id, medium id -> [(compound id, amount_mM)], medium names)."""
     fetcher = MediaDBFetcher(output_dir=dump.parent)
     if not fetcher.parse_sql_dump(dump):
         raise SystemExit(f"Could not parse {dump}")
@@ -83,7 +85,8 @@ def load_mediadb(dump: Path) -> tuple[dict[str, dict[str, str]], dict[str, list[
             (str(entry.get("compound_id") or ""), str(entry.get("concentration") or ""))
             for entry in entries
         ]
-    return fetcher.compounds, compositions
+    medium_names = {m["id"]: str(m.get("name") or "").strip() for m in fetcher.media}
+    return fetcher.compounds, compositions, medium_names
 
 
 def medium_id(record: dict[str, Any]) -> str | None:
@@ -127,6 +130,53 @@ def resolve(
     return None, f"{len(names)} candidates at this medium: {sorted(names)[:4]}"
 
 
+def damaged_medium_name(value: str) -> bool:
+    """Whether a stored medium name shows parser damage.
+
+    Two shapes, from the two bugs:
+
+    * a leading quote, from the record splitter stopping at a paren —
+      `'Defined freshwater medium (CoSO4`;
+    * a glued-on `','...` tail, from the field splitter losing quote tracking
+      at an apostrophe — `Spizizen's medium ... Nakano et al','N`.
+
+    Deliberately narrow. The medium's MEDIADB id names its row exactly, so the
+    dump value could simply be imposed on every record — but that would also
+    overwrite deliberate curation. Only values carrying evidence of damage are
+    replaced. A name that differs from the dump only by trailing whitespace
+    (`'Supplemented BG11 + Glucose '`) is left alone: that is the dump's own
+    value, not damage.
+    """
+    return value.startswith("'") or "','" in value
+
+
+def repair_medium_name(record: dict[str, Any], true_name: str) -> list[str]:
+    """Restore the medium's own name where the same bug truncated it.
+
+    `media_term.term.label` and `original_name` were written from the truncated
+    `media_names` row, so `Defined freshwater medium (CoSO4) + 20 mM Iron
+    citrate + 113.2 mM Acetate` became `'Defined freshwater medium (CoSO4`.
+    That is not merely ugly: 29 distinct media collapse onto that one string,
+    and what the truncation removed is exactly what tells them apart.
+
+    Keyed on the record's MEDIADB id alone, so there is no inference here —
+    unlike the ingredient case, the id names the row directly.
+
+    `name` is deliberately left alone. It is the record's slug, used for
+    matching and deduplication, and renaming 182 of them is a different change
+    with different risks.
+    """
+    changed = []
+    term = (record.get("media_term") or {}).get("term") or {}
+    if damaged_medium_name(str(term.get("label", ""))):
+        term["label"] = true_name
+        changed.append("media_term.term.label")
+    if damaged_medium_name(str(record.get("original_name", ""))):
+        record["original_name"] = true_name
+        changed.append("original_name")
+    return changed
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
@@ -143,7 +193,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    compounds, compositions = load_mediadb(args.dump)
+    compounds, compositions, medium_names = load_mediadb(args.dump)
     print(f"{len(compounds)} compounds, {len(compositions)} media from {args.dump.name}")
 
     stats: Counter = Counter()
@@ -155,48 +205,61 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(record, dict):
             continue
 
+        source_id = medium_id(record)
+        true_name = medium_names.get(source_id or "", "")
+        name_fields = repair_medium_name(record, true_name) if true_name else []
+        if name_fields:
+            stats["medium_names_repaired"] += 1
+            stats["name_fields_repaired"] += len(name_fields)
+
         damaged = [
             ingredient
             for ingredient in record.get("ingredients") or []
             if isinstance(ingredient, dict)
             and looks_truncated(str(ingredient.get("preferred_term", "")))
         ]
-        if not damaged:
-            continue
-        stats["records_with_damage"] += 1
+        if damaged:
+            stats["records_with_damaged_ingredients"] += 1
 
-        source_id = medium_id(record)
-        if not source_id:
+        repaired = 0
+        if damaged and not source_id:
             for ingredient in damaged:
                 failures.append((path.name, str(ingredient["preferred_term"]), "no MEDIADB:<id>"))
-            continue
-
-        pool = compositions.get(source_id, [])
-        repaired = 0
-        for ingredient in damaged:
-            fragment = str(ingredient["preferred_term"])
-            concentration = (ingredient.get("concentration") or {}).get("value")
-            name, reason = resolve(fragment, concentration, pool, compounds)
-            if not name:
-                failures.append((path.name, fragment, reason))
-                continue
-            ingredient["preferred_term"] = name
-            renames[(fragment, name)] += 1
-            repaired += 1
-
-        if not repaired:
-            continue
+        elif damaged:
+            pool = compositions.get(source_id, [])
+            for ingredient in damaged:
+                fragment = str(ingredient["preferred_term"])
+                concentration = (ingredient.get("concentration") or {}).get("value")
+                name, reason = resolve(fragment, concentration, pool, compounds)
+                if not name:
+                    failures.append((path.name, fragment, reason))
+                    continue
+                ingredient["preferred_term"] = name
+                renames[(fragment, name)] += 1
+                repaired += 1
         stats["ingredients_repaired"] += repaired
+
+        if not repaired and not name_fields:
+            continue
+
+        summary = []
+        if repaired:
+            summary.append(
+                f"{repaired} ingredient name(s), resolved against MEDIADB:{source_id}'s own "
+                f"compound list by unique prefix match and, where more than one matched, "
+                f"an equal Amount_mM"
+            )
+        if name_fields:
+            summary.append(f"the medium's own name in {', '.join(name_fields)}")
         record.setdefault("curation_history", []).append(
             {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "curator": CURATOR,
                 "action": ACTION,
                 "notes": (
-                    f"Restored {repaired} ingredient name(s) truncated at a parenthesis by "
-                    f"the MediaDB SQL parser. Resolved against MEDIADB:{source_id}'s own "
-                    f"compound list in {args.dump.name}, requiring a unique prefix match "
-                    f"and, where more than one matched, an equal Amount_mM."
+                    f"Restored {' and '.join(summary)}. The MediaDB SQL parser truncated "
+                    f"every value containing a parenthesis at that parenthesis; recovered "
+                    f"from {args.dump.name}."
                 ),
             }
         )
@@ -207,7 +270,7 @@ def main(argv: list[str] | None = None) -> int:
             break
 
     verb = "Repaired" if args.apply else "Would repair"
-    print(f"\n{verb} {stats['records_repaired']} records / {stats['ingredients_repaired']} names")
+    print(f"\n{verb} {stats['records_repaired']} records")
     for key in sorted(stats):
         print(f"  {key}: {stats[key]}")
     if renames:

--- a/src/culturemech/fetch/mediadb_fetcher.py
+++ b/src/culturemech/fetch/mediadb_fetcher.py
@@ -18,13 +18,12 @@ Reference:
 """
 
 import argparse
-import json
-import re
 import csv
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-from datetime import datetime, timezone
+import json
 import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -78,7 +77,7 @@ class MediaDBFetcher:
             logger.error("sqlparse not installed. Install with: pip install sqlparse")
             return False
 
-        with open(sql_file, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(sql_file, encoding="utf-8", errors="ignore") as f:
             sql_content = f.read()
 
         # Parse SQL statements
@@ -92,13 +91,13 @@ class MediaDBFetcher:
                 continue
 
             # Look for INSERT statements
-            if stmt.upper().startswith('INSERT INTO'):
+            if stmt.upper().startswith("INSERT INTO"):
                 self._parse_insert_statement(stmt)
 
         # Link compositions to media after all parsing is done
         self._link_compositions_to_media()
 
-        logger.info(f"✓ Parsed SQL dump:")
+        logger.info("✓ Parsed SQL dump:")
         logger.info(f"  Media: {len(self.media)}")
         logger.info(f"  Compounds: {len(self.compounds)}")
         logger.info(f"  Organisms: {len(self.organisms)}")
@@ -134,7 +133,7 @@ class MediaDBFetcher:
         self._parse_media_tsv(tsv_dir)
         self._parse_compositions_tsv(tsv_dir)
 
-        logger.info(f"✓ Parsed TSV files:")
+        logger.info("✓ Parsed TSV files:")
         logger.info(f"  Media: {len(self.media)}")
         logger.info(f"  Compounds: {len(self.compounds)}")
         logger.info(f"  Organisms: {len(self.organisms)}")
@@ -144,41 +143,41 @@ class MediaDBFetcher:
     def _parse_insert_statement(self, stmt: str):
         """Parse INSERT statement to extract data."""
         # Extract table name
-        table_match = re.match(r'INSERT INTO\s+`?(\w+)`?', stmt, re.IGNORECASE)
+        table_match = re.match(r"INSERT INTO\s+`?(\w+)`?", stmt, re.IGNORECASE)
         if not table_match:
             return
 
         table_name = table_match.group(1).lower()
 
         # Extract values
-        values_match = re.search(r'VALUES\s*(\(.*\));?$', stmt, re.IGNORECASE | re.DOTALL)
+        values_match = re.search(r"VALUES\s*(\(.*\));?$", stmt, re.IGNORECASE | re.DOTALL)
         if not values_match:
             return
 
         values_str = values_match.group(1)
 
         # Parse based on table type (use exact table names to avoid conflicts)
-        if table_name == 'media_names':
+        if table_name == "media_names":
             self._parse_media_insert(values_str)
-        elif table_name == 'media_compounds':
+        elif table_name == "media_compounds":
             self._parse_media_compounds_insert(values_str)
-        elif table_name == 'compounds':
+        elif table_name == "compounds":
             self._parse_compound_insert(values_str)
-        elif table_name == 'organisms':
+        elif table_name == "organisms":
             self._parse_organism_insert(values_str)
 
     def _parse_media_insert(self, values_str: str):
         """Parse media_names table INSERT values."""
         try:
-            records = re.findall(r'\(([^)]+)\)', values_str)
+            records = self._split_sql_records(values_str)
             for record in records:
                 parts = self._split_sql_values(record)
                 if len(parts) >= 2:
                     medium = {
-                        'id': self._clean_sql_value(parts[0]),
-                        'name': self._clean_sql_value(parts[1]),
-                        'is_minimal': self._clean_sql_value(parts[2]) if len(parts) > 2 else '',
-                        'composition': []
+                        "id": self._clean_sql_value(parts[0]),
+                        "name": self._clean_sql_value(parts[1]),
+                        "is_minimal": self._clean_sql_value(parts[2]) if len(parts) > 2 else "",
+                        "composition": [],
                     }
                     self.media.append(medium)
         except Exception as e:
@@ -187,7 +186,7 @@ class MediaDBFetcher:
     def _parse_media_compounds_insert(self, values_str: str):
         """Parse media_compounds table INSERT values (stores for later linking)."""
         try:
-            records = re.findall(r'\(([^)]+)\)', values_str)
+            records = self._split_sql_records(values_str)
 
             for record in records:
                 parts = self._split_sql_values(record)
@@ -200,11 +199,15 @@ class MediaDBFetcher:
                     if med_id not in self.media_compositions:
                         self.media_compositions[med_id] = []
 
-                    self.media_compositions[med_id].append({
-                        'compound_id': comp_id,
-                        'concentration': float(amount_mm) if amount_mm and amount_mm != 'NULL' else 0.0,
-                        'unit': 'mM'
-                    })
+                    self.media_compositions[med_id].append(
+                        {
+                            "compound_id": comp_id,
+                            "concentration": (
+                                float(amount_mm) if amount_mm and amount_mm != "NULL" else 0.0
+                            ),
+                            "unit": "mM",
+                        }
+                    )
 
         except Exception as e:
             logger.debug(f"Error parsing media_compounds insert: {e}")
@@ -213,8 +216,8 @@ class MediaDBFetcher:
         """Link stored compositions to media after all parsing is complete."""
         linked_count = 0
         for medium in self.media:
-            if medium['id'] in self.media_compositions:
-                medium['composition'] = self.media_compositions[medium['id']]
+            if medium["id"] in self.media_compositions:
+                medium["composition"] = self.media_compositions[medium["id"]]
                 linked_count += 1
 
         logger.info(f"Linked compositions to {linked_count}/{len(self.media)} media")
@@ -222,16 +225,25 @@ class MediaDBFetcher:
     def _parse_compound_insert(self, values_str: str):
         """Parse compound table INSERT values."""
         try:
-            records = re.findall(r'\(([^)]+)\)', values_str)
+            records = self._split_sql_records(values_str)
             for record in records:
                 parts = self._split_sql_values(record)
-                if len(parts) >= 2:
+                # Column order is the `compounds` CREATE TABLE in the dump:
+                #   compID | KEGG_ID | BiGG_ID | name | seed_id | pubchem_ids
+                #   | chebi_ids | formula
+                # The previous mapping read parts[1] as the name, which is
+                # KEGG_ID, and parts[3] (the real name) as the ChEBI id. On the
+                # very first row — (1,'C00001','h2o','Water',...) — that gave
+                # name='C00001' and chebi_id='Water'.
+                if len(parts) >= 4:
                     compound_id = self._clean_sql_value(parts[0])
                     self.compounds[compound_id] = {
-                        'id': compound_id,
-                        'name': self._clean_sql_value(parts[1]) if len(parts) > 1 else '',
-                        'kegg_id': self._clean_sql_value(parts[2]) if len(parts) > 2 else '',
-                        'chebi_id': self._clean_sql_value(parts[3]) if len(parts) > 3 else '',
+                        "id": compound_id,
+                        "name": self._clean_sql_value(parts[3]),
+                        "kegg_id": self._clean_sql_value(parts[1]),
+                        "bigg_id": self._clean_sql_value(parts[2]),
+                        "chebi_id": self._clean_sql_value(parts[6]) if len(parts) > 6 else "",
+                        "formula": self._clean_sql_value(parts[7]) if len(parts) > 7 else "",
                     }
         except Exception as e:
             logger.debug(f"Error parsing compound insert: {e}")
@@ -239,122 +251,182 @@ class MediaDBFetcher:
     def _parse_organism_insert(self, values_str: str):
         """Parse organism table INSERT values."""
         try:
-            records = re.findall(r'\(([^)]+)\)', values_str)
+            records = self._split_sql_records(values_str)
             for record in records:
                 parts = self._split_sql_values(record)
                 if len(parts) >= 2:
                     organism_id = self._clean_sql_value(parts[0])
                     self.organisms[organism_id] = {
-                        'id': organism_id,
-                        'name': self._clean_sql_value(parts[1])
+                        "id": organism_id,
+                        "name": self._clean_sql_value(parts[1]),
                     }
         except Exception as e:
             logger.debug(f"Error parsing organism insert: {e}")
 
     def _parse_organisms_tsv(self, tsv_dir: Path):
         """Parse organisms TSV file."""
-        for filename in ['organisms.txt', 'organisms.tsv', 'species.txt']:
+        for filename in ["organisms.txt", "organisms.tsv", "species.txt"]:
             file_path = tsv_dir / filename
             if not file_path.exists():
                 continue
 
             logger.info(f"Loading {filename}...")
-            with open(file_path, encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
+            with open(file_path, encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
-                    org_id = row.get('id') or row.get('organism_id')
+                    org_id = row.get("id") or row.get("organism_id")
                     if org_id:
                         self.organisms[org_id] = {
-                            'id': org_id,
-                            'name': row.get('name') or row.get('organism_name', ''),
-                            'ncbi_taxonomy_id': row.get('ncbi_taxonomy_id', ''),
+                            "id": org_id,
+                            "name": row.get("name") or row.get("organism_name", ""),
+                            "ncbi_taxonomy_id": row.get("ncbi_taxonomy_id", ""),
                         }
             return
 
     def _parse_compounds_tsv(self, tsv_dir: Path):
         """Parse compounds TSV file."""
-        for filename in ['compounds.txt', 'compounds.tsv', 'chemicals.txt']:
+        for filename in ["compounds.txt", "compounds.tsv", "chemicals.txt"]:
             file_path = tsv_dir / filename
             if not file_path.exists():
                 continue
 
             logger.info(f"Loading {filename}...")
-            with open(file_path, encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
+            with open(file_path, encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
-                    comp_id = row.get('id') or row.get('compound_id')
+                    comp_id = row.get("id") or row.get("compound_id")
                     if comp_id:
                         self.compounds[comp_id] = {
-                            'id': comp_id,
-                            'name': row.get('name') or row.get('compound_name', ''),
-                            'kegg_id': row.get('kegg_id', ''),
-                            'chebi_id': row.get('chebi_id', ''),
-                            'pubchem_id': row.get('pubchem_id', ''),
-                            'bigg_id': row.get('bigg_id', ''),
-                            'seed_id': row.get('seed_id', ''),
+                            "id": comp_id,
+                            "name": row.get("name") or row.get("compound_name", ""),
+                            "kegg_id": row.get("kegg_id", ""),
+                            "chebi_id": row.get("chebi_id", ""),
+                            "pubchem_id": row.get("pubchem_id", ""),
+                            "bigg_id": row.get("bigg_id", ""),
+                            "seed_id": row.get("seed_id", ""),
                         }
             return
 
     def _parse_media_tsv(self, tsv_dir: Path):
         """Parse media TSV file."""
-        for filename in ['media_names.txt', 'media.tsv', 'media_names.tsv']:
+        for filename in ["media_names.txt", "media.tsv", "media_names.tsv"]:
             file_path = tsv_dir / filename
             if not file_path.exists():
                 continue
 
             logger.info(f"Loading {filename}...")
-            with open(file_path, encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
+            with open(file_path, encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
                     medium = {
-                        'id': row.get('id') or row.get('media_id'),
-                        'name': row.get('name') or row.get('media_name', ''),
-                        'composition': []
+                        "id": row.get("id") or row.get("media_id"),
+                        "name": row.get("name") or row.get("media_name", ""),
+                        "composition": [],
                     }
                     self.media.append(medium)
             return
 
     def _parse_compositions_tsv(self, tsv_dir: Path):
         """Parse media compositions TSV file."""
-        for filename in ['media_compositions.txt', 'compositions.tsv', 'media_composition.tsv']:
+        for filename in ["media_compositions.txt", "compositions.tsv", "media_composition.tsv"]:
             file_path = tsv_dir / filename
             if not file_path.exists():
                 continue
 
             logger.info(f"Loading {filename}...")
-            with open(file_path, encoding='utf-8') as f:
-                reader = csv.DictReader(f, delimiter='\t')
+            with open(file_path, encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter="\t")
                 for row in reader:
-                    media_id = row.get('media_id') or row.get('medium_id')
-                    compound_id = row.get('compound_id')
+                    media_id = row.get("media_id") or row.get("medium_id")
+                    compound_id = row.get("compound_id")
 
                     # Find the medium and add composition
                     for medium in self.media:
-                        if medium['id'] == media_id:
-                            medium['composition'].append({
-                                'compound_id': compound_id,
-                                'concentration': row.get('concentration', ''),
-                                'unit': row.get('unit', ''),
-                            })
+                        if medium["id"] == media_id:
+                            medium["composition"].append(
+                                {
+                                    "compound_id": compound_id,
+                                    "concentration": row.get("concentration", ""),
+                                    "unit": row.get("unit", ""),
+                                }
+                            )
                             break
             return
 
-    def _split_sql_values(self, values: str) -> List[str]:
+    def _split_sql_records(self, values_str: str) -> list[str]:
+        """Split `(...),(...),(...)` into records, respecting quotes and parens.
+
+        This replaces `re.findall(r'\\(([^)]+)\\)', ...)`, whose `[^)]+` stopped at
+        the FIRST closing paren. Any value containing one was truncated there,
+        and the remaining columns of that row were lost:
+
+            (16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')
+
+        became the four fields `16413, NULL, NULL, 'Iron(III`, which is how
+        `'Iron(III` ended up as an ingredient name in 75 recipes. Chemical
+        names carry parentheses constantly — oxidation states, stereo
+        descriptors — so this hit exactly the compounds hardest to re-derive.
+        """
+        records: list[str] = []
+        field_start = None
+        depth = 0
+        in_quotes = False
+        index = 0
+        while index < len(values_str):
+            char = values_str[index]
+            if in_quotes:
+                # MySQL dumps escape a quote as \' inside a quoted string.
+                if char == "\\":
+                    index += 2
+                    continue
+                if char == "'":
+                    in_quotes = False
+                index += 1
+                continue
+            if char == "'":
+                in_quotes = True
+            elif char == "(":
+                depth += 1
+                if depth == 1:
+                    field_start = index + 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0 and field_start is not None:
+                    records.append(values_str[field_start:index])
+                    field_start = None
+            index += 1
+        return records
+
+    def _split_sql_values(self, values: str) -> list[str]:
         """Split SQL values by comma, respecting quoted strings."""
         parts = []
-        current = ''
+        current = ""
         in_quotes = False
         quote_char = None
 
-        for char in values:
+        index = 0
+        while index < len(values):
+            char = values[index]
+            # A backslash escape. The dump writes chemical primes this way —
+            # `'Pantetheine 4\\'-phosphate'` — and without this the escaped quote
+            # was read as the end of the string, so quote tracking inverted and
+            # every later comma in the row split in the wrong place. That is why
+            # 48 compound names came out as fragments like
+            # `'Pantetheine 4'-phosphate','cpd00834','115254','16858`.
+            if in_quotes and char == "\\" and index + 1 < len(values):
+                current += values[index : index + 2]
+                index += 2
+                continue
             if char in ('"', "'") and (not in_quotes or char == quote_char):
                 in_quotes = not in_quotes
                 quote_char = char if in_quotes else None
-            elif char == ',' and not in_quotes:
+            elif char == "," and not in_quotes:
                 parts.append(current.strip())
-                current = ''
+                current = ""
+                index += 1
                 continue
             current += char
+            index += 1
 
         if current.strip():
             parts.append(current.strip())
@@ -366,12 +438,13 @@ class MediaDBFetcher:
         value = value.strip()
 
         # Handle NULL
-        if value.upper() == 'NULL':
-            return ''
+        if value.upper() == "NULL":
+            return ""
 
         # Remove quotes
-        if (value.startswith("'") and value.endswith("'")) or \
-           (value.startswith('"') and value.endswith('"')):
+        if (value.startswith("'") and value.endswith("'")) or (
+            value.startswith('"') and value.endswith('"')
+        ):
             value = value[1:-1]
 
         # Unescape
@@ -385,51 +458,50 @@ class MediaDBFetcher:
 
         # Export media
         media_file = self.output_dir / "mediadb_media.json"
-        with open(media_file, 'w', encoding='utf-8') as f:
-            json.dump({
-                'count': len(self.media),
-                'data': self.media
-            }, f, indent=2, ensure_ascii=False)
+        with open(media_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {"count": len(self.media), "data": self.media}, f, indent=2, ensure_ascii=False
+            )
         logger.info(f"✓ Saved {len(self.media)} media to {media_file}")
 
         # Export compounds
         compounds_file = self.output_dir / "mediadb_compounds.json"
-        with open(compounds_file, 'w', encoding='utf-8') as f:
-            json.dump({
-                'count': len(self.compounds),
-                'data': list(self.compounds.values())
-            }, f, indent=2, ensure_ascii=False)
+        with open(compounds_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {"count": len(self.compounds), "data": list(self.compounds.values())},
+                f,
+                indent=2,
+                ensure_ascii=False,
+            )
         logger.info(f"✓ Saved {len(self.compounds)} compounds to {compounds_file}")
 
         # Export organisms
         organisms_file = self.output_dir / "mediadb_organisms.json"
-        with open(organisms_file, 'w', encoding='utf-8') as f:
-            json.dump({
-                'count': len(self.organisms),
-                'data': list(self.organisms.values())
-            }, f, indent=2, ensure_ascii=False)
+        with open(organisms_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {"count": len(self.organisms), "data": list(self.organisms.values())},
+                f,
+                indent=2,
+                ensure_ascii=False,
+            )
         logger.info(f"✓ Saved {len(self.organisms)} organisms to {organisms_file}")
 
         # Export statistics
         stats = {
-            'fetch_date': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-            'source': 'MediaDB',
-            'total_media': len(self.media),
-            'total_compounds': len(self.compounds),
-            'total_organisms': len(self.organisms),
-            'url': 'https://mediadb.systemsbiology.net/'
+            "fetch_date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "source": "MediaDB",
+            "total_media": len(self.media),
+            "total_compounds": len(self.compounds),
+            "total_organisms": len(self.organisms),
+            "url": "https://mediadb.systemsbiology.net/",
         }
 
         stats_file = self.output_dir / "fetch_stats.json"
-        with open(stats_file, 'w', encoding='utf-8') as f:
+        with open(stats_file, "w", encoding="utf-8") as f:
             json.dump(stats, f, indent=2)
         logger.info(f"✓ Saved statistics to {stats_file}")
 
-    def fetch_all(
-        self,
-        sql_file: Optional[Path] = None,
-        tsv_dir: Optional[Path] = None
-    ):
+    def fetch_all(self, sql_file: Path | None = None, tsv_dir: Path | None = None):
         """
         Fetch all MediaDB data using specified method.
 
@@ -477,33 +549,21 @@ class MediaDBFetcher:
 
 def main():
     """CLI entry point."""
-    parser = argparse.ArgumentParser(
-        description="Fetch MediaDB media database"
-    )
+    parser = argparse.ArgumentParser(description="Fetch MediaDB media database")
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         type=Path,
         default="data/raw/mediadb",
-        help="Output directory for fetched data"
+        help="Output directory for fetched data",
     )
-    parser.add_argument(
-        "--sql",
-        type=Path,
-        help="Path to MediaDB SQL dump file"
-    )
-    parser.add_argument(
-        "--tsv",
-        type=Path,
-        help="Path to directory containing MediaDB TSV exports"
-    )
+    parser.add_argument("--sql", type=Path, help="Path to MediaDB SQL dump file")
+    parser.add_argument("--tsv", type=Path, help="Path to directory containing MediaDB TSV exports")
 
     args = parser.parse_args()
 
     fetcher = MediaDBFetcher(output_dir=args.output)
-    fetcher.fetch_all(
-        sql_file=args.sql,
-        tsv_dir=args.tsv
-    )
+    fetcher.fetch_all(sql_file=args.sql, tsv_dir=args.tsv)
 
 
 if __name__ == "__main__":

--- a/src/culturemech/import/mediadb_importer.py
+++ b/src/culturemech/import/mediadb_importer.py
@@ -21,6 +21,7 @@ Reference:
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from importlib import import_module
 from pathlib import Path
@@ -100,6 +101,8 @@ class MediaDBImporter:
         self.compounds = self.compounds_data.get("data", [])
         self.organisms = self.organisms_data.get("data", [])
 
+        self._refuse_a_stale_compound_export()
+
         # Index compounds by ID for quick lookup
         self.compounds_by_id = {comp["id"]: comp for comp in self.compounds}
 
@@ -114,6 +117,49 @@ class MediaDBImporter:
         logger.info(f"Loaded {len(self.organisms)} organism associations")
         logger.info(
             f"Cached {len(self.existing_media_names)} existing media names for deduplication"
+        )
+
+    # A KEGG compound id: the shape that appears in `name` only when the export
+    # predates the column-mapping fix.
+    _KEGG_ID = re.compile(r"^C\d{5}$")
+
+    def _refuse_a_stale_compound_export(self) -> None:
+        """Stop rather than re-import an export built by the old SQL parser.
+
+        Two bugs in `mediadb_fetcher` (#387) put a KEGG id in `name`, the real
+        name in `chebi_id`, and truncated any value containing a parenthesis at
+        that parenthesis. `mediadb_compounds.json` is gitignored, so a checkout
+        can hold a pre-fix copy indefinitely, and importing from it would put
+        fragments like `'Iron(III` back into the corpus — including from the
+        ~1,600 damaged rows that never reached a recipe the first time.
+
+        Detected on shape, not on a version stamp, because the export carries
+        no version: a `name` that is a KEGG id, or a `chebi_id` that is a
+        truncated quoted string, cannot happen in a correctly parsed export.
+        """
+        # `name` holding a KEGG id is not damage on its own: four MediaDB
+        # compounds are genuinely unnamed and carry their KEGG id as the name
+        # (`{'name': 'C15810', 'kegg_id': 'C15810'}`). Under the shifted mapping
+        # the two disagree, because `kegg_id` then holds the BiGG id
+        # (`{'name': 'C00149', 'kegg_id': 'mal-L'}`). The disagreement is the
+        # signal; a bare count of KEGG-shaped names refuses a good export.
+        shifted = sum(
+            1
+            for compound in self.compounds
+            if self._KEGG_ID.match(str(compound.get("name", "")))
+            and str(compound.get("name", "")) != str(compound.get("kegg_id", ""))
+        )
+        truncated = sum(
+            1 for compound in self.compounds if str(compound.get("chebi_id", "")).startswith("'")
+        )
+        if not shifted and not truncated:
+            return
+        raise RuntimeError(
+            f"{self.mediadb_dir / 'mediadb_compounds.json'} was built by the pre-#387 "
+            f"SQL parser: {shifted} compound(s) have a KEGG id in `name` and "
+            f"{truncated} have a truncated `chebi_id`. Importing from it would put "
+            f'names like "\'Iron(III" back into the corpus. Re-run `just fetch-mediadb` '
+            f"to regenerate it."
         )
 
     def _load_json(self, filename: str) -> dict:

--- a/tests/test_mediadb_sql_parsing.py
+++ b/tests/test_mediadb_sql_parsing.py
@@ -1,0 +1,139 @@
+"""MediaDB SQL rows must survive parentheses and escaped quotes.
+
+Chemical names are full of both — oxidation states (`Iron(III) chloride`),
+stereo descriptors (`(S)-Malate`), and primes (`Pantetheine 4'-phosphate`) —
+and two parsing bugs cut them in half.
+
+`_parse_*_insert` split records with `re.findall(r'\\(([^)]+)\\)', ...)`, whose
+`[^)]+` stops at the FIRST closing paren, so
+
+    (16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')
+
+became the four fields `16413, NULL, NULL, 'Iron(III`. That fragment reached
+the corpus as an ingredient name in 75 recipes (#387).
+
+`_split_sql_values` then tracked quotes without honouring backslash escapes, so
+a prime written `4\\'-phosphate` read as the end of the string and every later
+comma in the row split in the wrong place — 48 more compound names.
+
+Every literal here is copied from `data/raw/mediadb/media_database.07Oct2015.sql`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from culturemech.fetch.mediadb_fetcher import MediaDBFetcher
+
+
+@pytest.fixture
+def fetcher(tmp_path) -> MediaDBFetcher:
+    return MediaDBFetcher(output_dir=tmp_path)
+
+
+# --- record splitting ----------------------------------------------------
+
+
+def test_a_value_containing_a_paren_does_not_truncate_the_record(fetcher):
+    records = fetcher._split_sql_records(
+        "(16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')"
+    )
+    assert records == ["16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3'"]
+
+
+def test_consecutive_records_are_separated(fetcher):
+    records = fetcher._split_sql_records("(1,'a'),(2,'b(c)'),(3,'d')")
+    assert records == ["1,'a'", "2,'b(c)'", "3,'d'"]
+
+
+def test_a_paren_inside_quotes_does_not_open_a_record(fetcher):
+    """`m7G(5')pppAn` carries an unbalanced-looking paren and a prime."""
+    records = fetcher._split_sql_records("(1714,'C01973','','m7G(5')pppAn','cpd11982')")
+    assert len(records) == 1
+
+
+def test_an_escaped_quote_does_not_end_the_string(fetcher):
+    records = fetcher._split_sql_records("(1039,'Pantetheine 4\\'-phosphate','x')")
+    assert records == ["1039,'Pantetheine 4\\'-phosphate','x'"]
+
+
+# --- field splitting -----------------------------------------------------
+
+
+def test_an_escaped_quote_keeps_the_field_boundaries(fetcher):
+    parts = fetcher._split_sql_values(
+        "1039,'C01134','pan4p','Pantetheine 4\\'-phosphate','cpd00834'"
+    )
+    assert len(parts) == 5
+    assert fetcher._clean_sql_value(parts[3]) == "Pantetheine 4'-phosphate"
+
+
+def test_a_comma_inside_a_quoted_field_is_not_a_separator(fetcher):
+    """`chebi_ids` legitimately holds `'16858,4222'`."""
+    parts = fetcher._split_sql_values("1039,'16858,4222','C11H23N2O7PS'")
+    assert len(parts) == 3
+    assert fetcher._clean_sql_value(parts[1]) == "16858,4222"
+
+
+# --- the compounds column mapping ---------------------------------------
+
+
+def test_the_compound_columns_follow_the_dumps_own_schema(fetcher):
+    """`compID | KEGG_ID | BiGG_ID | name | seed_id | pubchem | chebi | formula`.
+
+    The old mapping read parts[1] as the name — that is KEGG_ID — and parts[3],
+    the real name, as the ChEBI id. On row 1 that gave name='C00001' and
+    chebi_id='Water'.
+    """
+    fetcher._parse_compound_insert("(1,'C00001','h2o','Water','cpd00001','444718','15377','H2O')")
+    assert fetcher.compounds["1"] == {
+        "id": "1",
+        "name": "Water",
+        "kegg_id": "C00001",
+        "bigg_id": "h2o",
+        "chebi_id": "15377",
+        "formula": "H2O",
+    }
+
+
+def test_a_null_column_becomes_empty_not_the_string_NULL(fetcher):
+    fetcher._parse_compound_insert(
+        "(16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')"
+    )
+    compound = fetcher.compounds["16413"]
+    assert compound["name"] == "Iron(III) chloride"
+    assert compound["kegg_id"] == ""
+    assert compound["formula"] == "FeCl3"
+
+
+# --- against the real dump ----------------------------------------------
+
+DUMP = Path(__file__).resolve().parents[1] / "data/raw/mediadb/media_database.07Oct2015.sql"
+
+
+@pytest.mark.skipif(not DUMP.exists(), reason="raw MediaDB dump is not present locally")
+def test_the_real_dump_parses_without_fragmenting_names(fetcher):
+    """The end-to-end check: no compound name may look like a cut-off fragment.
+
+    Four names legitimately end in a prime (`Premithramycin A2'`,
+    `Nebramycin factor 5'`, `Nebramycin factor 4'`, `R'C(R)S-S(R)CR'`), so the
+    assertion is about fragments — a name still carrying a field separator, or
+    one opening with a quote it never closes.
+    """
+    assert fetcher.parse_sql_dump(DUMP)
+    assert len(fetcher.compounds) > 14000
+
+    fragments = [
+        compound
+        for compound in fetcher.compounds.values()
+        if compound["name"].startswith("'") or "','" in compound["name"]
+    ]
+    assert fragments == [], f"{len(fragments)} names are still fragments"
+
+    # The three the corpus damage came from.
+    by_id = fetcher.compounds
+    assert by_id["16413"]["name"] == "Iron(III) chloride"
+    assert by_id["16416"]["name"] == "Chromium(III) Chloride"
+    assert by_id["1"]["name"] == "Water"

--- a/tests/test_mediadb_sql_parsing.py
+++ b/tests/test_mediadb_sql_parsing.py
@@ -137,3 +137,71 @@ def test_the_real_dump_parses_without_fragmenting_names(fetcher):
     assert by_id["16413"]["name"] == "Iron(III) chloride"
     assert by_id["16416"]["name"] == "Chromium(III) Chloride"
     assert by_id["1"]["name"] == "Water"
+
+
+# --- the importer's stale-export guard ----------------------------------
+
+
+def _importer_class():
+    from importlib import import_module
+
+    module = import_module("culturemech.import.mediadb_importer")
+    return next(
+        value
+        for name, value in vars(module).items()
+        if name.endswith("Importer") and isinstance(value, type)
+    )
+
+
+def _export(tmp_path: Path, compounds: list[dict]) -> Path:
+    import json
+
+    directory = tmp_path / "mediadb"
+    directory.mkdir()
+    for name, payload in (
+        ("mediadb_compounds.json", compounds),
+        ("mediadb_media.json", []),
+        ("mediadb_organisms.json", []),
+    ):
+        (directory / name).write_text(json.dumps({"count": len(payload), "data": payload}))
+    return directory
+
+
+def test_a_correct_export_is_accepted(tmp_path):
+    directory = _export(
+        tmp_path,
+        [{"id": "1", "name": "Water", "kegg_id": "C00001", "bigg_id": "h2o", "chebi_id": "15377"}],
+    )
+    assert _importer_class()(str(directory), str(tmp_path / "out")).compounds
+
+
+def test_an_unnamed_compound_is_not_mistaken_for_damage(tmp_path):
+    """Four MediaDB compounds genuinely carry their KEGG id as the name.
+
+    `{'name': 'C15810', 'kegg_id': 'C15810'}` is real data. A guard that counted
+    KEGG-shaped names alone refused the correct export — verified, it did.
+    """
+    directory = _export(
+        tmp_path,
+        [{"id": "14209", "name": "C15810", "kegg_id": "C15810", "bigg_id": "", "chebi_id": ""}],
+    )
+    assert _importer_class()(str(directory), str(tmp_path / "out")).compounds
+
+
+def test_a_shifted_export_is_refused(tmp_path):
+    """The pre-#387 shape: name holds the KEGG id, kegg_id holds the BiGG id."""
+    directory = _export(
+        tmp_path,
+        [{"id": "145", "name": "C00149", "kegg_id": "mal-L", "chebi_id": "'(S"}],
+    )
+    with pytest.raises(RuntimeError, match="pre-#387 SQL parser"):
+        _importer_class()(str(directory), str(tmp_path / "out"))
+
+
+def test_a_truncated_chebi_id_alone_is_enough_to_refuse(tmp_path):
+    directory = _export(
+        tmp_path,
+        [{"id": "16413", "name": "Iron", "kegg_id": "", "chebi_id": "'Iron(III"}],
+    )
+    with pytest.raises(RuntimeError, match="truncated"):
+        _importer_class()(str(directory), str(tmp_path / "out"))

--- a/tests/test_mediadb_sql_parsing.py
+++ b/tests/test_mediadb_sql_parsing.py
@@ -205,3 +205,66 @@ def test_a_truncated_chebi_id_alone_is_enough_to_refuse(tmp_path):
     )
     with pytest.raises(RuntimeError, match="truncated"):
         _importer_class()(str(directory), str(tmp_path / "out"))
+
+
+# --- medium-name damage -------------------------------------------------
+
+
+def test_a_leading_quote_marks_a_truncated_medium_name():
+    from repair_mediadb_names import damaged_medium_name
+
+    assert damaged_medium_name("'Defined freshwater medium (CoSO4")
+
+
+def test_a_glued_field_tail_marks_a_damaged_medium_name():
+    """From the escaped-quote bug: `Spizizen's medium` glued the next field on."""
+    from repair_mediadb_names import damaged_medium_name
+
+    assert damaged_medium_name("Spizizen's medium ... Nakano et al','N")
+
+
+def test_a_healthy_medium_name_is_left_alone():
+    from repair_mediadb_names import damaged_medium_name
+
+    assert not damaged_medium_name("M9 (gupta) with lactose")
+    assert not damaged_medium_name("Defined freshwater medium (CoSO4) + 100 mM Fe2O3")
+
+
+def test_trailing_whitespace_is_not_damage():
+    """`'Supplemented BG11 + Glucose '` is the dump's own value, space and all."""
+    from repair_mediadb_names import damaged_medium_name
+
+    assert not damaged_medium_name("Supplemented BG11 + Glucose ")
+
+
+def test_the_medium_name_repair_touches_only_the_two_damaged_fields():
+    from repair_mediadb_names import repair_medium_name
+
+    record = {
+        "name": "m9_gupta",
+        "original_name": "'M9 (gupta",
+        "media_term": {
+            "preferred_term": "MediaDB Medium 109",
+            "term": {"id": "MEDIADB:109", "label": "'M9 (gupta"},
+        },
+    }
+    changed = repair_medium_name(record, "M9 (gupta) with lactose")
+
+    assert sorted(changed) == ["media_term.term.label", "original_name"]
+    assert record["original_name"] == "M9 (gupta) with lactose"
+    assert record["media_term"]["term"]["label"] == "M9 (gupta) with lactose"
+    # The id and the record slug are identifiers; the repair must not touch them.
+    assert record["media_term"]["term"]["id"] == "MEDIADB:109"
+    assert record["media_term"]["preferred_term"] == "MediaDB Medium 109"
+    assert record["name"] == "m9_gupta"
+
+
+def test_an_undamaged_record_is_not_rewritten():
+    from repair_mediadb_names import repair_medium_name
+
+    record = {
+        "original_name": "M9 (gupta) with lactose",
+        "media_term": {"term": {"id": "MEDIADB:109", "label": "M9 (gupta) with lactose"}},
+    }
+    assert repair_medium_name(record, "Something Else Entirely") == []
+    assert record["original_name"] == "M9 (gupta) with lactose"


### PR DESCRIPTION
Closes the second half of #387.

I said in #387 that this part was "not recoverable from the records". That was
wrong: the authoritative MySQL dump is in `data/raw/mediadb/`, and every name is
in it.

## Root cause — three bugs in `mediadb_fetcher`

**1. Record splitting.** All four `_parse_*_insert` methods used
`re.findall(r'\(([^)]+)\)', ...)`. `[^)]+` stops at the first closing paren:

```
(16413,NULL,NULL,'Iron(III) chloride','','24380','30808','FeCl3')
  -> 16413 | NULL | NULL | 'Iron(III        (rest of the row lost)
```

**2. Escaped quotes.** `_split_sql_values` tracked quotes without honouring
backslash escapes. The dump writes primes as `'Pantetheine 4\'-phosphate'`, so
the escaped quote read as end-of-string and later commas split in the wrong
place — **48 more** mangled names. Fixing (1) alone left these.

**3. Column mapping.** From the dump's own `CREATE TABLE`:
`compID | KEGG_ID | BiGG_ID | name | seed_id | pubchem_ids | chebi_ids | formula`.
The parser read `parts[1]` as the name (that is KEGG_ID) and `parts[3]` — the
real name — as the ChEBI id. Row 1 came out `name='C00001'`, `chebi_id='Water'`.
`bigg_id` and `formula` were discarded entirely.

Result on the real dump: **14,797 compounds, 471 media, zero fragmented names.**

## Two repairs

### 111 ingredient names, across 101 records

A lookup table would have been wrong: `'(S` is **`(S)-Malate`** in four recipes
and **`(S)-Lactate`** in two others. Resolution is per record —
`media_term.term.id` gives the medium, `media_compounds` gives its actual
compound list, the fragment must prefix exactly one, and where more than one
matches the recorded concentration must equal that compound's `Amount_mM`.

**111 of 111 resolved. Zero ambiguity, zero manual decisions.**

Independently verified against MediaDB's `chebi_ids` — a column the resolution
does not use — including the two cases most easily swapped:

| restored | MediaDB ChEBI id | ChEBI label |
|---|---|---|
| Iron(III) chloride | CHEBI:30808 | iron trichloride |
| Chromium(III) Chloride | CHEBI:53351 | chromium(3+) trichloride |
| (S)-Malate | CHEBI:30797 | (S)-malic acid |
| **(R)-Lactate** | CHEBI:42111 | **(R)-lactic acid** |
| **(S)-Lactate** | CHEBI:422 | **(S)-lactic acid** |
| (9Z)-Octadecenoic acid | CHEBI:16196 | oleic acid |
| Cyanocob(III)alamin | CHEBI:17439 | cyanocob(III)alamin |
| (R,R)-Butane-2,3-diol | CHEBI:16982 | (R,R)-butane-2,3-diol |

Every one agrees. The remaining three have no ChEBI id in MediaDB.

### 194 medium names, across 182 records — found in review

I first checked whether `_parse_media_insert` had damaged medium names and
concluded it had not. **That check was wrong** — it tested
`dump_name.startswith(corpus_value)`, and the corpus value carries a leading
quote, so it never matched. Comparing for equality found 182 damaged records.

This is worse than the ingredient damage, because the cut lands exactly where
these media differ:

```
'Defined freshwater medium (CoSO4        <- 29 DISTINCT media, one string
  MEDIADB:416 = ... (CoSO4) + 100 mM Fe2O3 + 113.2 mM Acetate
  MEDIADB:418 = ... (CoSO4) + 20 mM Iron citrate + 113.2 mM Acetate
  MEDIADB:419 = ... (CoSO4) + 5 mM nitrate + 113.2 mM Acetate
```

Four such collisions covered 68 media. **All are now distinct — 0 labels shared
by more than one MEDIADB id, down from 4.**

A second shape appeared only after fixing the first, invisible to a
`startswith("'")` test: 12 names carry a glued-on `','N` tail from bug (2),
where `Spizizen's medium` inverted quote tracking.

This repair needs no inference — the MEDIADB id names the dump row directly.
The detector stays narrow rather than imposing the dump value everywhere, so
deliberate curation is not overwritten, and a name differing only by trailing
whitespace (`'Supplemented BG11 + Glucose '`, the dump's own value) is untouched.

## The stale intermediate — also found in review

`mediadb_compounds.json` is gitignored, so a checkout can hold a pre-fix copy.
The one here held **1,703 truncated and 14,695 shifted rows** — a re-import
without a re-fetch would have put `'Iron(III` straight back, plus damage from
~1,600 fragments that had not yet reached a recipe. The importer now refuses a
pre-fix export.

**My first guard was wrong**, and only testing the negative case caught it: it
counted any `name` matching `C\d{5}` and refused the *correctly* regenerated
export, because four MediaDB compounds are genuinely unnamed and carry their
KEGG id as the name. Under the shifted mapping the columns *disagree*
(`{'name': 'C00149', 'kegg_id': 'mal-L'}`) — that disagreement is the signal.

```
regenerated (correct)    ACCEPTED, 14797 compounds
pre-fix backup (stale)   REFUSED, 14695 shifted / 1703 truncated
```

## Verification

- Across all **253** touched records: no top-level key changed, no unowned
  field changed, no MEDIADB id changed, no `media_term.preferred_term` changed,
  no ingredient field other than `preferred_term` changed, `curation_history`
  only appended to.
- 468 of 469 MediaDB labels now match the dump exactly.
- Gates: `validate-strict` 0 errors / 15,877 files; `assign-ids-check`,
  `check-chebi-grounding`, `audit-concentration-plausibility` all exit 0;
  `test-fast` 1430 passed.
- New tests fail without the fix (old regex restored: `2 failed, 7 passed`).

## Reviewer notes

- Part of the line count is `record_io` re-wrapping long `notes:` lines an
  earlier `width=120` run had reflowed — the "residual 7%" its docstring
  describes. Semantically null, confirmed by the comparison above.
- The dump is gitignored, so `test_the_real_dump_parses_without_fragmenting_names`
  skips in CI. The unit tests carry the coverage; every literal is copied from
  the dump.

## Not in this PR

- **#390** — `mediadb_importer.py` hardcodes rows 1-4 as Water/ATP/NAD+/NADH to
  work around bug (3). The fixed parser now yields exactly those four, so it is
  a no-op. That patch only ever covered 4 of 14,797 compounds; the other 14,793
  were shifted too and nobody noticed.
- **#392** — `name`, the record slug, still encodes the truncated medium name
  for those 182 records. It is used for matching and deduplication, so renaming
  is a different change with a different blast radius.
- One remaining damaged ingredient name, `Trace metals 'Gaffron\xad+Se'` in
  `pcr_s11_medium.yaml`: not truncation, a real name with a soft hyphen
  (U+00AD), in a record with no MediaDB id. Left for #387.