### PR TITLE
Report what the KGX export drops, and what kind of thing it is (#372)

### DIFF
--- a/data/import_tracking/derived_artifacts.tsv
+++ b/data/import_tracking/derived_artifacts.tsv
@@ -45,6 +45,7 @@ data/import_tracking/reports/primary_term_reground_changes.tsv	UNKNOWN	no writer
 data/import_tracking/reports/review_need_ranking.tsv	CURRENT_VIEW	score_review_need.py	scripts/score_review_need.py	scripts/score_review_need.py	yes
 data/import_tracking/reports/selective_agent_mismatch.tsv	CURRENT_VIEW	audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	scripts/audit_selective_agent_mismatch.py	yes
 data/import_tracking/reports/top5-curation-proposals.json	UNKNOWN	writer purity unestablished (apply_curation_proposals.py)		scripts/apply_curation_proposals.py	
+data/import_tracking/reports/ungrounded_ingredients.tsv	CURRENT_VIEW	audit_ungrounded_ingredients.py	scripts/audit_ungrounded_ingredients.py	scripts/audit_ungrounded_ingredients.py	
 data/import_tracking/reports/unparsed_composition.tsv	CURRENT_VIEW	audit_unparsed_composition.py	scripts/audit_unparsed_composition.py	scripts/audit_unparsed_composition.py	yes
 data/import_tracking/reports/unparsed_compositions.tsv	CURRENT_VIEW	report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	scripts/report_unparsed_compositions.py	yes
 data/import_tracking/researched_media.json	CURRENT_VIEW	prioritize_deep_research_candidates.py		scripts/prioritize_deep_research_candidates.py; scripts/refresh_researched_manifest.py; scripts/researched_manifest.py	

--- a/data/import_tracking/reports/ungrounded_ingredients.tsv
+++ b/data/import_tracking/reports/ungrounded_ingredients.tsv
@@ -1,0 +1,3218 @@
+ingredient	kind	rows	records	example_record	has_local_term	section
+See source for composition	PLACEHOLDER	4775	4775	CultureMech:000062	no	ingredients
+Agar (if needed)	UNRESOLVED_CHEMICAL	289	289	CultureMech:008628	no	ingredients
+Trace vitamins (see Medium [M190])	CROSS_REFERENCE	284	283	CultureMech:007553	no	solutions
+Seven vitamins solution	SOLUTION_NAME	179	179	CultureMech:004073	no	solutions
+5% Na2S・9H2O solution	SOLUTION_NAME	169	169	CultureMech:007605	no	solutions
+Calf brains	UNRESOLVED_CHEMICAL	164	164	CultureMech:007623	yes	ingredients
+8% NaHCO3 solution*	SOLUTION_NAME	125	125	CultureMech:015860	no	ingredients
+Trace element solution (see Medium [M180])	CROSS_REFERENCE	117	117	CultureMech:007553	no	solutions
+FeCl2 solution (see Medium [M180])	CROSS_REFERENCE	113	113	CultureMech:007553	no	solutions
+Trace minerals (see Medium [M142])	CROSS_REFERENCE	111	111	CultureMech:007842	no	solutions
+Na-resazurin solution (0.1% w/v)	SOLUTION_NAME	90	90	CultureMech:008808	no	solutions
+Sea Salt	UNRESOLVED_CHEMICAL	90	90	CultureMech:000529	no	ingredients
+Selenite--tungstate solution (see Medium [M431])	CROSS_REFERENCE	85	85	CultureMech:007553	no	solutions
+PPLO broth	UNRESOLVED_CHEMICAL	83	83	CultureMech:002467	no	ingredients
+Casamino acids (BD-Difco)	UNRESOLVED_CHEMICAL	82	82	CultureMech:007537	no	ingredients
+HCl (25%; 7.7 M)	UNRESOLVED_CHEMICAL	75	75	CultureMech:009039	no	ingredients
+Iron(III) chloride	UNRESOLVED_CHEMICAL	75	75	CultureMech:007383	no	ingredients
+CMRL 1066	UNRESOLVED_CHEMICAL	74	74	CultureMech:002564	no	ingredients
+DI Water	UNRESOLVED_CHEMICAL	72	72	CultureMech:009048	no	ingredients
+N2 gas	UNRESOLVED_CHEMICAL	71	71	CultureMech:009133	no	ingredients
+Trace salt solution	SOLUTION_NAME	61	61	CultureMech:005991	no	solutions
+[1,1′-Biphenyl]-2-ol	UNRESOLVED_CHEMICAL	59	59	CultureMech:005566	no	ingredients
+KOH solution	SOLUTION_NAME	57	57	CultureMech:007968	no	solutions
+Hipolypepton*	UNRESOLVED_CHEMICAL	57	57	CultureMech:008189	no	solutions
+Horse blood	UNRESOLVED_CHEMICAL	52	52	CultureMech:003807	no	ingredients
+8% NaHCO3 solution	SOLUTION_NAME	49	49	CultureMech:015863	no	ingredients
+Vitamin B12 solution (see Medium [M401])	CROSS_REFERENCE	44	44	CultureMech:010380	no	solutions
+Wolin's vitamin solution (10x)	SOLUTION_NAME	42	42	CultureMech:004073	no	solutions
+Oxygen gas	UNRESOLVED_CHEMICAL	42	42	CultureMech:007686	no	ingredients
+Trace element solution (see Medium [M439])	CROSS_REFERENCE	42	42	CultureMech:007760	no	solutions
+Wolfe's mineral elixir	SOLUTION_NAME	41	41	CultureMech:003735	no	solutions
+Na2CO3 solution	SOLUTION_NAME	40	40	CultureMech:007581	no	solutions
+5% Na2S·9H2O solution	SOLUTION_NAME	39	38	CultureMech:015840	no	ingredients
+5% L--Cysteine・HCl・H2O solution	SOLUTION_NAME	35	35	CultureMech:007605	no	solutions
+Vitamin solution (see Medium [M401])	CROSS_REFERENCE	34	34	CultureMech:010380	no	solutions
+ZMB_ALS	UNRESOLVED_CHEMICAL	33	33	CultureMech:015795	no	ingredients
+Trace element solution (see below)	SOLUTION_NAME	32	32	CultureMech:007671	no	solutions
+Thiamine solution (see Medium [M401])	CROSS_REFERENCE	31	31	CultureMech:010380	no	solutions
+Trace vitamins solution (see Medium [M278])	CROSS_REFERENCE	30	30	CultureMech:007605	no	solutions
+10% Yeast extract solution	SOLUTION_NAME	29	29	CultureMech:015832	no	ingredients
+5% L-Cysteine・HCl・H2O solution	SOLUTION_NAME	29	29	CultureMech:009119	no	solutions
+Trace mineral solution (see below)	SOLUTION_NAME	28	28	CultureMech:007831	no	solutions
+Sol. 1	UNRESOLVED_CHEMICAL	28	28	CultureMech:009918	no	ingredients
+Bacto Casamino Acids (Difco)	UNRESOLVED_CHEMICAL	28	28	CultureMech:008724	no	ingredients
+Se/W solution (see Medium [M278])	CROSS_REFERENCE	27	27	CultureMech:009810	no	solutions
+MnCl2·4H2O	UNRESOLVED_CHEMICAL	26	26	CultureMech:015836	no	ingredients
+Vitamin solution (see below)	SOLUTION_NAME	25	25	CultureMech:007901	no	solutions
+Trace element solution (see Medium [M278])	CROSS_REFERENCE	25	25	CultureMech:009810	no	solutions
+CoCl2·6H2O	UNRESOLVED_CHEMICAL	24	24	CultureMech:015836	no	ingredients
+1 M Glucose solution	SOLUTION_NAME	23	23	CultureMech:015856	no	ingredients
+5% L-Cysteine·HCl·H2O solution	SOLUTION_NAME	22	21	CultureMech:015840	no	ingredients
+H3BO4	UNRESOLVED_CHEMICAL	22	22	CultureMech:004114	no	ingredients
+Trace element solution SL--10 (see Medium [M433])	CROSS_REFERENCE	22	22	CultureMech:007522	no	solutions
+Na2S・9H2O solutions	SOLUTION_NAME	21	21	CultureMech:009810	no	solutions
+Trace vitamins (see Medium No. 197)	CROSS_REFERENCE	21	21	CultureMech:002262	no	ingredients
+DL-Serine	UNRESOLVED_CHEMICAL	21	21	CultureMech:007212	no	ingredients
+Artificial seawater	UNRESOLVED_CHEMICAL	20	20	CultureMech:000200	no	solutions
+Deionized water	UNRESOLVED_CHEMICAL	20	20	CultureMech:000138	no	ingredients
+Potato	UNRESOLVED_CHEMICAL	20	20	CultureMech:002908	no	ingredients
+KP buffer*	SOLUTION_NAME	19	19	CultureMech:008192	no	solutions
+Sodium glycerophosphate	UNRESOLVED_CHEMICAL	19	19	CultureMech:001809	no	ingredients
+Pancreatic digest of casein	UNRESOLVED_CHEMICAL	19	19	CultureMech:003541	no	ingredients
+Sodium resazurin (0.1% w/v)	UNRESOLVED_CHEMICAL	18	18	CultureMech:009169	no	ingredients
+Marine Broth	UNRESOLVED_CHEMICAL	18	18	CultureMech:005909	no	ingredients
+Modified Brock's salt base solution (see Medium [M156])	CROSS_REFERENCE	17	17	CultureMech:007855	no	solutions
+Bacto agar (BD-Difco)	UNRESOLVED_CHEMICAL	17	17	CultureMech:009470	no	ingredients
+NiCl2·6H2O	UNRESOLVED_CHEMICAL	17	17	CultureMech:007450	no	solutions.composition
+Trace element mixture*	SOLUTION_NAME	17	17	CultureMech:007467	no	ingredients
+Sodium ammonium phosphate	UNRESOLVED_CHEMICAL	17	17	CultureMech:007128	no	ingredients
+Sodium phosphate dibasic heptahydrate	UNRESOLVED_CHEMICAL	17	17	CultureMech:015484	no	ingredients
+MoLS4	UNRESOLVED_CHEMICAL	17	17	CultureMech:015609	no	ingredients
+Trace vitamins* (see Medium No. 197 )	CROSS_REFERENCE	16	16	CultureMech:015832	no	ingredients
+Skim milk	UNRESOLVED_CHEMICAL	16	16	CultureMech:004167	no	ingredients
+MnSO4·xH2O	UNRESOLVED_CHEMICAL	16	16	CultureMech:008148	no	ingredients
+3% Na2S・9H2O solution	SOLUTION_NAME	16	16	CultureMech:010132	no	solutions
+B12	UNRESOLVED_CHEMICAL	16	16	CultureMech:001265	no	ingredients
+L-Cysteine . HCl	UNRESOLVED_CHEMICAL	16	16	CultureMech:009258	no	ingredients
+CaCl2・2H2O	UNRESOLVED_CHEMICAL	16	16	CultureMech:003049	no	ingredients
+NaHCO3 solution	SOLUTION_NAME	16	15	CultureMech:007544	no	solutions
+Soilwater: GR+ Medium	UNRESOLVED_CHEMICAL	15	15	CultureMech:000001	no	ingredients
+MgSO4 x 7 H2O stock solution	SOLUTION_NAME	15	15	CultureMech:000189	no	solutions
+CO2 gas	UNRESOLVED_CHEMICAL	15	15	CultureMech:009347	no	ingredients
+N-Z amine	UNRESOLVED_CHEMICAL	15	15	CultureMech:002829	no	ingredients
+Ferric citrate solution* (0.1%)	SOLUTION_NAME	15	15	CultureMech:007457	no	ingredients
+Ground beef (fat free)	UNRESOLVED_CHEMICAL	15	15	CultureMech:009104	no	ingredients
+VOSO4・xH2O	UNRESOLVED_CHEMICAL	14	14	CultureMech:007831	no	ingredients
+5% NaHCO3 solution	SOLUTION_NAME	14	14	CultureMech:009347	no	solutions
+Trace elements solution (Pfennig, 1965)	SOLUTION_NAME	14	14	CultureMech:000244	no	solutions
+1.0 M Sodium acetate solution	SOLUTION_NAME	14	14	CultureMech:015833	no	ingredients
+Sheep blood	UNRESOLVED_CHEMICAL	14	14	CultureMech:015847	no	ingredients
+Vitamin B12 solution (see Medium No. 403)	CROSS_REFERENCE	14	14	CultureMech:003096	no	solutions
+Trace element solution (Vishniac & Santer, 1957)	SOLUTION_NAME	14	14	CultureMech:004110	no	solutions
+HCl (25%)	UNRESOLVED_CHEMICAL	13	13	CultureMech:009209	no	ingredients
+Bacto Marine Broth 2216 (Difco)	UNRESOLVED_CHEMICAL	13	13	CultureMech:008340	no	ingredients
+L-Cysteine·HCl·H2O	UNRESOLVED_CHEMICAL	13	13	CultureMech:015837	no	ingredients
+Standard vitamin solution	SOLUTION_NAME	13	13	CultureMech:005254	no	solutions
+Fe(III)dicitrate	UNRESOLVED_CHEMICAL	13	13	CultureMech:007319	no	ingredients
+MJ(-N) synthetic seawater (see Medium [M260])	CROSS_REFERENCE	13	13	CultureMech:007687	no	solutions
+NaOH 1 N	UNRESOLVED_CHEMICAL	13	13	CultureMech:009104	no	ingredients
+L-cysteine hydrochloride	UNRESOLVED_CHEMICAL	13	13	CultureMech:009104	no	ingredients
+dehydrated Wilkins-Chalgren medium	UNRESOLVED_CHEMICAL	13	13	CultureMech:005039	no	ingredients
+Wolfe's mineral solution (see Medium [M257])	CROSS_REFERENCE	12	12	CultureMech:007633	no	solutions
+Air	UNRESOLVED_CHEMICAL	12	12	CultureMech:008437	no	ingredients
+Ferric citrate (0.1%, w/v)	UNRESOLVED_CHEMICAL	12	12	CultureMech:007755	no	ingredients
+Fe2(SO4)3・xH2O	UNRESOLVED_CHEMICAL	12	12	CultureMech:009641	no	ingredients
+KNO3 stock solution	SOLUTION_NAME	11	11	CultureMech:000191	no	solutions
+FeCl2 solution (see Medium No. 187 )	CROSS_REFERENCE	11	11	CultureMech:015860	no	ingredients
+Trace element solution (see Medium No. 187 )	CROSS_REFERENCE	11	11	CultureMech:015860	no	ingredients
+SL-6 trace element solution (see Medium [M158])	CROSS_REFERENCE	11	11	CultureMech:007650	no	solutions
+Allen’s trace element solution	SOLUTION_NAME	11	11	CultureMech:008892	no	solutions
+Trace element solution (see Medium [M296])	CROSS_REFERENCE	11	11	CultureMech:009735	no	solutions
+Sol. 2	UNRESOLVED_CHEMICAL	11	11	CultureMech:009918	no	ingredients
+1% Yeast extract solution	SOLUTION_NAME	11	11	CultureMech:010396	no	solutions
+HCl (35%)	UNRESOLVED_CHEMICAL	11	11	CultureMech:009549	no	ingredients
+Heart Infusion Broth	UNRESOLVED_CHEMICAL	11	11	CultureMech:004003	no	ingredients
+Bacto Middlebrook 7H10 agar	UNRESOLVED_CHEMICAL	11	11	CultureMech:006191	yes	ingredients
+Trace element solution SL-11	SOLUTION_NAME	11	11	CultureMech:006543	no	solutions
+Sodium phosphate buffer (10 mM; pH7.1)	SOLUTION_NAME	11	11	CultureMech:007472	no	solutions.composition
+0.1% Resazurin solution	SOLUTION_NAME	11	11	CultureMech:007780	no	solutions
+95% ethanol	UNRESOLVED_CHEMICAL	11	11	CultureMech:009104	no	ingredients
+Vitamin solution (see Medium No. 403)	CROSS_REFERENCE	11	11	CultureMech:002296	no	solutions
+Thiamine solution (see Medium No. 403)	CROSS_REFERENCE	11	11	CultureMech:002296	no	solutions
+K2HPO4 stock solution	SOLUTION_NAME	10	10	CultureMech:000192	no	solutions
+Corn meal agar	UNRESOLVED_CHEMICAL	10	10	CultureMech:000061	yes	ingredients
+Trace mineral solution (see Medium [M888])	CROSS_REFERENCE	10	10	CultureMech:007605	no	solutions
+Sulfur, powdered	UNRESOLVED_CHEMICAL	10	10	CultureMech:008969	no	ingredients
+Thiamine . HCl	UNRESOLVED_CHEMICAL	10	10	CultureMech:009258	no	ingredients
+MgSO4・7H2O	UNRESOLVED_CHEMICAL	10	10	CultureMech:003286	no	ingredients
+Lactobacilli MRS broth	UNRESOLVED_CHEMICAL	10	10	CultureMech:002842	no	ingredients
+Methane gas	UNRESOLVED_CHEMICAL	10	10	CultureMech:008437	no	ingredients
+10% Glucose solution	SOLUTION_NAME	10	10	CultureMech:015845	no	ingredients
+Poly[(R)-3-hydroxybutyric acid]	UNRESOLVED_CHEMICAL	10	10	CultureMech:004228	no	ingredients
+Meat infusion	UNRESOLVED_CHEMICAL	10	10	CultureMech:005305	no	ingredients
+10% Na2CO3 solution	SOLUTION_NAME	10	10	CultureMech:007454	no	ingredients
+Vitamin B12 (0.002% (w/v))	UNRESOLVED_CHEMICAL	10	10	CultureMech:007457	no	ingredients
+Sodium phosphate buffer (25 mM; pH 3.4)	SOLUTION_NAME	10	10	CultureMech:007472	no	solutions.composition
+O2	UNRESOLVED_CHEMICAL	10	10	CultureMech:007543	no	ingredients
+15% MgCl2・6H2O solution	SOLUTION_NAME	10	10	CultureMech:007558	no	solutions
+Rumen fluid, clarified (see Medium [M258])	CROSS_REFERENCE	10	10	CultureMech:007832	no	solutions
+Agar, if necessary	UNRESOLVED_CHEMICAL	10	10	CultureMech:008871	no	ingredients
+Lactobacilli MRS broth (BD-Difco)	UNRESOLVED_CHEMICAL	10	10	CultureMech:009073	no	ingredients
+SAG medium 1 micronutrient solution	SOLUTION_NAME	9	9	CultureMech:000192	no	solutions
+1 M MgCl2 solution	SOLUTION_NAME	9	8	CultureMech:015832	no	ingredients
+MDS salt water (see Medium [M578])	CROSS_REFERENCE	9	9	CultureMech:007514	no	solutions
+Se/W solution (see Medium [M888])	CROSS_REFERENCE	9	9	CultureMech:007605	no	solutions
+Vitamin solution* (see below)	SOLUTION_NAME	9	9	CultureMech:007623	no	solutions
+Trace element solution (see Medium [M1148])	CROSS_REFERENCE	9	8	CultureMech:007674	no	solutions
+FeSO4 x 7 H2O solution (0.1% w/v in 0.1 N H2SO4)	SOLUTION_NAME	9	9	CultureMech:009217	no	solutions
+Solution A:	SOLUTION_NAME	9	9	CultureMech:009238	no	solutions
+Solution B:	SOLUTION_NAME	9	9	CultureMech:009238	no	solutions
+Trace metal solution (see below)	SOLUTION_NAME	9	9	CultureMech:009425	no	solutions
+SL--4 trace element solution (see Medium [M335])	CROSS_REFERENCE	9	9	CultureMech:010349	no	solutions
+Wolfe's Vitamin Solution	SOLUTION_NAME	9	9	CultureMech:009258	no	solutions
+2 N NaOH	UNRESOLVED_CHEMICAL	9	9	CultureMech:009216	no	ingredients
+1.0 M Glucose solution	SOLUTION_NAME	9	9	CultureMech:015857	no	ingredients
+10% MgCl2・6H2O solution	SOLUTION_NAME	9	9	CultureMech:007689	no	solutions
+5% NaHCO3 solution*	SOLUTION_NAME	9	9	CultureMech:007744	no	solutions
+Na2S・9H2O solution	SOLUTION_NAME	9	9	CultureMech:007800	no	solutions
+Trace element solution SL8 (see Medium [M183])	CROSS_REFERENCE	9	9	CultureMech:008434	no	solutions
+Selenite-tungstate solution	SOLUTION_NAME	8	8	CultureMech:004073	no	solutions
+NaOH solution	SOLUTION_NAME	8	8	CultureMech:009210	no	solutions
+H2SO4 solution	SOLUTION_NAME	8	7	CultureMech:009224	no	solutions
+5% Na2S・9H2O	UNRESOLVED_CHEMICAL	8	8	CultureMech:010380	no	ingredients
+N NaOH	UNRESOLVED_CHEMICAL	8	8	CultureMech:009208	no	ingredients
+Mg(SO4) x 7 H2O	UNRESOLVED_CHEMICAL	8	8	CultureMech:001268	no	ingredients
+1 M Sodium acetate solution	SOLUTION_NAME	8	8	CultureMech:015834	no	ingredients
+1.0 M Sodium thiosulfate solution	SOLUTION_NAME	8	8	CultureMech:015852	no	ingredients
+NaHSeO3	UNRESOLVED_CHEMICAL	8	8	CultureMech:003858	no	ingredients
+Trace element solution (SLA)	SOLUTION_NAME	8	8	CultureMech:005067	no	solutions
+Vitamin solution (VA)	SOLUTION_NAME	8	8	CultureMech:005067	no	solutions
+Absolute ethanol	UNRESOLVED_CHEMICAL	8	8	CultureMech:006479	no	ingredients
+Bacto Agar (Difco)	UNRESOLVED_CHEMICAL	8	8	CultureMech:007483	no	ingredients
+Mineral solution (see below)	SOLUTION_NAME	8	8	CultureMech:007543	no	solutions
+Thiamine・HCl・2H2O	UNRESOLVED_CHEMICAL	8	8	CultureMech:007565	no	ingredients
+Substrate solution (see below)	SOLUTION_NAME	8	8	CultureMech:007689	no	solutions
+Trace metal solution (see Medium [M288])	CROSS_REFERENCE	8	8	CultureMech:007766	no	solutions
+Starch (soluble)	UNRESOLVED_CHEMICAL	8	8	CultureMech:009104	no	ingredients
+Marine broth 2216 (BD-Difco)	UNRESOLVED_CHEMICAL	8	8	CultureMech:009718	no	ingredients
+Na2SiO3	UNRESOLVED_CHEMICAL	8	8	CultureMech:009769	no	ingredients
+Yeast extract--malt extract agar (ISP--2) (see Medium [M35])	CROSS_REFERENCE	8	8	CultureMech:010146	no	solutions
+Ammonium phosphate	UNRESOLVED_CHEMICAL	8	8	CultureMech:007204	no	ingredients
+Lysine-HCl	UNRESOLVED_CHEMICAL	8	8	CultureMech:007240	no	ingredients
+Sodium borate	UNRESOLVED_CHEMICAL	8	8	CultureMech:007098	no	ingredients
+Sodium EDTA	UNRESOLVED_CHEMICAL	8	8	CultureMech:007177	no	ingredients
+Chromium(III) Chloride	UNRESOLVED_CHEMICAL	8	8	CultureMech:007080	no	ingredients
+Marine agar 2216 (see Medium [M110])	CROSS_REFERENCE	8	8	CultureMech:007573	no	solutions
+Nickel Sulfate	UNRESOLVED_CHEMICAL	8	8	CultureMech:007073	no	ingredients
+Filtered natural seawater	UNRESOLVED_CHEMICAL	7	7	CultureMech:000089	no	ingredients
+Trace vitamins (see Medium No. 197 )	CROSS_REFERENCE	7	7	CultureMech:015840	no	ingredients
+Selenite-tungstate solution (see Medium No. 431 )	CROSS_REFERENCE	7	7	CultureMech:015860	no	ingredients
+Fatty acid mixture (see Medium [M258])	CROSS_REFERENCE	7	7	CultureMech:007622	no	solutions
+Wolfe's mineral elixir (see Medium [M471])	CROSS_REFERENCE	7	7	CultureMech:007901	no	solutions
+5% L--Cysteine・HCl・H2O	UNRESOLVED_CHEMICAL	7	7	CultureMech:010240	no	ingredients
+Trace element solution (see Medium [M235])	CROSS_REFERENCE	7	7	CultureMech:010257	no	solutions
+Trace elements solution (see below)	SOLUTION_NAME	7	7	CultureMech:010419	no	solutions
+Glacial acetic acid	UNRESOLVED_CHEMICAL	7	7	CultureMech:003240	no	ingredients
+Fe(III)NH4-EDTA	UNRESOLVED_CHEMICAL	7	7	CultureMech:003842	no	ingredients
+Oat flakes	UNRESOLVED_CHEMICAL	7	7	CultureMech:004213	no	ingredients
+dehydrated RCM medium	UNRESOLVED_CHEMICAL	7	7	CultureMech:006148	no	ingredients
+Tween 80 solution**	SOLUTION_NAME	7	7	CultureMech:007501	no	ingredients
+Artificial seawater (see below)	UNRESOLVED_CHEMICAL	7	7	CultureMech:007626	no	ingredients
+10% (w/v) Yeast extract solution	SOLUTION_NAME	7	7	CultureMech:007668	no	solutions
+Trace minerals solution (see Medium [M221])	CROSS_REFERENCE	7	7	CultureMech:007699	no	solutions
+1 M Fructose solution	SOLUTION_NAME	7	7	CultureMech:007736	no	solutions
+Ammonium citrate	UNRESOLVED_CHEMICAL	7	7	CultureMech:008827	no	ingredients
+Zinc Acetate	UNRESOLVED_CHEMICAL	7	7	CultureMech:007177	no	ingredients
+Rye grass	UNRESOLVED_CHEMICAL	7	7	CultureMech:000401	no	ingredients
+CaCO3(optional)	UNRESOLVED_CHEMICAL	6	6	CultureMech:000005	no	ingredients
+Bristol Medium	UNRESOLVED_CHEMICAL	6	6	CultureMech:000035	no	ingredients
+NaNO3 stock solution	SOLUTION_NAME	6	6	CultureMech:000189	no	solutions
+Air-dried sieved calcareous soil	UNRESOLVED_CHEMICAL	6	6	CultureMech:000138	no	ingredients
+50% (v/v) Methanol	UNRESOLVED_CHEMICAL	6	6	CultureMech:015858	no	ingredients
+Sodium resazurin solution (0.1% w/v)	SOLUTION_NAME	6	6	CultureMech:004073	no	solutions
+1 M NaHCO3 solution*	SOLUTION_NAME	6	6	CultureMech:007671	no	solutions
+Phosphate solution (see below)	SOLUTION_NAME	6	6	CultureMech:007756	no	solutions
+1 N HCl	UNRESOLVED_CHEMICAL	6	6	CultureMech:009169	no	ingredients
+AIK(SO4)2 x 12 H2O	UNRESOLVED_CHEMICAL	6	6	CultureMech:009173	no	ingredients
+10 N H2SO4	UNRESOLVED_CHEMICAL	6	6	CultureMech:009235	no	ingredients
+Solution C:	SOLUTION_NAME	6	6	CultureMech:009238	no	solutions
+Synthetic seawater (2 x) (see Medium [M236])	CROSS_REFERENCE	6	6	CultureMech:010312	no	solutions
+1 M NH4Cl solution	SOLUTION_NAME	6	6	CultureMech:015831	no	ingredients
+1.0 M Sodium fumarate solution	SOLUTION_NAME	6	6	CultureMech:015833	no	ingredients
+N-Z-Case	UNRESOLVED_CHEMICAL	6	6	CultureMech:002965	no	ingredients
+Na-aspartate	UNRESOLVED_CHEMICAL	6	6	CultureMech:003551	no	ingredients
+Fe2(SO4)3 x H2O	UNRESOLVED_CHEMICAL	6	6	CultureMech:003629	no	ingredients
+Na	UNRESOLVED_CHEMICAL	6	6	CultureMech:003646	no	ingredients
+Bovine serum	UNRESOLVED_CHEMICAL	6	6	CultureMech:005285	no	ingredients
+Vitamin solution**	SOLUTION_NAME	6	6	CultureMech:007452	no	ingredients
+NaHCO3 (10% (w/v))	UNRESOLVED_CHEMICAL	6	6	CultureMech:007457	no	ingredients
+Concentrated HCl	UNRESOLVED_CHEMICAL	6	6	CultureMech:007463	no	ingredients
+N-Z-Amine A	UNRESOLVED_CHEMICAL	6	6	CultureMech:007479	no	ingredients
+Mineral solution (see Medium [M1029])	CROSS_REFERENCE	6	6	CultureMech:007546	no	solutions
+VFA solution (see Medium [M124])	CROSS_REFERENCE	6	6	CultureMech:007572	no	solutions
+R agar (see Medium [M19])	CROSS_REFERENCE	6	6	CultureMech:007576	no	solutions
+Salt solution No. 1 (see Medium [M124])	CROSS_REFERENCE	6	6	CultureMech:007600	no	solutions
+Salt solution No. 2 (see Medium [M124])	CROSS_REFERENCE	6	6	CultureMech:007600	no	solutions
+Trace elements solution (see Medium [M1094])	CROSS_REFERENCE	6	6	CultureMech:007612	no	solutions
+1 M MgCl2・6H2O solution	SOLUTION_NAME	6	6	CultureMech:007616	no	solutions
+Solution A (see below)	SOLUTION_NAME	6	6	CultureMech:007619	no	solutions
+1 M Na2S2O3 solution	SOLUTION_NAME	6	6	CultureMech:007684	no	solutions
+25% L--Ascorbic acid solution	SOLUTION_NAME	6	6	CultureMech:007780	no	solutions
+Trace elements solution (see Medium [M305])	CROSS_REFERENCE	6	6	CultureMech:007800	no	solutions
+Fetal bovine serum (heat-inactivated)	UNRESOLVED_CHEMICAL	6	6	CultureMech:009030	no	ingredients
+sheep blood	UNRESOLVED_CHEMICAL	6	6	CultureMech:009079	no	ingredients
+(NH4)2CO3	UNRESOLVED_CHEMICAL	6	6	CultureMech:009296	no	ingredients
+Vishniac and Santer trace elements solution	SOLUTION_NAME	6	6	CultureMech:009639	no	solutions
+N--Z amine, type A (Sheffield)	UNRESOLVED_CHEMICAL	6	6	CultureMech:009750	no	ingredients
+2% Na2S・9H2O solution	SOLUTION_NAME	6	6	CultureMech:009944	no	solutions
+L--Cysteine・H2O・HCl	UNRESOLVED_CHEMICAL	6	6	CultureMech:009948	no	ingredients
+Micronutrient solution SL7 (see Medium [M535])	CROSS_REFERENCE	6	6	CultureMech:009959	no	solutions
+Marine agar 2216 (BD-Difco)	UNRESOLVED_CHEMICAL	6	6	CultureMech:010079	no	ingredients
+GAM broth	UNRESOLVED_CHEMICAL	6	6	CultureMech:002931	no	ingredients
+20% MgCl2・6H2O solution	SOLUTION_NAME	6	6	CultureMech:002671	no	solutions
+Ferrous ammonium sulfate	UNRESOLVED_CHEMICAL	6	6	CultureMech:007380	no	ingredients
+Yeast extract*	UNRESOLVED_CHEMICAL	6	6	CultureMech:008560	no	solutions
+Cereal leaves	UNRESOLVED_CHEMICAL	6	6	CultureMech:000375	no	ingredients
+Erdschreiber's Medium	UNRESOLVED_CHEMICAL	5	5	CultureMech:000004	no	ingredients
+Lab-Lemco powder	UNRESOLVED_CHEMICAL	5	5	CultureMech:000060	no	ingredients
+Bacto-tryptone stock solution	SOLUTION_NAME	5	5	CultureMech:000203	no	solutions
+Yeast extract stock solution	SOLUTION_NAME	5	5	CultureMech:000203	no	solutions
+Trace element solution (see Medium No. 1079 )	CROSS_REFERENCE	5	5	CultureMech:015832	no	ingredients
+Methanol*	UNRESOLVED_CHEMICAL	5	5	CultureMech:015871	no	ingredients
+0.2 M Cellobiose solution	SOLUTION_NAME	5	5	CultureMech:007797	no	solutions
+Agar (if necessary)	UNRESOLVED_CHEMICAL	5	5	CultureMech:008432	no	ingredients
+NiCl2 x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	5	5	CultureMech:009173	no	solutions
+Trace elements (see below)	UNRESOLVED_CHEMICAL	5	5	CultureMech:009897	no	solutions
+0.2% FeSO4・6H2O solution	SOLUTION_NAME	5	5	CultureMech:010234	no	solutions
+VOSO4·nH2O	UNRESOLVED_CHEMICAL	5	5	CultureMech:008286	no	ingredients
+Defibrinated Blood	UNRESOLVED_CHEMICAL	5	5	CultureMech:001823	no	ingredients
+8.0% NaHCO3 solution*	SOLUTION_NAME	5	5	CultureMech:015835	no	ingredients
+1.0 M Sodium lactate solution	SOLUTION_NAME	5	5	CultureMech:015835	no	ingredients
+Trace element solution (see Medium No. 439 )	CROSS_REFERENCE	5	5	CultureMech:015841	no	ingredients
+10 N NaOH	UNRESOLVED_CHEMICAL	5	5	CultureMech:015879	no	ingredients
+Se/W solution (see below)	SOLUTION_NAME	5	5	CultureMech:015869	no	ingredients
+Trace element solution SL10	SOLUTION_NAME	5	5	CultureMech:006894	no	solutions
+Bicarbonate solution (1.0 M)***	SOLUTION_NAME	5	5	CultureMech:007472	no	ingredients
+Vitamine solution	SOLUTION_NAME	5	5	CultureMech:007472	no	solutions
+Distilled water, make up to	UNRESOLVED_CHEMICAL	5	5	CultureMech:007481	no	ingredients
+10% (w/v) Na2CO3 solution	SOLUTION_NAME	5	5	CultureMech:007539	no	solutions
+Metals ''44'' (see Medium [M140])	CROSS_REFERENCE	5	5	CultureMech:007547	no	solutions
+Hemin solution (see Medium [M470])	CROSS_REFERENCE	5	5	CultureMech:007572	no	solutions
+Casamino acids, vitamin assay (BD-Difco)	UNRESOLVED_CHEMICAL	5	5	CultureMech:007595	no	ingredients
+SrSO4	UNRESOLVED_CHEMICAL	5	5	CultureMech:007611	no	ingredients
+Solution B (see below)	SOLUTION_NAME	5	5	CultureMech:007619	no	solutions
+Mineral salt solution (see Medium [M299])	CROSS_REFERENCE	5	5	CultureMech:007648	no	solutions
+Modified Wolfe's solution (see Medium [M641])	CROSS_REFERENCE	5	4	CultureMech:007658	no	solutions
+3% L--Cysteine・HCl・H2O solution	SOLUTION_NAME	5	5	CultureMech:007663	no	solutions
+10% CaCl2・2H2O solution	SOLUTION_NAME	5	5	CultureMech:007689	no	solutions
+Heart infusion broth (BD-Difco)	UNRESOLVED_CHEMICAL	5	5	CultureMech:007697	no	ingredients
+Vitamin solution (see Medium [M560])	CROSS_REFERENCE	5	5	CultureMech:007706	no	solutions
+1 M CaCl2・2H2O solution	SOLUTION_NAME	5	5	CultureMech:007727	no	solutions
+air	UNRESOLVED_CHEMICAL	5	5	CultureMech:007770	no	ingredients
+4% Na2SO3 solution	SOLUTION_NAME	5	5	CultureMech:007780	no	solutions
+Se/W solution (see Medium [M312])	CROSS_REFERENCE	5	5	CultureMech:007825	no	solutions
+GAM broth (Nissui)	UNRESOLVED_CHEMICAL	5	5	CultureMech:007862	no	ingredients
+R2A agar (BD-Difco)	UNRESOLVED_CHEMICAL	5	5	CultureMech:007863	no	ingredients
+glucose solution	SOLUTION_NAME	5	5	CultureMech:007916	no	solutions
+Na2S2O3 solution	SOLUTION_NAME	5	5	CultureMech:008332	no	solutions
+Thiamine-HCl·H2O (Vitamin B1)	UNRESOLVED_CHEMICAL	5	5	CultureMech:008761	no	ingredients
+Neutralized sulfide solution	SOLUTION_NAME	5	5	CultureMech:008767	no	solutions
+Trypticase (BBL)	UNRESOLVED_CHEMICAL	5	5	CultureMech:008769	no	ingredients
+CaCl2 (anhydrous)	UNRESOLVED_CHEMICAL	5	5	CultureMech:008816	no	ingredients
+Potato, peeled and cut	UNRESOLVED_CHEMICAL	5	5	CultureMech:008982	no	ingredients
+95% Ethanol	UNRESOLVED_CHEMICAL	5	5	CultureMech:009145	no	ingredients
+2 M H2SO4	UNRESOLVED_CHEMICAL	5	5	CultureMech:009176	no	ingredients
+Nissui Modified GAM Broth*	UNRESOLVED_CHEMICAL	5	5	CultureMech:009553	no	solutions
+Distilled deionized water	UNRESOLVED_CHEMICAL	5	5	CultureMech:009627	no	ingredients
+Trace mineral solution (see Medium [M319])	CROSS_REFERENCE	5	5	CultureMech:009734	no	solutions
+Trace salts solution (see below)	SOLUTION_NAME	5	5	CultureMech:009815	no	solutions
+HCl (25%, v/v)	UNRESOLVED_CHEMICAL	5	5	CultureMech:009908	no	ingredients
+Vitamin solution (see Medium [M554])	CROSS_REFERENCE	5	5	CultureMech:009949	no	solutions
+NaHCO3 (10%, w/v)	UNRESOLVED_CHEMICAL	5	5	CultureMech:009959	no	ingredients
+10% Na2S2O3 solution	SOLUTION_NAME	5	5	CultureMech:010222	no	solutions
+Fe-citrate	UNRESOLVED_CHEMICAL	5	5	CultureMech:008317	no	ingredients
+P IV Metals solution*	SOLUTION_NAME	5	5	CultureMech:008317	no	solutions
+NAD	UNRESOLVED_CHEMICAL	5	5	CultureMech:009431	no	ingredients
+2,4-Dihydroxybenzoic acid	UNRESOLVED_CHEMICAL	5	5	CultureMech:001624	no	ingredients
+Cl-	UNRESOLVED_CHEMICAL	5	5	CultureMech:007064	no	ingredients
+Olive oil	UNRESOLVED_CHEMICAL	5	5	CultureMech:002549	no	ingredients
+Horse serum*	UNRESOLVED_CHEMICAL	5	5	CultureMech:008194	no	solutions
+Na-Nitrilotriacetat	UNRESOLVED_CHEMICAL	5	5	CultureMech:001133	no	ingredients
+sterile dH2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:000003	no	ingredients
+Ca(NO3)2•4H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:000171	no	ingredients
+F/2 Medium	UNRESOLVED_CHEMICAL	4	4	CultureMech:000177	no	ingredients
+KCl stock solution	SOLUTION_NAME	4	4	CultureMech:000189	no	solutions
+CaCl2 x 2 H2O stock solution	SOLUTION_NAME	4	4	CultureMech:000189	no	solutions
+Saturated CaSO4 solution	SOLUTION_NAME	4	4	CultureMech:000193	no	solutions
+NaCl stock solution	SOLUTION_NAME	4	4	CultureMech:000194	no	solutions
+(NH4)2HPO4 stock solution	SOLUTION_NAME	4	4	CultureMech:000195	no	solutions
+Bacto agar	UNRESOLVED_CHEMICAL	4	4	CultureMech:000069	no	ingredients
+Bring	UNRESOLVED_CHEMICAL	4	4	CultureMech:000097	no	ingredients
+Complan	UNRESOLVED_CHEMICAL	4	4	CultureMech:000111	no	ingredients
+Prepared dried soil	UNRESOLVED_CHEMICAL	4	4	CultureMech:000128	no	ingredients
+0.1 M Dithiothreitol solution	SOLUTION_NAME	4	4	CultureMech:015860	no	ingredients
+Cystein-HCl x 2 H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:005107	no	ingredients
+Na-meta silicate	UNRESOLVED_CHEMICAL	4	4	CultureMech:006129	no	ingredients
+Potassium phosphate buffer (see Medium [M578])	CROSS_REFERENCE	4	4	CultureMech:007514	no	solutions
+Trace mineral solution (see Medium [M1153])	CROSS_REFERENCE	4	4	CultureMech:007709	no	solutions
+Nitrilotriacetic acid trisodium salt monohydrate	UNRESOLVED_CHEMICAL	4	4	CultureMech:007710	no	ingredients
+8% Na2CO3 solution	SOLUTION_NAME	4	4	CultureMech:007743	no	solutions
+10% Tryptone solution	SOLUTION_NAME	4	4	CultureMech:007901	no	solutions
+Na2WO4·H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:008134	no	ingredients
+25% HCl (7.7 M)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008147	no	ingredients
+Salt base solution (see Medium [M142])	CROSS_REFERENCE	4	4	CultureMech:008551	no	solutions
+5% Na2S·9H2O solution (pH 7.0)	SOLUTION_NAME	4	3	CultureMech:008551	no	solutions
+Trace minerals solution (see below)	SOLUTION_NAME	4	4	CultureMech:008809	no	solutions
+Rumen fluid, clarified (see below)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009157	no	ingredients
+Sulfur (powdered)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009181	no	ingredients
+KI solution (0.01% w/v)	SOLUTION_NAME	4	4	CultureMech:009181	no	solutions
+Solution D:	SOLUTION_NAME	4	4	CultureMech:009238	no	solutions
+1% CaCl2・2H2O solution	SOLUTION_NAME	4	4	CultureMech:009347	no	solutions
+Trace metal solution (see Medium [M292])	CROSS_REFERENCE	4	4	CultureMech:009470	no	solutions
+Agar, Noble (BD-Difco)	UNRESOLVED_CHEMICAL	4	4	CultureMech:010230	no	ingredients
+Trace metal solution (see Medium [M805])	CROSS_REFERENCE	4	4	CultureMech:010234	no	solutions
+1 M MgSO4 solution	SOLUTION_NAME	4	4	CultureMech:010349	no	solutions
+Sodium glutamate・H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:010368	no	ingredients
+Trace element solution (see Medium [M940])	CROSS_REFERENCE	4	4	CultureMech:009692	no	solutions
+Gellan gum (if needed)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008724	no	ingredients
+1.0 M Sodium formate solution	SOLUTION_NAME	4	4	CultureMech:015841	no	ingredients
+1.0 M Sodium pyruvate solution	SOLUTION_NAME	4	4	CultureMech:015848	no	ingredients
+0.5 M Potassium phosphate buffer (pH 7.0)	SOLUTION_NAME	4	4	CultureMech:015865	no	ingredients
+Horikoshi-I medium	UNRESOLVED_CHEMICAL	4	4	CultureMech:002705	no	ingredients
+Bicarbonate	UNRESOLVED_CHEMICAL	4	4	CultureMech:004776	no	ingredients
+Fresh egg mixture	SOLUTION_NAME	4	4	CultureMech:005071	no	ingredients
+Na3-citrate x 3 H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:006241	no	ingredients
+3,4,5-Trimethoxycinnamic acid	UNRESOLVED_CHEMICAL	4	4	CultureMech:006348	no	ingredients
+Cheese whey	UNRESOLVED_CHEMICAL	4	4	CultureMech:006432	no	ingredients
+NaSiO3 x 9 H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:006512	yes	ingredients
+1-Butanol	UNRESOLVED_CHEMICAL	4	4	CultureMech:007336	no	ingredients
+Vitamin solution*	SOLUTION_NAME	4	4	CultureMech:007450	no	ingredients
+Trace elements solution*	SOLUTION_NAME	4	4	CultureMech:007452	no	ingredients
+Sulfide solution (1.0 M)*******	SOLUTION_NAME	4	4	CultureMech:007472	no	ingredients
+Agar (if needed)*	UNRESOLVED_CHEMICAL	4	4	CultureMech:007481	no	ingredients
+K2HPO4 (anhydrous base)	UNRESOLVED_CHEMICAL	4	4	CultureMech:007483	no	ingredients
+Tris (hydroxymethyl) aminomethane	UNRESOLVED_CHEMICAL	4	4	CultureMech:007488	no	ingredients
+10% (w/v) Glucose solution	SOLUTION_NAME	4	4	CultureMech:007539	no	solutions
+0.05% Resazurin solution	SOLUTION_NAME	4	4	CultureMech:007572	no	solutions
+Menadione solution (see Medium [M470])	CROSS_REFERENCE	4	4	CultureMech:007572	no	solutions
+10% KNO3 solution	SOLUTION_NAME	4	4	CultureMech:007575	no	solutions
+1% Resazurin solution	SOLUTION_NAME	4	4	CultureMech:007583	no	solutions
+Salt solution (see Medium [M695])	CROSS_REFERENCE	4	4	CultureMech:007603	no	solutions
+1 M KNO3 solution	SOLUTION_NAME	4	4	CultureMech:007612	no	solutions
+Iron(III) citrate solution (see Medium [M1072])	CROSS_REFERENCE	4	4	CultureMech:007641	no	solutions
+2.5% Glucose solution	SOLUTION_NAME	4	4	CultureMech:007648	no	solutions
+Trace vitamins solution (see Medium [M701])	CROSS_REFERENCE	4	4	CultureMech:007661	no	solutions
+glycerin solution	SOLUTION_NAME	4	4	CultureMech:007689	no	solutions
+1 M Sodium pyruvate solution	SOLUTION_NAME	4	4	CultureMech:007695	no	solutions
+Natural seawater (filtrated)	UNRESOLVED_CHEMICAL	4	4	CultureMech:007701	no	ingredients
+sodium lactate solution	SOLUTION_NAME	4	4	CultureMech:007731	no	solutions
+sodium pyruvate solution	SOLUTION_NAME	4	4	CultureMech:007828	no	solutions
+Gelrite (if needed)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008451	no	ingredients
+Columbia blood agar base (Oxoid CM331)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008712	no	ingredients
+MgCl2 (anhydrous)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008832	no	ingredients
+DNA (fish sperm; SERVA)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009030	no	ingredients
+Yeastolate (BD; 2%, autoclaved)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009030	no	ingredients
+Swine serum (heat-inactivated)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009030	no	ingredients
+CMRL-1066 medium (10x concentrated; GIBCO)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009030	no	ingredients
+EDTA (disodium magnesium salt)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009072	no	ingredients
+Lab--Lemco powder (Oxoid)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009099	no	ingredients
+Sheep Blood (defibrinated)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009142	no	ingredients
+1N NaOH	UNRESOLVED_CHEMICAL	4	4	CultureMech:009145	no	ingredients
+0.025% Resazurin	UNRESOLVED_CHEMICAL	4	4	CultureMech:009145	no	ingredients
+Castenholz basal salt solution (see Medium [M266])	CROSS_REFERENCE	4	4	CultureMech:009252	no	solutions
+AlK(SO4)2 (anhydrous)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009627	no	ingredients
+Na2SeO3 (anhydrous)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009627	no	ingredients
+Modified MJ synthetic seawater (see Medium [M493])	CROSS_REFERENCE	4	4	CultureMech:009882	no	solutions
+Vitamin B12 (2 mg/ml)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009913	no	ingredients
+agar (BD-Difco)	UNRESOLVED_CHEMICAL	4	4	CultureMech:009949	no	ingredients
+Clarified rumen fluid	UNRESOLVED_CHEMICAL	4	4	CultureMech:009962	no	ingredients
+Trace mineral solution (see Medium [M190])	CROSS_REFERENCE	4	4	CultureMech:010042	no	solutions
+CaCl2 solution	SOLUTION_NAME	4	4	CultureMech:010421	no	solutions
+Na2CO3*	UNRESOLVED_CHEMICAL	4	4	CultureMech:008403	no	solutions
+Tryptose-phosphate	UNRESOLVED_CHEMICAL	4	4	CultureMech:001155	no	ingredients
+Nutrient Broth (OXOID)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008539	no	ingredients
+ZnCl2 x 6 H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:000328	no	ingredients
+Lab Lemco powder	UNRESOLVED_CHEMICAL	4	4	CultureMech:000331	no	ingredients
+Cornmeal extract	UNRESOLVED_CHEMICAL	4	4	CultureMech:008443	no	ingredients
+Seawater (2% salinity)	UNRESOLVED_CHEMICAL	4	4	CultureMech:007963	no	ingredients
+CrK(SO4)2 x 12 H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:002214	no	ingredients
+D-Gluconic acid	UNRESOLVED_CHEMICAL	4	4	CultureMech:007093	no	ingredients
+(S)-Malate	UNRESOLVED_CHEMICAL	4	4	CultureMech:007119	no	ingredients
+Propenoate	UNRESOLVED_CHEMICAL	4	4	CultureMech:007151	no	ingredients
+Inorganic salts-starch agar	UNRESOLVED_CHEMICAL	4	4	CultureMech:002712	yes	ingredients
+Glucose*	UNRESOLVED_CHEMICAL	4	4	CultureMech:008429	no	solutions
+Sulfur (powder)*	UNRESOLVED_CHEMICAL	4	4	CultureMech:008228	no	solutions
+Charcoal-filtered, natural seawater	UNRESOLVED_CHEMICAL	4	4	CultureMech:003513	no	ingredients
+Thiosulfate solution*******	SOLUTION_NAME	4	4	CultureMech:008559	no	solutions
+5-Hydroxyectoine	UNRESOLVED_CHEMICAL	4	4	CultureMech:007018	no	ingredients
+Sorbitan mono-oleate	UNRESOLVED_CHEMICAL	4	4	CultureMech:008329	no	ingredients
+R agar	UNRESOLVED_CHEMICAL	4	4	CultureMech:003224	yes	ingredients
+Na2MoO3·2H2O	UNRESOLVED_CHEMICAL	4	4	CultureMech:008060	no	ingredients
+Rifampicin solution (500 μg/ml)*	SOLUTION_NAME	4	4	CultureMech:008270	no	solutions
+Pyridoxine-HCl (VitaminB6)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008709	no	ingredients
+Riboflavin (Vitamine B2)	UNRESOLVED_CHEMICAL	4	4	CultureMech:008709	no	ingredients
+Dv_base_medium	UNRESOLVED_CHEMICAL	4	4	CultureMech:015517	no	ingredients
+Aseptically add the foetal calf serum to a final concentration of	UNRESOLVED_CHEMICAL	3	3	CultureMech:000085	no	ingredients
+Agar (Molecular Genetics)	UNRESOLVED_CHEMICAL	3	3	CultureMech:000106	no	ingredients
+NH4MgPO4	UNRESOLVED_CHEMICAL	3	3	CultureMech:000228	no	ingredients
+Sodium Thiosulfate Pentahydrate (agar media only,sterile)	UNRESOLVED_CHEMICAL	3	3	CultureMech:000022	no	ingredients
+SE2 (Soil Extract 2)	UNRESOLVED_CHEMICAL	3	3	CultureMech:000041	no	solutions
+Na-acetate stock solution	SOLUTION_NAME	3	3	CultureMech:000193	no	solutions
+MgSO .7H 0	UNRESOLVED_CHEMICAL	3	3	CultureMech:000066	no	ingredients
+SES (Soil Extract with Added Salts)	UNRESOLVED_CHEMICAL	3	3	CultureMech:000111	no	solutions
+NaHCO3 stock solution	SOLUTION_NAME	3	3	CultureMech:000217	no	solutions
+Trace element solution (see Medium No. 899 )	CROSS_REFERENCE	3	3	CultureMech:015858	no	ingredients
+Vitamin solution (see Medium No. 898 )	CROSS_REFERENCE	3	3	CultureMech:015860	no	ingredients
+Ni-Se-W solution (see below)	SOLUTION_NAME	3	3	CultureMech:015871	no	ingredients
+50% (v/v) Methanol solution	SOLUTION_NAME	3	3	CultureMech:007633	no	solutions
+2 M Sodium pyruvate solution*	SOLUTION_NAME	3	3	CultureMech:007671	no	solutions
+Vitamin solution (see Medium [M991])	CROSS_REFERENCE	3	2	CultureMech:007710	no	solutions
+Trace element solution* (see below)	SOLUTION_NAME	3	3	CultureMech:007759	no	solutions
+1 M NH4Cl	UNRESOLVED_CHEMICAL	3	3	CultureMech:007797	no	ingredients
+Salt base solution (see below)	SOLUTION_NAME	3	3	CultureMech:007968	no	solutions
+CoSO4·7H20	UNRESOLVED_CHEMICAL	3	3	CultureMech:008148	no	ingredients
+Mineral solution I (see below)	SOLUTION_NAME	3	3	CultureMech:009019	no	solutions
+Mineral solution II (see below)	SOLUTION_NAME	3	3	CultureMech:009019	no	solutions
+clarified rumen fluid	UNRESOLVED_CHEMICAL	3	3	CultureMech:009157	no	ingredients
+2 N H2SO4	UNRESOLVED_CHEMICAL	3	3	CultureMech:009181	no	ingredients
+KCl solution (0.1% w/v)	SOLUTION_NAME	3	3	CultureMech:009209	no	solutions
+SrCl2 x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	3	3	CultureMech:009222	no	solutions
+Sulfur, powder	UNRESOLVED_CHEMICAL	3	3	CultureMech:009230	no	ingredients
+FeCl3 solution (see below)	SOLUTION_NAME	3	3	CultureMech:009897	no	solutions
+VULCANISAETA MEDIUM (see Medium [M291])	CROSS_REFERENCE	3	3	CultureMech:009979	no	solutions
+Trace vitamins solution (see below)	SOLUTION_NAME	3	3	CultureMech:010109	no	solutions
+K2HSO4	UNRESOLVED_CHEMICAL	3	3	CultureMech:010231	no	ingredients
+Major metals (see Medium [M969])	CROSS_REFERENCE	3	3	CultureMech:010396	no	solutions
+Trace metal 1 solution (see Medium [M969])	CROSS_REFERENCE	3	3	CultureMech:010396	no	solutions
+Casamino acids (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008541	no	ingredients
+Rumen fluid, clarified	UNRESOLVED_CHEMICAL	3	3	CultureMech:009213	no	ingredients
+Fe2(SO4)3	UNRESOLVED_CHEMICAL	3	3	CultureMech:002433	no	ingredients
+Aged seawater	UNRESOLVED_CHEMICAL	3	3	CultureMech:008637	no	ingredients
+Whole egg	UNRESOLVED_CHEMICAL	3	3	CultureMech:003238	no	ingredients
+Trace metal mix	UNRESOLVED_CHEMICAL	3	3	CultureMech:001128	no	solutions
+Hemin solution (see below)	SOLUTION_NAME	3	3	CultureMech:015879	no	ingredients
+Modified Wolfe’s mineral solution (see Medium No. 915 )	CROSS_REFERENCE	3	3	CultureMech:015865	no	ingredients
+Vitamin solution* (see Medium No. 915 )	CROSS_REFERENCE	3	3	CultureMech:015865	no	ingredients
+Na-caseinate	UNRESOLVED_CHEMICAL	3	3	CultureMech:003542	no	ingredients
+Fe(NH4)2(SO4)2 x 12 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:003878	no	ingredients
+Difco marine broth	UNRESOLVED_CHEMICAL	3	3	CultureMech:003929	no	ingredients
+Fastidious Anaerobe Agar	UNRESOLVED_CHEMICAL	3	3	CultureMech:003951	yes	ingredients
+Na2-ß-glycerophosphate x 5 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:003985	no	ingredients
+Fe(III) citrate solution (0.1% in water)	SOLUTION_NAME	3	3	CultureMech:004707	no	solutions
+Vitamin B12 solution (10 mg in 100 ml water)	SOLUTION_NAME	3	3	CultureMech:004707	no	solutions
+Trace element solution SL-6	SOLUTION_NAME	3	3	CultureMech:004707	no	solutions
+Resazurin solution (0.1%)	SOLUTION_NAME	3	3	CultureMech:004707	no	solutions
+Blood agar No 2	UNRESOLVED_CHEMICAL	3	3	CultureMech:005245	no	ingredients
+Czapek Dox agar	UNRESOLVED_CHEMICAL	3	3	CultureMech:005999	yes	ingredients
+OXOID Legionella CYE-Agar base	UNRESOLVED_CHEMICAL	3	3	CultureMech:006055	no	ingredients
+Cresol	UNRESOLVED_CHEMICAL	3	3	CultureMech:006387	no	ingredients
+Mycobactine J	UNRESOLVED_CHEMICAL	3	3	CultureMech:006479	no	ingredients
+Solution B: potassium phosphate buffer	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Potassium phosphate buffer (pH 7.5)	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions.composition
+Solution C1: Wolin's vitamin solution (10x)	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution C2: seven vitamins solution	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution D: Na2CO3 solution	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution E: Na-pyruvate solution	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution F: Na2-fumarate solution	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution G: FeSO4 in 0.1 N H2SO4	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Solution H: L-Cysteine HCl solution	SOLUTION_NAME	3	3	CultureMech:006625	no	solutions
+Vitamin solution CA	SOLUTION_NAME	3	3	CultureMech:006721	no	solutions
+Na2O4W x 2 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:006980	no	ingredients
+Trace element solution**	SOLUTION_NAME	3	3	CultureMech:007450	no	ingredients
+Fe(III) ammonium citrate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007452	no	ingredients
+Bis Tris Propane	UNRESOLVED_CHEMICAL	3	3	CultureMech:007452	no	ingredients
+20% NaCl solution	SOLUTION_NAME	3	3	CultureMech:007454	no	ingredients
+Ebios (tablets)*	UNRESOLVED_CHEMICAL	3	3	CultureMech:007458	no	ingredients
+Bacto-Yeast Nitrogen Base w/o Amino acids (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:007460	no	ingredients
+Trace elements solution**	SOLUTION_NAME	3	3	CultureMech:007461	no	ingredients
+Na-glycerophosphate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007462	no	ingredients
+MgO	UNRESOLVED_CHEMICAL	3	3	CultureMech:007463	no	ingredients
+Trace element solution*	SOLUTION_NAME	3	3	CultureMech:007465	no	ingredients
+Sulfide solution****	SOLUTION_NAME	3	3	CultureMech:007467	no	ingredients
+Vitamin solution***	SOLUTION_NAME	3	3	CultureMech:007474	no	ingredients
+Solution A	SOLUTION_NAME	3	3	CultureMech:007487	no	solutions
+Solution B	SOLUTION_NAME	3	3	CultureMech:007487	no	solutions
+Diammonium hydrogencitrate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007490	no	ingredients
+Trace vitamins	UNRESOLVED_CHEMICAL	3	3	CultureMech:007497	no	solutions
+Casamino Acids (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:007504	no	ingredients
+15% Na2CO3 solution	SOLUTION_NAME	3	3	CultureMech:007510	no	ingredients
+1 M Sodium lactate solution	SOLUTION_NAME	3	3	CultureMech:007513	no	solutions
+H2SO4 (concentrated)	UNRESOLVED_CHEMICAL	3	3	CultureMech:007535	no	ingredients
+Selenite--tungstate solution (see Medium [M558])	CROSS_REFERENCE	3	3	CultureMech:007557	no	solutions
+0.1 M Tris--HCl buffer (pH 7.5)	SOLUTION_NAME	3	3	CultureMech:007565	no	ingredients
+Modified Hutner's basal salts (see Medium [M941])	CROSS_REFERENCE	3	3	CultureMech:007565	no	solutions
+Cellobiose or Cellulose MN 300	UNRESOLVED_CHEMICAL	3	3	CultureMech:007566	no	ingredients
+Salt solution (see below)	SOLUTION_NAME	3	3	CultureMech:007572	no	solutions
+Ni-Se-W solution (see Medium [M236])	CROSS_REFERENCE	3	3	CultureMech:007588	no	solutions
+Fe(2+) solution (see below)	SOLUTION_NAME	3	3	CultureMech:007595	no	solutions
+Horikoshi-I medium (see Medium [M174])	CROSS_REFERENCE	3	3	CultureMech:007609	no	solutions
+Starch, soluble	UNRESOLVED_CHEMICAL	3	3	CultureMech:007610	no	ingredients
+Ammonium Fe(III) citrate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007626	no	ingredients
+Vitamin solution (see Medium [M299])	CROSS_REFERENCE	3	3	CultureMech:007648	no	solutions
+Bottom layer	UNRESOLVED_CHEMICAL	3	3	CultureMech:007658	no	ingredients
+Top layer	UNRESOLVED_CHEMICAL	3	3	CultureMech:007658	no	ingredients
+Artificial saltwater (see Medium [M642])	CROSS_REFERENCE	3	3	CultureMech:007659	no	solutions
+10% Na2S2O3・5H2O solution	SOLUTION_NAME	3	3	CultureMech:007687	no	solutions
+β-NAD	UNRESOLVED_CHEMICAL	3	3	CultureMech:007698	no	ingredients
+Fe(III)・EDTA	UNRESOLVED_CHEMICAL	3	3	CultureMech:007722	no	ingredients
+(NH4)Mo7O24・4H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:007722	no	ingredients
+Fe--Ni--WO--Se solution (see Medium [M1199])	CROSS_REFERENCE	3	3	CultureMech:007768	no	solutions
+0.2% Hemin solution	SOLUTION_NAME	3	3	CultureMech:007780	no	solutions
+VFA solution (see below)	SOLUTION_NAME	3	3	CultureMech:007780	no	solutions
+2 M HEPES buffer (pH 7.0)	SOLUTION_NAME	3	3	CultureMech:007819	no	ingredients
+Tomato juice, filtered	UNRESOLVED_CHEMICAL	3	3	CultureMech:007886	no	ingredients
+0.1 N NaOH	UNRESOLVED_CHEMICAL	3	3	CultureMech:007897	no	ingredients
+10% Peptone solution	SOLUTION_NAME	3	3	CultureMech:007900	no	solutions
+1.0% Yeast extract solution	SOLUTION_NAME	3	3	CultureMech:007919	no	solutions
+SL--7 trace element solution (see Medium [M538])	CROSS_REFERENCE	3	3	CultureMech:007930	no	solutions
+Corn meal agar (BD-Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:007957	no	ingredients
+3Na-EDTA	UNRESOLVED_CHEMICAL	3	3	CultureMech:008128	no	ingredients
+Casamino acids, vitamin assay (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008143	no	ingredients
+(NH4)6MoO7O24·4H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:008452	no	ingredients
+Salts solution (see below)	SOLUTION_NAME	3	3	CultureMech:008618	no	solutions
+α-Ketoglutarate	UNRESOLVED_CHEMICAL	3	3	CultureMech:008727	no	ingredients
+0.2 N NaOH	UNRESOLVED_CHEMICAL	3	3	CultureMech:008744	no	ingredients
+Proteose Peptone #3	UNRESOLVED_CHEMICAL	3	3	CultureMech:008799	no	ingredients
+Resazurin (0,1%)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008844	no	ingredients
+Solution E:	SOLUTION_NAME	3	3	CultureMech:008866	no	solutions
+Agar, if required	UNRESOLVED_CHEMICAL	3	3	CultureMech:008943	no	ingredients
+EDTA・Fe(III)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008972	no	ingredients
+MRS broth (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009062	no	ingredients
+Columbia agar	UNRESOLVED_CHEMICAL	3	3	CultureMech:009079	no	ingredients
+AIK(SO4)2	UNRESOLVED_CHEMICAL	3	3	CultureMech:009135	no	ingredients
+Ground beef (fat-free)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009145	no	ingredients
+Ground beef (free of fat)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009262	no	ingredients
+L-cysteine . HCl	UNRESOLVED_CHEMICAL	3	3	CultureMech:009262	no	ingredients
+0.025% Resazurin solution	SOLUTION_NAME	3	3	CultureMech:009262	no	solutions
+polyoxyethylene sorbitan mono-oleate (Tween 80)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009377	no	ingredients
+CH3COONa.3H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:009377	no	ingredients
+Lab-Lemco (Oxoid)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009377	no	ingredients
+1 M Sodium fumarate solution	SOLUTION_NAME	3	3	CultureMech:009520	no	solutions
+MnCI2.4H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:009592	no	ingredients
+Na2WO2・2H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:009746	no	ingredients
+Corn steep liquor	UNRESOLVED_CHEMICAL	3	3	CultureMech:009794	no	ingredients
+Trace mineral solution (see Medium [M409])	CROSS_REFERENCE	3	3	CultureMech:009795	no	solutions
+Reinforced clostridial medium (BD-Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009869	no	ingredients
+Tryptose (BD-Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009877	no	ingredients
+Trace element solution SL--12 (see Medium [M497])	CROSS_REFERENCE	3	3	CultureMech:009886	no	solutions
+Trace element solution SL7 (see below)	SOLUTION_NAME	3	3	CultureMech:009908	no	solutions
+Na2S・9H2O (final conc.)	UNRESOLVED_CHEMICAL	3	3	CultureMech:009927	no	ingredients
+Mineral solution (see Medium [M520])	CROSS_REFERENCE	3	3	CultureMech:009934	no	solutions
+Vitamin solution (see Medium [M520])	CROSS_REFERENCE	3	3	CultureMech:009934	no	solutions
+Mineral solution 1 (see below)	SOLUTION_NAME	3	3	CultureMech:010057	no	solutions
+Mineral solution 2 (see below)	SOLUTION_NAME	3	3	CultureMech:010057	no	solutions
+5.0% Na2S・9H2O solution	SOLUTION_NAME	3	3	CultureMech:010129	no	solutions
+Tryptone soya broth (Oxoid)	UNRESOLVED_CHEMICAL	3	3	CultureMech:010198	no	ingredients
+1.0 M FeSO4 solution (pH 2.0)	SOLUTION_NAME	3	3	CultureMech:010313	no	solutions
+Trace element solution (filter--sterilized) (see Medium [M773])	CROSS_REFERENCE	3	3	CultureMech:010313	no	solutions
+D-Glutamate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007193	no	ingredients
+Vitamins	UNRESOLVED_CHEMICAL	3	3	CultureMech:008779	no	ingredients
+Bacto Casamino acids (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008707	no	ingredients
+Pancreatic Digest of Casein	UNRESOLVED_CHEMICAL	3	3	CultureMech:009246	no	ingredients
+bicarbonate	UNRESOLVED_CHEMICAL	3	3	CultureMech:006101	no	ingredients
+Czapek-Dox liquid medium	UNRESOLVED_CHEMICAL	3	3	CultureMech:001250	no	ingredients
+Orotate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007092	no	ingredients
+MEM-Medium	UNRESOLVED_CHEMICAL	3	3	CultureMech:001238	no	ingredients
+Fe(NH4)2(SO4)2	UNRESOLVED_CHEMICAL	3	3	CultureMech:006098	no	ingredients
+Wolfe’s vitamin solution	SOLUTION_NAME	3	3	CultureMech:009602	no	solutions
+f/2 Trace Metal Mix	UNRESOLVED_CHEMICAL	3	3	CultureMech:001202	no	solutions
+Vitamin 3 Mix	UNRESOLVED_CHEMICAL	3	3	CultureMech:001202	no	solutions
+MnCl2 x 6 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:002294	no	ingredients
+HCl solution	SOLUTION_NAME	3	3	CultureMech:009297	no	solutions
+Bacto Heart Infusion Broth (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008126	no	ingredients
+sodium	UNRESOLVED_CHEMICAL	3	3	CultureMech:004253	no	ingredients
+KNO3 solution	SOLUTION_NAME	3	3	CultureMech:002671	no	solutions
+Bacto Tyrptone (Difco)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008689	no	ingredients
+Ampicillin solution (50 mg/ml)*	SOLUTION_NAME	3	3	CultureMech:008514	no	solutions
+Catalase (beef)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008986	no	ingredients
+Vitamin Solution V10	SOLUTION_NAME	3	3	CultureMech:004069	no	solutions
+La(NO3)3 x 6 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:001219	no	ingredients
+Ce(NO3)3 x 6 H2O	UNRESOLVED_CHEMICAL	3	3	CultureMech:001219	no	ingredients
+Dextrose (BD 215530)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008980	no	ingredients
+Oleic Acid (Sigma Cat # O-1008)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008980	no	ingredients
+Catalase (beef) (Sigma C-9322)	UNRESOLVED_CHEMICAL	3	3	CultureMech:008980	no	ingredients
+Metal 44 solution****	SOLUTION_NAME	3	3	CultureMech:008578	no	solutions
+Trypton	UNRESOLVED_CHEMICAL	3	3	CultureMech:009655	no	ingredients
+Reinforced clostridial medium	UNRESOLVED_CHEMICAL	3	3	CultureMech:002960	no	ingredients
+Orthophosphate	UNRESOLVED_CHEMICAL	3	3	CultureMech:007283	no	ingredients
+Magnesium	UNRESOLVED_CHEMICAL	3	3	CultureMech:007283	no	ingredients
+Sodium	UNRESOLVED_CHEMICAL	3	3	CultureMech:007283	no	ingredients
+NH4+	UNRESOLVED_CHEMICAL	3	3	CultureMech:007283	no	ingredients
+Fe2+	UNRESOLVED_CHEMICAL	3	3	CultureMech:007283	no	ingredients
+3,5-Dihydroxybenzoic acid	UNRESOLVED_CHEMICAL	3	3	CultureMech:006673	no	ingredients
+CaCO3*	UNRESOLVED_CHEMICAL	3	3	CultureMech:008006	no	solutions
+Na2CO3**	UNRESOLVED_CHEMICAL	3	3	CultureMech:008024	no	solutions
+Spectinomycin solution (500 μg/ml)*	SOLUTION_NAME	3	3	CultureMech:008270	no	solutions
+Kanamycin solution (500 μg/ml)*	SOLUTION_NAME	3	3	CultureMech:008273	no	solutions
+Yeast Nitrogen Base	UNRESOLVED_CHEMICAL	3	3	CultureMech:002601	no	ingredients
+Trypticase soy broth	UNRESOLVED_CHEMICAL	3	3	CultureMech:010482	no	ingredients
+Spring sampling GW821 filtered with 0.2uM filter	UNRESOLVED_CHEMICAL	3	3	CultureMech:015524	no	ingredients
+R2A	UNRESOLVED_CHEMICAL	3	3	CultureMech:015693	no	ingredients
+Enriched Seawater Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000003	no	ingredients
+Soil+Seawater Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000019	no	ingredients
+Natural sea-salt	UNRESOLVED_CHEMICAL	2	2	CultureMech:000019	no	ingredients
+Bold 1NV Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000030	no	ingredients
+Waris Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000236	no	ingredients
+Euglena Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000236	no	ingredients
+JM (Jaworski's Medium)	UNRESOLVED_CHEMICAL	2	2	CultureMech:000041	no	solutions
+KH2PO4 stock solution	SOLUTION_NAME	2	2	CultureMech:000189	no	solutions
+Ca(NO3)2 x 4 H2O stock solution	SOLUTION_NAME	2	2	CultureMech:000192	no	solutions
+Na2SiO3 x 9 H2O stock solution	SOLUTION_NAME	2	2	CultureMech:000192	no	solutions
+BG-11 Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000026	no	ingredients
+K2HPO4 x 3 H2O stock solution	SOLUTION_NAME	2	2	CultureMech:000194	no	solutions
+CaCl2 stock solution	SOLUTION_NAME	2	2	CultureMech:000059	no	solutions
+Peat extract	UNRESOLVED_CHEMICAL	2	2	CultureMech:000199	no	solutions
+Peat soil	UNRESOLVED_CHEMICAL	2	2	CultureMech:000199	no	solutions.composition
+First, add to 50 ml of deionised water and pH to 7.2 with	UNRESOLVED_CHEMICAL	2	2	CultureMech:000078	no	ingredients
+3N-BBM+V	UNRESOLVED_CHEMICAL	2	2	CultureMech:000083	no	solutions
+SES medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000089	no	solutions
+Na2HPO4.2H2O stock solution	SOLUTION_NAME	2	2	CultureMech:000089	no	solutions
+CoSO .7H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:000092	no	ingredients
+Volvic mineral water	UNRESOLVED_CHEMICAL	2	2	CultureMech:000093	no	ingredients
+Extra salts (ASW stock 1)	SOLUTION_NAME	2	2	CultureMech:000107	no	solutions
+Soil Extract 1 (SE1)	UNRESOLVED_CHEMICAL	2	2	CultureMech:000107	no	solutions
+Add NaSiO .5H O	UNRESOLVED_CHEMICAL	2	2	CultureMech:000125	no	ingredients
+MgSO4.7H2O stock solution	SOLUTION_NAME	2	2	CultureMech:000130	no	solutions
+Soil Extract 2 (SE2)	UNRESOLVED_CHEMICAL	2	2	CultureMech:000130	no	solutions
+Disodium EDTA	UNRESOLVED_CHEMICAL	2	2	CultureMech:000214	no	solutions.composition
+Dissolve	UNRESOLVED_CHEMICAL	2	1	CultureMech:000143	no	ingredients
+Wolfe's mineral solution (see Medium No. 265 )	CROSS_REFERENCE	2	2	CultureMech:015840	no	ingredients
+Rumen fluid, clarified (see Medium No. 266)	CROSS_REFERENCE	2	2	CultureMech:015860	no	ingredients
+Casamino acids (BD Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:015860	no	ingredients
+Trace mineral solution (see Medium No. 151 )	CROSS_REFERENCE	2	2	CultureMech:015871	no	ingredients
+2 M trimethylammonium chloride solution*	SOLUTION_NAME	2	2	CultureMech:015871	no	ingredients
+Polar lipid fraction	UNRESOLVED_CHEMICAL	2	2	CultureMech:004668	no	ingredients
+water (distilled or tapwater)	UNRESOLVED_CHEMICAL	2	2	CultureMech:006068	no	ingredients
+1 M NH4Cl solution*	SOLUTION_NAME	2	2	CultureMech:007514	no	solutions
+METHANOGENIUM MEDIUM (see Medium [M257])	CROSS_REFERENCE	2	2	CultureMech:007554	no	solutions
+1 M Trimethylamine solution	SOLUTION_NAME	2	2	CultureMech:007605	no	solutions
+0.5 M Tris--HCl solution (pH 8.0)	SOLUTION_NAME	2	2	CultureMech:007650	no	solutions
+Basal mineral NaCl medium (see Medium [M1148])	CROSS_REFERENCE	2	2	CultureMech:007674	no	solutions
+4 M NH4Cl solution	SOLUTION_NAME	2	2	CultureMech:007674	no	solutions
+Soda based mineral medium (see Medium [M1150])	CROSS_REFERENCE	2	2	CultureMech:007675	no	solutions
+METHANOTHERMOCOCCUS HHB MEDIUM (see Medium [M1279])	CROSS_REFERENCE	2	2	CultureMech:007814	no	solutions
+Trace minerals (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007968	no	ingredients
+Modified Brock's salt base solution (see below)	SOLUTION_NAME	2	2	CultureMech:008118	no	solutions
+FeSO2·7H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008148	no	ingredients
+Iron stock solution (see below)	SOLUTION_NAME	2	2	CultureMech:008809	no	solutions
+Casamino acids (BD BBL)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008892	no	ingredients
+Basal Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:009123	no	ingredients
+Fe(NH4)2(SO4)2 x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	2	2	CultureMech:009201	no	solutions
+2N NaOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:009210	no	ingredients
+2-(N-Morpholino)ethanesulfonic acid (MES)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009210	no	ingredients
+2-Mercaptoethanesulfonic acid (Coenzyme M)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009210	no	ingredients
+NH4Cl solution (0.1% w/v)	SOLUTION_NAME	2	2	CultureMech:009210	no	solutions
+KH2PO4 solution (0.1% w/v)	SOLUTION_NAME	2	2	CultureMech:009210	no	solutions
+TRIS-HCl (1.0 M solution, pH 8.0)	SOLUTION_NAME	2	2	CultureMech:009210	no	solutions
+NaNTA (0.5 M solution)	SOLUTION_NAME	2	2	CultureMech:009210	no	solutions
+TiCl3 (15% w/v solution in HCl; Riedel-de Haen)	SOLUTION_NAME	2	2	CultureMech:009210	no	solutions
+Citric acid solution (0.1% w/v)	SOLUTION_NAME	2	2	CultureMech:009222	no	solutions
+CaCl2 x 2 H2O solution (0.1% w/v)	SOLUTION_NAME	2	2	CultureMech:009228	no	solutions
+HCl (32%)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009425	no	ingredients
+Sludge fluid	UNRESOLVED_CHEMICAL	2	2	CultureMech:009612	no	ingredients
+Fatty acid mixture	SOLUTION_NAME	2	2	CultureMech:009612	no	ingredients
+Growth stimulating factors (see Medium [M296])	CROSS_REFERENCE	2	2	CultureMech:009735	no	solutions
+Trace mineral solution (see Medium [M362])	CROSS_REFERENCE	2	2	CultureMech:010098	no	solutions
+Salt base solution (see Medium [M711])	CROSS_REFERENCE	2	2	CultureMech:010120	no	solutions
+50 mM Coenzyme M solution	SOLUTION_NAME	2	2	CultureMech:010396	no	solutions
+10% (w/v) Trypticase peptone (BD-BBL) solution	SOLUTION_NAME	2	2	CultureMech:010408	no	solutions
+10% (w/v) Yeast extract (BD-Difco) solution	SOLUTION_NAME	2	2	CultureMech:010408	no	solutions
+(NH4)2SO4·7H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008183	no	ingredients
+Fe2(SO4)3·nH2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008183	no	ingredients
+Basal mineral NaCl medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:002262	no	ingredients
+Titanium(III) chloride	UNRESOLVED_CHEMICAL	2	2	CultureMech:009523	no	ingredients
+0.5 M Coenzyme M solution	SOLUTION_NAME	2	2	CultureMech:009523	no	solutions
+Na-terephthalate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008179	no	ingredients
+Mineral base 1*	UNRESOLVED_CHEMICAL	2	2	CultureMech:008603	no	solutions
+Mineral base 2**	UNRESOLVED_CHEMICAL	2	2	CultureMech:008603	no	solutions
+Cysteine-Sulfide Reducing Agent	UNRESOLVED_CHEMICAL	2	2	CultureMech:009258	no	ingredients
+3% Trimethylamine solution*	SOLUTION_NAME	2	2	CultureMech:009543	no	solutions
+Homo-PIPES	UNRESOLVED_CHEMICAL	2	2	CultureMech:004033	no	ingredients
+5% Na2S•9H2O solution	SOLUTION_NAME	2	2	CultureMech:009692	no	solutions
+R2A Broth (DAIGO)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008637	no	ingredients
+Agar  (if needed)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008340	no	ingredients
+100x Vitamin solution	SOLUTION_NAME	2	2	CultureMech:000859	no	solutions
+R2A Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:003150	no	ingredients
+"R2A Broth \""DAIGO\""*"	UNRESOLVED_CHEMICAL	2	2	CultureMech:008720	no	solutions
+DL-Dithiothreitol (DTT)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009314	no	ingredients
+Sea water*	UNRESOLVED_CHEMICAL	2	2	CultureMech:008494	no	solutions
+Fish meat extract	UNRESOLVED_CHEMICAL	2	2	CultureMech:002537	no	ingredients
+Maize extract	UNRESOLVED_CHEMICAL	2	2	CultureMech:000273	no	ingredients
+Vitamin-free casamino acids	UNRESOLVED_CHEMICAL	2	2	CultureMech:001809	no	ingredients
+Tryptic Digest of beef heart	UNRESOLVED_CHEMICAL	2	2	CultureMech:001823	no	ingredients
+BCYE agar	UNRESOLVED_CHEMICAL	2	2	CultureMech:002367	yes	ingredients
+Brucella Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:002469	no	ingredients
+Se/W solution* (see Medium No. 852 )	CROSS_REFERENCE	2	2	CultureMech:015831	no	ingredients
+Mineral solution A (see below)	SOLUTION_NAME	2	2	CultureMech:015836	no	ingredients
+Sodium phosphate buffer (10 mM, pH 7.1)	SOLUTION_NAME	2	2	CultureMech:015841	no	ingredients
+0.1 M KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:015843	no	ingredients
+Vitamin B12 solution* (see Medium No. 403 )	CROSS_REFERENCE	2	2	CultureMech:015843	no	ingredients
+VFA mix (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:015879	no	ingredients
+Vitamin solution I (see below)	SOLUTION_NAME	2	2	CultureMech:015879	no	ingredients
+Selenite tungstate solution (see Medium No. 431 )	CROSS_REFERENCE	2	2	CultureMech:015853	no	ingredients
+10% Cellobiose solution*	SOLUTION_NAME	2	2	CultureMech:015854	no	ingredients
+0.01 M FeSO4·7H2O solution (in 0.02 N HCl)	SOLUTION_NAME	2	2	CultureMech:015865	no	ingredients
+40% Na2S2O3·5H2O solution	SOLUTION_NAME	2	2	CultureMech:015866	no	ingredients
+5% Na2HPO4 solution	SOLUTION_NAME	2	2	CultureMech:015868	no	ingredients
+5% KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:015868	no	ingredients
+5% L-Cysteine·HCl·H2O solution (pH 7.0)	SOLUTION_NAME	2	2	CultureMech:015877	no	ingredients
+Se-acid	UNRESOLVED_CHEMICAL	2	2	CultureMech:003500	no	ingredients
+HBO3	UNRESOLVED_CHEMICAL	2	2	CultureMech:003500	no	ingredients
+Sigma Sea salts	UNRESOLVED_CHEMICAL	2	2	CultureMech:003537	no	ingredients
+Infusion Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:003541	no	ingredients
+Liver Concentrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:003605	no	ingredients
+Potassium Aspartate	UNRESOLVED_CHEMICAL	2	2	CultureMech:003605	no	ingredients
+Potassium Glutamate	UNRESOLVED_CHEMICAL	2	2	CultureMech:003605	no	ingredients
+H3PO4	UNRESOLVED_CHEMICAL	2	2	CultureMech:003830	no	ingredients
+Sodium polygalacturonate	UNRESOLVED_CHEMICAL	2	2	CultureMech:004022	no	ingredients
+KH2PO4 x 7 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:004060	no	ingredients
+Trace element solution SL-8	SOLUTION_NAME	2	2	CultureMech:004095	no	solutions
+Cellulose MN 300	UNRESOLVED_CHEMICAL	2	2	CultureMech:004212	no	ingredients
+Diethyl phosphonate	UNRESOLVED_CHEMICAL	2	2	CultureMech:004612	no	ingredients
+Trace element solution (A)	SOLUTION_NAME	2	2	CultureMech:004655	no	solutions
+Vitamin solution (B)	SOLUTION_NAME	2	2	CultureMech:004655	no	solutions
+Tea	UNRESOLVED_CHEMICAL	2	2	CultureMech:004671	no	ingredients
+Wilkins-Chalgren-Anaerobe-Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:004799	no	ingredients
+Sterile serum	UNRESOLVED_CHEMICAL	2	2	CultureMech:004799	no	ingredients
+Proteose yeastolate	UNRESOLVED_CHEMICAL	2	2	CultureMech:005218	no	ingredients
+Bordet-Gengou-Agar-Base	UNRESOLVED_CHEMICAL	2	2	CultureMech:005286	no	ingredients
+Casman-Agar-Base	UNRESOLVED_CHEMICAL	2	2	CultureMech:005287	no	ingredients
+Ox-bile	UNRESOLVED_CHEMICAL	2	2	CultureMech:005586	no	ingredients
+poly-ß-hydroxybutyric acid	UNRESOLVED_CHEMICAL	2	2	CultureMech:005589	no	ingredients
+Pennassay Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:005971	no	ingredients
+Corn steep powder	UNRESOLVED_CHEMICAL	2	2	CultureMech:006052	no	ingredients
+Blood Agar Base	UNRESOLVED_CHEMICAL	2	2	CultureMech:006192	no	ingredients
+Difco 0001	UNRESOLVED_CHEMICAL	2	2	CultureMech:006268	no	ingredients
+NaNH4HPO4 x 4 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:006312	no	ingredients
+Dung extract	UNRESOLVED_CHEMICAL	2	2	CultureMech:006480	no	ingredients
+Diced potato	UNRESOLVED_CHEMICAL	2	2	CultureMech:006490	no	ingredients
+SL-9	UNRESOLVED_CHEMICAL	2	2	CultureMech:006559	no	solutions
+Poly hexamethylene carbonate	UNRESOLVED_CHEMICAL	2	2	CultureMech:006736	no	ingredients
+Na3-citrate x 5 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:006777	no	ingredients
+Yeast cell paste	UNRESOLVED_CHEMICAL	2	2	CultureMech:006902	no	ingredients
+MgCl2 x 4 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:006934	no	ingredients
+Propanoate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007328	no	ingredients
+Propane-1-ol	UNRESOLVED_CHEMICAL	2	2	CultureMech:007335	no	ingredients
+Benzaldehyde	UNRESOLVED_CHEMICAL	2	2	CultureMech:007340	no	ingredients
+p-Hydroxybenzyl alcohol	UNRESOLVED_CHEMICAL	2	2	CultureMech:007345	no	ingredients
+4-Cresol	UNRESOLVED_CHEMICAL	2	2	CultureMech:007347	no	ingredients
+Se/W solution***	SOLUTION_NAME	2	2	CultureMech:007450	no	ingredients
+Resazurin solution****	SOLUTION_NAME	2	2	CultureMech:007450	no	ingredients
+Se/W solution	SOLUTION_NAME	2	2	CultureMech:007450	no	solutions
+Resazurin solution	SOLUTION_NAME	2	2	CultureMech:007450	no	solutions
+Artificial sea water	UNRESOLVED_CHEMICAL	2	2	CultureMech:007462	no	ingredients
+Substrates*	UNRESOLVED_CHEMICAL	2	2	CultureMech:007463	no	ingredients
+Selenite-tungstate solution**	SOLUTION_NAME	2	2	CultureMech:007467	no	ingredients
+Trace element mixture	SOLUTION_NAME	2	2	CultureMech:007467	no	solutions
+Bicarbonate solution (1.0 M)	SOLUTION_NAME	2	2	CultureMech:007467	no	solutions
+Sulfide solution (1.0 M)	SOLUTION_NAME	2	2	CultureMech:007467	no	solutions
+Agar solution*	SOLUTION_NAME	2	2	CultureMech:007473	no	ingredients
+10xM9 solution**	SOLUTION_NAME	2	2	CultureMech:007473	no	ingredients
+MgSO4 solution (1 M)***	SOLUTION_NAME	2	2	CultureMech:007473	no	ingredients
+CaCl2 solution (0.1 M)***	SOLUTION_NAME	2	2	CultureMech:007473	no	ingredients
+Phenanthrene solution (250 mM) in dimethyl sulfoxide (DMSO)****	SOLUTION_NAME	2	2	CultureMech:007473	no	ingredients
+Seawater (2% Salinity)*	UNRESOLVED_CHEMICAL	2	2	CultureMech:007476	no	ingredients
+Trace salts solution	SOLUTION_NAME	2	2	CultureMech:007483	no	solutions
+Solution A*	SOLUTION_NAME	2	2	CultureMech:007487	no	ingredients
+Solution B**	SOLUTION_NAME	2	2	CultureMech:007487	no	ingredients
+Methanol**	UNRESOLVED_CHEMICAL	2	2	CultureMech:007489	no	ingredients
+Pepton	UNRESOLVED_CHEMICAL	2	2	CultureMech:007491	no	ingredients
+KP buffer	SOLUTION_NAME	2	2	CultureMech:007499	no	solutions
+50% Sodium lactate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007510	no	ingredients
+K solution**	SOLUTION_NAME	2	2	CultureMech:007510	no	ingredients
+M solution***	SOLUTION_NAME	2	2	CultureMech:007510	no	ingredients
+C solution****	SOLUTION_NAME	2	2	CultureMech:007510	no	ingredients
+(NH4)2Fe(SO4)2・6H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:007530	no	ingredients
+0.2 M Sodium thiosulfate solution	SOLUTION_NAME	2	2	CultureMech:007546	no	solutions
+Chelated iron solution (see Medium [M863])	CROSS_REFERENCE	2	2	CultureMech:007561	no	solutions
+0.2 M KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:007561	no	solutions
+0.2 M Na2HPO4 solution	SOLUTION_NAME	2	2	CultureMech:007561	no	solutions
+Ampicillin (50 mg/ml)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007565	no	ingredients
+N--Acetyl--D--glucosamine (Sigma)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007565	no	ingredients
+5% (w/v) glycerin solution	SOLUTION_NAME	2	2	CultureMech:007569	no	solutions
+Modified trace element mixture (see below)	SOLUTION_NAME	2	2	CultureMech:007577	no	solutions
+2% MgCl2・6H2O solution	SOLUTION_NAME	2	2	CultureMech:007583	no	solutions
+10% (w/v) NaHCO3 solution*	SOLUTION_NAME	2	2	CultureMech:007583	no	solutions
+3% (w/v) Na2S・9H2O solution	SOLUTION_NAME	2	2	CultureMech:007583	no	solutions
+SW--25 solution (see below)	SOLUTION_NAME	2	2	CultureMech:007585	no	solutions
+Basal medium (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007589	no	ingredients
+130 mM FeCl2 solution	SOLUTION_NAME	2	2	CultureMech:007590	no	solutions
+8% (w/v) Na2CO3	UNRESOLVED_CHEMICAL	2	2	CultureMech:007600	no	ingredients
+Vitamin mixture (see below)	SOLUTION_NAME	2	2	CultureMech:007600	no	ingredients
+0.01 M Iron(III) citrate solution	SOLUTION_NAME	2	2	CultureMech:007601	no	solutions
+Nitsch's trace elements (see Medium [M266])	CROSS_REFERENCE	2	2	CultureMech:007601	no	solutions
+(NH4)2Fe(SO4)2·6H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:007611	no	ingredients
+0.5 M Na2HPO4--NaH2PO4 buffer (pH 7.3)	SOLUTION_NAME	2	2	CultureMech:007619	no	ingredients
+Solution A (see Medium [M1100])	CROSS_REFERENCE	2	2	CultureMech:007620	no	solutions
+Solution B (see Medium [M1100])	CROSS_REFERENCE	2	2	CultureMech:007620	no	solutions
+FeSO4・7H2O solution (see below)	SOLUTION_NAME	2	2	CultureMech:007625	no	solutions
+250 mM Dithiothreitol solution	SOLUTION_NAME	2	2	CultureMech:007630	no	solutions
+1 M Glucose solution*	SOLUTION_NAME	2	2	CultureMech:007638	no	solutions
+3.3% KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:007641	no	solutions
+Small dried sardine	UNRESOLVED_CHEMICAL	2	2	CultureMech:007642	no	ingredients
+Maize meal	UNRESOLVED_CHEMICAL	2	2	CultureMech:007642	no	ingredients
+Artificial seawater (see Medium [M299])	CROSS_REFERENCE	2	2	CultureMech:007648	no	solutions
+8% NaHCO3 solution (filter--sterilized)	SOLUTION_NAME	2	2	CultureMech:007653	no	solutions
+Trace element solution (see Medium [M224])	CROSS_REFERENCE	2	2	CultureMech:007655	no	solutions
+1 M K2HPO4 solution	SOLUTION_NAME	2	2	CultureMech:007656	no	solutions
+0.2% Fe(NH4)2(SO4)・6H2O (in 0.037% HCl)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007657	no	ingredients
+Trace elements (see Medium [M631])	CROSS_REFERENCE	2	2	CultureMech:007657	no	solutions
+FeS solution (see Medium [M641])	CROSS_REFERENCE	2	2	CultureMech:007658	no	solutions
+Trace element solution (see Medium [M701])	CROSS_REFERENCE	2	2	CultureMech:007661	no	solutions
+0.5 M Crotonic acid (pH 7.0)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007669	no	ingredients
+Vitamin solution (see Medium [M609])	CROSS_REFERENCE	2	2	CultureMech:007676	no	solutions
+0.5 M MES solution (pH 5.7)	SOLUTION_NAME	2	2	CultureMech:007679	no	solutions
+Trace vitamins (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007681	no	ingredients
+Methanol--utilizing bacteria medium B (see Medium [M70])	CROSS_REFERENCE	2	2	CultureMech:007715	no	solutions
+0.1% Sodium dithionite solution	SOLUTION_NAME	2	2	CultureMech:007724	no	solutions
+Yeast autolysate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007726	no	ingredients
+1 M Glucose	UNRESOLVED_CHEMICAL	2	2	CultureMech:007744	no	ingredients
+10% Tryptone solution (autoclaved)	SOLUTION_NAME	2	2	CultureMech:007748	no	solutions
+Phosphate buffer (see below)	SOLUTION_NAME	2	2	CultureMech:007752	no	ingredients
+0.25 M Ferric citrate solution (pH 7.0)	SOLUTION_NAME	2	2	CultureMech:007752	no	solutions
+Micronutrient solution (SL7) (see Medium [M572])	CROSS_REFERENCE	2	2	CultureMech:007755	no	solutions
+NaCO3 solution	SOLUTION_NAME	2	2	CultureMech:007758	no	solutions
+Trace metal solution SL12 (see Medium [M581])	CROSS_REFERENCE	2	2	CultureMech:007778	no	solutions
+EDTA・Na2	UNRESOLVED_CHEMICAL	2	2	CultureMech:007784	no	ingredients
+1.0 M NaHCO3 solution*	SOLUTION_NAME	2	2	CultureMech:007784	no	solutions
+1.0 M KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:007784	no	solutions
+0.2 M CeCl3 solution*	SOLUTION_NAME	2	2	CultureMech:007784	no	solutions
+1% Hemin solution	SOLUTION_NAME	2	2	CultureMech:007791	no	solutions
+Vitamin solution (see Medium [M1239])	CROSS_REFERENCE	2	2	CultureMech:007801	no	solutions
+Phosphates solution	SOLUTION_NAME	2	2	CultureMech:007818	no	solutions
+Phosphate buffer (see Medium [M560])	CROSS_REFERENCE	2	2	CultureMech:007819	no	solutions
+Basal salts solution (see below)	SOLUTION_NAME	2	2	CultureMech:007829	no	solutions
+Solution I (see below)	SOLUTION_NAME	2	2	CultureMech:007832	no	solutions
+Solution II (see below)	SOLUTION_NAME	2	2	CultureMech:007832	no	solutions
+L--cysteine・HCl	UNRESOLVED_CHEMICAL	2	2	CultureMech:007834	no	ingredients
+10 mM CuCl2 solution	SOLUTION_NAME	2	2	CultureMech:007843	no	solutions
+10 mM CeCl3 solution	SOLUTION_NAME	2	2	CultureMech:007843	no	solutions
+Phosphate buffer solution (see below)	SOLUTION_NAME	2	2	CultureMech:007848	no	solutions
+1.0 M L-Sodium lactate solution	SOLUTION_NAME	2	2	CultureMech:007851	no	solutions
+0.01% Coenzyme M solution	SOLUTION_NAME	2	2	CultureMech:007868	no	solutions
+8.0% NaHCO3 solution	SOLUTION_NAME	2	2	CultureMech:007875	no	solutions
+1 mM CuSO4・5H2O solution	SOLUTION_NAME	2	2	CultureMech:007880	no	solutions
+8% NaHCO3 solution**	SOLUTION_NAME	2	2	CultureMech:007890	no	solutions
+R2A agar (DB-Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007915	no	ingredients
+Phosphate solution (see Medium [M798])	CROSS_REFERENCE	2	2	CultureMech:007916	no	solutions
+Trace metal solution (see Medium [M798])	CROSS_REFERENCE	2	2	CultureMech:007916	no	solutions
+Vitamin solution (see Medium [M798])	CROSS_REFERENCE	2	2	CultureMech:007916	no	solutions
+Mineral salt solution (see Medium [M798])	CROSS_REFERENCE	2	2	CultureMech:007916	no	solutions
+100 mM NH4Cl solution	SOLUTION_NAME	2	2	CultureMech:007930	no	solutions
+500 mM MnO2 solution	SOLUTION_NAME	2	2	CultureMech:007930	no	solutions
+300 mM Na2S2O3 solution	SOLUTION_NAME	2	2	CultureMech:007930	no	solutions
+Oatmeal (Quaker White Oats)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007935	no	ingredients
+Sake	UNRESOLVED_CHEMICAL	2	2	CultureMech:007936	no	ingredients
+Liver extract concentrate (NBCo)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007936	no	ingredients
+Bacto Todd Hewitt Broth (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008070	no	ingredients
+Trace element solution (see Medium [M120])	CROSS_REFERENCE	2	2	CultureMech:008108	no	solutions
+Metal salt solution 44****	SOLUTION_NAME	2	2	CultureMech:008121	no	solutions
+Fe2+ solution*	SOLUTION_NAME	2	2	CultureMech:008143	no	solutions
+Bacto Vitamin Assay Casamino Acids (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008144	no	ingredients
+Vitamin B12 (0.002%) solution	SOLUTION_NAME	2	2	CultureMech:008356	no	solutions
+Bacto Agar	UNRESOLVED_CHEMICAL	2	2	CultureMech:008412	no	ingredients
+Artificial marine water	UNRESOLVED_CHEMICAL	2	2	CultureMech:008417	no	ingredients
+Hutner's basal salts**	UNRESOLVED_CHEMICAL	2	2	CultureMech:008452	no	solutions
+HEPES*	UNRESOLVED_CHEMICAL	2	2	CultureMech:008512	no	solutions
+1M HEPES-KOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:008527	no	ingredients
+Stock solution1*	SOLUTION_NAME	2	2	CultureMech:008527	no	solutions
+Trace A5+Co**	UNRESOLVED_CHEMICAL	2	2	CultureMech:008527	no	solutions
+Agar Noble (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008537	no	ingredients
+1.0% Hemin solution	SOLUTION_NAME	2	2	CultureMech:008629	no	solutions
+sterile defibrinated horse blood	UNRESOLVED_CHEMICAL	2	2	CultureMech:008712	no	ingredients
+Charcoal activated	UNRESOLVED_CHEMICAL	2	2	CultureMech:008727	no	ingredients
+ACES buffer	SOLUTION_NAME	2	2	CultureMech:008727	no	ingredients
+Pyridoxine-HCl (Vitamin B6)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008761	no	ingredients
+Riboflavin (Vitamin B2)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008761	no	ingredients
+Fe(III) citrate solution	SOLUTION_NAME	2	2	CultureMech:008767	no	solutions
+IsoVitaleX (BD 211876)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008799	no	ingredients
+Dried Bovine Hemoglobin (BD 212392)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008799	no	ingredients
+Swine serum	UNRESOLVED_CHEMICAL	2	2	CultureMech:008816	no	ingredients
+Phenol red solution	SOLUTION_NAME	2	2	CultureMech:008816	no	solutions
+Lactobacilli MRS	UNRESOLVED_CHEMICAL	2	2	CultureMech:008839	no	ingredients
+Sorbitan Monooleate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008839	no	ingredients
+Ammonium Citrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008839	no	ingredients
+1M Na2CO3	UNRESOLVED_CHEMICAL	2	2	CultureMech:008844	no	ingredients
+Yeast extrakt	UNRESOLVED_CHEMICAL	2	2	CultureMech:008844	no	ingredients
+2N H2SO4	UNRESOLVED_CHEMICAL	2	2	CultureMech:008844	no	ingredients
+Solution D+C+E	SOLUTION_NAME	2	2	CultureMech:008844	no	solutions
+Difco Marine Broth 2216	UNRESOLVED_CHEMICAL	2	2	CultureMech:008853	no	ingredients
+Trace element solution SL-6(see below)	SOLUTION_NAME	2	2	CultureMech:008878	no	solutions
+Soil extract (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008896	no	ingredients
+Agar (alternative)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008899	no	ingredients
+Castenholz Salts, 2x	UNRESOLVED_CHEMICAL	2	2	CultureMech:008899	no	ingredients
+1% TYE Solution	SOLUTION_NAME	2	2	CultureMech:008899	no	solutions
+Nitsch's Trace Elements (see below)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008899	no	solutions
+FeCl3 solution (0.03%, see below)	SOLUTION_NAME	2	2	CultureMech:008899	no	solutions
+0.01 M Fe citrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008920	no	ingredients
+(NH4)6MoO7O24 x 4 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008932	no	ingredients
+Distilled water to	UNRESOLVED_CHEMICAL	2	2	CultureMech:008962	no	ingredients
+Trace Elements Solution SL-6	SOLUTION_NAME	2	2	CultureMech:008962	no	solutions
+Leptospira Enrichment EMJH	UNRESOLVED_CHEMICAL	2	2	CultureMech:008992	no	ingredients
+Glucose (50% aqueous solution)	SOLUTION_NAME	2	2	CultureMech:009030	no	solutions
+Arginine HCl (50% aqueous solution)	SOLUTION_NAME	2	2	CultureMech:009031	no	solutions
+Horse serum (heat-inactivated)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009044	no	ingredients
+Vitamin solution:	SOLUTION_NAME	2	2	CultureMech:009050	no	solutions
+FeSO4 x 7H2O solution (0.1% w/v in 0.1 N H2SO4)	SOLUTION_NAME	2	2	CultureMech:009051	no	solutions
+Solution F:	SOLUTION_NAME	2	2	CultureMech:009053	no	solutions
+clarified tomato juice	UNRESOLVED_CHEMICAL	2	2	CultureMech:009061	no	ingredients
+MRS broth (Oxoid)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009068	no	ingredients
+Heart Infusion Broth (BD 238400)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009146	no	ingredients
+Na2CO3 (5% w/v)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009287	no	ingredients
+Heat inactivated fetal bovine serum	UNRESOLVED_CHEMICAL	2	2	CultureMech:009312	no	ingredients
+Glucose Solution	SOLUTION_NAME	2	2	CultureMech:009312	no	solutions
+sterile bovine serum (heat inactivated at 56°C for 45 min)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009321	no	ingredients
+sterile 10% w/v NaHCO3 solution	SOLUTION_NAME	2	2	CultureMech:009321	no	solutions
+sterile 30% w/v glucose solution	SOLUTION_NAME	2	2	CultureMech:009321	no	solutions
+1M MgSO4	UNRESOLVED_CHEMICAL	2	2	CultureMech:009332	no	ingredients
+K2HPO4 (anhydrous)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009332	no	ingredients
+chocolate agar	UNRESOLVED_CHEMICAL	2	2	CultureMech:009398	no	ingredients
+Natural seawater	UNRESOLVED_CHEMICAL	2	2	CultureMech:009538	no	ingredients
+Trace element solution SLA (see Medium [M352])	CROSS_REFERENCE	2	2	CultureMech:009542	no	solutions
+Vitamin solution VA (see Medium [M352])	CROSS_REFERENCE	2	2	CultureMech:009542	no	solutions
+Antifoam SI (Wako)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009558	no	ingredients
+Antifoam solution (only for liquid medium)*	SOLUTION_NAME	2	2	CultureMech:009558	no	solutions
+Resazurin (0.1%)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009627	no	ingredients
+Whatman #1 filter paper	UNRESOLVED_CHEMICAL	2	2	CultureMech:009627	no	ingredients
+Wolfe's Modified Mineral Elixir	SOLUTION_NAME	2	2	CultureMech:009627	no	ingredients
+Pantothenic acid calcium salt	UNRESOLVED_CHEMICAL	2	2	CultureMech:009627	no	ingredients
+2-3 N KOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:009627	no	ingredients
+FeNa.EDTA	UNRESOLVED_CHEMICAL	2	2	CultureMech:009667	no	ingredients
+PE Medium (see Medium [M298])	CROSS_REFERENCE	2	2	CultureMech:009709	no	solutions
+Soil extract (see Medium [M94])	CROSS_REFERENCE	2	2	CultureMech:009715	no	solutions
+Inorganic salts--starch agar (ISP--4) (see Medium [M50])	CROSS_REFERENCE	2	2	CultureMech:009725	no	solutions
+PY4S AGAR (see Medium [M357])	CROSS_REFERENCE	2	2	CultureMech:009738	no	solutions
+SrCl2・H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:009744	no	ingredients
+o--phthalic acid	UNRESOLVED_CHEMICAL	2	2	CultureMech:009766	no	ingredients
+Glycerol--asparagine agar (ISP--5) (see Medium [M52])	CROSS_REFERENCE	2	2	CultureMech:009792	no	solutions
+Poorly crystalline iron(III) oxide (see Medium [M409])	CROSS_REFERENCE	2	2	CultureMech:009795	no	solutions
+Trace mineral solution (see Medium [M363])	CROSS_REFERENCE	2	2	CultureMech:009796	no	solutions
+hopped beer	UNRESOLVED_CHEMICAL	2	2	CultureMech:009811	no	ingredients
+1.0 M Sodium lactate solution*	SOLUTION_NAME	2	2	CultureMech:009816	no	solutions
+25% HCl	UNRESOLVED_CHEMICAL	2	2	CultureMech:009817	no	ingredients
+Selenite--tungstate solution (see below)	SOLUTION_NAME	2	2	CultureMech:009817	no	solutions
+Vitamin solution (filter--sterilized, see below)	SOLUTION_NAME	2	2	CultureMech:009819	no	solutions
+sodium dithionite solution	SOLUTION_NAME	2	2	CultureMech:009823	no	solutions
+PYG MEDIUM (B) (see Medium [M423])	CROSS_REFERENCE	2	2	CultureMech:009843	no	solutions
+1 N NaOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:009849	no	ingredients
+Riboflavin solution (see Medium [M463])	CROSS_REFERENCE	2	2	CultureMech:009852	no	solutions
+Carrot, peeled and cut	UNRESOLVED_CHEMICAL	2	2	CultureMech:009858	no	ingredients
+dithiothreitol solution	SOLUTION_NAME	2	2	CultureMech:009879	no	solutions
+Tomato juice, filtered, pH 7.0	UNRESOLVED_CHEMICAL	2	2	CultureMech:009889	no	ingredients
+L--cysteine・HCl・H2O solution	SOLUTION_NAME	2	2	CultureMech:009912	no	solutions
+Micronutrient solution SL7 (see below)	SOLUTION_NAME	2	2	CultureMech:009913	no	solutions
+PY4S agar (see Medium [M357])	CROSS_REFERENCE	2	2	CultureMech:009915	no	solutions
+1 mM CuSO4 solution	SOLUTION_NAME	2	2	CultureMech:009916	no	solutions
+Thioglycollate medium (Sigma)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009923	no	ingredients
+FeSO4 solution (see below)	SOLUTION_NAME	2	2	CultureMech:009925	no	solutions
+Calcium malate	UNRESOLVED_CHEMICAL	2	2	CultureMech:009943	no	ingredients
+THIORHODOCOCCUS BHEEMLICUM MEDIUM (see Medium [M565])	CROSS_REFERENCE	2	2	CultureMech:009961	no	solutions
+15% MgCl2・6H2O solution*	SOLUTION_NAME	2	2	CultureMech:009977	no	solutions
+sterile defibrinated rabbit blood	UNRESOLVED_CHEMICAL	2	2	CultureMech:009988	no	ingredients
+Trace mineral solution (see Medium [M509])	CROSS_REFERENCE	2	2	CultureMech:009994	no	solutions
+Cellulose (Avicel or MN 300)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010000	no	ingredients
+Soluble starch (BD-Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+N-Z-Case (Wako)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+MnCl2・4H2O (5.0 g/L in 0.01 N H2SO4)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+ZnSO4・7H2O (0.6 g/L in 0.01 N H2SO4)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+CuSO4・5H2O (0.15 g/L in 0.01 N H2SO4)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+VOSO4・xH2O (1 g/L)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+Na2MoO4・2H2O (12 g/L)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+CoCl2・6H2O (8.0 g/L in 0.01 N H2SO4)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+NiCl2・6H2O (0.2 g/L in 0.01 N H2SO4)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010027	no	ingredients
+MODIFIED THERMUS MEDIUM WITH 3% NaCl (see Medium [M634])	CROSS_REFERENCE	2	2	CultureMech:010036	no	solutions
+Modified Wolfe's solution (see below)	SOLUTION_NAME	2	1	CultureMech:010042	no	solutions
+0.07% Hemin solution	SOLUTION_NAME	2	2	CultureMech:010048	no	solutions
+Na2S2O3・5H2O(final conc.)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010065	no	ingredients
+0.4 M NH4HCO3 solution	SOLUTION_NAME	2	2	CultureMech:010071	no	solutions
+GAM agar, modified (Nissui)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010075	no	ingredients
+8% NaHCO3solution*	SOLUTION_NAME	2	2	CultureMech:010103	no	solutions
+Ampicillin solution (0.1 g/ml)*	SOLUTION_NAME	2	2	CultureMech:010104	no	solutions
+Gelrite (gellan gum) solution	SOLUTION_NAME	2	1	CultureMech:010112	no	solutions
+Oatmeal agar (ISP--3) (see Medium [M42])	CROSS_REFERENCE	2	2	CultureMech:010116	no	solutions
+Sodium citrate・2H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:010134	no	ingredients
+2.2% Sodium butyrate solution	SOLUTION_NAME	2	2	CultureMech:010139	no	solutions
+5% L--Cysteine・H2O・HCl solution	SOLUTION_NAME	2	2	CultureMech:010139	no	solutions
+7% KH2PO4 solution	SOLUTION_NAME	2	2	CultureMech:010152	no	solutions
+RAVOT MODIFIED MEDIUM FOR THERMOANAEROVIBRIO SP. R101 (see Medium [M748])	CROSS_REFERENCE	2	2	CultureMech:010154	no	solutions
+10 mM FeSO4 solution (pH 2.0)	SOLUTION_NAME	2	2	CultureMech:010157	no	solutions
+Malted wheat meal	UNRESOLVED_CHEMICAL	2	2	CultureMech:010159	no	ingredients
+Phosphate solution (see Medium [M762])	CROSS_REFERENCE	2	2	CultureMech:010170	no	solutions
+DESULFOVIBRIO MEDIUM (see Medium [M384])	CROSS_REFERENCE	2	2	CultureMech:010183	no	solutions
+12.5% Na2S2O3・5H2O solution*	SOLUTION_NAME	2	2	CultureMech:010192	no	solutions
+0.1 M MgSO4 solution	SOLUTION_NAME	2	2	CultureMech:010194	no	solutions
+10% L--Sodium lactate solution	SOLUTION_NAME	2	2	CultureMech:010202	no	solutions
+Mineral salt solution (see below)	SOLUTION_NAME	2	2	CultureMech:010208	no	solutions
+Bacto m TGE broth (BD-Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010241	no	ingredients
+ACIDIC DILUTED ASM MEDIUM (see Medium [M850])	CROSS_REFERENCE	2	2	CultureMech:010267	no	solutions
+Trace element solution (see Medium [M850])	CROSS_REFERENCE	2	2	CultureMech:010268	no	solutions
+Iron stock solution (see Medium [M850])	CROSS_REFERENCE	2	2	CultureMech:010268	no	solutions
+Phosphate buffer stock solution (see Medium [M850])	CROSS_REFERENCE	2	2	CultureMech:010268	no	solutions
+Anaerobic water	UNRESOLVED_CHEMICAL	2	2	CultureMech:010279	no	ingredients
+1 M L--Sodium lactate solution	SOLUTION_NAME	2	2	CultureMech:010284	no	solutions
+Titanium chloride	UNRESOLVED_CHEMICAL	2	2	CultureMech:010286	no	ingredients
+Trace metal solution (see Medium [M80])	CROSS_REFERENCE	2	2	CultureMech:010287	no	solutions
+Modified UBS solution (see Medium [M896])	CROSS_REFERENCE	2	2	CultureMech:010314	no	solutions
+Bacto agar(BD-Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:010371	no	ingredients
+0.5 M Glycine--NaOH buffer (pH 10.0)	SOLUTION_NAME	2	2	CultureMech:010372	no	ingredients
+Modified Wolfe's mineral solution (see Medium [M961])	CROSS_REFERENCE	2	2	CultureMech:010389	no	solutions
+Vitamin solution (see Medium [M961])	CROSS_REFERENCE	2	2	CultureMech:010389	no	solutions
+1M NaHCO3 solution*	SOLUTION_NAME	2	2	CultureMech:009698	no	solutions
+Ethanol**	UNRESOLVED_CHEMICAL	2	2	CultureMech:008100	no	solutions
+Trace minerals (see Medium No. 151	CROSS_REFERENCE	2	2	CultureMech:002189	no	ingredients
+Activated carbon	UNRESOLVED_CHEMICAL	2	2	CultureMech:001956	no	ingredients
+4-Amino-5-hydroxymethyl-2-methylpyrimidine	UNRESOLVED_CHEMICAL	2	2	CultureMech:007382	no	ingredients
+Agar, Noble (BD 214230)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008960	no	ingredients
+CH3COONa	UNRESOLVED_CHEMICAL	2	2	CultureMech:009571	no	ingredients
+Colloidal chitin	UNRESOLVED_CHEMICAL	2	2	CultureMech:002440	no	ingredients
+Sterile Defibrinated Rabbit Blood	UNRESOLVED_CHEMICAL	2	2	CultureMech:008893	no	ingredients
+Brucella Broth (BD 211088)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008874	no	ingredients
+MEM alpha Modification	UNRESOLVED_CHEMICAL	2	2	CultureMech:001256	no	ingredients
+Adenine sulfate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008827	no	ingredients
+Bacto Casamino Acid (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008763	no	ingredients
+NaOH (1N)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009264	no	ingredients
+Ground Beef (fat-free)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009264	no	ingredients
+ATCC Medium 1490	UNRESOLVED_CHEMICAL	2	2	CultureMech:009143	no	ingredients
+PPLO medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:009427	no	ingredients
+IMDM-Medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:000636	no	ingredients
+Ferric nitrilotriacetate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007294	no	ingredients
+Hydrochloric acid, 25%	UNRESOLVED_CHEMICAL	2	2	CultureMech:009297	no	ingredients
+Na2S2O3 (if needed)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008209	no	ingredients
+Vitamin B12 solution (0.001%)	SOLUTION_NAME	2	2	CultureMech:008209	no	solutions
+Ferric citrate solution (0.1%)*	SOLUTION_NAME	2	2	CultureMech:008209	no	solutions
+Acetate solution***	SOLUTION_NAME	2	2	CultureMech:008209	no	solutions
+Na2S·9H2O (neutralized)****	UNRESOLVED_CHEMICAL	2	2	CultureMech:008209	no	solutions
+YE	UNRESOLVED_CHEMICAL	2	2	CultureMech:009006	no	ingredients
+DW	UNRESOLVED_CHEMICAL	2	2	CultureMech:008468	no	ingredients
+α-D-Glucose monohydrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:001040	no	ingredients
+Na3-NTA x H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:001138	no	ingredients
+Yeast	UNRESOLVED_CHEMICAL	2	2	CultureMech:008771	no	ingredients
+KH2PO4 x 2 H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:002915	no	ingredients
+Daigo's IMK Medium*	UNRESOLVED_CHEMICAL	2	2	CultureMech:008569	no	solutions
+N1 Metals solution*	SOLUTION_NAME	2	2	CultureMech:008320	no	solutions
+10 N NaOH solution	SOLUTION_NAME	2	2	CultureMech:001068	no	solutions
+Hygromycin B solution (50 mg/ml)*	SOLUTION_NAME	2	2	CultureMech:008514	no	solutions
+Kanamycin solution (50 mg/ml)*	SOLUTION_NAME	2	2	CultureMech:008599	no	solutions
+Rifampicin solution (50 mg/ml)*	SOLUTION_NAME	2	2	CultureMech:008553	no	solutions
+Streptomycin solution (50 mg/ml)*	SOLUTION_NAME	2	2	CultureMech:008552	no	solutions
+Ox bile, desiccated	UNRESOLVED_CHEMICAL	2	2	CultureMech:008670	no	ingredients
+Leibovitz's L-15 medium	UNRESOLVED_CHEMICAL	2	2	CultureMech:003278	no	ingredients
+M17 broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:009066	no	ingredients
+M17 broth (Oxoid)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009418	no	ingredients
+Lactose solution 10% (w/v)	SOLUTION_NAME	2	2	CultureMech:009418	no	solutions
+EDDHA	UNRESOLVED_CHEMICAL	2	2	CultureMech:007194	no	ingredients
+NH4VO3	UNRESOLVED_CHEMICAL	2	2	CultureMech:009338	no	ingredients
+Bacto m TGE broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:003139	no	ingredients
+Middlebrook 7H9 broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:008986	no	ingredients
+ADC Enrichment	UNRESOLVED_CHEMICAL	2	2	CultureMech:008986	no	ingredients
+MARINE AGAR 2216 (see Medium [M110])	CROSS_REFERENCE	2	2	CultureMech:010162	no	solutions
+Phenol red (0.04%)	UNRESOLVED_CHEMICAL	2	2	CultureMech:007643	no	ingredients
+1.0 mg/ml EDTA・Fe(III) solution	SOLUTION_NAME	2	2	CultureMech:007643	no	solutions
+FeCl3 solution	SOLUTION_NAME	2	2	CultureMech:008830	no	solutions
+Calcium D(+)-panthothenate	UNRESOLVED_CHEMICAL	2	2	CultureMech:008224	no	ingredients
+Bicarbonate solution (1.0 M)*****	SOLUTION_NAME	2	2	CultureMech:008224	no	solutions
+Sulfide solution******	SOLUTION_NAME	2	2	CultureMech:008225	no	solutions
+Wolfe’s Mineral Solution (see below)	SOLUTION_NAME	2	2	CultureMech:009040	no	solutions
+ciprofloxacin (if needed)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009469	no	ingredients
+Calcium chloride dehydrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:009202	no	ingredients
+Potassium dibasic phosphate trihydrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:009202	no	ingredients
+Polyvinyl alcohol	UNRESOLVED_CHEMICAL	2	2	CultureMech:007183	no	ingredients
+Tween 80 (BD)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009413	no	ingredients
+Middlebrook ADC Growth Supplement	UNRESOLVED_CHEMICAL	2	2	CultureMech:008984	no	ingredients
+Middlebrook 7H9 broth (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008989	no	ingredients
+Middlebrook 7H9 Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:008978	no	ingredients
+Sodium Pantothenate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007181	no	ingredients
+β-glycerophosphate-2Na	UNRESOLVED_CHEMICAL	2	2	CultureMech:008383	no	ingredients
+HMSS solution***	SOLUTION_NAME	2	2	CultureMech:008578	no	solutions
+Vitamin B12 (0.1 mg/ml, filter sterilized)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009024	no	ingredients
+Methanol(filter sterilized)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009024	no	ingredients
+Paraamino benzoic acid	UNRESOLVED_CHEMICAL	2	2	CultureMech:009619	no	ingredients
+dried baker's yeast	UNRESOLVED_CHEMICAL	2	2	CultureMech:008029	no	ingredients
+Dry yeast	UNRESOLVED_CHEMICAL	2	2	CultureMech:008725	no	ingredients
+Magnesium sulphate 7H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008831	no	ingredients
+Manganese sulphate 4H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008831	no	ingredients
+Sodium acetate 3H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008831	no	ingredients
+`Lab-Lemco’ powder	UNRESOLVED_CHEMICAL	2	2	CultureMech:008831	no	ingredients
+MRS broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:003148	no	ingredients
+Mercaptoethanesulfonic acid	UNRESOLVED_CHEMICAL	2	2	CultureMech:009199	no	ingredients
+Cerophyll	UNRESOLVED_CHEMICAL	2	2	CultureMech:000373	no	ingredients
+EDTA, sodium salt	UNRESOLVED_CHEMICAL	2	2	CultureMech:008446	no	ingredients
+DI water	UNRESOLVED_CHEMICAL	2	2	CultureMech:008956	no	ingredients
+0.1N HCl	UNRESOLVED_CHEMICAL	2	2	CultureMech:008849	no	ingredients
+0.1N NaOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:008849	no	ingredients
+Vitamin B12 solution (0.01%)	SOLUTION_NAME	2	2	CultureMech:008166	no	solutions
+Neutralized sulfide solution***	SOLUTION_NAME	2	2	CultureMech:008166	no	solutions
+Distilled water make up to	UNRESOLVED_CHEMICAL	2	2	CultureMech:007960	no	ingredients
+Niacine	UNRESOLVED_CHEMICAL	2	2	CultureMech:008107	no	ingredients
+SABOURAUD- Glucose-Bouillon	UNRESOLVED_CHEMICAL	2	2	CultureMech:004154	no	ingredients
+Fe(III)NH4-Citrate	UNRESOLVED_CHEMICAL	2	2	CultureMech:009649	no	ingredients
+dTMP	UNRESOLVED_CHEMICAL	2	2	CultureMech:007188	no	ingredients
+Yeast Extract Solution	SOLUTION_NAME	2	2	CultureMech:009147	no	solutions
+Standard I Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:006156	no	ingredients
+Zinc	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Copper	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Calcium	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Molybdenum	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Cobalt ion	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Borate	UNRESOLVED_CHEMICAL	2	2	CultureMech:007283	no	ingredients
+Heart, Infusion from 500 g	UNRESOLVED_CHEMICAL	2	2	CultureMech:008848	no	ingredients
+Todd Hewitt Broth	UNRESOLVED_CHEMICAL	2	2	CultureMech:002606	no	ingredients
+Press yeast	UNRESOLVED_CHEMICAL	2	2	CultureMech:007981	no	ingredients
+Potato*	UNRESOLVED_CHEMICAL	2	2	CultureMech:007981	no	solutions
+Liver infusion from*	UNRESOLVED_CHEMICAL	2	2	CultureMech:007981	no	solutions
+Thioglycolate Medium Dehydrated**	UNRESOLVED_CHEMICAL	2	2	CultureMech:007981	no	solutions
+Bacto PPLO Broth (Difco)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008010	no	ingredients
+Wolfe's modified mineral solution*	SOLUTION_NAME	2	2	CultureMech:008013	no	solutions
+VFA**	UNRESOLVED_CHEMICAL	2	2	CultureMech:008013	no	solutions
+Bacto Yeast Extract (Difco)*	UNRESOLVED_CHEMICAL	2	2	CultureMech:008060	no	solutions
+NaS2・9H2O	UNRESOLVED_CHEMICAL	2	2	CultureMech:008487	no	ingredients
+0.5 N NaOH	UNRESOLVED_CHEMICAL	2	2	CultureMech:009615	no	ingredients
+nicotinamide adenine dinucleotide (NAD)	UNRESOLVED_CHEMICAL	2	2	CultureMech:009486	no	ingredients
+bovine serum	UNRESOLVED_CHEMICAL	2	2	CultureMech:009486	no	ingredients
+Trypticase Soy (BBL)	UNRESOLVED_CHEMICAL	2	2	CultureMech:008385	no	ingredients
+Oatmeal agar	UNRESOLVED_CHEMICAL	2	2	CultureMech:002371	yes	ingredients
+Iron-EDTA	UNRESOLVED_CHEMICAL	2	2	CultureMech:015438	no	ingredients
+DYIII Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000001	no	ingredients
+Allen Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000013	no	ingredients
+Modified Bold 3N Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000023	no	ingredients
+Tricine (adjust to pH 8)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000025	no	ingredients
+CaCl 2H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000139	no	ingredients
+MgSO 7H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000139	no	ingredients
+Na EDTA.2H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000139	no	ingredients
+Modified COMBO Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000156	no	ingredients
+Na2Glycerophosphate.5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000159	no	ingredients
+Sterile dH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000177	no	ingredients
+Soilwater: Peat Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000182	no	ingredients
+Barley grains autoclaved	UNRESOLVED_CHEMICAL	1	1	CultureMech:000182	no	ingredients
+Barley grains(add after dH2O)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000224	no	ingredients
+Soilwater: GR- Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000228	no	ingredients
+Organic Peat	UNRESOLVED_CHEMICAL	1	1	CultureMech:000230	no	ingredients
+ASM trace element solution	SOLUTION_NAME	1	1	CultureMech:000189	no	solutions
+ASM vitamin B12 working stock	SOLUTION_NAME	1	1	CultureMech:000189	no	solutions
+ASM vitamin B1 stock	SOLUTION_NAME	1	1	CultureMech:000189	no	solutions
+Barley grain	UNRESOLVED_CHEMICAL	1	1	CultureMech:000043	no	ingredients
+Na2CO3 stock solution	SOLUTION_NAME	1	1	CultureMech:000192	no	solutions
+Fe-citrate stock solution	SOLUTION_NAME	1	1	CultureMech:000192	no	solutions
+Citric acid stock solution	SOLUTION_NAME	1	1	CultureMech:000192	no	solutions
+MoO	UNRESOLVED_CHEMICAL	1	1	CultureMech:000053	no	ingredients
+BB (Bold's Basal Medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000054	no	solutions
+MErds (Modified Foyns Erdschreiber Medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000054	no	solutions
+NH4Cl stock solution	SOLUTION_NAME	1	1	CultureMech:000193	no	solutions
+Asparagine stock solution	SOLUTION_NAME	1	1	CultureMech:000193	no	solutions
+Co(NO )2.6H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000055	no	ingredients
+Thiamine stock solution	SOLUTION_NAME	1	1	CultureMech:000194	no	solutions
+Biotin stock solution	SOLUTION_NAME	1	1	CultureMech:000194	no	solutions
+Vitamin B12 stock solution	SOLUTION_NAME	1	1	CultureMech:000194	no	solutions
+PIV metal solution	SOLUTION_NAME	1	1	CultureMech:000194	no	solutions
+MBB trace element stock I	SOLUTION_NAME	1	1	CultureMech:000195	no	solutions
+MBB trace element stock II	SOLUTION_NAME	1	1	CultureMech:000195	no	solutions
+MBB trace element stock III	SOLUTION_NAME	1	1	CultureMech:000195	no	solutions
+MBB trace element stock IV	SOLUTION_NAME	1	1	CultureMech:000195	no	solutions
+Sphagnum extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:000153	no	ingredients
+(NH4)2SO4 stock solution	SOLUTION_NAME	1	1	CultureMech:000198	no	solutions
+EG (Euglena gracilis Medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000071	no	solutions
+NaH2PO4 x H2O stock solution	SOLUTION_NAME	1	1	CultureMech:000202	no	solutions
+f/2 micronutrient working stock solution	SOLUTION_NAME	1	1	CultureMech:000202	no	solutions
+f/2 vitamin working stock solution	SOLUTION_NAME	1	1	CultureMech:000202	no	solutions
+NaNO3(autoclave before adding)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000167	no	ingredients
+Na2HPO4•7H2O(autoclave before adding)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000167	no	ingredients
+Beef extract stock solution	SOLUTION_NAME	1	1	CultureMech:000203	no	solutions
+Na VO	UNRESOLVED_CHEMICAL	1	1	CultureMech:000072	no	ingredients
+Na HPO .12H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000073	no	ingredients
+Sterile	UNRESOLVED_CHEMICAL	1	1	CultureMech:000073	no	ingredients
+Na HPO .7H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000086	no	ingredients
+Thoroughly disperse the agar in cold	UNRESOLVED_CHEMICAL	1	1	CultureMech:000090	no	ingredients
+Fe(NH4)2(SO4)2.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000092	no	ingredients
+TES (Dry Buffer)	SOLUTION_NAME	1	1	CultureMech:000094	no	ingredients
+Bring 500 ml of	UNRESOLVED_CHEMICAL	1	1	CultureMech:000100	no	ingredients
+Glucose stock solution	SOLUTION_NAME	1	1	CultureMech:000206	no	solutions
+Liver extract stock solution	SOLUTION_NAME	1	1	CultureMech:000206	no	solutions
+CaCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:000109	no	ingredients
+Soil extract (SE1)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000110	no	ingredients
+Salt solution stock	SOLUTION_NAME	1	1	CultureMech:000110	no	ingredients
+PES ES-enrichment solution	SOLUTION_NAME	1	1	CultureMech:000207	no	solutions
+Chapman-Andresen's Modified Pringsheim's Solution	SOLUTION_NAME	1	1	CultureMech:000132	no	solutions
+PJ (Prescott's and James's Solution)	SOLUTION_NAME	1	1	CultureMech:000131	no	solutions
+MnSO .7H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000135	no	ingredients
+Spirulina solution I	SOLUTION_NAME	1	1	CultureMech:000213	no	solutions
+Spirulina solution II	SOLUTION_NAME	1	1	CultureMech:000213	no	solutions
+SrCl 6H O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000140	no	ingredients
+NH VO	UNRESOLVED_CHEMICAL	1	1	CultureMech:000140	no	ingredients
+Ca-panthothenate	UNRESOLVED_CHEMICAL	1	1	CultureMech:000140	no	ingredients
+Pyridoxine.HCL	UNRESOLVED_CHEMICAL	1	1	CultureMech:000140	no	ingredients
+Fe-EDTA complex	UNRESOLVED_CHEMICAL	1	1	CultureMech:000214	no	solutions
+Unicellular green algae micronutrient solution	SOLUTION_NAME	1	1	CultureMech:000214	no	solutions
+Volvox micronutrient solution	SOLUTION_NAME	1	1	CultureMech:000215	no	solutions
+Volvox Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000237	no	ingredients
+Vitamin B . (Cyanocobalamin)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000142	no	ingredients
+Vitamin B (Thiamine.HCl)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000142	no	ingredients
+FeCl .6H 0	UNRESOLVED_CHEMICAL	1	1	CultureMech:000142	no	ingredients
+MnCl .4H 0	UNRESOLVED_CHEMICAL	1	1	CultureMech:000142	no	ingredients
+EDTA(Disodium salt)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000142	no	ingredients
+Na EDTA.2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000143	no	ingredients
+WEES PII metal mix without Fe	UNRESOLVED_CHEMICAL	1	1	CultureMech:000216	no	solutions
+WEES Fe-EDTA solution	SOLUTION_NAME	1	1	CultureMech:000216	no	solutions
+WEES vitamin stock solution	SOLUTION_NAME	1	1	CultureMech:000216	no	solutions
+WEES soil extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:000216	no	solutions
+WC micronutrient solution	SOLUTION_NAME	1	1	CultureMech:000217	no	solutions
+WC vitamin solution	SOLUTION_NAME	1	1	CultureMech:000217	no	solutions
+Z-medium Fe-EDTA complex	UNRESOLVED_CHEMICAL	1	1	CultureMech:000218	no	solutions
+Z-medium micronutrient solution	SOLUTION_NAME	1	1	CultureMech:000218	no	solutions
+NiSO4(NH4)2SO4 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000218	no	solutions.composition
+Al2(SO4)3K2SO4 x 24 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000218	no	solutions.composition
+Nicotinamide (Niacinamide)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000146	no	ingredients
+Neutral base salt medium (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015832	no	ingredients
+Base soda medium (see Medium No. 1207 )	CROSS_REFERENCE	1	1	CultureMech:015832	no	ingredients
+Se/W solution (see Medium No. 852 )	CROSS_REFERENCE	1	1	CultureMech:015832	no	ingredients
+10% Soluble starch solution	SOLUTION_NAME	1	1	CultureMech:015832	no	ingredients
+8% NaHCO3 soluiton*	UNRESOLVED_CHEMICAL	1	1	CultureMech:015858	no	ingredients
+Nutrient broth (BD Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015860	no	ingredients
+1.0 M HEPES solution (pH 7.2)	SOLUTION_NAME	1	1	CultureMech:015860	no	ingredients
+1.0 M HEPES solution (pH 7.7)	SOLUTION_NAME	1	1	CultureMech:015861	no	ingredients
+Brain heart infusion (BD Difico)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015863	no	ingredients
+Proteose peptone (BD Difico)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015863	no	ingredients
+Rumen fluid, clarified (see Medium No. 266 )	CROSS_REFERENCE	1	1	CultureMech:015863	no	ingredients
+Na2WO2·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015871	no	ingredients
+3% Trimethylamine·HCl solution*	SOLUTION_NAME	1	1	CultureMech:007553	no	solutions
+trimethylamine・HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:007554	no	ingredients
+Sludge fluid (see Medium [M911])	CROSS_REFERENCE	1	1	CultureMech:007622	no	solutions
+Kao and Michayluk vitamin solution (Sigma--Aldrich)	SOLUTION_NAME	1	1	CultureMech:007667	no	solutions
+Soda based mineral medium (sterilized, see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007674	no	ingredients
+Halobacteria medium (see Medium [M159])	CROSS_REFERENCE	1	1	CultureMech:007740	no	solutions
+1.4% Coenzyme M solution*	SOLUTION_NAME	1	1	CultureMech:007756	no	solutions
+HCl (conc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007759	no	ingredients
+50 mM NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:007759	no	solutions
+1.4% Coenzyme M solution	SOLUTION_NAME	1	1	CultureMech:007842	no	solutions
+1 M Trimethylamine・HCl solution	SOLUTION_NAME	1	1	CultureMech:007842	no	solutions
+Trace mineral solution (see Medium [M447])	CROSS_REFERENCE	1	1	CultureMech:007855	no	solutions
+10% Fe2(SO4)3 solution (in 0.01 N H2SO4 solution)	SOLUTION_NAME	1	1	CultureMech:007901	no	solutions
+Fe(NH4)2SO4·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008192	no	ingredients
+Sulfolobus medium (see Medium [M156])	CROSS_REFERENCE	1	1	CultureMech:008217	no	solutions
+FeCl2 solution (see below)	SOLUTION_NAME	1	1	CultureMech:008380	no	solutions
+Tris-HCl buffer**	SOLUTION_NAME	1	1	CultureMech:008422	no	solutions
+Carbonate mixture*	SOLUTION_NAME	1	1	CultureMech:008422	no	solutions
+KAl(SO4)2·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008456	no	ingredients
+Na2MoO7・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008475	no	ingredients
+Methanol (10%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008601	no	ingredients
+Marine medium/Synthetic seawater mix solution (see below)	SOLUTION_NAME	1	1	CultureMech:008680	no	solutions
+Synthetic seawater mix	UNRESOLVED_CHEMICAL	1	1	CultureMech:008808	no	ingredients
+(NH4)2(Fe(SO4)2 x 6 H2O solution (0.01% w/v)	SOLUTION_NAME	1	1	CultureMech:008808	no	solutions
+General salts solution (see below)	SOLUTION_NAME	1	1	CultureMech:008809	no	solutions
+Synthetic seawater (2 x, see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008954	no	ingredients
+calcium chloride solution	SOLUTION_NAME	1	1	CultureMech:008961	no	solutions
+Fe/Mn solution	SOLUTION_NAME	1	1	CultureMech:008961	no	solutions
+Wolfe's mineral elixier	UNRESOLVED_CHEMICAL	1	1	CultureMech:009048	no	ingredients
+Powdered sulfur	UNRESOLVED_CHEMICAL	1	1	CultureMech:009123	no	ingredients
+Wolfe's mineral solution (see below)	SOLUTION_NAME	1	1	CultureMech:009148	no	solutions
+Fatty acid mixture (see below)	SOLUTION_NAME	1	1	CultureMech:009157	no	ingredients
+Thiamine x HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009165	no	ingredients
+Pyridoxine x HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009165	no	ingredients
+SrCl3 x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009181	no	solutions
+Trimethylamine x HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009201	no	ingredients
+Homo-PIPES (SIGMA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009209	no	ingredients
+NaOH (0.38 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009209	no	ingredients
+2-Mercaptoethanesulfonate (coenzyme M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009209	no	ingredients
+Nitrilotriacetate solution (0.5 M, neutralized with 10 N NaOH)	SOLUTION_NAME	1	1	CultureMech:009209	no	solutions
+TiCl3 solution (15% w/v in HCl, RIEDEL-de HAEN)	SOLUTION_NAME	1	1	CultureMech:009209	no	solutions
+(NH4)2Fe(SO4)2 x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009218	no	solutions
+(NH4)2Ni(SO4)2 solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009218	no	solutions
+Na2WO4 x 2 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009218	no	solutions
+Marine trace elements	UNRESOLVED_CHEMICAL	1	1	CultureMech:009218	no	solutions
+Fe(NH4)2(SO4)2 x 7 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009219	no	solutions
+Modified Wolin’s mineral solution	SOLUTION_NAME	1	1	CultureMech:009221	no	solutions
+K2HPO4 x 3 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009228	no	solutions
+FeCl3 solution (0.01% w/v in 0.2 N HCl)	SOLUTION_NAME	1	1	CultureMech:009228	no	solutions
+KI solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009230	no	solutions
+SrCl2x 6 H2O solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009238	no	solutions
+33% Sodium acetate solution	SOLUTION_NAME	1	1	CultureMech:009347	no	solutions
+1.42% Coenzyme M solution	SOLUTION_NAME	1	1	CultureMech:009347	no	solutions
+Tris・HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009425	no	ingredients
+H2SO4 (0.1 N)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009612	no	ingredients
+Thermococcus medium (see Medium [M273])	CROSS_REFERENCE	1	1	CultureMech:009724	no	solutions
+Iron stock solution (see Medium [M221])	CROSS_REFERENCE	1	1	CultureMech:009872	no	solutions
+5% Na2S・9H2O solution (adjusted pH to 7.0)	SOLUTION_NAME	1	1	CultureMech:009897	no	solutions
+K2S4O6 solution	SOLUTION_NAME	1	1	CultureMech:009995	no	solutions
+50% Methanol	UNRESOLVED_CHEMICAL	1	1	CultureMech:010052	no	ingredients
+Fe2(SO4)3·xH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010098	no	ingredients
+Iron (powder, 20 - 60 mesh, Nacalai)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010098	no	ingredients
+Marine trace elements solution (see Medium [M209])	CROSS_REFERENCE	1	1	CultureMech:010098	no	solutions
+Trace element solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:010181	no	solutions
+Sludge fluid (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010331	no	ingredients
+Tungstate solution (see below)	SOLUTION_NAME	1	1	CultureMech:010380	no	solutions
+10 mM Sodium acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010396	no	ingredients
+Trace metal 2 solution (see below)	SOLUTION_NAME	1	1	CultureMech:010396	no	solutions
+4 mM Na2S・9H2O solution*	SOLUTION_NAME	1	1	CultureMech:010396	no	solutions
+1.0 M MES solution* (pH 7.45)	SOLUTION_NAME	1	1	CultureMech:010396	no	solutions
+83 mM TiNTA solution (see Medium [M969])	CROSS_REFERENCE	1	1	CultureMech:010396	no	solutions
+Vitamin solution (see Medium [M969])	CROSS_REFERENCE	1	1	CultureMech:010396	no	solutions
+5% (w/v) Na2S・9H2O solution	SOLUTION_NAME	1	1	CultureMech:010408	no	solutions
+10% KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:010419	no	solutions
+CO2  gas	UNRESOLVED_CHEMICAL	1	1	CultureMech:009233	no	ingredients
+KOH solusion	UNRESOLVED_CHEMICAL	1	1	CultureMech:009220	no	ingredients
+5% (w/v) Na2S x 9 H2O solution	SOLUTION_NAME	1	1	CultureMech:003283	no	solutions
+Sodium citrate·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009523	no	ingredients
+Titanium citrate solution* (see below)	SOLUTION_NAME	1	1	CultureMech:009523	no	solutions
+KP7 buffer*	SOLUTION_NAME	1	1	CultureMech:008267	no	solutions
+Iron granule (1-2 mm)***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008281	no	solutions
+Resazurin (0.025% solution)	SOLUTION_NAME	1	1	CultureMech:009258	no	solutions
+L-Cysteine . HCl solution	SOLUTION_NAME	1	1	CultureMech:009258	no	solutions
+Na2S . 9H2O solution	SOLUTION_NAME	1	1	CultureMech:009258	no	solutions
+50% (v/v) Methanol solution*	SOLUTION_NAME	1	1	CultureMech:009543	no	solutions
+Cystein-HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:008309	no	ingredients
+Anaerobe Basal Broth CM0957	UNRESOLVED_CHEMICAL	1	1	CultureMech:001125	no	ingredients
+Rumen fluid***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008344	no	solutions
+FeSO4·7H2O****	UNRESOLVED_CHEMICAL	1	1	CultureMech:008344	no	solutions
+Carbonate solution***	SOLUTION_NAME	1	1	CultureMech:008489	no	solutions
+Na2SeO4 solution (0.1% w/v)	SOLUTION_NAME	1	1	CultureMech:009213	no	solutions
+Na2WO4 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:002022	no	ingredients
+Coenzyme M (2-mercaptoethanesulfonic acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009215	no	ingredients
+DTT (DL-Dithiothreitol)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009215	no	ingredients
+Se/W/AI solution***	SOLUTION_NAME	1	1	CultureMech:008672	no	solutions
+FeNaEDTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:009549	no	ingredients
+Sodium alpha-ketoglutamate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009549	no	ingredients
+HEPES buffer*	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+1 M NaHCO3 buffer**	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+KH2PO4 solution***	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+FeNaEDTA solution****	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+NH4Cl solution******	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+Sodium alpha-Ketoglutamate solution*******	SOLUTION_NAME	1	1	CultureMech:009549	no	solutions
+0.2% FeSO4 . 7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009208	no	ingredients
+0.1% Resazurin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009208	no	ingredients
+25% Sodium acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009208	no	ingredients
+20% Sodium formate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009208	no	ingredients
+Mineral Solution #1	SOLUTION_NAME	1	1	CultureMech:009208	no	solutions
+Mineral Solution #2	SOLUTION_NAME	1	1	CultureMech:009208	no	solutions
+20% Yeast Extract - Trypticase Solution	SOLUTION_NAME	1	1	CultureMech:009208	no	solutions
+12.5% Na2S stock solution	SOLUTION_NAME	1	1	CultureMech:009208	no	solutions
+Selenite-tungstate solution (see Medium No. 431)	CROSS_REFERENCE	1	1	CultureMech:003235	no	solutions
+Sulfur (powder)***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008136	no	solutions
+1 N H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009226	no	ingredients
+powdered sulfur	UNRESOLVED_CHEMICAL	1	1	CultureMech:008908	no	ingredients
+sulfide ore	UNRESOLVED_CHEMICAL	1	1	CultureMech:008908	no	ingredients
+Mn(II) x EDTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:002439	no	ingredients
+Sodium formate (Wako)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009451	no	ingredients
+17β-Estradiol	UNRESOLVED_CHEMICAL	1	1	CultureMech:008495	no	ingredients
+Extract Bonito*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008125	no	solutions
+Heart infusion broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:008810	no	ingredients
+Nutrient agar (Oxoid CM3)	UNRESOLVED_CHEMICAL	1	1	CultureMech:000411	no	ingredients
+2x Yeast Extract Tryptone (2xYT)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009454	no	ingredients
+yeast autolysate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+biotin (Sigma Aldrich, St Louis, MO, USA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+pyridoxal-phosphate (Sigma Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+pyridoxal-HCl (Sigma Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+hydroxocobalamin acetate salt	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+hydroxocobalamin hydrochloride	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+methylcobalamin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+cyanocobalamin (Sigma Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+tryptophan (Sigma Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009318	no	ingredients
+Combined trace element solution*	SOLUTION_NAME	1	1	CultureMech:001255	no	solutions
+MWC Vitamin mix**	UNRESOLVED_CHEMICAL	1	1	CultureMech:001255	no	solutions
+Bacto Panton	UNRESOLVED_CHEMICAL	1	1	CultureMech:001823	no	ingredients
+Bacto Bitone	UNRESOLVED_CHEMICAL	1	1	CultureMech:001823	no	ingredients
+Na-tetrathionate	UNRESOLVED_CHEMICAL	1	1	CultureMech:002151	no	ingredients
+Trace element solution* (see Medium No. 899 )	CROSS_REFERENCE	1	1	CultureMech:015833	no	ingredients
+RST trace elements (see Medium No. 933 )	CROSS_REFERENCE	1	1	CultureMech:015834	no	ingredients
+8.0 % NaHCO3 solution*	SOLUTION_NAME	1	1	CultureMech:015834	no	ingredients
+RST vitamin solution* (see Medium No. 1097 )	CROSS_REFERENCE	1	1	CultureMech:015834	no	ingredients
+Reducing agent solution (see Medium No. 521 )	CROSS_REFERENCE	1	1	CultureMech:015834	no	ingredients
+Trace vitamins solution* (see below)	SOLUTION_NAME	1	1	CultureMech:015836	no	ingredients
+4% Glycogen solution	SOLUTION_NAME	1	1	CultureMech:015836	no	ingredients
+Mineral solution B* (see below)	SOLUTION_NAME	1	1	CultureMech:015836	no	ingredients
+Ni(NH4)2(SO4)2·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015836	no	ingredients
+VOSO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:015836	no	ingredients
+0.1% Fe(III) citrate solution	SOLUTION_NAME	1	1	CultureMech:015837	no	ingredients
+0.01% Vitamin B12 solution	SOLUTION_NAME	1	1	CultureMech:015837	no	ingredients
+SL-6 Trace element solution (see Medium No. 167 )	CROSS_REFERENCE	1	1	CultureMech:015837	no	ingredients
+Trace Metal Mix A5 (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015838	no	ingredients
+EDTA·Na2	UNRESOLVED_CHEMICAL	1	1	CultureMech:015838	no	ingredients
+Na2MnO4·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015838	no	ingredients
+1 M MgSO4solution	SOLUTION_NAME	1	1	CultureMech:015839	no	ingredients
+10% Casein peptone solution	SOLUTION_NAME	1	1	CultureMech:015839	no	ingredients
+Vitamin mixture solution* (see below)	SOLUTION_NAME	1	1	CultureMech:015841	no	ingredients
+10 mM Spermidine solution* (freshly prepared)	SOLUTION_NAME	1	1	CultureMech:015841	no	ingredients
+Selenite-tungstate solution* (see Medium No. 431 )	CROSS_REFERENCE	1	1	CultureMech:015842	no	ingredients
+Vitamin mixture solution* (see Medium No. 1363 )	CROSS_REFERENCE	1	1	CultureMech:015842	no	ingredients
+Selenite-tungustate solution (see below)	SOLUTION_NAME	1	1	CultureMech:015843	no	ingredients
+1.0 mM CeCl3 solution*	SOLUTION_NAME	1	1	CultureMech:015843	no	ingredients
+1.0 N H2SO4 solution*	SOLUTION_NAME	1	1	CultureMech:015843	no	ingredients
+Mineral solution A (see Medium No. 1353 )	CROSS_REFERENCE	1	1	CultureMech:015844	no	ingredients
+1.0 M Na2S2O3 solution	SOLUTION_NAME	1	1	CultureMech:015844	no	ingredients
+0.5 M Na2HPO4 solution (pH 8.0)	SOLUTION_NAME	1	1	CultureMech:015844	no	ingredients
+Trace element solution (see Medium No. 284 )	CROSS_REFERENCE	1	1	CultureMech:015845	no	ingredients
+Trace vitamins solution* (see Medium No. 284 )	CROSS_REFERENCE	1	1	CultureMech:015845	no	ingredients
+Eugon agar (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015847	no	ingredients
+Artificial seawater (see Medium No. 736 )	CROSS_REFERENCE	1	1	CultureMech:015847	no	ingredients
+Culture supernatant (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015849	no	ingredients
+Vitamin solution (see Medium No. 403 )	CROSS_REFERENCE	1	1	CultureMech:015850	no	ingredients
+Thiamine solution (see Medium No. 403 )	CROSS_REFERENCE	1	1	CultureMech:015850	no	ingredients
+Vitamin B12 solution (see Medium No. 403 )	CROSS_REFERENCE	1	1	CultureMech:015850	no	ingredients
+1 M MgCl2·6H2O solution	SOLUTION_NAME	1	1	CultureMech:015853	no	ingredients
+1 M CaCl2·2H2O solution	SOLUTION_NAME	1	1	CultureMech:015853	no	ingredients
+Vitamin solution (see Medium No. 403 )*	CROSS_REFERENCE	1	1	CultureMech:015853	no	ingredients
+Thiamine solution (see Medium No. 403 )*	CROSS_REFERENCE	1	1	CultureMech:015853	no	ingredients
+Vitamin B12 solution (see Medium No. 403 )*	CROSS_REFERENCE	1	1	CultureMech:015853	no	ingredients
+1 M Sodium formate solution	SOLUTION_NAME	1	1	CultureMech:015853	no	ingredients
+0.002% CuCl2·2H2O solution	SOLUTION_NAME	1	1	CultureMech:015855	no	ingredients
+2 M Sodium thiosulfate solution*	SOLUTION_NAME	1	1	CultureMech:015855	no	ingredients
+Wolfe’s mineral solution (see Medium No. 265 )	CROSS_REFERENCE	1	1	CultureMech:015857	no	ingredients
+Modified A5 solution (see below)	SOLUTION_NAME	1	1	CultureMech:015859	no	ingredients
+0.1 M M FeCl2 solution	SOLUTION_NAME	1	1	CultureMech:015859	no	ingredients
+1.0 M NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:015859	no	ingredients
+Se/W solution (see Medium No. 317 )	CROSS_REFERENCE	1	1	CultureMech:015862	no	ingredients
+0.1% FeSO4·7H2O solution (in 0.1 N H2SO4)	SOLUTION_NAME	1	1	CultureMech:015862	no	ingredients
+Modified Hutner's basal salts (see Medium No. 900 )	CROSS_REFERENCE	1	1	CultureMech:015864	no	ingredients
+Distilled waterv	UNRESOLVED_CHEMICAL	1	1	CultureMech:015865	no	ingredients
+EDTA•2Na	UNRESOLVED_CHEMICAL	1	1	CultureMech:015867	no	ingredients
+10% Yeast extract (Oxoid) solution	SOLUTION_NAME	1	1	CultureMech:015867	no	ingredients
+MgSO4-7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015868	no	ingredients
+L-Cysteine•HCl•H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015868	no	ingredients
+1M Glycerin solution	SOLUTION_NAME	1	1	CultureMech:015868	no	ingredients
+MgCl2•6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015869	no	ingredients
+Sodium aceate•3H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015869	no	ingredients
+Casamino acids (BD-Difico)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015869	no	ingredients
+Tryptone (BD-Difico)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015869	no	ingredients
+Trace mineral solution (see Medium No. 852 )	CROSS_REFERENCE	1	1	CultureMech:015869	no	ingredients
+Trace vitamins solution (see Medium No. 284 )	CROSS_REFERENCE	1	1	CultureMech:015869	no	ingredients
+5% L-Cysteine•HCl•H2O solution	SOLUTION_NAME	1	1	CultureMech:015869	no	ingredients
+Na2WO4•2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015869	no	ingredients
+Na2HPO4·12H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:015872	no	ingredients
+Vitamin solution* (see Medium No. 403 )	CROSS_REFERENCE	1	1	CultureMech:015874	no	ingredients
+Thiamine solution* (see Medium No. 403 )	CROSS_REFERENCE	1	1	CultureMech:015874	no	ingredients
+1 M NaHCO3 solution	SOLUTION_NAME	1	1	CultureMech:015874	no	ingredients
+1 M Coenzyme M solution	SOLUTION_NAME	1	1	CultureMech:015874	no	ingredients
+Horse Serum (Gibco)*	UNRESOLVED_CHEMICAL	1	1	CultureMech:015875	no	ingredients
+Na2S2O4 x 2 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:003289	no	ingredients
+alginic	UNRESOLVED_CHEMICAL	1	1	CultureMech:004037	no	ingredients
+Sodium Phosphite	UNRESOLVED_CHEMICAL	1	1	CultureMech:007386	no	ingredients
+D-Ribose 5-phosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007389	no	ingredients
+Methylphosphonic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:007390	no	ingredients
+2-Aminoethylphosphonate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007391	no	ingredients
+O-Phospho-L-serine	UNRESOLVED_CHEMICAL	1	1	CultureMech:007392	no	ingredients
+Trace metal solution*	SOLUTION_NAME	1	1	CultureMech:007456	no	ingredients
+Trace element solution SL7**	SOLUTION_NAME	1	1	CultureMech:007457	no	ingredients
+Trace element solution SL7	SOLUTION_NAME	1	1	CultureMech:007457	no	solutions
+Na2HPO4·7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007463	no	ingredients
+Bicarbonate solution***	SOLUTION_NAME	1	1	CultureMech:007467	no	ingredients
+Vitamin solution****	SOLUTION_NAME	1	1	CultureMech:007472	no	ingredients
+Thiamine solution*****	SOLUTION_NAME	1	1	CultureMech:007472	no	ingredients
+Vitamin B12 solution******	SOLUTION_NAME	1	1	CultureMech:007472	no	ingredients
+Thiamine solution	SOLUTION_NAME	1	1	CultureMech:007472	no	solutions
+Vitamin B12 solution	SOLUTION_NAME	1	1	CultureMech:007472	no	solutions
+10xM9 solution	SOLUTION_NAME	1	1	CultureMech:007473	no	solutions
+Trace element solution****	SOLUTION_NAME	1	1	CultureMech:007474	no	ingredients
+FeS slurry solution*****	SOLUTION_NAME	1	1	CultureMech:007474	no	ingredients
+Mineral base 1	UNRESOLVED_CHEMICAL	1	1	CultureMech:007474	no	solutions
+Mineral base 2	UNRESOLVED_CHEMICAL	1	1	CultureMech:007474	no	solutions
+Trace salts solution*	SOLUTION_NAME	1	1	CultureMech:007483	no	ingredients
+Seawater**	UNRESOLVED_CHEMICAL	1	1	CultureMech:007488	no	ingredients
+Trace mineral solution**	SOLUTION_NAME	1	1	CultureMech:007497	no	ingredients
+Trace vitamins***	UNRESOLVED_CHEMICAL	1	1	CultureMech:007497	no	ingredients
+Salts solution***	SOLUTION_NAME	1	1	CultureMech:007501	no	ingredients
+Tween 80 solution	SOLUTION_NAME	1	1	CultureMech:007501	no	solutions
+Trace minerals*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007503	no	ingredients
+Solution A.	SOLUTION_NAME	1	1	CultureMech:007509	no	solutions
+Solution B.	SOLUTION_NAME	1	1	CultureMech:007509	no	solutions
+Biotin solution*	SOLUTION_NAME	1	1	CultureMech:007510	no	ingredients
+Biotin solution	SOLUTION_NAME	1	1	CultureMech:007510	no	solutions
+K solution	SOLUTION_NAME	1	1	CultureMech:007510	no	solutions
+M solution	SOLUTION_NAME	1	1	CultureMech:007510	no	solutions
+C solution	SOLUTION_NAME	1	1	CultureMech:007510	no	solutions
+5% L--Sodium lactate solution	SOLUTION_NAME	1	1	CultureMech:007519	no	solutions
+Mineral solution (see Medium [M500])	CROSS_REFERENCE	1	1	CultureMech:007522	no	solutions
+Vitamin solution (see Medium [M500])	CROSS_REFERENCE	1	1	CultureMech:007522	no	solutions
+A5 solution (see below)	SOLUTION_NAME	1	1	CultureMech:007528	no	solutions
+Trace element solution (see Medium [M766])	CROSS_REFERENCE	1	1	CultureMech:007531	no	solutions
+EBIOS* (dried yeast tablets)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007533	no	ingredients
+Iron(II) sulfate solution	SOLUTION_NAME	1	1	CultureMech:007535	no	solutions
+Trace mineral solution (see Medium [M1025])	CROSS_REFERENCE	1	1	CultureMech:007540	no	solutions
+sodium sulfide solution	SOLUTION_NAME	1	1	CultureMech:007543	no	solutions
+10% (w/v) Peptone solution	SOLUTION_NAME	1	1	CultureMech:007543	no	solutions
+20% (w/v) Glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:007545	no	ingredients
+10 x CMD stock solution (see below)	SOLUTION_NAME	1	1	CultureMech:007545	no	solutions
+5 x CMD micronutrient solution (see below)	SOLUTION_NAME	1	1	CultureMech:007545	no	solutions
+6.25 N H2SO4 solution	SOLUTION_NAME	1	1	CultureMech:007545	no	solutions
+8.0% (w/v) NaHCO3 solution*	SOLUTION_NAME	1	1	CultureMech:007546	no	solutions
+0.2 M Sodium acetate solution	SOLUTION_NAME	1	1	CultureMech:007546	no	solutions
+0.1 M Tris-HCl buffer (pH 7.5)	SOLUTION_NAME	1	1	CultureMech:007547	no	ingredients
+Hutner's basal salts (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007547	no	ingredients
+Thiamine·HCl·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007547	no	ingredients
+(NH4)6MoO24·4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007547	no	ingredients
+METHANOCALDOCOCCUS JANNASCHII MEDIUM (see Medium [M225])	CROSS_REFERENCE	1	1	CultureMech:007550	no	solutions
+5% Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:007551	no	solutions
+1% NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:007551	no	solutions
+1% KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:007551	no	solutions
+MRS medium (see Medium [M1])	CROSS_REFERENCE	1	1	CultureMech:007555	no	solutions
+10% MgSO4・7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007556	no	ingredients
+Modified SL-4 trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:007561	no	solutions
+Modified SL--4 trace element solution (see Medium [M1045])	CROSS_REFERENCE	1	1	CultureMech:007562	no	solutions
+1 M Disodium fumarate solution	SOLUTION_NAME	1	1	CultureMech:007564	no	solutions
+Vitamin solution No. 6 (see below)	SOLUTION_NAME	1	1	CultureMech:007565	no	solutions
+gelrite (Gellan Gum)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007567	no	ingredients
+Vitamin solution No. 6 (see Medium [M1049])	CROSS_REFERENCE	1	1	CultureMech:007567	no	solutions
+PIPES (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007568	no	ingredients
+Wolfe's modified mineral elixir (see Medium [M214])	CROSS_REFERENCE	1	1	CultureMech:007574	no	solutions
+Vitamin solution (see Medium [M214])	CROSS_REFERENCE	1	1	CultureMech:007574	no	solutions
+MODIFIED HB-1 MEDIUM (see Medium [M769])	CROSS_REFERENCE	1	1	CultureMech:007575	no	solutions
+3% Na2S・9H2O solution (neutralized)	SOLUTION_NAME	1	1	CultureMech:007575	no	solutions
+20% MES (pH 5.5) solution	SOLUTION_NAME	1	1	CultureMech:007575	no	solutions
+HEPES (free acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007577	no	ingredients
+1 M Sodium pyruvate solution*	SOLUTION_NAME	1	1	CultureMech:007577	no	solutions
+7.5 mM EDTA・Na・Fe(III) solution* (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007577	no	solutions
+HEPES solution (see below)	SOLUTION_NAME	1	1	CultureMech:007577	no	solutions
+20% (w/v) Glucose solution	SOLUTION_NAME	1	1	CultureMech:007583	no	solutions
+0.5 M L--Serine solution	SOLUTION_NAME	1	1	CultureMech:007584	no	solutions
+SW--25 solution (see Medium [M1068])	CROSS_REFERENCE	1	1	CultureMech:007586	no	solutions
+UBS solution (see Medium [M752])	CROSS_REFERENCE	1	1	CultureMech:007588	no	solutions
+1 M FeSO4 solution (pH 2.0)	SOLUTION_NAME	1	1	CultureMech:007588	no	solutions
+NaHCO3 (5%, w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007589	no	ingredients
+Sucrose (20%, w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007589	no	ingredients
+Modified Allen's trace metal solution (see below)	SOLUTION_NAME	1	1	CultureMech:007590	no	solutions
+Iron(III) citrate solution (see below)	SOLUTION_NAME	1	1	CultureMech:007590	no	solutions
+25 mM L--Cysteine・HCI solution	SOLUTION_NAME	1	1	CultureMech:007590	no	solutions
+Modified MJ synthetic seawater B (see Medium [M933])	CROSS_REFERENCE	1	1	CultureMech:007596	no	solutions
+5% Na2S・9H2O (autoclaved)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007597	no	ingredients
+8% NaHCO3 solution (filter-sterilized)	SOLUTION_NAME	1	1	CultureMech:007597	no	solutions
+Agar (Purified)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007598	no	ingredients
+A--solution (see below)	SOLUTION_NAME	1	1	CultureMech:007598	no	solutions
+B--solution (see below)	SOLUTION_NAME	1	1	CultureMech:007598	no	solutions
+0.1% (w/v) resazurin--Na	UNRESOLVED_CHEMICAL	1	1	CultureMech:007600	no	ingredients
+Pyridoxamine・2HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:007600	no	ingredients
+Phosphate solution (see Medium [M1085])	CROSS_REFERENCE	1	1	CultureMech:007602	no	solutions
+Ferrihydrite suspension (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007611	no	ingredients
+CrK(SO4)2·12H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007611	no	ingredients
+10% (w/v) Maltose solution	SOLUTION_NAME	1	1	CultureMech:007613	no	solutions
+15% MgSO4・7H2O solution	SOLUTION_NAME	1	1	CultureMech:007615	no	solutions
+30 mM CaCl2・2H2O solution	SOLUTION_NAME	1	1	CultureMech:007616	no	solutions
+20 mM MgSO4・7H2O solution	SOLUTION_NAME	1	1	CultureMech:007616	no	solutions
+20 mM (NH4)2HPO4 solution	SOLUTION_NAME	1	1	CultureMech:007616	no	solutions
+Catalase (Sigma C--10)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007617	no	ingredients
+Vitamins mix solution (see Medium [M290])	CROSS_REFERENCE	1	1	CultureMech:007619	no	solutions
+0.1 N H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:007625	no	ingredients
+0.1 M L--Cysteine・HCl・H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007638	no	ingredients
+10% Yeast extract solution*	SOLUTION_NAME	1	1	CultureMech:007638	no	solutions
+10% Casamino acids solution*	SOLUTION_NAME	1	1	CultureMech:007638	no	solutions
+Aromatic fatty acids solution (see below)	SOLUTION_NAME	1	1	CultureMech:007638	no	solutions
+20 mM NaOH solution	SOLUTION_NAME	1	1	CultureMech:007638	no	solutions
+Carboxymethyl cellulose, sodium salt	UNRESOLVED_CHEMICAL	1	1	CultureMech:007639	no	ingredients
+7% CaCl2・2H2O solution	SOLUTION_NAME	1	1	CultureMech:007639	no	solutions
+25% MgSO4・7H2O solution	SOLUTION_NAME	1	1	CultureMech:007639	no	solutions
+2% FeCl3・6H2O solution	SOLUTION_NAME	1	1	CultureMech:007639	no	solutions
+BCYE agar (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007640	no	ingredients
+Legionella agar enrichment (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007640	no	ingredients
+20% (w/v) MES solution (pH 6.0)	SOLUTION_NAME	1	1	CultureMech:007641	no	solutions
+DB CHARACTERIZATION MEDIUM NO. 2 (see Medium [M578])	CROSS_REFERENCE	1	1	CultureMech:007646	no	solutions
+Nutrient broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007649	no	ingredients
+1 M Glycerin solution	SOLUTION_NAME	1	1	CultureMech:007656	no	solutions
+0.2 M FeCl2 solution (freshly prepared)	SOLUTION_NAME	1	1	CultureMech:007659	no	solutions
+3% L-Cysteine・HCl・H2O solution	SOLUTION_NAME	1	1	CultureMech:007661	no	solutions
+0.5 M Maltose solution	SOLUTION_NAME	1	1	CultureMech:007668	no	solutions
+Acid trace element solution (see Medium [M609])	CROSS_REFERENCE	1	1	CultureMech:007676	no	solutions
+Alkaline trace element solution (see Medium [M609])	CROSS_REFERENCE	1	1	CultureMech:007676	no	solutions
+20% (w/v) sucrose solution	SOLUTION_NAME	1	1	CultureMech:007678	no	solutions
+Visniac trace elements (see Medium [M925])	CROSS_REFERENCE	1	1	CultureMech:007681	no	solutions
+Tomato juice (Del Monte)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007683	no	ingredients
+Tomato juice solution (see below)	SOLUTION_NAME	1	1	CultureMech:007683	no	solutions
+Liver extract (see Medium [M6])	CROSS_REFERENCE	1	1	CultureMech:007683	no	solutions
+Casamino acids (BD--Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007685	no	ingredients
+trisodium citrate solution	SOLUTION_NAME	1	1	CultureMech:007691	no	solutions
+maltose solution	SOLUTION_NAME	1	1	CultureMech:007692	no	solutions
+RST trace elements (see Medium [M979])	CROSS_REFERENCE	1	1	CultureMech:007695	no	solutions
+RST vitamin solution* (see below)	SOLUTION_NAME	1	1	CultureMech:007695	no	solutions
+Reducing agent solution (see Medium [M522])	CROSS_REFERENCE	1	1	CultureMech:007695	no	solutions
+10 mM Potassium phosphate buffer (pH 7.2)	SOLUTION_NAME	1	1	CultureMech:007698	no	ingredients
+Solution 1 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Solution 2 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Solution 3 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Solution 4 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+0.25 M EDTA・2Na solution (pH 8.0)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Solution 5 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Solution 6 (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Vitamin solution A (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+Vitamin solution B (see below)	SOLUTION_NAME	1	1	CultureMech:007698	no	solutions
+1.0 M Glucose solution (autoclaved)	SOLUTION_NAME	1	1	CultureMech:007699	no	solutions
+Alkaline solution (see below)	SOLUTION_NAME	1	1	CultureMech:007699	no	solutions
+Trace element solution SL--11 (see below)	SOLUTION_NAME	1	1	CultureMech:007704	no	solutions
+1 M Maltose solution	SOLUTION_NAME	1	1	CultureMech:007706	no	solutions
+SW--25 solution (see Medium [M1191])	CROSS_REFERENCE	1	1	CultureMech:007718	no	solutions
+10% Na2S2O3・5H2O solution*	SOLUTION_NAME	1	1	CultureMech:007719	no	solutions
+Vitamin mixture(see below)	SOLUTION_NAME	1	1	CultureMech:007722	no	ingredients
+Metal mixture (see below)	SOLUTION_NAME	1	1	CultureMech:007722	no	ingredients
+MnCl2・6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007722	no	ingredients
+Vitamin mixture (see Medium [M1196])	CROSS_REFERENCE	1	1	CultureMech:007723	no	solutions
+Metal mixture (see Medium [M1196])	CROSS_REFERENCE	1	1	CultureMech:007723	no	solutions
+Artificial seawater (see Medium [M1196])	CROSS_REFERENCE	1	1	CultureMech:007723	no	solutions
+Fe--Ni--WO--Se solution (see below)	SOLUTION_NAME	1	1	CultureMech:007724	no	solutions
+1 M Fructose solution*	SOLUTION_NAME	1	1	CultureMech:007729	no	solutions
+1 M Glycerin solution*	SOLUTION_NAME	1	1	CultureMech:007730	no	solutions
+Trace element solution (see Medium [M1205])	CROSS_REFERENCE	1	1	CultureMech:007733	no	solutions
+1 M Ammonium ferric citrate solution	SOLUTION_NAME	1	1	CultureMech:007735	no	solutions
+Vitamin solution II (see below)	SOLUTION_NAME	1	1	CultureMech:007738	no	solutions
+Ca(NO3)2・6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007745	no	ingredients
+1 M TES solution (pH 8.0)	SOLUTION_NAME	1	1	CultureMech:007745	no	solutions
+5 x Salts solution (see below)	SOLUTION_NAME	1	1	CultureMech:007745	no	solutions
+100 x BG--FPC solution (see below)	SOLUTION_NAME	1	1	CultureMech:007745	no	solutions
+Basic mineral salt medium 1 (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007748	no	ingredients
+Basal medium 2 (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007748	no	ingredients
+1.0 Yeast extract solution (autoclaved)	SOLUTION_NAME	1	1	CultureMech:007748	no	solutions
+Casein solution	SOLUTION_NAME	1	1	CultureMech:007748	no	solutions
+2 M NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:007748	no	solutions
+1.0% Yeast extract solution (autoclaved)	SOLUTION_NAME	1	1	CultureMech:007749	no	solutions
+Basic mineral salt medium 1 (see Medium [M1220])	CROSS_REFERENCE	1	1	CultureMech:007749	no	solutions
+Basal medium 2 (see Medium [M1220])	CROSS_REFERENCE	1	1	CultureMech:007749	no	solutions
+1.88 M CaCl2・2H2O solution	SOLUTION_NAME	1	1	CultureMech:007753	no	solutions
+Xylan (Tokyo Kasei or Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007758	no	ingredients
+1.5% Naphthalene solution (see below)	SOLUTION_NAME	1	1	CultureMech:007762	no	solutions
+R2A agar (BD--Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007764	no	ingredients
+1 M Sodium propionate solution	SOLUTION_NAME	1	1	CultureMech:007766	no	solutions
+Inorganic salts-starch agar (ISP-4) (see Medium [M50])	CROSS_REFERENCE	1	1	CultureMech:007767	no	solutions
+Modified trace vitamins (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007770	no	ingredients
+Modified Allen's trace metal solution (see Medium [M1072])	CROSS_REFERENCE	1	1	CultureMech:007774	no	solutions
+5% (w/v) CaCl2・2H2O solution	SOLUTION_NAME	1	1	CultureMech:007774	no	solutions
+5% (w/v) MgSO4・7H2O solution	SOLUTION_NAME	1	1	CultureMech:007774	no	solutions
+25 mM L-Cysteine・HCl solution	SOLUTION_NAME	1	1	CultureMech:007774	no	solutions
+10% Toray silicone SH 5535 solution	SOLUTION_NAME	1	1	CultureMech:007780	no	solutions
+Salt solution No. 1 (see below)	SOLUTION_NAME	1	1	CultureMech:007780	no	solutions
+Salt solution No. 2 (see below)	SOLUTION_NAME	1	1	CultureMech:007780	no	solutions
+Kanamycin sulfate (dissolved in distilled water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007781	no	ingredients
+Rifampicin (dissolved in methanol)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007781	no	ingredients
+Vitamins solution* (see below)	SOLUTION_NAME	1	1	CultureMech:007784	no	solutions
+Trace element solution (see Medium [M1253])	CROSS_REFERENCE	1	1	CultureMech:007785	no	solutions
+Vitamins solution (see Medium [M1253])	CROSS_REFERENCE	1	1	CultureMech:007785	no	solutions
+0.1% Vitamin K1	UNRESOLVED_CHEMICAL	1	1	CultureMech:007791	no	ingredients
+2 M NaHCO3 solution	SOLUTION_NAME	1	1	CultureMech:007795	no	solutions
+1 M Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:007795	no	solutions
+10% NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:007796	no	solutions
+10% Cellobiose solution	SOLUTION_NAME	1	1	CultureMech:007796	no	solutions
+CaCl2・2H2O solution	SOLUTION_NAME	1	1	CultureMech:007800	no	solutions
+5% MgCl2・6H2O solution	SOLUTION_NAME	1	1	CultureMech:007808	no	solutions
+1 M Sodium octanoate solution	SOLUTION_NAME	1	1	CultureMech:007811	no	solutions
+Trace element solution (see Medium [M1267])	CROSS_REFERENCE	1	1	CultureMech:007816	no	solutions
+3 mM KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:007817	no	solutions
+7.5 mM FeNaEDTA solution* (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007817	no	solutions
+HEPES solution (see Medium [M1060])	CROSS_REFERENCE	1	1	CultureMech:007817	no	solutions
+Modified trace element mixture (see Medium [M1060])	CROSS_REFERENCE	1	1	CultureMech:007817	no	solutions
+Oatmeal agar (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007822	no	ingredients
+0.1% FeSO4・7H2O solution (in 0.1 N H2SO4)	SOLUTION_NAME	1	1	CultureMech:007825	no	solutions
+40% (w/v) D-Fructose solution	SOLUTION_NAME	1	1	CultureMech:007825	no	solutions
+25% (w/v) Glycerin solution	SOLUTION_NAME	1	1	CultureMech:007829	no	solutions
+Vitamin K1 solution (see below)	SOLUTION_NAME	1	1	CultureMech:007835	no	solutions
+0.1 x Artificial seawater	UNRESOLVED_CHEMICAL	1	1	CultureMech:007839	no	ingredients
+1 M HEPES solution (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007848	no	solutions
+BG-FPC (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007860	no	ingredients
+25% Yeast extract solution*	SOLUTION_NAME	1	1	CultureMech:007860	no	solutions
+0.6% Ammonium ferric citrate solution	SOLUTION_NAME	1	1	CultureMech:007860	no	solutions
+CM+YE medium (see Medium [M51])	CROSS_REFERENCE	1	1	CultureMech:007861	no	solutions
+SL-9 mineral solution (see below)	SOLUTION_NAME	1	1	CultureMech:007868	no	solutions
+Se-Ni-W solution (see below)	SOLUTION_NAME	1	1	CultureMech:007873	no	solutions
+10% Trypticase peptone solution	SOLUTION_NAME	1	1	CultureMech:007873	no	solutions
+0.25 M Lactose solution	SOLUTION_NAME	1	1	CultureMech:007875	no	solutions
+1% FeSO4・6H2O solution (in 0.02 N H2SO4)	SOLUTION_NAME	1	1	CultureMech:007876	no	solutions
+30% Seawater solution (see below)	SOLUTION_NAME	1	1	CultureMech:007877	no	solutions
+Fe2(SO4)3・nH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007880	no	ingredients
+4% Sodium benzoate solution*	SOLUTION_NAME	1	1	CultureMech:007890	no	solutions
+Pyrocatechol solution* (see below)	SOLUTION_NAME	1	1	CultureMech:007890	no	solutions
+Stearic solution (see below)	SOLUTION_NAME	1	1	CultureMech:007891	no	solutions
+2 N NaOH solution	SOLUTION_NAME	1	1	CultureMech:007891	no	solutions
+Rabbit serum heat--inactivated at 56C for 1 hr	UNRESOLVED_CHEMICAL	1	1	CultureMech:007897	no	ingredients
+TPP/VFA mixture (see below)	SOLUTION_NAME	1	1	CultureMech:007897	no	ingredients
+7.5% NaHCO3 solution	SOLUTION_NAME	1	1	CultureMech:007897	no	solutions
+1.0 M sodium butyrate solution	SOLUTION_NAME	1	1	CultureMech:007902	no	solutions
+Columbia blood agar base (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007904	no	ingredients
+5% Xylitol solution	SOLUTION_NAME	1	1	CultureMech:007906	no	solutions
+5% Fucose solution	SOLUTION_NAME	1	1	CultureMech:007906	no	solutions
+Mn(II)・EDTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:007907	no	ingredients
+0.25% Resazurin solution	SOLUTION_NAME	1	1	CultureMech:007908	no	solutions
+10% (w/v) Colloidal chitin solution	SOLUTION_NAME	1	1	CultureMech:007909	no	solutions
+MODIFIED REINFORCED CLOSTRIDIAL MEDIUM (see Medium [M1305])	CROSS_REFERENCE	1	1	CultureMech:007911	no	solutions
+Se-Ni-W solution (see Medium [M1337])	CROSS_REFERENCE	1	1	CultureMech:007912	no	solutions
+1 N NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:007919	no	solutions
+2.0 M Sodium crotonate solution*	SOLUTION_NAME	1	1	CultureMech:007919	no	solutions
+0.1% Sodium dithionite solution (in 1 M NaHCO3)*	SOLUTION_NAME	1	1	CultureMech:007919	no	solutions
+GS2 salt solution (see below)	SOLUTION_NAME	1	1	CultureMech:007921	no	solutions
+1.25% FeSO4 solution	SOLUTION_NAME	1	1	CultureMech:007921	no	solutions
+Modified MJ synthetic seawater C (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007923	no	ingredients
+Modified MJ synthetic seawater C	UNRESOLVED_CHEMICAL	1	1	CultureMech:007925	no	ingredients
+10 mM Na2HPO4 solution	SOLUTION_NAME	1	1	CultureMech:007930	no	solutions
+10% (w/v) Xylose solution	SOLUTION_NAME	1	1	CultureMech:007931	no	solutions
+1.0 M Maltose solution	SOLUTION_NAME	1	1	CultureMech:007933	no	solutions
+Sea salts (Sigma-Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007934	no	ingredients
+0.1% Na2SeO3 solution	SOLUTION_NAME	1	1	CultureMech:007934	no	solutions
+1M Sodium thiosulfate solution	SOLUTION_NAME	1	1	CultureMech:007934	no	solutions
+PPLO broth w/o Crystal Violet (BD-Difco 255420)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007937	no	ingredients
+Bovine calf serum (heat-inactivated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007937	no	ingredients
+1% Phenol red solution (see below)	SOLUTION_NAME	1	1	CultureMech:007937	no	solutions
+1% Urea - 4% yeast extract solution (see below)	SOLUTION_NAME	1	1	CultureMech:007937	no	solutions
+CoCl2-6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007938	no	ingredients
+NiCl2-6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007938	no	ingredients
+0.5 M L-Rhamnose solution*	SOLUTION_NAME	1	1	CultureMech:007938	no	solutions
+Brucella broth (BD-BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007939	no	ingredients
+Fetal bovine serum (Biowest; heat inactivated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007939	no	ingredients
+Vitox (Oxoid) (1 vial/10 ml of rehydration fluid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007939	no	ingredients
+Amphotericin B (5 mg/ml DMSO)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007939	no	ingredients
+Skirrow supplement (Oxoid) (1 vial/2 ml of sterile, purified water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007939	no	ingredients
+0.1% Fe(NH4) citrate solution	SOLUTION_NAME	1	1	CultureMech:007941	no	solutions
+0.5% MgSO4·7H2O solution	SOLUTION_NAME	1	1	CultureMech:007941	no	solutions
+Standard mineral base (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007946	no	ingredients
+1 M Na2HPO4--KH2PO4 buffer (pH 6.8)	SOLUTION_NAME	1	1	CultureMech:007946	no	ingredients
+Hutner's vitamin free mineral base (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007946	no	ingredients
+Metals ''44'' (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007946	no	ingredients
+Cow's milk (whole fat)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007990	no	ingredients
+Oxgall (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007990	no	ingredients
+sterile defibrillated blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:008017	no	ingredients
+Bacto Blood Agar Base (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008017	no	ingredients
+Fluid thioglycolate (BD-BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008034	no	ingredients
+Tryptose phosphate broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008044	no	ingredients
+Nissui GAM Broth*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008071	no	solutions
+Bacto Marine Agar 2216 (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008095	no	ingredients
+Sterile horse serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008098	no	ingredients
+PPLO broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008098	no	ingredients
+0.4% Phenol red solution	SOLUTION_NAME	1	1	CultureMech:008098	no	solutions
+25% Solution of fresh baker's yeast extract (Gibco 360-8180)	SOLUTION_NAME	1	1	CultureMech:008098	no	solutions
+Sodium pyruvate**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008116	no	solutions
+20 mM Potassium phosphate buffer	SOLUTION_NAME	1	1	CultureMech:008117	no	ingredients
+Glucose solution (2.5%, filter-sterilized)	SOLUTION_NAME	1	1	CultureMech:008121	no	solutions
+"Mineral salt solution* (\""Hutner/Cohen-Bazire\"")"	SOLUTION_NAME	1	1	CultureMech:008121	no	solutions
+Czapek-Dox Liquid Medium, Modified (OXOID)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008144	no	ingredients
+Hipolypepton**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008160	no	solutions
+Noble Agar (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008195	no	ingredients
+Vitamin solution (see Medium [M162])	CROSS_REFERENCE	1	1	CultureMech:008195	no	solutions
+**Tween 80 solution (see Medium [M1675])	CROSS_REFERENCE	1	1	CultureMech:008234	no	solutions
+***Salts solution (see Medium [M1675])	CROSS_REFERENCE	1	1	CultureMech:008234	no	solutions
+**Tween 80 solution (see Medium [M1692])	CROSS_REFERENCE	1	1	CultureMech:008253	no	solutions
+***Salts solution (see Medium [M1692])	CROSS_REFERENCE	1	1	CultureMech:008253	no	solutions
+CM0149 Broth (OXOID)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008256	no	ingredients
+Nissui Potato Dextrose Agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:008284	no	ingredients
+Trace element solution SL-12B*	SOLUTION_NAME	1	1	CultureMech:008356	no	solutions
+Thioglycolate solution*	SOLUTION_NAME	1	1	CultureMech:008364	no	solutions
+1 N NaOH solution	SOLUTION_NAME	1	1	CultureMech:008386	no	solutions
+**Trace element solution SL7 (see Medium [M1835])	CROSS_REFERENCE	1	1	CultureMech:008409	no	solutions
+Wolfe's mineral elixier*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008410	no	solutions
+Trace element solution SL8 (see below)	SOLUTION_NAME	1	1	CultureMech:008413	no	solutions
+Balch's vitamin solution*	SOLUTION_NAME	1	1	CultureMech:008420	no	solutions
+MJ synthetic seawater**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008420	no	solutions
+Balch's trace mineral solution***	SOLUTION_NAME	1	1	CultureMech:008420	no	solutions
+*Trace elements solution (see Medium [M1875])	CROSS_REFERENCE	1	1	CultureMech:008451	no	solutions
+Metal salt solution 44***	SOLUTION_NAME	1	1	CultureMech:008452	no	solutions
+20 mM Potassium phosphate buffer (pH 7.8)	SOLUTION_NAME	1	1	CultureMech:008454	no	ingredients
+*Trace elements solution (see Medium [M1879])	CROSS_REFERENCE	1	1	CultureMech:008455	no	solutions
+Bromophenol blue (0.5% in 0.2N KOH)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008501	no	ingredients
+Dichloran (0.2% in ethanol)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008510	no	ingredients
+Fe-EDTA(III)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008512	no	ingredients
+CMRL 1066 (Gibco 330--1540)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008529	no	ingredients
+sterile rabbit serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008529	no	ingredients
+Sodium benzoate solution (3 g/50 ml)*	SOLUTION_NAME	1	1	CultureMech:008537	no	solutions
+4% Na2CO3--CO2 buffer	SOLUTION_NAME	1	1	CultureMech:008618	no	ingredients
+HCl (25% or 7.7 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008620	no	ingredients
+Selenite/tungstate solution**	SOLUTION_NAME	1	1	CultureMech:008620	no	solutions
+H2SO4 Solution (0.25 N)	SOLUTION_NAME	1	1	CultureMech:008627	no	solutions
+Trypto--soya agar (Nissui)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008691	no	ingredients
+CYC agar (see Medium [M41])	CROSS_REFERENCE	1	1	CultureMech:008723	no	solutions
+50% Glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:008734	no	ingredients
+10% Cysteine	UNRESOLVED_CHEMICAL	1	1	CultureMech:008734	no	ingredients
+Hemin (0.1% in 0.05 N NaOH)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008734	no	ingredients
+Wolfe's modified mineral elixir (see below)	SOLUTION_NAME	1	1	CultureMech:008744	no	ingredients
+Reducing solution (see below)	SOLUTION_NAME	1	1	CultureMech:008744	no	solutions
+Cyanocobalamin (Vitamin B12)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008761	no	ingredients
+Medium 87	UNRESOLVED_CHEMICAL	1	1	CultureMech:008767	no	ingredients
+Soytone (BD 243620)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008780	no	ingredients
+NaVO3 . nH2O (meta)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008780	no	ingredients
+1% (w/v) Phenol red	UNRESOLVED_CHEMICAL	1	1	CultureMech:008805	no	ingredients
+25% (w/v) Glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:008805	no	ingredients
+Salmon sperm DNA (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008805	no	ingredients
+PPLO broth powder (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008805	no	ingredients
+IsoVitaleX solution (Becton Dickinson)	SOLUTION_NAME	1	1	CultureMech:008805	no	solutions
+Basal broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:008816	no	ingredients
+Meticillin	UNRESOLVED_CHEMICAL	1	1	CultureMech:008816	no	ingredients
+Bacto pleuropneumonia-like organisms (PPLO) broth without crystal violet	UNRESOLVED_CHEMICAL	1	1	CultureMech:008816	no	ingredients
+Stock A	SOLUTION_NAME	1	1	CultureMech:008816	no	ingredients
+Stock B	SOLUTION_NAME	1	1	CultureMech:008816	no	ingredients
+Hanks' balanced salt solution	SOLUTION_NAME	1	1	CultureMech:008816	no	solutions
+Difco Bacto Marine Broth (DIFCO 2216)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008832	no	ingredients
+Medium 29	UNRESOLVED_CHEMICAL	1	1	CultureMech:008844	no	ingredients
+Na-ampicillin (may be omitted for pure cultures)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008864	no	ingredients
+Agar-agar (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008864	no	ingredients
+Hutners basal salts (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008864	no	ingredients
+(NH4)MoO7O24 x 4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008864	no	ingredients
+“Metals 44” (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008864	no	ingredients
+Solution C: Trace element solution SL-10	SOLUTION_NAME	1	1	CultureMech:008866	no	solutions
+HEPES (10mM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008869	no	ingredients
+Ni2SO4x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008870	no	ingredients
+H2SeO3(selenous acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008870	no	ingredients
+Trace element solution SL-4 (see below)	SOLUTION_NAME	1	1	CultureMech:008878	no	solutions
+Agar (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008882	no	ingredients
+*Wolfe's Mineral Solution (see below)	SOLUTION_NAME	1	1	CultureMech:008883	no	solutions
+Potassium hydroxide solution	SOLUTION_NAME	1	1	CultureMech:008883	no	solutions
+0.17 mM FeCl3 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008884	no	ingredients
+Nitrilotriacetic acid (C6H9NO6)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008884	no	ingredients
+Cyanocobalamine (vitamin B12)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008887	no	ingredients
+Yeast cell paste (bakers yeast,washed in deion. water) wet weight	UNRESOLVED_CHEMICAL	1	1	CultureMech:008887	no	ingredients
+di-Na-ß-glycerophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008887	no	ingredients
+Sea water salts solution (see below)	SOLUTION_NAME	1	1	CultureMech:008887	no	solutions
+Trace elements solution SL-4	SOLUTION_NAME	1	1	CultureMech:008887	no	solutions
+leafy soil	UNRESOLVED_CHEMICAL	1	1	CultureMech:008896	no	ingredients
+Yeast nitrogen base (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008916	no	ingredients
+Gellan Gum (Phytagel)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008921	no	ingredients
+CaCl2 x 2 H2O solution	SOLUTION_NAME	1	1	CultureMech:008921	no	solutions
+cellobiose (filter-sterilized)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008924	no	ingredients
+0.1M Tris/HCl buffer pH 7.5	SOLUTION_NAME	1	1	CultureMech:008932	no	ingredients
+Hutner's basal salts	UNRESOLVED_CHEMICAL	1	1	CultureMech:008932	no	ingredients
+Artifical sea water	UNRESOLVED_CHEMICAL	1	1	CultureMech:008932	no	ingredients
+"\""Metals 44\"""	UNRESOLVED_CHEMICAL	1	1	CultureMech:008932	no	ingredients
+5% Fe(III) citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008939	no	ingredients
+Soytone (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008939	no	ingredients
+Agar if required	UNRESOLVED_CHEMICAL	1	1	CultureMech:008942	no	ingredients
+TRIS x HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:008947	no	ingredients
+4% horse blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:008948	no	ingredients
+Glucose (α-, D+)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+Na-citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+Proteose yeastolate (TC) (DIFCO 5577-15)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+HEPES buffer (acid) (SIGMA H3375)	SOLUTION_NAME	1	1	CultureMech:008950	no	solutions.composition
+CMRL 1066/10 x Glutamin (GIBCO 042-1545)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+Solution C	SOLUTION_NAME	1	1	CultureMech:008950	no	solutions
+bovine serum albumine, fract. V (important: Sigma No A9647)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+Solution D	SOLUTION_NAME	1	1	CultureMech:008950	no	solutions
+Rabbit serum, inactivated(GIBCO 037-06120M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008950	no	solutions.composition
+N-Z-Amine	UNRESOLVED_CHEMICAL	1	1	CultureMech:008955	no	ingredients
+Na2CO3 (sterilized as a separate solution)	SOLUTION_NAME	1	1	CultureMech:008962	no	solutions
+Todd Hewitt Broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008964	no	ingredients
+Distilled water (for liquid medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008973	no	ingredients
+Distilled water (for solid medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008974	no	ingredients
+Leptospira Medium Base EMJH (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008992	no	ingredients
+Nutrient Broth (BD cat 234000)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009000	no	ingredients
+Heart Infusion Agar (BD 211065)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009008	no	ingredients
+MgCl2 x 6 H2O (200.0 g/l)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009037	no	ingredients
+KSCN solution (2 M -194 g/l)	SOLUTION_NAME	1	1	CultureMech:009037	no	solutions
+Agar Noble (if required)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009044	no	ingredients
+Yeast Extract #3 (ATCC 9678, see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009044	no	ingredients
+Yeast (Store bought Fleischmann’s yeast)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009044	no	ingredients
+benzene solution	SOLUTION_NAME	1	1	CultureMech:009050	no	solutions
+Broth Medium Marine Broth 2216 (BD 279110)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009055	no	ingredients
+sterile defibrinated sheep blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009063	no	ingredients
+Man-Rogosa-Sharpe (MRS) broth (Biokar Diagnostic, Beauvais, France)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009069	no	ingredients
+Bacto-yeast	UNRESOLVED_CHEMICAL	1	1	CultureMech:009070	no	ingredients
+CuSO2・5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009072	no	ingredients
+Crotonic acid (ALDRICH 113018)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009097	no	ingredients
+Na-crotonate solution	SOLUTION_NAME	1	1	CultureMech:009097	no	solutions
+Ca(NO3)2 x 5 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009101	no	ingredients
+Mineral base A	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+Mineral base B	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+Mineral base C	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+Mineral base D	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+PIPES (10 mM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+NaII CO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+Na2WO4 (10 mM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+FeCl3 (25mM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+NH4Cl (14% w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+KH2PO4 (7% w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009135	no	ingredients
+Trace Metals	UNRESOLVED_CHEMICAL	1	1	CultureMech:009137	no	ingredients
+erythromycin solution	SOLUTION_NAME	1	1	CultureMech:009138	no	solutions
+Resazurin (0.1% w/v in water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009146	no	ingredients
+L-Cysteine x HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009146	no	ingredients
+NaHCO3 (7.5% w/v in water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009146	no	ingredients
+Thiamine pyrophosphate (0.2% w/v in water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009146	no	ingredients
+TPP/VFA Solution	SOLUTION_NAME	1	1	CultureMech:009146	no	solutions
+Blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009149	no	ingredients
+Medium 535	UNRESOLVED_CHEMICAL	1	1	CultureMech:009149	no	ingredients
+8 N NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009153	no	ingredients
+Wilkins-Chalgren medium (Oxoid CM0643)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009154	no	ingredients
+Growth-stimulating factors	UNRESOLVED_CHEMICAL	1	1	CultureMech:009155	no	ingredients
+Glucose (sterilized separately)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009158	no	ingredients
+Synthetic seawater (2 x conc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009161	no	ingredients
+MJ(-N) synthetic seawater (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009177	no	ingredients
+SULFOLOBUS MEDIUM (see Medium [M156])	CROSS_REFERENCE	1	1	CultureMech:009187	no	solutions
+Fe(NH4)2(SO4)2 x 7 H2O (0.1% w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009190	no	ingredients
+Castenholz basal salt solution (see below)	SOLUTION_NAME	1	1	CultureMech:009225	no	solutions
+FeCl3・6H2O solution (0.03%)	SOLUTION_NAME	1	1	CultureMech:009225	no	solutions
+Nitsch's trace elements (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009225	no	solutions
+Titanium (III) citrate, neutralized	UNRESOLVED_CHEMICAL	1	1	CultureMech:009244	no	ingredients
+TiCl2	UNRESOLVED_CHEMICAL	1	1	CultureMech:009244	no	ingredients
+Meat filtrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009268	no	ingredients
+Trimethylamine . HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009271	no	ingredients
+Na3EDTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:009285	no	ingredients
+Vitamin solution of medium 141	SOLUTION_NAME	1	1	CultureMech:009296	no	solutions
+Vitamin solution of medium 503	SOLUTION_NAME	1	1	CultureMech:009296	no	solutions
+5% Na2CO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009299	no	ingredients
+Potassium phosphate buffer (1 M, pH 7.1)	SOLUTION_NAME	1	1	CultureMech:009303	no	ingredients
+CaSO4 (saturated aq. solution)	SOLUTION_NAME	1	1	CultureMech:009303	no	solutions
+Casamino acids (BD Bacto)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009306	no	ingredients
+Columbia Agar Plates with 5% sheep blood (BBL 4354005)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009320	no	ingredients
+Destilled water	UNRESOLVED_CHEMICAL	1	1	CultureMech:009323	no	ingredients
+PIPES buffer (Sigma)	SOLUTION_NAME	1	1	CultureMech:009329	no	ingredients
+Na2S-9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009329	no	ingredients
+10 mM Na2WO4 solution	SOLUTION_NAME	1	1	CultureMech:009329	no	solutions
+25 mM FeCl3 solution	SOLUTION_NAME	1	1	CultureMech:009329	no	solutions
+14% (wt/vol) NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:009329	no	solutions
+7% (wt/vol) KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:009329	no	solutions
+20% Glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:009332	no	ingredients
+TPGY broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009355	no	ingredients
+NH4CI	UNRESOLVED_CHEMICAL	1	1	CultureMech:009371	no	ingredients
+FeSO4·4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009372	no	ingredients
+AKI(SO4)2	UNRESOLVED_CHEMICAL	1	1	CultureMech:009381	no	ingredients
+sterile defibrinated horse serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:009392	no	ingredients
+Maltose--hemin solution	SOLUTION_NAME	1	1	CultureMech:009403	no	solutions
+cellobiose solution	SOLUTION_NAME	1	1	CultureMech:009436	no	solutions
+Vitamins mix solution (see below)	SOLUTION_NAME	1	1	CultureMech:009446	no	solutions
+Growth stimulating factors (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009492	no	ingredients
+*Trace element solution (SL-10) (see Medium [M2073])	CROSS_REFERENCE	1	1	CultureMech:009511	no	solutions
+**Se/W solution (see Medium [M2073])	CROSS_REFERENCE	1	1	CultureMech:009511	no	solutions
+0.1% Na2SeO4 solution	SOLUTION_NAME	1	1	CultureMech:009520	no	solutions
+NB Mineral elixir solution (see below)	SOLUTION_NAME	1	1	CultureMech:009520	no	solutions
+5% Na2CO3 solution*	SOLUTION_NAME	1	1	CultureMech:009520	no	solutions
+Corn meal agar (Nissui)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009521	no	ingredients
+2.5% N-Acetyl-D-glucosamine solution	SOLUTION_NAME	1	1	CultureMech:009525	no	solutions
+Selenite tungstate solution (see below)	SOLUTION_NAME	1	1	CultureMech:009531	no	solutions
+Na2S·9H2O solution (see Medium [M3029])	CROSS_REFERENCE	1	1	CultureMech:009542	no	solutions
+Fe(III) citrate solution (0.1 g in 100 ml)	SOLUTION_NAME	1	1	CultureMech:009544	no	solutions
+sulfidic ore	UNRESOLVED_CHEMICAL	1	1	CultureMech:009547	no	ingredients
+Gellan Gum (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009575	no	ingredients
+Distilled water 100.00 ml	UNRESOLVED_CHEMICAL	1	1	CultureMech:009590	no	ingredients
+Na2S x 9 H2O 3.00 g	UNRESOLVED_CHEMICAL	1	1	CultureMech:009590	no	ingredients
+Trace metal mix A5 + Co*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009592	no	solutions
+Na2WO2.2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009593	no	ingredients
+Ttrace element solution	SOLUTION_NAME	1	1	CultureMech:009593	no	solutions
+KI (0.01% w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009594	no	ingredients
+H2O (deionized)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009595	no	ingredients
+Trace element sol. SL-6	UNRESOLVED_CHEMICAL	1	1	CultureMech:009596	no	solutions
+Elemental sulfer	UNRESOLVED_CHEMICAL	1	1	CultureMech:009597	no	ingredients
+MJ synthetic seawater	UNRESOLVED_CHEMICAL	1	1	CultureMech:009597	no	ingredients
+Sea Salt (SIGMA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009598	no	ingredients
+MOPS buffer (SIGMA)	SOLUTION_NAME	1	1	CultureMech:009603	no	ingredients
+FeCl3 Solution	SOLUTION_NAME	1	1	CultureMech:009610	no	solutions
+4 N KOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009624	no	ingredients
+0.1 M H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009679	no	ingredients
+Cysteine hydrochloride hydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009686	no	ingredients
+Vitamin solution (medium 141; DSMZ)	SOLUTION_NAME	1	1	CultureMech:009686	no	solutions
+Trace element solution (medium 141; DSMZ)	SOLUTION_NAME	1	1	CultureMech:009686	no	solutions
+5% Sodium thiosulfate solution	SOLUTION_NAME	1	1	CultureMech:009690	no	solutions
+0.1 M Dithiothreitol solutuion*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009690	no	solutions
+Syringate solution (see below)	SOLUTION_NAME	1	1	CultureMech:009690	no	solutions
+2.5% Sodium dithionite solution	SOLUTION_NAME	1	1	CultureMech:009690	no	solutions
+2N NaOH solution	SOLUTION_NAME	1	1	CultureMech:009690	no	solutions
+Pectin (from citrus)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009697	no	ingredients
+Sal Solution*	SOLUTION_NAME	1	1	CultureMech:009703	no	solutions
+SL--4 trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:009713	no	solutions
+Yeast cell paste (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009714	no	ingredients
+Horikoshi--I medium (see Medium [M174])	CROSS_REFERENCE	1	1	CultureMech:009719	no	solutions
+Trace element solution SLA (see below)	SOLUTION_NAME	1	1	CultureMech:009732	no	solutions
+Vitamin solution VA (see below)	SOLUTION_NAME	1	1	CultureMech:009732	no	solutions
+Fe(SO4)3・xH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009734	no	ingredients
+0.1% (w/v) resazurin-Na	UNRESOLVED_CHEMICAL	1	1	CultureMech:009737	no	ingredients
+plant residue extract (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009738	no	ingredients
+rice straw	UNRESOLVED_CHEMICAL	1	1	CultureMech:009738	no	ingredients
+MJ BASAL MEDIUM (see Medium [M350])	CROSS_REFERENCE	1	1	CultureMech:009748	no	solutions
+Sol.1	UNRESOLVED_CHEMICAL	1	1	CultureMech:009754	no	ingredients
+crotonic acid solution	SOLUTION_NAME	1	1	CultureMech:009754	no	solutions
+cysteine・HCl solution	SOLUTION_NAME	1	1	CultureMech:009754	no	solutions
+Soil extract (See below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009760	no	ingredients
+sodium nicotinate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009770	no	ingredients
+Oatmeal agar (ISP-3) (see Medium [M42])	CROSS_REFERENCE	1	1	CultureMech:009776	no	solutions
+Fe(III) quinate solution (see below)	SOLUTION_NAME	1	1	CultureMech:009777	no	solutions
+5 mM Quinic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:009779	no	ingredients
+Sodium phosphate buffer (25 mM, pH 3.4)	SOLUTION_NAME	1	1	CultureMech:009785	no	ingredients
+Thiamine solution (see below)	SOLUTION_NAME	1	1	CultureMech:009785	no	solutions
+Vitamin B12 solution (see below)	SOLUTION_NAME	1	1	CultureMech:009785	no	solutions
+HNW MEDIUM (see Medium [M339])	CROSS_REFERENCE	1	1	CultureMech:009787	no	solutions
+Sol. 3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009797	no	ingredients
+Czapek--Dox liquid medium, modified (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009805	no	ingredients
+Trace element (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009818	no	solutions
+HCl (25%, 7.7 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009819	no	ingredients
+Trace element solution SL-10 (see below)	SOLUTION_NAME	1	1	CultureMech:009819	no	solutions
+N--Z Amine, type A (Sheffield)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009822	no	ingredients
+Mg(NO3)·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009835	no	ingredients
+Oatmeal, powdered (Quaker White Oats)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009836	no	ingredients
+84 g/L NaHCO3 solution (autoclaved under CO2 atmosphere)	SOLUTION_NAME	1	1	CultureMech:009838	no	solutions
+7 Vitamins solution (see Medium [M562])	CROSS_REFERENCE	1	1	CultureMech:009838	no	solutions
+Reinforced clostridial agar (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009842	no	ingredients
+Bacto agar (BD-Difco) (for solid medium)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009848	no	ingredients
+Riboflavin (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009851	no	ingredients
+sodium acetate solution	SOLUTION_NAME	1	1	CultureMech:009852	no	solutions
+ferric citrate solution	SOLUTION_NAME	1	1	CultureMech:009852	no	solutions
+L--cysteine・HCl solution	SOLUTION_NAME	1	1	CultureMech:009852	no	solutions
+CHOPPED MEAT MEDIUM (see Medium [M461])	CROSS_REFERENCE	1	1	CultureMech:009854	no	solutions
+TRYPTICASE SOY BLOOD AGAR (see Medium [M147])	CROSS_REFERENCE	1	1	CultureMech:009859	no	solutions
+Wolfe's mineral elixir (see below)	SOLUTION_NAME	1	1	CultureMech:009860	no	ingredients
+1 M Mannitol solution*	SOLUTION_NAME	1	1	CultureMech:009868	no	solutions
+Microelement solution (see below)	SOLUTION_NAME	1	1	CultureMech:009871	no	solutions
+Trace element solution (see Medium No. [480])	CROSS_REFERENCE	1	1	CultureMech:009879	no	solutions
+Modified MJ synthetic seawater (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009881	no	ingredients
+Trace element solution SL-12 (see below)	SOLUTION_NAME	1	1	CultureMech:009885	no	solutions
+Vitamin B12 (2 mg/100 ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009886	no	ingredients
+Na2S・9H2O (final concentration)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009886	no	ingredients
+Mueller Hinton II agar (BD-BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009896	no	ingredients
+Lactobacillus MRS broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009901	no	ingredients
+methane--air (50:50)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009902	no	ingredients
+20 x Phosphate solution (see below)	SOLUTION_NAME	1	1	CultureMech:009902	no	solutions
+1.0 M Sodium propionate solution*	SOLUTION_NAME	1	1	CultureMech:009903	no	solutions
+DL vitamins (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009904	no	ingredients
+DL minerals (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009904	no	ingredients
+Galactose stock solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:009904	no	solutions
+Vitamin B12 (20 μg/ml) (filter--sterilized)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009907	no	ingredients
+Ferric citrate solution (0.1%)	SOLUTION_NAME	1	1	CultureMech:009908	no	solutions
+Rhodobium gokurnum medium (see Medium [M517])	CROSS_REFERENCE	1	1	CultureMech:009909	no	solutions
+CaCl・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009912	no	ingredients
+Mineral medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009914	no	ingredients
+8.5% NaHCO3*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009914	no	solutions
+1% yeast extract solution	SOLUTION_NAME	1	1	CultureMech:009914	no	solutions
+2% Sodium pyruvate solution*	SOLUTION_NAME	1	1	CultureMech:009914	no	solutions
+Reducing agent solution (see below)	SOLUTION_NAME	1	1	CultureMech:009914	no	solutions
+Trace mineral solution (see Medium [M524])	CROSS_REFERENCE	1	1	CultureMech:009917	no	solutions
+MnCl2 solution (see below)	SOLUTION_NAME	1	1	CultureMech:009925	no	solutions
+CaCl2・2H2O solution (68 mM)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+Pyruvate solution (1 M)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+Resazurin solution (0.02%)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+K2HPO4 solution (609 mM)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+Dithionite solution (0.2 M)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+Basal salt solution (see below)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+SL--7 trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:009930	no	solutions
+Dithiothreitol (0.25 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009931	no	ingredients
+Pyridoxal・HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009931	no	ingredients
+Hemin (dissolved separately in 10 mM NaOH)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009931	no	ingredients
+Calcium folinic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:009931	no	ingredients
+β--NAD	UNRESOLVED_CHEMICAL	1	1	CultureMech:009931	no	ingredients
+NaHCO3 solution (10%, w/v)	SOLUTION_NAME	1	1	CultureMech:009931	no	solutions
+Sugar solution (250 mM each of xylose, maltose and cellobiose)	SOLUTION_NAME	1	1	CultureMech:009931	no	solutions
+Vitamin solution** (see below), 10--fold diluted	SOLUTION_NAME	1	1	CultureMech:009931	no	solutions
+Co--factors solution*** (see below)	SOLUTION_NAME	1	1	CultureMech:009931	no	solutions
+5% Sodium lactate (autoclaved)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009942	no	ingredients
+4% Fe(NH4)2(SO4)2・6H2O solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:009942	no	solutions
+5% K2HPO4 solution (autoclaved)	SOLUTION_NAME	1	1	CultureMech:009942	no	solutions
+1% Sodium ascorbate solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:009942	no	solutions
+KH2PO4 (dissolve first, adjust pH to 7.0)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009952	no	ingredients
+Sodium fumarate (adjust pH to 7.0)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009952	no	ingredients
+SL10 elements (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009952	no	ingredients
+NH4OH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009954	no	ingredients
+1 M Phosphate buffer (pH 7.2, see below)	SOLUTION_NAME	1	1	CultureMech:009955	no	ingredients
+0.09 M KNO3 solution	SOLUTION_NAME	1	1	CultureMech:009955	no	solutions
+Trace x 10 solution (see below)	SOLUTION_NAME	1	1	CultureMech:009957	no	solutions
+Mg/Ca solution (see below)	SOLUTION_NAME	1	1	CultureMech:009957	no	solutions
+Na benzoate solution (see below)	SOLUTION_NAME	1	1	CultureMech:009957	no	solutions
+7 Vitamins solution (see below)	SOLUTION_NAME	1	1	CultureMech:009957	no	solutions
+Vitamin K1 (1 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009962	no	ingredients
+Mineral solution B (see below)	SOLUTION_NAME	1	1	CultureMech:009962	no	solutions
+KH2PO4・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009966	no	ingredients
+Resazurin solution (1%)	SOLUTION_NAME	1	1	CultureMech:009966	no	solutions
+Micronutrient solution (SL7) (see below)	SOLUTION_NAME	1	1	CultureMech:009968	no	solutions
+MDS salt water (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009974	no	ingredients
+Potassium phosphate buffer* (see below)	SOLUTION_NAME	1	1	CultureMech:009974	no	ingredients
+1 M K2HPO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009974	no	ingredients
+1 M KH2PO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009974	no	ingredients
+1 M CaCl2 solution	SOLUTION_NAME	1	1	CultureMech:009974	no	solutions
+Cellulose powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:009975	no	ingredients
+Trace metal solution SL12 (see below)	SOLUTION_NAME	1	1	CultureMech:009977	no	solutions
+1.0 M Sodium acetate (filter--sterilized)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009980	no	ingredients
+5% NaHCO3 solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:009980	no	solutions
+Vitamin B12 solution (20 μg/L)	SOLUTION_NAME	1	1	CultureMech:009981	no	solutions
+V8 canned vegetable juice (Campbell)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009986	no	ingredients
+HCl (25% v/ v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009990	no	ingredients
+Fe--Citrate solution (0.1%, w/v)	SOLUTION_NAME	1	1	CultureMech:009990	no	solutions
+20% Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:009991	no	solutions
+Starch solution (see below)	SOLUTION_NAME	1	1	CultureMech:009992	no	solutions
+Trypticase soy agar (see Medium [M66])	CROSS_REFERENCE	1	1	CultureMech:009997	no	solutions
+benzene (water-saturated, autoclaved)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009999	no	ingredients
+Sodium β--glycerophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010000	no	ingredients
+5.0 mM Toluene (water--saturated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010006	no	ingredients
+1.0 M NaNO3 solution	SOLUTION_NAME	1	1	CultureMech:010006	no	solutions
+Vitamin solution (see Medium [M1032])	CROSS_REFERENCE	1	1	CultureMech:010007	no	solutions
+6 N HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:010008	no	ingredients
+Acid trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:010008	no	solutions
+Alkaline trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:010008	no	solutions
+Cooked meat medium (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010012	no	ingredients
+Metal solution (see below)	SOLUTION_NAME	1	1	CultureMech:010014	no	solutions
+Metal solution (see Medium [M614])	CROSS_REFERENCE	1	1	CultureMech:010015	no	solutions
+Phosphate solution (see Medium [M614])	CROSS_REFERENCE	1	1	CultureMech:010015	no	solutions
+MnCl4・4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010025	no	ingredients
+Trace element solution SL12B (see below)	SOLUTION_NAME	1	1	CultureMech:010025	no	solutions
+Blood agar base (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010030	no	ingredients
+Sodium lactate solution (50%)	SOLUTION_NAME	1	1	CultureMech:010032	no	solutions
+0.5 M Na2S・9H2O solution	SOLUTION_NAME	1	1	CultureMech:010032	no	solutions
+FeS solution (see below)	SOLUTION_NAME	1	1	CultureMech:010042	no	solutions
+Artificial saltwater (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010043	no	ingredients
+Hunter's basal salts (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010045	no	ingredients
+Hunter's basal salts (see Medium [M644])	CROSS_REFERENCE	1	1	CultureMech:010046	no	solutions
+Trace element solution (see Medium [M481])	CROSS_REFERENCE	1	1	CultureMech:010058	no	solutions
+EDTA・2Na・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010059	no	ingredients
+Na2S・9H2O(final conc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010065	no	ingredients
+Na2S2O3・5H2O (final conc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010068	no	ingredients
+0.5 x Artificial seawater (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010069	no	ingredients
+0.5 x Artificial seawater (see Medium [M666])	CROSS_REFERENCE	1	1	CultureMech:010070	no	solutions
+6.0% Sodium lactate solution (filter--sterilized)	SOLUTION_NAME	1	1	CultureMech:010074	no	solutions
+R2A broth (Daigo)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010080	no	ingredients
+Artificial seawater (see Medium [M675])	CROSS_REFERENCE	1	1	CultureMech:010080	no	solutions
+10% Casamino acids solution	SOLUTION_NAME	1	1	CultureMech:010083	no	solutions
+0.1 M Dithiothreitol solution*	SOLUTION_NAME	1	1	CultureMech:010083	no	solutions
+1 mM Na2SeO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:010088	no	ingredients
+0.4% CaCl2・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010088	no	ingredients
+2 M Sodium acetate (pH 7.0)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010088	no	ingredients
+130 mM FeCl2	UNRESOLVED_CHEMICAL	1	1	CultureMech:010088	no	ingredients
+Ferric quinate solution (see below)	SOLUTION_NAME	1	1	CultureMech:010092	no	solutions
+Ferric quinate solution (see Medium [M687])	CROSS_REFERENCE	1	1	CultureMech:010093	no	solutions
+8% (w/v) Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:010099	no	solutions
+0.1% (w/v) Sodium resazurin solution	SOLUTION_NAME	1	1	CultureMech:010099	no	solutions
+S I solution (see below)	SOLUTION_NAME	1	1	CultureMech:010099	no	solutions
+S II solution (see below)	SOLUTION_NAME	1	1	CultureMech:010099	no	solutions
+fatty acid mixture	SOLUTION_NAME	1	1	CultureMech:010100	no	ingredients
+Brucella agar (BD-BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010102	no	ingredients
+1,2--Dichloropropane (10 mg/ml in methanol)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010104	no	ingredients
+Vancomycin・HCl solution (10 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:010104	no	solutions
+5% Na2S・9H2O solution*	SOLUTION_NAME	1	1	CultureMech:010105	no	solutions
+L--Cysteine・HCl・H2O solution*	SOLUTION_NAME	1	1	CultureMech:010105	no	solutions
+5% L--Cysteine・HCl・H2O solution (separately sterilized)	SOLUTION_NAME	1	1	CultureMech:010106	no	solutions
+Liver extract (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010107	no	ingredients
+liver powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:010107	no	ingredients
+Acetate (final concentration)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010108	no	ingredients
+Thiosulfate (final concentration)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010108	no	ingredients
+Methanol solution (see below)*	SOLUTION_NAME	1	1	CultureMech:010114	no	solutions
+Sodium formate solution (see below)*	SOLUTION_NAME	1	1	CultureMech:010115	no	solutions
+Thiamine・HCl (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010117	no	ingredients
+2% KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:010122	no	solutions
+10% Yeast extract (BD-Difco) solution	SOLUTION_NAME	1	1	CultureMech:010125	no	solutions
+Modified trace element solution SL--12 (see below)	SOLUTION_NAME	1	1	CultureMech:010128	no	solutions
+Seven vitamins solution (see below)	SOLUTION_NAME	1	1	CultureMech:010128	no	solutions
+Base solution A (see below)	SOLUTION_NAME	1	1	CultureMech:010134	no	solutions
+Base solution B (see below)	SOLUTION_NAME	1	1	CultureMech:010134	no	solutions
+Fe citrate solution (see below)	SOLUTION_NAME	1	1	CultureMech:010134	no	solutions
+7% NaHCO3 solution*	SOLUTION_NAME	1	1	CultureMech:010137	no	solutions
+2.5% L--Cysteine・HCl・H2O solution	SOLUTION_NAME	1	1	CultureMech:010137	no	solutions
+Lowenstein--Jensen medium slants (BD 220908)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010144	no	ingredients
+24% Na2S・9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010145	no	ingredients
+(NH4)6Mo7O7・4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010145	no	ingredients
+Se--W solution (see below)	SOLUTION_NAME	1	1	CultureMech:010145	no	solutions
+10 mM NaOH solution	SOLUTION_NAME	1	1	CultureMech:010145	no	solutions
+1 M NaNO3 solution	SOLUTION_NAME	1	1	CultureMech:010149	no	solutions
+Soluble starch (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010150	no	ingredients
+Hy--Case Amino (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010150	no	ingredients
+7% K2HPO4solution	SOLUTION_NAME	1	1	CultureMech:010152	no	solutions
+7% K2HPO4 solution	SOLUTION_NAME	1	1	CultureMech:010153	no	solutions
+HBS solution (see below)	SOLUTION_NAME	1	1	CultureMech:010157	no	solutions
+1 M ZnSO4 solution	SOLUTION_NAME	1	1	CultureMech:010157	no	solutions
+1 M Glycerol solution	SOLUTION_NAME	1	1	CultureMech:010157	no	solutions
+UBS solution (see below)	SOLUTION_NAME	1	1	CultureMech:010158	no	solutions
+0.1 M K2S4O6 solution	SOLUTION_NAME	1	1	CultureMech:010158	no	solutions
+Rye--bran extract (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010159	no	ingredients
+Rye--bran	UNRESOLVED_CHEMICAL	1	1	CultureMech:010159	no	ingredients
+Trypsin (Sigma--Aldrich)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010159	no	ingredients
+0.1 M L--Sodium lactate solution*	SOLUTION_NAME	1	1	CultureMech:010169	no	solutions
+8.0% Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:010172	no	solutions
+3.0% L--Cysteine・HCl・H2O solution	SOLUTION_NAME	1	1	CultureMech:010172	no	solutions
+KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:010172	no	solutions
+CoSO4・7H2	UNRESOLVED_CHEMICAL	1	1	CultureMech:010173	no	ingredients
+0.05 M PIPES (pH 7.0) solution	SOLUTION_NAME	1	1	CultureMech:010176	no	solutions
+3% Na2S·9H2O solution (neutralized)	SOLUTION_NAME	1	1	CultureMech:010176	no	solutions
+8.5% NaHCO3 solution	SOLUTION_NAME	1	1	CultureMech:010180	no	solutions
+100 mM FeCl2 solution	SOLUTION_NAME	1	1	CultureMech:010180	no	solutions
+15% Sodium formate solution	SOLUTION_NAME	1	1	CultureMech:010184	no	solutions
+NE23-3 MEDIUM (see Medium [M505])	CROSS_REFERENCE	1	1	CultureMech:010185	no	solutions
+0.1 M Potassium phosphate buffer, pH 7.5	SOLUTION_NAME	1	1	CultureMech:010186	no	ingredients
+25% Sodium pyruvate solution*	SOLUTION_NAME	1	1	CultureMech:010186	no	solutions
+16% Sodium fumarate solution*	SOLUTION_NAME	1	1	CultureMech:010186	no	solutions
+Trisodium citrate・H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010192	no	ingredients
+1.0 M KNO3 solution	SOLUTION_NAME	1	1	CultureMech:010194	no	solutions
+Horse serum (heat--inactivated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010196	no	ingredients
+25% Yeast Extract Solution	SOLUTION_NAME	1	1	CultureMech:010196	no	solutions
+lactic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:010199	no	ingredients
+5% Na2S・9H2Osolution	SOLUTION_NAME	1	1	CultureMech:010202	no	solutions
+2.0 M NH4HCO3 solution	SOLUTION_NAME	1	1	CultureMech:010203	no	solutions
+washed agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:010207	no	ingredients
+32% HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:010208	no	ingredients
+1.0 M Betaine solution	SOLUTION_NAME	1	1	CultureMech:010208	no	solutions
+2% Malachite green solution	SOLUTION_NAME	1	1	CultureMech:010210	no	solutions
+0.1% Fe(NH4) citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010215	no	ingredients
+0.5% MgSO4・7H2O solution	SOLUTION_NAME	1	1	CultureMech:010215	no	solutions
+MINERAL MEDIUM FOR HYDROGENOPHILUS ISLANDICUM (see Medium [M803])	CROSS_REFERENCE	1	1	CultureMech:010216	no	solutions
+Thioglycolate--ascorbate solution* (see below)	SOLUTION_NAME	1	1	CultureMech:010221	no	solutions
+25% KH2PO4 solution	SOLUTION_NAME	1	1	CultureMech:010226	no	solutions
+Microelement solution (see Medium [M484])	CROSS_REFERENCE	1	1	CultureMech:010244	no	solutions
+0.1 M Sodium sulfite solution	SOLUTION_NAME	1	1	CultureMech:010244	no	solutions
+Sodium dithionite solution (100 mg/L)*	SOLUTION_NAME	1	1	CultureMech:010244	no	solutions
+MRS broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010252	no	ingredients
+S6 medium (see Medium [M81])	CROSS_REFERENCE	1	1	CultureMech:010254	no	solutions
+R2A broth (DAIGO) (Nihon Pharm. Co.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010255	no	ingredients
+1,4--dithiothreitol (DTT)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010263	no	ingredients
+NaHPO4・12H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010271	no	ingredients
+1.0 M Phosphate buffer (see below)	SOLUTION_NAME	1	1	CultureMech:010273	no	ingredients
+Trichloroethylene (10 mg/ml in methanol)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010279	no	ingredients
+1.0 M MOPS solution (pH 7.4)	SOLUTION_NAME	1	1	CultureMech:010279	no	solutions
+25 mM Ti(III) NTA solution (see below)	SOLUTION_NAME	1	1	CultureMech:010279	no	solutions
+Chelated iron solution (see below)	SOLUTION_NAME	1	1	CultureMech:010280	no	solutions
+1.0 M Sodium lactate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010283	no	ingredients
+Artificial seawater (see Medium [M761])	CROSS_REFERENCE	1	1	CultureMech:010285	no	solutions
+Titanium citrate solution (see below)	SOLUTION_NAME	1	1	CultureMech:010286	no	solutions
+10% Fructose solution	SOLUTION_NAME	1	1	CultureMech:010295	no	solutions
+100 x Vitamin mixture (see below)	SOLUTION_NAME	1	1	CultureMech:010303	no	ingredients
+m TGE BROTH MEDIUM (see Medium [M828])	CROSS_REFERENCE	1	1	CultureMech:010305	no	solutions
+lactate solution	SOLUTION_NAME	1	1	CultureMech:010311	no	solutions
+Modified UBS solution (see below)	SOLUTION_NAME	1	1	CultureMech:010313	no	solutions
+100 mM Potassium tetrathionate solution	SOLUTION_NAME	1	1	CultureMech:010315	no	solutions
+testosterone	UNRESOLVED_CHEMICAL	1	1	CultureMech:010316	no	ingredients
+Pyridoxamine・HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:010316	no	ingredients
+testosterone solution	SOLUTION_NAME	1	1	CultureMech:010316	no	solutions
+Selenite--tungstate solution	SOLUTION_NAME	1	1	CultureMech:010316	no	solutions
+Inorganic salts-starch agar (ISP--4) (see Medium [M50])	CROSS_REFERENCE	1	1	CultureMech:010319	no	solutions
+1% Sodium dithionite solution* (freshly prepared)	SOLUTION_NAME	1	1	CultureMech:010322	no	solutions
+sodium dithionate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010335	no	ingredients
+0.5% Na2CO3 solution	SOLUTION_NAME	1	1	CultureMech:010335	no	solutions
+4.8% KAl(SO4)2・12H2O solution	SOLUTION_NAME	1	1	CultureMech:010335	no	solutions
+6% Sodium benzoate solution	SOLUTION_NAME	1	1	CultureMech:010335	no	solutions
+Larchwood xylan (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010340	no	ingredients
+Visniac trace elements (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010346	no	solutions
+Modified MJ synthetic seawater B (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010355	no	ingredients
+5% Na2S・9H2O solution (pH 7.5)	SOLUTION_NAME	1	1	CultureMech:010355	no	solutions
+Probumin Universal Grade (Millipore)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010359	no	ingredients
+TC Yeastolate (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010359	no	ingredients
+Rabbit serum sterile non--hemolyzed young (Pel--Freez code No. 31125)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010359	no	ingredients
+MEM alpha Modification (BioWest)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010359	no	ingredients
+5% Na2S·9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010363	no	ingredients
+Modified Hutner's basal salts (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010364	no	ingredients
+(NH4)6MoO24・4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010364	no	ingredients
+Na2S・9H2O (10%, w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010376	no	ingredients
+5% Yeast extract solution	SOLUTION_NAME	1	1	CultureMech:010376	no	solutions
+0.5 M Sodium acetate solution	SOLUTION_NAME	1	1	CultureMech:010376	no	solutions
+0.5 M Sodium succinate solution	SOLUTION_NAME	1	1	CultureMech:010376	no	solutions
+Seven vitamins solution (see Medium [M720])	CROSS_REFERENCE	1	1	CultureMech:010376	no	solutions
+1.0 x Artificial seawater (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010378	no	ingredients
+1.0 x Artificial seawater (see Medium [M954])	CROSS_REFERENCE	1	1	CultureMech:010379	no	solutions
+Modified Wolfe's mineral solution (see below)	SOLUTION_NAME	1	1	CultureMech:010386	no	solutions
+0.01 M FeSO4·5H2Osolution (in 0.02 N HCl)	SOLUTION_NAME	1	1	CultureMech:010386	no	solutions
+5% L--Cysteine・HCl・H2O solution (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:010389	no	solutions
+0.01 M FeSO4・5H2Osolution (in 0.02 N HCl) (optional)	SOLUTION_NAME	1	1	CultureMech:010389	no	solutions
+Major metals (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010394	no	ingredients
+20 mM Sodium acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:010394	no	ingredients
+1 M Tris base (pH 8)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010394	no	ingredients
+Trace metal 1 solution (see below)	SOLUTION_NAME	1	1	CultureMech:010394	no	solutions
+2% Yeast extract solution	SOLUTION_NAME	1	1	CultureMech:010394	no	solutions
+0.5 M HOMOPIPES solution* (pH 5.4)	SOLUTION_NAME	1	1	CultureMech:010394	no	solutions
+83 mM TiNTA solution* (see below)	SOLUTION_NAME	1	1	CultureMech:010394	no	solutions
+15% TiCl3 solution	SOLUTION_NAME	1	1	CultureMech:010394	no	solutions
+fructose solution	SOLUTION_NAME	1	1	CultureMech:010398	no	solutions
+sodium octanoate solution	SOLUTION_NAME	1	1	CultureMech:010399	no	solutions
+Leibovitz's L--15 medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:010402	no	ingredients
+1.0 M Methanol solution	SOLUTION_NAME	1	1	CultureMech:010409	no	solutions
+0.025 M Crotonic acid solution (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:010410	no	solutions
+Na2S2O4・2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:010415	no	ingredients
+0.1 N H2SO4 solution	SOLUTION_NAME	1	1	CultureMech:010415	no	solutions
+Skim milk (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010417	no	ingredients
+Rabbit serum heat--inactivated at 56&#8451; for 30 min	UNRESOLVED_CHEMICAL	1	1	CultureMech:010421	no	ingredients
+10 x Korthof's basal medium (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010421	no	ingredients
+Gauze's synthetic medium No. 1 (see Medium [M72])	CROSS_REFERENCE	1	1	CultureMech:010424	no	solutions
+Salt solution R (see below)	SOLUTION_NAME	1	1	CultureMech:010429	no	solutions
+100 mM Na2HPO4 solution	SOLUTION_NAME	1	1	CultureMech:009698	no	solutions
+Vitamin solution (see Medium [M1395])	CROSS_REFERENCE	1	1	CultureMech:009698	no	solutions
+Yeast--starch agar (A) (see Medium [M34])	CROSS_REFERENCE	1	1	CultureMech:010249	no	solutions
+Cellobiose or Cellulose (MN 300)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008423	no	ingredients
+Rice Extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:008655	no	ingredients
+Fe2(SO4)3·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008367	no	ingredients
+1 N HCl solution	SOLUTION_NAME	1	1	CultureMech:009693	no	solutions
+Larchwood xylan	UNRESOLVED_CHEMICAL	1	1	CultureMech:003349	no	ingredients
+Na2-tartrate x 2 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:001041	no	ingredients
+K2HPO4·7H2O (6 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+MgSO4·7H2O (6 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+Na2CO3 (4 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+CaCl2·2H2O (2.5 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+Na2SiO3·9H2O (4.64 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+Citric acid·H2O (4.8 g/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+Sterile air	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+K2HPO4·7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008820	no	ingredients
+Kanamycin solution (25 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008611	no	solutions
+Nalidixic acid solution (100 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008611	no	solutions
+Nalidixic acid solution (50 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008610	no	solutions
+Vitamin K	UNRESOLVED_CHEMICAL	1	1	CultureMech:009243	no	ingredients
+0.1 M Phenol solution* (freshly prepared)	SOLUTION_NAME	1	1	CultureMech:007549	no	solutions
+Fe-Citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009631	no	ingredients
+10-M NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009631	no	ingredients
+Trace metals	UNRESOLVED_CHEMICAL	1	1	CultureMech:009631	no	ingredients
+FeSO4 x 7 H2O (0.2% w/v)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009205	no	ingredients
+5% Na2S・9H2O solution (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007716	no	solutions
+Wilkins Chalgrene Anaerobe Broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:001945	no	ingredients
+Bicarbonate-buffered basal medium (BBM)	SOLUTION_NAME	1	1	CultureMech:008779	no	ingredients
+Minerals	UNRESOLVED_CHEMICAL	1	1	CultureMech:008779	no	ingredients
+API 50 CHB/E Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009376	no	ingredients
+Trace elements solution (Pfennig & Lippert, 1966)	SOLUTION_NAME	1	1	CultureMech:000963	no	solutions
+SL10	UNRESOLVED_CHEMICAL	1	1	CultureMech:000992	no	ingredients
+MnCl4 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:002487	no	ingredients
+Artificial seawater (4x, see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007903	no	ingredients
+add deionized water to	UNRESOLVED_CHEMICAL	1	1	CultureMech:009091	no	ingredients
+Fastidious Anaerobe Agar (acumedia)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009091	no	ingredients
+Trace element solution SLA	SOLUTION_NAME	1	1	CultureMech:002717	no	solutions
+Vitamin solution VA	SOLUTION_NAME	1	1	CultureMech:002717	no	solutions
+Base Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:008854	no	ingredients
+3N NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:008854	no	ingredients
+1M Potassium Phosphate (pH 7.0)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008854	no	ingredients
+0.1M L-arginine	UNRESOLVED_CHEMICAL	1	1	CultureMech:008854	no	ingredients
+Stock Solutions	SOLUTION_NAME	1	1	CultureMech:008854	no	solutions
+CuSO4･7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009571	no	ingredients
+*trace elements solution	SOLUTION_NAME	1	1	CultureMech:009571	no	solutions
+ACES (N-(2-Acetamido)-2-aminoethanesulfonic acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008646	no	ingredients
+Soluble iron pyrophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008646	no	ingredients
+α-Ketoglutarate potassium	UNRESOLVED_CHEMICAL	1	1	CultureMech:008646	no	ingredients
+L-Cysteine hydrochloride	UNRESOLVED_CHEMICAL	1	1	CultureMech:008646	no	ingredients
+Acetaldehyde**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008613	no	solutions
+Benzaldehyde**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008614	no	solutions
+Formaldehyde**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008615	no	solutions
+Na2MoO4·4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	ingredients
+20 x PO4*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+100 x (NH4)2SO4**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+1000 x FeSO4***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+1000 x MgCl2****	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+1000 x Trace elements*****	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+1000 x Na2MoO4******	UNRESOLVED_CHEMICAL	1	1	CultureMech:008625	no	solutions
+distilled or deionized water	UNRESOLVED_CHEMICAL	1	1	CultureMech:009411	no	ingredients
+Cobalt sulfate heptahydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008825	no	ingredients
+di‐Potassium hydrogen orthophosphate trihydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008825	no	ingredients
+Sodium dihydrogen orthophosphate monohydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008825	no	ingredients
+CAS amino acids	UNRESOLVED_CHEMICAL	1	1	CultureMech:008825	no	ingredients
+ACES Buffer	SOLUTION_NAME	1	1	CultureMech:009559	no	ingredients
+Marine Broth 2216**	UNRESOLVED_CHEMICAL	1	1	CultureMech:009559	no	solutions
+Legionella CYE Agar Base*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009559	no	solutions
+MnSO4・xH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:002778	no	ingredients
+Trace metal mix A5 + Co	UNRESOLVED_CHEMICAL	1	1	CultureMech:009170	no	ingredients
+Trace metal mix A5+Co contains (gl-l)*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008951	no	solutions
+Bovine blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:008835	no	ingredients
+Tween 80 (pH 8.0)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009059	no	ingredients
+BL Agar*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008201	no	solutions
+BL AGAR (GLUCOSE BLOOD LIVER AGAR) (see Medium [M6])	CROSS_REFERENCE	1	1	CultureMech:009801	no	solutions
+Heart muscle infusion solids	UNRESOLVED_CHEMICAL	1	1	CultureMech:003056	no	ingredients
+Blood agar medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:008862	no	ingredients
+TNM-FH Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:001033	no	ingredients
+L-15 medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:001155	no	ingredients
+Kanamycin*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008539	no	solutions
+Sodium benzoate*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008539	no	solutions
+Bordet-Gengou Agar Base (BD 248200)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008893	no	ingredients
+Bordet Gengou agar (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009394	no	ingredients
+defibrinated horse blood (TCS Biologicals)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009394	no	ingredients
+sheep’s blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009393	no	ingredients
+Bordet-Gengou agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009393	no	ingredients
+Bordet-Gengou Broth Base (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008894	no	ingredients
+laked horse blood (Hema Resource & Supply, Aurora, OR)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009466	no	ingredients
+horse blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009397	no	ingredients
+calf blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009396	no	ingredients
+brain–heart infusion agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009396	no	ingredients
+C. difficile supplement	UNRESOLVED_CHEMICAL	1	1	CultureMech:009359	no	ingredients
+Beef heart infusion solids	UNRESOLVED_CHEMICAL	1	1	CultureMech:008801	no	ingredients
+Brain infusion solids	UNRESOLVED_CHEMICAL	1	1	CultureMech:008801	no	ingredients
+thiamine monophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009497	no	ingredients
+brain-heart infusion broth (Difco Laboratories)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009497	no	ingredients
+Difco brain-heart infusion broth (BD Biosciences)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009499	no	ingredients
+brain-heart infusion broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009375	no	ingredients
+hemin (ICN)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009491	no	ingredients
+NAD (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009491	no	ingredients
+Brewer anaerobic agar (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010090	no	ingredients
+Sheep Blood, defibrinated	UNRESOLVED_CHEMICAL	1	1	CultureMech:009246	no	ingredients
+Yeastolate (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008994	no	ingredients
+N-acetylglucosamine (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008994	no	ingredients
+N-2-hydroxyethylpiperazine-N-2-ethanesulfonic acid (HEPES, Sigma Chemical Co., St. Louis, MO)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008994	no	ingredients
+10X concentrate of CMRL 1066 without glutamine (Gibco Laboratories, GrandIsland, NY, No.330-1540)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008994	no	ingredients
+Basal salts medium (BSM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008988	no	ingredients
+(NH4)SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:008988	no	ingredients
+FeCl3 x 6H2O solution (0.1% w/v in 0.2 N HCl)	SOLUTION_NAME	1	1	CultureMech:009111	no	solutions
+Clarified Vero E6 cell culture supernatant fluid	UNRESOLVED_CHEMICAL	1	1	CultureMech:003345	no	solutions
+Iscove's Modified Dulbecco's Medium (IMDM, GlutaMAX)	UNRESOLVED_CHEMICAL	1	1	CultureMech:003345	no	solutions.composition
+Wolin’s vitamin solution	SOLUTION_NAME	1	1	CultureMech:009229	no	solutions
+Aspartic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:008827	no	ingredients
+Tyrosine	UNRESOLVED_CHEMICAL	1	1	CultureMech:008827	no	ingredients
+Retinol	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Deoxyribose	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+alpha-Tocopherol	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Cyanocob(III)alamin	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Vitamin D3	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Ferric nitrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Arginine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Histidine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Adenosine sulfate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Guanine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:007240	no	ingredients
+Ca3(PO4)2	UNRESOLVED_CHEMICAL	1	1	CultureMech:008766	no	ingredients
+Spermine phosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007212	no	ingredients
+Diammonium tartrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007232	no	ingredients
+3 M HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009589	no	ingredients
+(NH4)2SO4FeSO4 × 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009589	no	ingredients
+(NH4)2SO4NiSO4 × 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009589	no	ingredients
+Na2SeO4 × 5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009589	no	ingredients
+Pulp of sour stone cherries	UNRESOLVED_CHEMICAL	1	1	CultureMech:001374	no	ingredients
+isovitalex (BD Biosciences)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009498	no	ingredients
+chocolate agar plates	UNRESOLVED_CHEMICAL	1	1	CultureMech:009498	no	ingredients
+Hemoglobin	UNRESOLVED_CHEMICAL	1	1	CultureMech:008743	no	ingredients
+PolyViteX	UNRESOLVED_CHEMICAL	1	1	CultureMech:008743	no	ingredients
+Columbia blood agar base	UNRESOLVED_CHEMICAL	1	1	CultureMech:002436	yes	ingredients
+Chopped Meat Broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009264	no	ingredients
+Resazurin Solution (0.025%)	SOLUTION_NAME	1	1	CultureMech:009264	no	solutions
+Resazurin Soln (0.025%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009272	no	ingredients
+Formate and Fumarate Solution	SOLUTION_NAME	1	1	CultureMech:009185	no	solutions
+CHROMagerTM Malassezia/Candida*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008463	no	solutions
+Ethlyene Diamine Tetraacetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009124	no	ingredients
+Pyrodoxamine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009124	no	ingredients
+Na selenite	UNRESOLVED_CHEMICAL	1	1	CultureMech:009124	no	ingredients
+Solution 1+2+3	SOLUTION_NAME	1	1	CultureMech:009124	no	solutions
+Solution 2+3	SOLUTION_NAME	1	1	CultureMech:009124	no	solutions
+Heavy Metal Solution	SOLUTION_NAME	1	1	CultureMech:009124	no	solutions
+Modified Hogland trace elements solution	SOLUTION_NAME	1	1	CultureMech:009124	no	solutions
+Chrysalis extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:008263	no	ingredients
+Antifoam C	UNRESOLVED_CHEMICAL	1	1	CultureMech:009356	no	ingredients
+Carbon source (i.e. cellobiose)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009245	no	ingredients
+FeSO4 (1.25% solution)	SOLUTION_NAME	1	1	CultureMech:009245	no	solutions
+Resazurin (1.0% solution)	SOLUTION_NAME	1	1	CultureMech:009245	no	solutions
+Gellangum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008443	no	ingredients
+Columbia Agar with 5% Sheep Blood (BD-BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008653	no	ingredients
+bovine blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009496	no	ingredients
+Columbia blood agar (Difco Laboratories, Detroit, Mich.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009496	no	ingredients
+Columbia blood agar (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008812	no	ingredients
+Special peptone	UNRESOLVED_CHEMICAL	1	1	CultureMech:008812	no	ingredients
+Columbia broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:008843	no	ingredients
+Tris (Hydroxymethyl) Aminomethane	UNRESOLVED_CHEMICAL	1	1	CultureMech:008843	no	ingredients
+Magnesium Sulfate (anhydrous)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008843	no	ingredients
+Tris (Hydroxymethyl) Aminomethane HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:008843	no	ingredients
+Tryptic Digest of Beef Heart	UNRESOLVED_CHEMICAL	1	1	CultureMech:008843	no	ingredients
+4.98% FeSO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009573	no	ingredients
+Corn and fish meal mixture (feed for birds)	SOLUTION_NAME	1	1	CultureMech:007954	no	ingredients
+Seawater (2% Salinity)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007956	no	ingredients
+Vitamin solution A (1000 x stock)	SOLUTION_NAME	1	1	CultureMech:002279	no	solutions
+Vitamin solution B (1000 x stock)	SOLUTION_NAME	1	1	CultureMech:002279	no	solutions
+T-Trace Metal Mix	UNRESOLVED_CHEMICAL	1	1	CultureMech:001160	no	solutions
+Czapek-Dox liquid medium, modified (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008542	no	ingredients
+Hy-Case Amino	UNRESOLVED_CHEMICAL	1	1	CultureMech:003067	no	ingredients
+Czapek concentrate (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008792	no	ingredients
+Seawater (1.75 % salinity)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008698	no	ingredients
+MRS broth (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009412	no	ingredients
+Manganous sulfate tetrahydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009412	no	ingredients
+L-cysteine · HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009351	no	ingredients
+de Man–Rogosa–Sharpe (MRS) broth (LabM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009473	no	ingredients
+De Man-Rogosa-Sharpe (MRS) broth (Biokar Diagnostic)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008813	no	ingredients
+MRS medium (Scharlau Chemie)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009325	no	ingredients
+Peptone proteose	UNRESOLVED_CHEMICAL	1	1	CultureMech:009325	no	ingredients
+Fe3+	UNRESOLVED_CHEMICAL	1	1	CultureMech:007064	no	ingredients
+20% (w/v) MES (pH 6.0) solution	SOLUTION_NAME	1	1	CultureMech:002236	no	solutions
+1 M Phosphate buffer	SOLUTION_NAME	1	1	CultureMech:009665	no	ingredients
+Stock A solution	SOLUTION_NAME	1	1	CultureMech:009665	no	solutions
+3-Chloro-4-hydroxyphenylacetic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:009144	no	ingredients
+L-Cysteine . HCl . H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009144	no	ingredients
+Distilled water 960.00	UNRESOLVED_CHEMICAL	1	1	CultureMech:009116	no	ingredients
+yeast extaract	UNRESOLVED_CHEMICAL	1	1	CultureMech:009098	no	ingredients
+Na-benzoate*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009103	no	solutions
+Trace element solution SL12B	SOLUTION_NAME	1	1	CultureMech:002963	no	solutions
+Dichloran-Glycerol-agar base	UNRESOLVED_CHEMICAL	1	1	CultureMech:001234	no	ingredients
+Glycerol (anhydrous)	UNRESOLVED_CHEMICAL	1	1	CultureMech:001234	no	ingredients
+Nutrient Broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008602	no	ingredients
+Na2MO4.2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009613	no	ingredients
+dl-Ca-pantothenate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009602	no	ingredients
+EZMix-N-Z-amine A	UNRESOLVED_CHEMICAL	1	1	CultureMech:009364	no	ingredients
+Ethyl octanoate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007090	no	ingredients
+Eagle's  minimum  essential  medium  (MEM) (Nissui  Co.,  Tokyo)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009389	no	ingredients
+EBIOS	UNRESOLVED_CHEMICAL	1	1	CultureMech:003317	no	ingredients
+Na2S·9H2O solution	SOLUTION_NAME	1	1	CultureMech:009540	no	solutions
+Dithiothreitol (DTT)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009172	no	ingredients
+DTT Solution	SOLUTION_NAME	1	1	CultureMech:009172	no	solutions
+50x Vogel-Bonner salts	UNRESOLVED_CHEMICAL	1	1	CultureMech:009335	no	ingredients
+NaNH4HPO4 . 4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009335	no	ingredients
+Trace vitamins solution (see Medium No. 284)	CROSS_REFERENCE	1	1	CultureMech:002234	no	solutions
+Oxoid Lab-Lemco Powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:009304	no	ingredients
+Wheat Grains	UNRESOLVED_CHEMICAL	1	1	CultureMech:001203	no	ingredients
+Sodium lactate, 60% syrup	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+4% Na2CO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+10% Glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+1% Sodium fumarate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+0.5% Dithiothreitol (DTT)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+4% L-Cysteine . HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+Menadione (Vitamin K3)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009136	no	ingredients
+NaHCO3 solution (20% w/v)	SOLUTION_NAME	1	1	CultureMech:009297	no	solutions
+Na2S . 9H2O solution (10% w/v)	SOLUTION_NAME	1	1	CultureMech:009297	no	solutions
+Sodium Selenite Solution	SOLUTION_NAME	1	1	CultureMech:009297	no	solutions
+Na2CO3  solution	SOLUTION_NAME	1	1	CultureMech:009297	no	solutions
+Fastidious Anaerobe Basal Broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:000654	no	ingredients
+MQ H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009688	no	ingredients
+2 M HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009688	no	ingredients
+1 M NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009688	no	ingredients
+Poorly crystalline iron(III) oxide (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009793	no	ingredients
+alpha,alpha-Trehalose	UNRESOLVED_CHEMICAL	1	1	CultureMech:007248	no	ingredients
+0.01 M H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:007799	no	ingredients
+Cr2(SO4)3・xH2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007799	no	ingredients
+1 M FeSO4 solution* (pH 2.0)	SOLUTION_NAME	1	1	CultureMech:007799	no	solutions
+2.5% Na2S . 9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009139	no	ingredients
+2.5% L-Cysteine . HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009139	no	ingredients
+Pyridoxamine . 2HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009139	no	ingredients
+Plain flour	UNRESOLVED_CHEMICAL	1	1	CultureMech:001094	no	ingredients
+NaCOOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009652	no	ingredients
+Ni2SO4 ⋅ 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009652	no	ingredients
+L-15 powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:001081	no	ingredients
+Trace minerals (see Medium No. 197	CROSS_REFERENCE	1	1	CultureMech:002974	no	ingredients
+Trace element solution (see Medium No. 187	CROSS_REFERENCE	1	1	CultureMech:003090	no	solutions
+1M MES solution	SOLUTION_NAME	1	1	CultureMech:009532	no	solutions
+1 M Na2S2O3·5H2O solution*	SOLUTION_NAME	1	1	CultureMech:009532	no	solutions
+Magnesium sulphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008822	no	ingredients
+Horse Serum (RM1239)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008822	no	ingredients
+Papaic digest of soyabean meal	UNRESOLVED_CHEMICAL	1	1	CultureMech:008822	no	ingredients
+0.25 M Potassium phosphate buffer (pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007826	no	ingredients
+10 mM Fe quinate solution* (see below)	SOLUTION_NAME	1	1	CultureMech:007826	no	solutions
+Polypepton*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008675	no	solutions
+GAM agar (Nissui)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010155	no	ingredients
+GC agar base (BD 228950)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008798	no	ingredients
+Fe(III)-citrate (19% Fe)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009275	no	ingredients
+Sodium-β-glycerophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009419	no	ingredients
+Glycerol-asparagine agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:002767	yes	ingredients
+M17 media (Oxoid LOT2216165)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009478	no	ingredients
+Grace's Insect Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:000986	no	ingredients
+CM-Cellulose	UNRESOLVED_CHEMICAL	1	1	CultureMech:008241	no	ingredients
+Ammonium tartrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008241	no	ingredients
+Difco Yeast Carbon Base	UNRESOLVED_CHEMICAL	1	1	CultureMech:008241	no	ingredients
+Yeast extaract	UNRESOLVED_CHEMICAL	1	1	CultureMech:008468	no	ingredients
+Trace element***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008483	no	solutions
+Fe-citrate 1% solution	SOLUTION_NAME	1	1	CultureMech:008384	no	solutions
+0.5 M EDTA solution	SOLUTION_NAME	1	1	CultureMech:007580	no	solutions
+Trace metal solution* (see below)	SOLUTION_NAME	1	1	CultureMech:007580	no	solutions
+DNA sodium salt (Sigma, D1501)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009333	no	ingredients
+PPLO	UNRESOLVED_CHEMICAL	1	1	CultureMech:009333	no	ingredients
+Heart infusion agar (Eiken)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008802	no	ingredients
+Heart Infusion Agar (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008877	no	ingredients
+Bacto Heart Infusion Broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:001090	no	ingredients
+Heart infusion broth (Eiken)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008803	no	ingredients
+Amphotericin	UNRESOLVED_CHEMICAL	1	1	CultureMech:000742	no	ingredients
+0.2% Fe(NH4)2(SO4)2・6H2O (in 0.037% HCl)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010201	no	ingredients
+Agar Noble	UNRESOLVED_CHEMICAL	1	1	CultureMech:008771	no	ingredients
+Yeast Extract #3	UNRESOLVED_CHEMICAL	1	1	CultureMech:008771	no	ingredients
+UPW	UNRESOLVED_CHEMICAL	1	1	CultureMech:009705	no	ingredients
+MgCl2 solution	SOLUTION_NAME	1	1	CultureMech:009705	no	solutions
+HS medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009200	no	ingredients
+cysteine . HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009200	no	ingredients
+Peptone (BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008278	no	ingredients
+Artificial Seawater	UNRESOLVED_CHEMICAL	1	1	CultureMech:008569	no	ingredients
+10% MgCl2·6H2O solution	SOLUTION_NAME	1	1	CultureMech:010377	no	solutions
+IRD MARINE CLOSTRIDA MEDIUM (see Medium [M953])	CROSS_REFERENCE	1	1	CultureMech:010411	no	solutions
+Agar, Noble (BD 214050), if needed	UNRESOLVED_CHEMICAL	1	1	CultureMech:008891	no	ingredients
+Trace Element Solution SL-7 (see below)	SOLUTION_NAME	1	1	CultureMech:008891	no	solutions
+Solution C (see below)	SOLUTION_NAME	1	1	CultureMech:008891	no	solutions
+ISP 7 Medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:001099	no	ingredients
+5% Na2S . 9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009223	no	ingredients
+ATCC Medium 1256	UNRESOLVED_CHEMICAL	1	1	CultureMech:009223	no	ingredients
+Trace Mineral Supplement (ATCC)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009605	no	ingredients
+Vitamin supplement (ATCC)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009605	no	ingredients
+YM broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:002569	no	ingredients
+GYP-sodium acetate-mineral salts broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:003045	no	ingredients
+10N H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009676	no	ingredients
+PPLO (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+Pig serum (Invitrogen)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+Horse serum (Invitrogen)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+100 mg/ml azlocillin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+100 mg/ml flucloxacillin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+1.0 M NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+0.1 M NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+azlocillin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+flucloxacillin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009462	no	ingredients
+Fresh baker's yeast extract solution	SOLUTION_NAME	1	1	CultureMech:009462	no	solutions
+Sterile solution A	SOLUTION_NAME	1	1	CultureMech:009462	no	solutions
+Sterile solution B	SOLUTION_NAME	1	1	CultureMech:009462	no	solutions
+Leibovitz's L-15 medium powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:001068	no	ingredients
+L-15B mineral stock solution D	SOLUTION_NAME	1	1	CultureMech:001068	no	solutions
+L-15B vitamin stock	SOLUTION_NAME	1	1	CultureMech:001068	no	solutions
+lactic	UNRESOLVED_CHEMICAL	1	1	CultureMech:004985	no	ingredients
+Lactobacilli MRS Agar (BD288210)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009016	no	ingredients
+Lactobacilli MRS Broth (BD 288130)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009017	no	ingredients
+Man Rogosa Sharp broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:000713	no	ingredients
+Kanamycin sulfate solution (50 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008689	no	solutions
+Cefpodoxime solution (10 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008599	no	solutions
+Sodium ampicillin solution (50 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008244	no	solutions
+Chloramphenicol solution (25 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008474	no	solutions
+Deferoxamine mesylate salt	UNRESOLVED_CHEMICAL	1	1	CultureMech:008564	no	ingredients
+Kanamycin solution (20 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008513	no	solutions
+Kanamycin sulfate solution (20 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008515	no	solutions
+Naphthalene solution (10,000 ppm)*	SOLUTION_NAME	1	1	CultureMech:008421	no	solutions
+Ciprofloxacin solution (5 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008600	no	solutions
+Nalidixic acid solution (30 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008600	no	solutions
+Tris, pH 7.5	UNRESOLVED_CHEMICAL	1	1	CultureMech:009458	no	ingredients
+Whole-fat cow's milk	UNRESOLVED_CHEMICAL	1	1	CultureMech:008670	no	ingredients
+Oxgall	UNRESOLVED_CHEMICAL	1	1	CultureMech:002512	no	ingredients
+Leptospira Medium Base EMJH	UNRESOLVED_CHEMICAL	1	1	CultureMech:000549	no	ingredients
+35% HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009657	no	ingredients
+(R,R)-Butane-2,3-diol	UNRESOLVED_CHEMICAL	1	1	CultureMech:007103	no	ingredients
+NaCl (VWR, X190-1KG)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009438	no	ingredients
+Whole eggs	UNRESOLVED_CHEMICAL	1	1	CultureMech:003059	yes	ingredients
+Whole Egg	UNRESOLVED_CHEMICAL	1	1	CultureMech:008979	no	ingredients
+K2PO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+Thauers vitamins	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+Titanium citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+Thioctic acid (lipoic acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+8% (wt/vol) Na2CO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+0.2 M Sodium citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+20% (wt/vol) TiCl3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009357	no	ingredients
+Resazurin (0.1% solution)	SOLUTION_NAME	1	1	CultureMech:009357	no	solutions
+1M KOH solution	SOLUTION_NAME	1	1	CultureMech:009357	no	solutions
+3-[N-morpho- lino] propanesulfonic acid (MOPS)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009075	no	ingredients
+Triptone	UNRESOLVED_CHEMICAL	1	1	CultureMech:009651	no	ingredients
+M17 broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009417	no	ingredients
+M17 medium (Scharlau)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008819	no	ingredients
+Penicillin G (100,000 U/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008142	no	ingredients
+Bacto PPLO Broth w/o CV (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008142	no	ingredients
+Schneider's Drosophila medium (Invitorogen, Gibco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008142	no	ingredients
+M2SGC medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009336	no	ingredients
+CaCl2 solution (0.1 M)**	SOLUTION_NAME	1	1	CultureMech:008644	no	solutions
+MgSO4 solution (1 M)**	SOLUTION_NAME	1	1	CultureMech:008644	no	solutions
+10xM9 solution*	SOLUTION_NAME	1	1	CultureMech:008644	no	solutions
+1M CaCl2	UNRESOLVED_CHEMICAL	1	1	CultureMech:009338	no	ingredients
+20% glucose	UNRESOLVED_CHEMICAL	1	1	CultureMech:009338	no	ingredients
+2% casamino acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:009338	no	ingredients
+x5 M9 salt (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009338	no	ingredients
+dimethyl sulfoxide (DMSO)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008631	no	ingredients
+Phenanthrene solution	SOLUTION_NAME	1	1	CultureMech:008631	no	solutions
+IPTG	UNRESOLVED_CHEMICAL	1	1	CultureMech:007009	no	ingredients
+Cellulose (or Cellobiose)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008259	no	ingredients
+β-Na2glycerophosphate· 5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008952	no	ingredients
+Sodium acetate·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008582	no	ingredients
+7 Vitamins solution	SOLUTION_NAME	1	1	CultureMech:002906	no	solutions
+Man-Rogosa-Sharpe (MRS) (Beijing Land Bridge Technology Co., Ltd. CM187)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009475	no	ingredients
+Man-Rogosa-Sharpe (MRS) broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009057	no	ingredients
+Difco Marine Agar 2216	UNRESOLVED_CHEMICAL	1	1	CultureMech:008852	no	ingredients
+Marine Broth 2216 (BD--Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007734	no	ingredients
+Marine Broth 2216 (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007874	no	ingredients
+Marine Broth  (MB) 2216  (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009390	no	ingredients
+Glucose (50%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008859	no	ingredients
+50xPYE	UNRESOLVED_CHEMICAL	1	1	CultureMech:008859	no	ingredients
+Riboflavin (0.2 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008859	no	ingredients
+MARINE CLOSTRIDIUM MEDIUM (see Medium [M1272])	CROSS_REFERENCE	1	1	CultureMech:007806	no	solutions
+Methanol solution (see below)	SOLUTION_NAME	1	1	CultureMech:003032	no	solutions
+(NH4)6Mo7O4·4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009576	no	ingredients
+Desicatted Ox-bile	UNRESOLVED_CHEMICAL	1	1	CultureMech:001249	no	ingredients
+(-)-Chloramphenicol	UNRESOLVED_CHEMICAL	1	1	CultureMech:001249	no	ingredients
+Tris-HC1 (pH 7.6)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008829	no	ingredients
+Calf serum (Gibco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008829	no	ingredients
+PPLO broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008829	no	ingredients
+NTA (sodium nitrilotriacetate)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009608	no	ingredients
+Na2NPO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009608	no	ingredients
+Double-distilled water	UNRESOLVED_CHEMICAL	1	1	CultureMech:009608	no	ingredients
+FeCl3 solution (0.29 g/liter)	SOLUTION_NAME	1	1	CultureMech:009608	no	solutions
+Medium D	UNRESOLVED_CHEMICAL	1	1	CultureMech:008830	no	ingredients
+1M NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:008830	no	ingredients
+H2SO4 (concd)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008830	no	ingredients
+0.25 N H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:008660	no	ingredients
+Thiosulfate solution******	SOLUTION_NAME	1	1	CultureMech:008470	no	solutions
+So(Sulfur Powder)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	ingredients
+DI WATER	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	ingredients
+Selenite-tungstate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	ingredients
+Vitamins (ATCC)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	ingredients
+2m HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	ingredients
+NaHCO3 (1M solution)	SOLUTION_NAME	1	1	CultureMech:009122	no	solutions
+Trace Elements (ATCC)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009122	no	solutions
+Na2Mo4O4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009565	no	ingredients
+0.04% Phenol red	UNRESOLVED_CHEMICAL	1	1	CultureMech:008754	no	ingredients
+Calcium solution*	SOLUTION_NAME	1	1	CultureMech:008754	no	solutions
+Chelated Fe solution**	SOLUTION_NAME	1	1	CultureMech:008754	no	solutions
+Dithionite (ca.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008224	no	ingredients
+Thiosulfate solution*****	SOLUTION_NAME	1	1	CultureMech:008635	no	solutions
+NaHCO3 (3% (w/v))	UNRESOLVED_CHEMICAL	1	1	CultureMech:008480	no	ingredients
+NaHCO3 solution (10% w/v)	SOLUTION_NAME	1	1	CultureMech:008530	no	solutions
+Benzoate solution***	SOLUTION_NAME	1	1	CultureMech:008636	no	solutions
+Bicarbobate solution****	SOLUTION_NAME	1	1	CultureMech:008636	no	solutions
+0.001% Coenzyme M solution	SOLUTION_NAME	1	1	CultureMech:010405	no	solutions
+RST trace elements (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:010405	no	solutions
+Trace element SL-10*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008566	no	solutions
+Na2S·9H2O (neutralized)***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008481	no	solutions
+Fe(III) slurry solution***	SOLUTION_NAME	1	1	CultureMech:008642	no	solutions
+FeCl3·6H2O solution	SOLUTION_NAME	1	1	CultureMech:008642	no	solutions
+Tryptose-phosphate broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:001032	no	ingredients
+lipoprotein concentrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:001032	no	ingredients
+3-Chloroacrylic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:001570	no	ingredients
+Benzothiazole	UNRESOLVED_CHEMICAL	1	1	CultureMech:001772	no	ingredients
+Methanol-utilizing bacteria medium B	UNRESOLVED_CHEMICAL	1	1	CultureMech:002435	no	ingredients
+LaCl3 x 7 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:001092	no	ingredients
+NdCl3 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:001092	no	ingredients
+PrCl3 x H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:001092	no	ingredients
+MH agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009469	no	ingredients
+Trace Mineral Supplement, Catalog No. MD-TMS	UNRESOLVED_CHEMICAL	1	1	CultureMech:009202	no	ingredients
+Co-enzyme M (mercaptoethanesulfonic acid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009202	no	ingredients
+Co-enzyme M (mercaptoethanesulfonic acid) (100 X solution):	SOLUTION_NAME	1	1	CultureMech:009202	no	solutions
+Bacto Middlebrook 7H10 agar (Difco 262710)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008914	no	ingredients
+Bacto Middlebrook OADC enrichment	UNRESOLVED_CHEMICAL	1	1	CultureMech:008914	no	ingredients
+Middlebrook 7H10 Agar (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009413	no	ingredients
+Middlebrook 7H10	UNRESOLVED_CHEMICAL	1	1	CultureMech:008980	no	ingredients
+OADC enrichment*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008525	no	solutions
+OADC Enrichment (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008990	no	ingredients
+Middlebrook 7H11 solid medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:008984	no	ingredients
+Middlebrook 7H9 Broth Base	UNRESOLVED_CHEMICAL	1	1	CultureMech:008983	no	ingredients
+4-(2-hydroxyethyl)-1-piperazineethanesulfonic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:001199	no	ingredients
+2,4-Dichlorophenoxyacetic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:001555	no	ingredients
+2-Chlorobenzoic acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:001568	no	ingredients
+3-Aminophenol	UNRESOLVED_CHEMICAL	1	1	CultureMech:001591	no	ingredients
+2-chloro-4(ethylamino)-6-(isopropylamino)-1,3,5-triazine	UNRESOLVED_CHEMICAL	1	1	CultureMech:001594	no	ingredients
+Cyanuric acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:001592	no	ingredients
+2-Nitrophenol	UNRESOLVED_CHEMICAL	1	1	CultureMech:001578	no	ingredients
+Phenyl acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:001552	no	ingredients
+Quinoline	UNRESOLVED_CHEMICAL	1	1	CultureMech:001576	no	ingredients
+Salicylate	UNRESOLVED_CHEMICAL	1	1	CultureMech:001554	no	ingredients
+6-methylnicotinate	UNRESOLVED_CHEMICAL	1	1	CultureMech:001593	no	ingredients
+xylan (oat spelts)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+pectin (apple)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+pectin (citrus peel)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+galatcomannan (Ceratonia siliqua)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+mannan (Saccharomyces cerevisiae)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+arabinan (sugar beet)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+arabinogalactan (larch)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+laminarin (brown algae)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+chitin (shrimp shells)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+alginate (brown algae)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008900	no	ingredients
+Mg2SO4.7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008789	no	ingredients
+Nicotine (Fluka)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009420	no	ingredients
+0.1M HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009420	no	ingredients
+solution of Ca(NO3)2	SOLUTION_NAME	1	1	CultureMech:009388	no	solutions
+heat-inactivated fetal bovine serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008873	no	ingredients
+Concentrated hydrochloric acid	UNRESOLVED_CHEMICAL	1	1	CultureMech:009660	no	ingredients
+Saturated CaCl2 solution	SOLUTION_NAME	1	1	CultureMech:009660	no	solutions
+Saturated FeSO4 solution	SOLUTION_NAME	1	1	CultureMech:009660	no	solutions
+Bauchop & Elsden solution	SOLUTION_NAME	1	1	CultureMech:009660	no	solutions
+MJ synthetic seawater for MMJYP2 medium *	UNRESOLVED_CHEMICAL	1	1	CultureMech:008503	no	solutions
+Balch's trace mineral solution**	SOLUTION_NAME	1	1	CultureMech:008503	no	solutions
+Nickel(II) ammonium sulfate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007034	no	ingredients
+Agar Noble (Difco 0142) (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009056	no	ingredients
+Trace Metals A-5 (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009056	no	ingredients
+Ager	UNRESOLVED_CHEMICAL	1	1	CultureMech:009700	no	ingredients
+100 x Vitamin mixture	SOLUTION_NAME	1	1	CultureMech:003193	no	solutions
+Starch from corn (SIGMA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008383	no	ingredients
+Casein sodium	UNRESOLVED_CHEMICAL	1	1	CultureMech:008383	no	ingredients
+Cyanocobalamin**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008383	no	solutions
+Concentrated H2SO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009678	no	ingredients
+Component I	UNRESOLVED_CHEMICAL	1	1	CultureMech:009183	no	ingredients
+Component II	UNRESOLVED_CHEMICAL	1	1	CultureMech:009183	no	ingredients
+Component III	UNRESOLVED_CHEMICAL	1	1	CultureMech:009183	no	ingredients
+CO	UNRESOLVED_CHEMICAL	1	1	CultureMech:009619	no	ingredients
+1.0 M MgSO4 solution	SOLUTION_NAME	1	1	CultureMech:009524	no	solutions
+1.0% yeast extract solution	SOLUTION_NAME	1	1	CultureMech:009526	no	solutions
+Probumin Universal Grade	UNRESOLVED_CHEMICAL	1	1	CultureMech:003244	no	ingredients
+NaOAc	UNRESOLVED_CHEMICAL	1	1	CultureMech:008797	no	ingredients
+Yeast dialysate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008797	no	ingredients
+GAM agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:003001	yes	ingredients
+GAM broth, modified (Nissui)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009699	no	ingredients
+Sodium citrate tribasic dihydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009628	no	ingredients
+Trace salt solution (10x)	SOLUTION_NAME	1	1	CultureMech:009628	no	solutions
+Vitamin solution (100x)	SOLUTION_NAME	1	1	CultureMech:009628	no	solutions
+0.5% phenol red (Flow)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009423	no	ingredients
+Fetal bovine serum (Flow), heat-inactivated	UNRESOLVED_CHEMICAL	1	1	CultureMech:009423	no	ingredients
+PPLO broth base without crystal violet (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009423	no	ingredients
+Penicillin G (Parke, Davis & Co)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009423	no	ingredients
+Bacto Agar (Difco, if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008029	no	ingredients
+calf thymus DNA (Sigma, Type I)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008029	no	ingredients
+thallium acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008029	no	ingredients
+horse serum (heat inactivated, 56℃ for 30 minutes)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008029	no	ingredients
+fresh yeast extract (25% solution)	SOLUTION_NAME	1	1	CultureMech:008029	no	solutions
+0.5% Phenol red (Flow)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008811	no	ingredients
+heat-inactivated horse serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008811	no	ingredients
+PPLO broth base without crystal violet (Difco）	UNRESOLVED_CHEMICAL	1	1	CultureMech:008811	no	ingredients
+Penicillin G (Parke)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008811	no	ingredients
+Agar (BD)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008833	no	ingredients
+Supplement A	UNRESOLVED_CHEMICAL	1	1	CultureMech:008991	no	ingredients
+Sterile Rabbit Serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008991	no	ingredients
+0.05% Hemin solution	SOLUTION_NAME	1	1	CultureMech:008991	no	solutions
+N-2-hydroxy- ethylpiperazine-N'-2-ethanesulfonic acid [HEPES; pH 7.2])	UNRESOLVED_CHEMICAL	1	1	CultureMech:009490	no	ingredients
+1.0 M MgSO4.7H2O (May and Baker)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008804	no	ingredients
+Ascorbic acid (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008804	no	ingredients
+β-Disodium glycerophosphate (grade II, Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008804	no	ingredients
+Polypeptone (BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008804	no	ingredients
+Phytone peptone (BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008804	no	ingredients
+0.1 M Tris/HCl (pH7.5)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008747	no	ingredients
+CuCl2⋅4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008747	no	ingredients
+Thiamine-HCl⋅H2O (Vitamin B1)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008747	no	ingredients
+Modified trace minerals (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009533	no	ingredients
+Modified trace vitamins solution* (see below)	SOLUTION_NAME	1	1	CultureMech:009533	no	solutions
+Fe NTA solution (see below)	SOLUTION_NAME	1	1	CultureMech:009533	no	solutions
+Phytone peptone (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007881	no	ingredients
+Potassium Phosphate monobasic crystal	UNRESOLVED_CHEMICAL	1	1	CultureMech:008678	no	ingredients
+Amonium phosphate-dibasic	UNRESOLVED_CHEMICAL	1	1	CultureMech:008678	no	ingredients
+FeCl3 (1% aqueous solution)	SOLUTION_NAME	1	1	CultureMech:008678	no	solutions
+6N HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009129	no	ingredients
+FeSO4(NH4)2SO4.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009129	no	ingredients
+Tri-ammonium citrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009331	no	ingredients
+NH4-tartrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008440	no	ingredients
+Fe-citrate 1.0 % solution	SOLUTION_NAME	1	1	CultureMech:008440	no	solutions
+ZnSO4 0.2 % solution	SOLUTION_NAME	1	1	CultureMech:008440	no	solutions
+Morpholinoethanesulfonic acid (MES)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009620	no	ingredients
+RibofIavin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009620	no	ingredients
+4% cysteine-sulfide solution	SOLUTION_NAME	1	1	CultureMech:009620	no	solutions
+Mineral stock solution	SOLUTION_NAME	1	1	CultureMech:009620	no	solutions
+Vitamin stock solution	SOLUTION_NAME	1	1	CultureMech:009620	no	solutions
+Trace metal stock solution	SOLUTION_NAME	1	1	CultureMech:009620	no	solutions
+Vitamin solution (see Medium [M940])	CROSS_REFERENCE	1	1	CultureMech:009529	no	solutions
+Trace element solution SL-10B*	SOLUTION_NAME	1	1	CultureMech:008358	no	solutions
+Inactivated horse serum (Hyclone)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009422	no	ingredients
+Thallium acetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009422	no	ingredients
+Na2 beta-glycerol PO4 x 5 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:000367	no	ingredients
+Resazurin (0.025%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009140	no	ingredients
+vitamin B12 solution	SOLUTION_NAME	1	1	CultureMech:002318	no	solutions
+Tris (hydroxymethyl aminomethane) 3.00 g	UNRESOLVED_CHEMICAL	1	1	CultureMech:009251	no	ingredients
+Mineral solution I (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+Mineral solution II (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+VFA mix (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+Hemin solution (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+Vitamin solution I (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+Vitamin solution II (see Medium [M1210])	CROSS_REFERENCE	1	1	CultureMech:009545	no	solutions
+Micronutrients	UNRESOLVED_CHEMICAL	1	1	CultureMech:009501	no	ingredients
+(NH4)6(MO7)24	UNRESOLVED_CHEMICAL	1	1	CultureMech:009501	no	ingredients
+Apple Juice	UNRESOLVED_CHEMICAL	1	1	CultureMech:009564	no	ingredients
+MRS agar (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009471	no	ingredients
+‘Lab-Lemco’ powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:009005	no	ingredients
+L-cysteine (Sigma)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009344	no	ingredients
+MRS broth (Criterion)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009344	no	ingredients
+MRS medium (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009064	no	ingredients
+MRS medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:002293	no	ingredients
+Tomato Juice (filtered)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008568	no	ingredients
+Lactobacillus MRS broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:002859	no	ingredients
+Trace Mineral Supplement, ATCC MD-TMS	UNRESOLVED_CHEMICAL	1	1	CultureMech:009199	no	ingredients
+Co-enzyme M (mercaptoethanesulfonic acid) Solution (100 X solution)	SOLUTION_NAME	1	1	CultureMech:009199	no	solutions
+MnCl3·4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009572	no	ingredients
+L-glutamic acid monosodium salt monohydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009572	no	ingredients
+Mueller Hinton II agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:002855	yes	ingredients
+Mueller Hinton Broth (BD 211443)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009151	no	ingredients
+Mueller Hinton (MH) agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009472	no	ingredients
+Mueller–Hinton (MH) broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009468	no	ingredients
+Yeast extract solution (15%)	SOLUTION_NAME	1	1	CultureMech:008815	no	solutions
+15% Yeast Extract Solution (Gibco 0689)	SOLUTION_NAME	1	1	CultureMech:008194	no	solutions
+Sodium crotonate	UNRESOLVED_CHEMICAL	1	1	CultureMech:002451	no	ingredients
+Agar (If needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008643	no	ingredients
+yeast nitrogen base (BD Difco, Franklin Lakes, NJ, USA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009384	no	ingredients
+casamino acid (BD Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009384	no	ingredients
+Hipolypeptone*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008750	no	solutions
+Purified Agar (e.g., Oxoid L28)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008446	no	ingredients
+HCl (concentrated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008446	no	ingredients
+Ferric ammonium citrate***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008446	no	solutions
+H2SO4 (conc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008824	no	ingredients
+Fe(III)-EDTA (0.66% [wt/vol] in water)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008840	no	ingredients
+0.1 M HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009587	no	ingredients
+NiCl3.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009587	no	ingredients
+CrCl3.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009587	no	ingredients
+Fructose solution	SOLUTION_NAME	1	1	CultureMech:009587	no	solutions
+Phenol red 0.5% (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008956	no	ingredients
+HCl(conc)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008956	no	ingredients
+6N NaOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:008956	no	ingredients
+0.5 M K2CO3 Solution	SOLUTION_NAME	1	1	CultureMech:008956	no	solutions
+Ferric (III) ammonium citrate*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008956	no	solutions
+NaHCO3*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008714	no	solutions
+Fe·EDTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:008567	no	ingredients
+Nutrient agar (see Medium [M65])	CROSS_REFERENCE	1	1	CultureMech:007712	no	solutions
+Bacto Nutrient Broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008239	no	ingredients
+Na2CO3 (anhydrous)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008325	no	ingredients
+Sodium-sesquicarbonate solution*	SOLUTION_NAME	1	1	CultureMech:008325	no	solutions
+Nutrient broth (NB) (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008787	no	ingredients
+Peptone from gelatine	UNRESOLVED_CHEMICAL	1	1	CultureMech:009430	no	ingredients
+chloramphenicol (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009479	no	ingredients
+kanamycin (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009479	no	ingredients
+gentamicin (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009479	no	ingredients
+(NH2)2CO	UNRESOLVED_CHEMICAL	1	1	CultureMech:009479	no	ingredients
+CaCO3 (reagent grade)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008078	no	ingredients
+NZ amine	UNRESOLVED_CHEMICAL	1	1	CultureMech:009401	no	ingredients
+Oatmeal (powder, Quaker White Oats)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008062	no	ingredients
+Na2MoO4 x2H2O (1 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+MnCl2 x4H2O (10 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+ZnSO4 x7H2O (10 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+CuCl2 x2H2O (10 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+CoSO4 x7H2O (1 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+Na2B4O7 x 10 H2O (25 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+VOSO4 x5H2O (1 mg/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+Distilled H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+Na2Sx6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+LiCl/Na2WO4/NaSeO3/Ni(NH4)2(SO4) (1 mg/ml each)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+NaSeO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+Ni(NH4)2(SO4)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009237	no	ingredients
+Wolfe's Vitamin Solution (1,000X_x0008_)	SOLUTION_NAME	1	1	CultureMech:009237	no	solutions
+Peptone(Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009569	no	ingredients
+L-Ornithine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:000962	no	ingredients
+MnCl3 . 4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009212	no	ingredients
+Na2SeO4 . 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009212	no	ingredients
+Seawater (autoclaved)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+HEPES-NaOH (pH 7.5)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Trace metals 'Gaffron­+Se'	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Na-PO4 (pH 7.5)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Na2-EDTA/FeCl3	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+KAI(SO4)2.12H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+VSO5.5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Cr(NO3)3.9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+SeO2	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Cd(NO3).4H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+50mM NaH2PO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+50mM Na2HPO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:008849	no	ingredients
+Na2-EDTA solution	SOLUTION_NAME	1	1	CultureMech:008849	no	solutions
+Sodium hygromycin solution (50 mg/ml)*	SOLUTION_NAME	1	1	CultureMech:008534	no	solutions
+Polypropylene glycol 4000 (PEG 4000)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008681	no	ingredients
+Polyethylene glycol (Mw 106-20000)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008360	no	ingredients
+Reducing Agent	UNRESOLVED_CHEMICAL	1	1	CultureMech:009267	no	ingredients
+Fe(SO4)2(NH4)2 . 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009267	no	ingredients
+Fe(SO4)·7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009617	no	ingredients
+2 g/L Resazurin	UNRESOLVED_CHEMICAL	1	1	CultureMech:009617	no	ingredients
+Cellulose*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007959	no	solutions
+CoCI2.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008863	no	ingredients
+NiCI2.6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008863	no	ingredients
+ZnCI2	UNRESOLVED_CHEMICAL	1	1	CultureMech:008863	no	ingredients
+Ethylenediamine-tetraacetate-di-Na-salt	UNRESOLVED_CHEMICAL	1	1	CultureMech:008863	no	ingredients
+Solution 3: Vitamin B12 solution	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+Solution 4: Na bicarbonate solution	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+Solution 5: Sodium sulfide solution	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+Solution 2 (SL 12)	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+5% Na bicarbonate solution	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+6% Sodium sulfide solution	SOLUTION_NAME	1	1	CultureMech:008863	no	solutions
+Resazurin (0.02%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+Na2S . 9H2O (2.5%)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+MgSO4 . 2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+Trace mineral	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+Phosphate buffer (1 M, pH 7.2)	SOLUTION_NAME	1	1	CultureMech:009311	no	ingredients
+Na2MoO3	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+Pyridoxine . HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+1M KH2PO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+1M Na2HPO4	UNRESOLVED_CHEMICAL	1	1	CultureMech:009311	no	ingredients
+Solution containing MgCl2	SOLUTION_NAME	1	1	CultureMech:008817	no	solutions
+Solution containing CaCl2	SOLUTION_NAME	1	1	CultureMech:008817	no	solutions
+3,4-Dihydroxyphenylacetate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007431	no	ingredients
+3-Hydroxypropanal	UNRESOLVED_CHEMICAL	1	1	CultureMech:007310	no	ingredients
+GDP	UNRESOLVED_CHEMICAL	1	1	CultureMech:007432	no	ingredients
+Disrilled water	UNRESOLVED_CHEMICAL	1	1	CultureMech:008509	no	ingredients
+Peptonized Milk (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008348	no	ingredients
+Potato Extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:009043	no	ingredients
+boiled potato	UNRESOLVED_CHEMICAL	1	1	CultureMech:009385	no	ingredients
+thioglycolate medium (Wako)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009385	no	ingredients
+meat extract (Wako Pure Chemical Industries, Osaka, Japan)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009385	no	ingredients
+Polypropylene glycol 2000 (PPG 2000)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008679	no	ingredients
+PPLO Broth Base w/o CV (Mycoplasma Broth Base) (BD 211458)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009049	no	ingredients
+Phenol red solution, 1% stock solution	SOLUTION_NAME	1	1	CultureMech:009049	no	solutions
+Glucose (20% solution)*	SOLUTION_NAME	1	1	CultureMech:009049	no	solutions
+Bovine serum*	UNRESOLVED_CHEMICAL	1	1	CultureMech:009049	no	solutions
+Yeast Extract Solution (GIBCO 18180)	SOLUTION_NAME	1	1	CultureMech:009049	no	solutions
+Horse Serum (not inactivated)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008814	no	ingredients
+PPLO Broth w/o CV	UNRESOLVED_CHEMICAL	1	1	CultureMech:008814	no	ingredients
+Fresh Baker’s Yeast Extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:008814	no	ingredients
+PPLO (pleuropneumonia-like organism) medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009512	no	ingredients
+Trace element solution (SL-10)*	SOLUTION_NAME	1	1	CultureMech:008662	no	solutions
+Pyroroquinoline quinone (PQQ)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008674	no	ingredients
+PVA117**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008674	no	solutions
+0.025% Resazurin, aqueous	UNRESOLVED_CHEMICAL	1	1	CultureMech:009274	no	ingredients
+R2A (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009495	no	ingredients
+CaCl2 (100 mM)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008478	no	ingredients
+Methylamine*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008687	no	solutions
+Glucosev	UNRESOLVED_CHEMICAL	1	1	CultureMech:009696	no	ingredients
+Skim milk powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:009426	no	ingredients
+Reinforced Clostridial medium (Oxoid CM149)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009180	no	ingredients
+Sodium lactate (60% solution)	SOLUTION_NAME	1	1	CultureMech:009180	no	solutions
+Reinforced clostridial medium (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009353	no	ingredients
+CysteineHCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009192	no	ingredients
+Titriplex1	UNRESOLVED_CHEMICAL	1	1	CultureMech:001218	no	ingredients
+Robertson cooked meat medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:009341	no	ingredients
+Ca(NO3)2 x 6 H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:002310	no	ingredients
+RPMI medium (Invitrogen, Carlsbad, CA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009482	no	ingredients
+Peptic Pepton (USB)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007960	no	ingredients
+Lab-Lemco Broth (OXOID)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007960	no	ingredients
+Murashige & Skoog's plant salt mixture*	SOLUTION_NAME	1	1	CultureMech:007960	no	solutions
+Rye-bran	UNRESOLVED_CHEMICAL	1	1	CultureMech:003075	no	ingredients
+Trypsin	UNRESOLVED_CHEMICAL	1	1	CultureMech:003075	no	ingredients
+S6 medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:003267	no	ingredients
+NaCI	UNRESOLVED_CHEMICAL	1	1	CultureMech:009071	no	ingredients
+Sodium monobasic phosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009654	no	ingredients
+Riboflavin solution (see Medium No. 462)	CROSS_REFERENCE	1	1	CultureMech:003114	no	solutions
+Seawater (3 % salinity)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008460	no	ingredients
+Turban shell (sazae) meat cut	UNRESOLVED_CHEMICAL	1	1	CultureMech:008460	no	ingredients
+CrystalSea Marine Mix (Marine Enterprises International, Inc.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008902	no	ingredients
+0.2NKOH	UNRESOLVED_CHEMICAL	1	1	CultureMech:009386	no	ingredients
+crystallized cane sugar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009386	no	ingredients
+Ultrapure water	UNRESOLVED_CHEMICAL	1	1	CultureMech:009681	no	ingredients
+sheep blood agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:009082	no	ingredients
+Dried shrimp	UNRESOLVED_CHEMICAL	1	1	CultureMech:008208	no	ingredients
+Bovine horn meal	UNRESOLVED_CHEMICAL	1	1	CultureMech:001549	no	ingredients
+Skirrow's selective medium (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009467	no	ingredients
+PPLO Broth w/o CV (Mycoplasma Broth) (BD 255420)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008776	no	ingredients
+42% L-Arginine HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:008776	no	ingredients
+0.1% Phenol red solution	SOLUTION_NAME	1	1	CultureMech:008776	no	solutions
+50% Fructose solution	SOLUTION_NAME	1	1	CultureMech:008776	no	solutions
+50% Glucose solution	SOLUTION_NAME	1	1	CultureMech:008776	no	solutions
+50% Sucrose solution	SOLUTION_NAME	1	1	CultureMech:008776	no	solutions
+Yeast Extract Solution (GIBCO 360-8180)	SOLUTION_NAME	1	1	CultureMech:008776	no	solutions
+MnSO4 · 5H2O 1 )	UNRESOLVED_CHEMICAL	1	1	CultureMech:009080	no	ingredients
+De-ionized water	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Mycoplasma Broth Base	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Fetal bovine serum (heated 56°C- I hour)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Phenol red (0.1% aqueous)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Penicillin G (100,000 units/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Polymyxin B (100,000 units/ml) (optional)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+CMRL 1066 tissue culture supplement- (10x)(with glutamine)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009489	no	ingredients
+Yeastolate (2% solution) (Difco)	SOLUTION_NAME	1	1	CultureMech:009489	no	solutions
+Fresh yeast extract (25% solution)	SOLUTION_NAME	1	1	CultureMech:009489	no	solutions
+Thallium acetate (1:50 solution)	SOLUTION_NAME	1	1	CultureMech:009489	no	solutions
+PPLO Broth w/o  Crystal Violet (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009147	no	ingredients
+TC Yeastolate (2% soln.) (BD 255772)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009147	no	ingredients
+Mycoplasma Growth Supplement (CMRL 1066)(10X)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009147	no	ingredients
+CMRL-1066 (ATCC 20-2206)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009147	no	ingredients
+Bakers’ yeast (live, pressed, starch-free)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009147	no	ingredients
+Phenol red solution (0.1% soln.)	SOLUTION_NAME	1	1	CultureMech:009147	no	solutions
+Reducing agent (100×)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009621	no	ingredients
+Fe(SO4)2(NH4Cl)2⋅6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009621	no	ingredients
+Resazurin-solution (0.025 vol%)	SOLUTION_NAME	1	1	CultureMech:009621	no	solutions
+Trace element solution (TE, 100×)	SOLUTION_NAME	1	1	CultureMech:009621	no	solutions
+Wolfe’s vitamin solution (100×)	SOLUTION_NAME	1	1	CultureMech:009621	no	solutions
+Fructose/MES solution (50×)	SOLUTION_NAME	1	1	CultureMech:009621	no	solutions
+Sterile human urine	UNRESOLVED_CHEMICAL	1	1	CultureMech:009456	no	ingredients
+Marine Broth 2216 (BD 279110)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008842	no	ingredients
+Agarose (Electrophoresis grade,  if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008622	no	ingredients
+FeCl2·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008622	no	ingredients
+Dimethyl sulfoxide**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008622	no	solutions
+Modified Hunter's vitamin-free mineral base*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008622	no	solutions
+Mofified metals 44***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008622	no	solutions
+Thiosulfate solution****	SOLUTION_NAME	1	1	CultureMech:008706	no	solutions
+Tropic Marine salt	UNRESOLVED_CHEMICAL	1	1	CultureMech:001183	no	ingredients
+Mycobactin J	UNRESOLVED_CHEMICAL	1	1	CultureMech:008987	no	ingredients
+Major salts solution (see below)	SOLUTION_NAME	1	1	CultureMech:007836	no	solutions
+Cysteine.HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009126	no	ingredients
+Bactp-Yeast Nitrogen Base w/o Amino Acids	UNRESOLVED_CHEMICAL	1	1	CultureMech:008682	no	ingredients
+FeSO4 . 7H2O (2%, w/v, in N HCl)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008823	no	ingredients
+NiCl3 . 6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009163	no	ingredients
+Anaerobic digestor sludge supernatant (SS)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009163	no	ingredients
+1M HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:009163	no	ingredients
+1 M Na2S2O3・5H2O*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007521	no	solutions
+Mineral solution (see Medium No. 976	CROSS_REFERENCE	1	1	CultureMech:003327	no	solutions
+Na2S·9H2O**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008204	no	solutions
+Trace element solution (mg per 200 ml)	SOLUTION_NAME	1	1	CultureMech:000586	no	solutions
+Todd–Hewitt broth (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009432	no	ingredients
+Heart Infusion from (solids)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009334	no	ingredients
+Peptonen	UNRESOLVED_CHEMICAL	1	1	CultureMech:009334	no	ingredients
+Todd Hewitt broth (Becton, Dickinson and Company, Franklin Lakes, NJ, USA)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009488	no	ingredients
+Todd–Hewitt (TH) broth (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009445	no	ingredients
+Sodium lactate solution (approx. 60%)	SOLUTION_NAME	1	1	CultureMech:007898	no	solutions
+Bacto-Yeast Nitrogen Base w/o Amino Acids and Ammonium Sulfate (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007974	no	ingredients
+Ethyl alcohol**	UNRESOLVED_CHEMICAL	1	1	CultureMech:007984	no	solutions
+SI Medium Dehydrated*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007984	no	solutions
+MnSO4 (0.01 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007985	no	ingredients
+Na2MoO4 (0.01 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007985	no	ingredients
+FeSO4 (0.02 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007985	no	ingredients
+Potassium phosphate buffer (0.02 M, pH 7.0)	SOLUTION_NAME	1	1	CultureMech:007985	no	ingredients
+Ethyl alcohol (99.5%)*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007985	no	solutions
+Potassium phosphate buffer (0.01 M, pH 7.2)	SOLUTION_NAME	1	1	CultureMech:007987	no	ingredients
+farm soil	UNRESOLVED_CHEMICAL	1	1	CultureMech:007988	no	ingredients
+Mercaptoacetic acid (80% solution)	SOLUTION_NAME	1	1	CultureMech:007989	no	solutions
+Fe2(SO4)3·(NH4)2SO4·24H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:007992	no	ingredients
+Bromophenol blue	UNRESOLVED_CHEMICAL	1	1	CultureMech:007993	no	ingredients
+Calcium lactate	UNRESOLVED_CHEMICAL	1	1	CultureMech:007994	no	ingredients
+Table wine	UNRESOLVED_CHEMICAL	1	1	CultureMech:007994	no	ingredients
+Agar (if needed)***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008002	no	solutions
+Glucose**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008003	no	solutions
+Active horse serum	UNRESOLVED_CHEMICAL	1	1	CultureMech:008010	no	ingredients
+Fresh baker's yeast extract (25% solution)*	SOLUTION_NAME	1	1	CultureMech:008010	no	solutions
+Cellulose****	UNRESOLVED_CHEMICAL	1	1	CultureMech:008013	no	solutions
+Catalase*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008022	no	solutions
+HMSS solution*	SOLUTION_NAME	1	1	CultureMech:008025	no	solutions
+PS solution**	SOLUTION_NAME	1	1	CultureMech:008025	no	solutions
+ZnCl2·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008040	no	ingredients
+FeSO4·7H2O (4.98% solution)	SOLUTION_NAME	1	1	CultureMech:008048	no	solutions
+Sulfur (powder)**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008049	no	solutions
+*Vitamin mixture (see Medium [M1508])	CROSS_REFERENCE	1	1	CultureMech:008053	no	solutions
+**Ferric quinate solution (see Medium [M1508])	CROSS_REFERENCE	1	1	CultureMech:008053	no	solutions
+***HMSS solution (see Medium [M1508])	CROSS_REFERENCE	1	1	CultureMech:008053	no	solutions
+Na2S (2% solution)*	SOLUTION_NAME	1	1	CultureMech:008072	no	solutions
+Fructose (20% solution)*	SOLUTION_NAME	1	1	CultureMech:008072	no	solutions
+Cysteine-HCl (2% solution)*	SOLUTION_NAME	1	1	CultureMech:008072	no	solutions
+N-Acetyl glucosamine**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008101	no	solutions
+Neutralized Na2S·9H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008109	no	ingredients
+Agar* (if needed)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008114	no	ingredients
+SL-6 trace element solution (see below)	SOLUTION_NAME	1	1	CultureMech:008140	no	solutions
+Resazurin solution (1 mg/ml)	SOLUTION_NAME	1	1	CultureMech:008162	no	solutions
+Penicillin G** (20,000 U/ml)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008178	no	ingredients
+Kanamycin sulfate solution (250 μg/ml)**	SOLUTION_NAME	1	1	CultureMech:008193	no	solutions
+Hipolypepton***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008321	no	solutions
+Methanol***	UNRESOLVED_CHEMICAL	1	1	CultureMech:008345	no	solutions
+Na2CO3 (10% solution)*	SOLUTION_NAME	1	1	CultureMech:008352	no	solutions
+Sodium tetrathionate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008365	no	ingredients
+Soybean protein isolate (SPI) or Skim milk	UNRESOLVED_CHEMICAL	1	1	CultureMech:008465	no	ingredients
+Trimethylamine・HCl	UNRESOLVED_CHEMICAL	1	1	CultureMech:008487	no	ingredients
+Fumarate solution (1.0 M)*	SOLUTION_NAME	1	1	CultureMech:008479	no	solutions
+Trace element mixture**	SOLUTION_NAME	1	1	CultureMech:008479	no	solutions
+Bicarbonate solution (1.0 M)****	SOLUTION_NAME	1	1	CultureMech:008479	no	solutions
+Sulfide solution (1.0 M)********	SOLUTION_NAME	1	1	CultureMech:008479	no	solutions
+Acetic acid**	UNRESOLVED_CHEMICAL	1	1	CultureMech:008532	no	solutions
+Na2CO3 solution** (1.0 M)	SOLUTION_NAME	1	1	CultureMech:008563	no	solutions
+TAPS*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008563	no	solutions
+Soytone Peptone (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008575	no	ingredients
+Sodium aspartate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008576	no	ingredients
+Molybdate solution**	SOLUTION_NAME	1	1	CultureMech:008577	no	solutions
+0.4 M Phosphate buffer ****	SOLUTION_NAME	1	1	CultureMech:008577	no	solutions
+KH2PO4 solutions	SOLUTION_NAME	1	1	CultureMech:008577	no	solutions
+YM broth (BD-Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008607	no	ingredients
+Magnesium glycerophosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008677	no	ingredients
+Marine trace elements (see below)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008690	no	solutions
+Na2S2O4 (sodium dithionite)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008713	no	ingredients
+D-(+)-Glucose anhydrous	UNRESOLVED_CHEMICAL	1	1	CultureMech:008748	no	ingredients
+Agar powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:008748	no	ingredients
+Vitamin B solution (see below)	SOLUTION_NAME	1	1	CultureMech:008907	no	solutions
+NaHCO3 (1 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008971	no	ingredients
+NH4Cl (1 M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008971	no	ingredients
+KH2PO4 (0.4 g/l)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008971	no	ingredients
+alpha-ketoglutaric acid (100 mM).	UNRESOLVED_CHEMICAL	1	1	CultureMech:008971	no	ingredients
+conc. HCl (~12.5M)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008971	no	ingredients
+FeNaEDTA solution (7.5 M)	SOLUTION_NAME	1	1	CultureMech:008971	no	solutions
+Na3-NTA	UNRESOLVED_CHEMICAL	1	1	CultureMech:009131	no	ingredients
+Antifoam (Union Carbide Corp., SAG-471)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009248	no	ingredients
+AlK(SO4)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009309	no	ingredients
+100× mineral solution	SOLUTION_NAME	1	1	CultureMech:009309	no	solutions
+N-Z Amine, type B (Sheffield)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009363	no	ingredients
+2 M KSCN solution	SOLUTION_NAME	1	1	CultureMech:009574	no	solutions
+MgSO4 7H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Cobalamin (1 μg/μL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Resazurin (1 mg/L)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+p-aminobenzoic acid (0.3 μg/μL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Folic acid (5 μg/μL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Pyridoxamine (15 μg/μL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Biotin (1 μg/μL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Glucose (0.1981 g/mL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Riboflavin (0.05 μg/mL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+Thiamine (0.05 μg/mL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009566	no	ingredients
+NH4Cl solution	SOLUTION_NAME	1	1	CultureMech:009580	no	solutions
+2 M Na2S2O3 solution	SOLUTION_NAME	1	1	CultureMech:009584	no	solutions
+Ground sulfur powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:009599	no	ingredients
+DL-Ca-pantothenate	UNRESOLVED_CHEMICAL	1	1	CultureMech:009599	no	ingredients
+SL-10 trace element solution	SOLUTION_NAME	1	1	CultureMech:009599	no	solutions
+Basal salts solution (see Medium [M298])	CROSS_REFERENCE	1	1	CultureMech:009614	no	solutions
+Phosphate solution (see Medium [M298])	CROSS_REFERENCE	1	1	CultureMech:009614	no	solutions
+Vitamin solution (see Medium [M298])	CROSS_REFERENCE	1	1	CultureMech:009614	no	solutions
+Fe(SO4)2(NH4)2·6H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009622	no	ingredients
+Trace element solution SL7 (see Medium [M517])	CROSS_REFERENCE	1	1	CultureMech:009985	no	solutions
+GYP--sodium acetate--mineral salts broth (see Medium [M60])	CROSS_REFERENCE	1	1	CultureMech:010019	no	solutions
+Tomato extract	UNRESOLVED_CHEMICAL	1	1	CultureMech:001409	no	ingredients
+Meat peptone (BD Bacto)	UNRESOLVED_CHEMICAL	1	1	CultureMech:007867	no	ingredients
+Cysteine HCl.H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:009342	no	ingredients
+cysteine.HC1	UNRESOLVED_CHEMICAL	1	1	CultureMech:009508	no	ingredients
+trypticase (BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009508	no	ingredients
+phytone (BBL)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009508	no	ingredients
+defibrinated ovine blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009370	no	ingredients
+trypticase soy yeast (TSY) broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:008997	no	ingredients
+Trypticase Peptone (BBL) or Hipolypepton*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007962	no	solutions
+Horse serum (Oxoid)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009132	no	ingredients
+ISP Medium 1 (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008471	no	ingredients
+tryptone yeast extract salt (TYES) broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009367	no	ingredients
+Tryptose blood agar base (Difco Laboratories, Detroit, MI)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009084	no	ingredients
+tryptose blood agar base (Difco)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009060	no	ingredients
+Bacto Tryptic Soy Broth*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008236	no	solutions
+K2CO3 solution	SOLUTION_NAME	1	1	CultureMech:008314	no	solutions
+Tween80	UNRESOLVED_CHEMICAL	1	1	CultureMech:008740	no	ingredients
+Lecithine	UNRESOLVED_CHEMICAL	1	1	CultureMech:008740	no	ingredients
+Sodium n-hexanoate	UNRESOLVED_CHEMICAL	1	1	CultureMech:008338	no	ingredients
+K solution*	SOLUTION_NAME	1	1	CultureMech:008338	no	solutions
+M solution**	SOLUTION_NAME	1	1	CultureMech:008338	no	solutions
+C solution***	SOLUTION_NAME	1	1	CultureMech:008338	no	solutions
+PPLO Broth w/o Crystal Violet (BD 255420)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+Pancreatic Digest of Gelatin (Hardy C6540)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+10X CMRL 1066 Medium (ATCC 20-2207)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+Urea (Sigma U5218)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+Fetal Bovine Serum (ATCC 30-2020)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+Phenol Red powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:008773	no	ingredients
+Additive Solution	SOLUTION_NAME	1	1	CultureMech:008773	no	solutions
+TC Yeastolate 10% solution (BD 255772)	SOLUTION_NAME	1	1	CultureMech:008773	no	solutions
+Phenol Red Solution	SOLUTION_NAME	1	1	CultureMech:008773	no	solutions
+CaCl2·2H20	UNRESOLVED_CHEMICAL	1	1	CultureMech:008319	no	ingredients
+beta-Na2glycerophosphate·5H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008319	no	ingredients
+P IV metals solution*	SOLUTION_NAME	1	1	CultureMech:008319	no	solutions
+V8 canned vegetable juice	UNRESOLVED_CHEMICAL	1	1	CultureMech:003014	no	ingredients
+V-8 Juice*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008056	no	solutions
+Vegetable juice*	UNRESOLVED_CHEMICAL	1	1	CultureMech:007955	no	solutions
+Li2B4O7	UNRESOLVED_CHEMICAL	1	1	CultureMech:000961	no	ingredients
+0.1 M Tris-HCl (pH 7.5)	UNRESOLVED_CHEMICAL	1	1	CultureMech:008333	no	ingredients
+H4MoNa2O6·2H2O	UNRESOLVED_CHEMICAL	1	1	CultureMech:008663	no	ingredients
+2x GY agar*	UNRESOLVED_CHEMICAL	1	1	CultureMech:008663	no	solutions
+2x VL55 buffer (pH5.5)**	SOLUTION_NAME	1	1	CultureMech:008663	no	solutions
+Trace element solution (SL-10)***	SOLUTION_NAME	1	1	CultureMech:008663	no	solutions
+Volvic water	UNRESOLVED_CHEMICAL	1	1	CultureMech:008496	no	ingredients
+Veal infusion broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:001704	no	ingredients
+vancomycin (Lilly France S.A., Fergesheim, France)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+human blood	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+cefsulodin (Takeda France S.A., Puteaux, France)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+Fungizone (Bristol-Myers Squibb Co.)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+trimethoprim (GlaxoSmithKline)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+Wilkins-Chalgren agar plates (Oxoid Ltd., Hampshire, UK)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009395	no	ingredients
+Dehydrated Wilkins-Chalgren medium (Oxoid CM0643)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009286	no	ingredients
+Wilkins-Chalgren Anaerobe Broth (Oxoid CM0643)	UNRESOLVED_CHEMICAL	1	1	CultureMech:009302	no	ingredients
+YEAST EXTRACT-MALT EXTRACT AGAR (ISP-2) (see Medium [M35])	CROSS_REFERENCE	1	1	CultureMech:010021	no	solutions
+YEM broth	UNRESOLVED_CHEMICAL	1	1	CultureMech:009435	no	ingredients
+Clarified tomato juice	UNRESOLVED_CHEMICAL	1	1	CultureMech:008858	no	ingredients
+Desiccated ox bile	UNRESOLVED_CHEMICAL	1	1	CultureMech:015870	no	ingredients
+Polypepton (Nihon Seiyaku)	UNRESOLVED_CHEMICAL	1	1	CultureMech:015873	no	ingredients
+BL Agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:010526	yes	ingredients
+LB broth powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:015381	no	ingredients
+Na-glycerol phosphate	UNRESOLVED_CHEMICAL	1	1	CultureMech:015365	no	ingredients
+Brewer anaerobic agar	UNRESOLVED_CHEMICAL	1	1	CultureMech:015412	yes	ingredients
+Dv_base_Y_medium	UNRESOLVED_CHEMICAL	1	1	CultureMech:015521	no	ingredients
+GAM Broth powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:015347	no	ingredients
+GAM Broth mod. powder	UNRESOLVED_CHEMICAL	1	1	CultureMech:015348	no	ingredients
+Trace vitamins solution (see Medium No.284)	CROSS_REFERENCE	1	1	CultureMech:015391	no	ingredients
+Trace mineral solution (see Medium No.852)	CROSS_REFERENCE	1	1	CultureMech:015391	no	ingredients
+Se/W solution (Medium No.852)	SOLUTION_NAME	1	1	CultureMech:015391	no	ingredients
+MoYLS4	UNRESOLVED_CHEMICAL	1	1	CultureMech:015635	no	ingredients
+Infusion from Potatoes	UNRESOLVED_CHEMICAL	1	1	CultureMech:015683	no	ingredients
+Copper(II) Nitrate Trihydrate	UNRESOLVED_CHEMICAL	1	1	CultureMech:015747	no	ingredients
+SDM_noCarbon	UNRESOLVED_CHEMICAL	1	1	CultureMech:015749	no	ingredients
+3-Sulfolactate	UNRESOLVED_CHEMICAL	1	1	CultureMech:015430	no	ingredients
+ZMB	UNRESOLVED_CHEMICAL	1	1	CultureMech:015830	no	ingredients

--- a/project.justfile
+++ b/project.justfile
@@ -427,6 +427,23 @@ audit-concentration-plausibility *args="":
 #                          #283 shape, where ucm.yaml lists eight ingredients
 #                          twice at 1000x/100x apart. Invisible to the three
 #                          above, which all key off the merge note.
+# Ingredient rows the KGX export drops for want of an identity (#372). The
+# export mints an edge only when the ingredient resolves and counts nothing it
+# discards, so the node/edge totals read as complete when they are not.
+#
+# Baselined on distinct NAMES, not rows: one grounding decision fixes every row
+# carrying a name, so the name count is the size of the work and the row count
+# is the size of the loss. 3,217 names / 14,793 rows today.
+#
+# The classification matters more than the total. Only 5,047 of those rows are
+# UNRESOLVED_CHEMICAL; the rest are one PLACEHOLDER string (4,775 rows),
+# SOLUTION_NAME (3,225) and CROSS_REFERENCE (1,746), none of which wants a
+# ChEBI id. See the issue before "fixing" this by emitting them.
+[group('Audit')]
+audit-ungrounded-ingredients *args="":
+    uv run --extra dev python scripts/audit_ungrounded_ingredients.py \
+        --max-names 3217 {{args}}
+
 [group('Audit')]
 audit-merged-duplicates *args="":
     uv run --extra dev python scripts/audit_merged_duplicates.py \

--- a/scripts/audit_ungrounded_ingredients.py
+++ b/scripts/audit_ungrounded_ingredients.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Report the ingredient rows the KGX export drops for want of an identity (#372).
+
+`kgx_export` mints an edge only when the ingredient resolves:
+
+    chem_id = _resolved_ingredient_id(ingredient, ingredient_resolver)
+    if not chem_id:
+        return None
+
+Two call sites do this — `ingredient_to_edge` and the solution-composition
+equivalent — and neither counts what it discarded. The rows leave no trace in
+the output, no warning, and no report, so the export's node and edge totals look
+complete when they are not.
+
+This audit answers the same question from the corpus side, using the same
+resolver, so it costs nothing in the export path and needs no koza run.
+
+## Names, not rows
+
+The headline is deliberately a **name** count. One grounding decision fixes
+every row carrying that name, so a row count says how much output is missing
+while a name count says how much work it takes to get it back — and the two
+differ by more than an order of magnitude here. Both are reported; only the
+name count is worth ratcheting.
+
+Read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from culturemech.ingredients import resolve_ingredient  # noqa: E402
+
+DEFAULT_RECORDS = REPO_ROOT / "data" / "normalized_yaml"
+DEFAULT_REPORT = REPO_ROOT / "data" / "import_tracking" / "reports" / "ungrounded_ingredients.tsv"
+HEADER = [
+    "ingredient",
+    "kind",
+    "rows",
+    "records",
+    "example_record",
+    "has_local_term",
+    "section",
+]
+
+# Why the classification matters: #372 proposes emitting these rows under
+# kg-microbe's `INGREDIENT_CATEGORY`. Most of them are not ingredients. Minting
+# 4,775 `biolink:ChemicalEntity` nodes called "See source for composition" would
+# be worse than dropping them, so the split has to come before the decision.
+_PLACEHOLDER = (
+    "see source",
+    "see recipe",
+    "not specified",
+    "unknown",
+    "as required",
+    "to be determined",
+)
+_CROSS_REFERENCE = ("see medium", "see m[", "medium [", "as in medium")
+_SOLUTION_WORDS = ("solution", "stock", "cocktail", "elixir", "mixture", "buffer")
+
+
+def classify_name(name: str) -> str:
+    """What kind of thing this unresolvable string actually is."""
+    lowered = name.strip().lower()
+    if not lowered:
+        return "EMPTY"
+    if any(token in lowered for token in _PLACEHOLDER):
+        return "PLACEHOLDER"
+    if any(token in lowered for token in _CROSS_REFERENCE):
+        return "CROSS_REFERENCE"
+    if any(token in lowered for token in _SOLUTION_WORDS):
+        return "SOLUTION_NAME"
+    return "UNRESOLVED_CHEMICAL"
+
+
+def _walk(items: Any, section: str, sink: list[tuple[str, str, dict[str, Any]]]) -> None:
+    for ingredient in items or []:
+        if not isinstance(ingredient, dict):
+            continue
+        name = str(ingredient.get("preferred_term") or "").strip()
+        sink.append((name, section, ingredient))
+        _walk(ingredient.get("composition"), f"{section}.composition", sink)
+
+
+def scan(records_dir: Path) -> tuple[list[dict[str, Any]], Counter]:
+    stats: Counter = Counter()
+    rows_by_name: Counter = Counter()
+    records_by_name: defaultdict[str, set[str]] = defaultdict(set)
+    example: dict[str, str] = {}
+    local_term: dict[str, bool] = {}
+    section_of: dict[str, str] = {}
+
+    for path in sorted(records_dir.glob("*/*.yaml")):
+        record = yaml.safe_load(path.read_text())
+        if not isinstance(record, dict):
+            continue
+        stats["records_scanned"] += 1
+        identifier = str(record.get("id") or path.name)
+
+        found: list[tuple[str, str, dict[str, Any]]] = []
+        _walk(record.get("ingredients"), "ingredients", found)
+        _walk(record.get("solutions"), "solutions", found)
+
+        for name, section, ingredient in found:
+            stats["rows_total"] += 1
+            # The whole ingredient, not just its name: the resolver also reads a
+            # record's own `term`, so a locally grounded row resolves without MIM
+            # and passing the bare name would over-report.
+            if resolve_ingredient(ingredient).is_resolved:
+                stats["rows_resolved"] += 1
+                continue
+            stats["rows_ungrounded"] += 1
+            rows_by_name[name] += 1
+            records_by_name[name].add(identifier)
+            example.setdefault(name, identifier)
+            term = ingredient.get("term")
+            local_term.setdefault(name, bool(isinstance(term, dict) and term.get("id")))
+            section_of.setdefault(name, section)
+
+    stats["names_ungrounded"] = len(rows_by_name)
+    for name, count in rows_by_name.items():
+        kind = classify_name(name)
+        stats[f"names:{kind}"] += 1
+        stats[f"rows:{kind}"] += count
+    report = [
+        {
+            "ingredient": name,
+            "kind": classify_name(name),
+            "rows": count,
+            "records": len(records_by_name[name]),
+            "example_record": example[name],
+            "has_local_term": "yes" if local_term[name] else "no",
+            "section": section_of[name],
+        }
+        for name, count in rows_by_name.most_common()
+    ]
+    return report, stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--records-dir", type=Path, default=DEFAULT_RECORDS)
+    parser.add_argument("--out", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument(
+        "--max-names",
+        type=int,
+        default=None,
+        help="Fail if the number of distinct unresolvable names exceeds this.",
+    )
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    report, stats = scan(args.records_dir)
+
+    total = stats["rows_total"] or 1
+    print(f"Scanned {stats['records_scanned']:,} records, {stats['rows_total']:,} ingredient rows")
+    print(f"  resolved   : {stats['rows_resolved']:,}")
+    print(
+        f"  ungrounded : {stats['rows_ungrounded']:,} rows "
+        f"({100 * stats['rows_ungrounded'] / total:.1f}%) "
+        f"across {stats['names_ungrounded']:,} distinct names"
+    )
+    print("\nThese rows produce no edge in the KGX export and are reported nowhere else.")
+    print("\nby kind (names / rows):")
+    for kind in ("UNRESOLVED_CHEMICAL", "SOLUTION_NAME", "CROSS_REFERENCE", "PLACEHOLDER", "EMPTY"):
+        if stats[f"names:{kind}"]:
+            print(f"  {kind:22s} {stats[f'names:{kind}']:6,} / {stats[f'rows:{kind}']:7,}")
+    if report:
+        print("\nmost frequent:")
+        for row in report[:10]:
+            print(f"  {row['rows']:6d} rows / {row['records']:5d} records  {row['ingredient']!r}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=HEADER, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(report)
+    print(f"\nWrote {args.out.relative_to(REPO_ROOT)}")
+
+    if args.max_names is not None and stats["names_ungrounded"] > args.max_names:
+        print(
+            f"\nFAIL: {stats['names_ungrounded']} unresolvable names > baseline "
+            f"{args.max_names}. A new import added ingredient names nothing can ground.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ungrounded_ingredients.py
+++ b/tests/test_ungrounded_ingredients.py
@@ -1,0 +1,56 @@
+"""What the KGX export drops, and what kind of thing it is (#372).
+
+`kgx_export` mints an edge only when an ingredient resolves, and neither of its
+two `if not chem_id: return None` sites counts what it discarded — so the
+export's totals read as complete while 14,793 rows leave no trace anywhere.
+
+The classification is the load-bearing part. #372 proposes emitting these rows
+under kg-microbe's `INGREDIENT_CATEGORY`, and most of them are not ingredients:
+one placeholder string accounts for 4,775 rows. Minting thousands of
+`biolink:ChemicalEntity` nodes called "See source for composition" would be
+worse than dropping them.
+
+Every literal is a real `preferred_term` from the corpus.
+"""
+
+from __future__ import annotations
+
+import pytest
+from audit_ungrounded_ingredients import classify_name
+
+
+@pytest.mark.parametrize(
+    ("name", "kind"),
+    [
+        ("See source for composition", "PLACEHOLDER"),
+        ("Trace vitamins (see Medium [M190])", "CROSS_REFERENCE"),
+        ("Trace element solution (see Medium [M180])", "CROSS_REFERENCE"),
+        ("Seven vitamins solution", "SOLUTION_NAME"),
+        ("5% Na2S・9H2O solution", "SOLUTION_NAME"),
+        ("Wolfe's mineral elixir", "SOLUTION_NAME"),
+        ("Sodium phosphate buffer", "SOLUTION_NAME"),
+        ("Calf brains", "UNRESOLVED_CHEMICAL"),
+        ("Agar (if needed)", "UNRESOLVED_CHEMICAL"),
+        ("", "EMPTY"),
+    ],
+)
+def test_a_name_is_classified_by_what_it_actually_is(name, kind):
+    assert classify_name(name) == kind
+
+
+def test_a_cross_reference_outranks_the_word_solution():
+    """`Trace element solution (see Medium [M180])` points at a medium.
+
+    It is both a solution name and a cross-reference; the cross-reference is the
+    actionable fact, because the target is a record we already hold.
+    """
+    assert classify_name("Trace element solution (see Medium [M180])") == "CROSS_REFERENCE"
+
+
+def test_a_plain_chemical_is_not_swept_into_a_bucket():
+    for name in ("Glucose", "NaCl", "MgSO4 x 7 H2O", "Yeast extract"):
+        assert classify_name(name) == "UNRESOLVED_CHEMICAL"
+
+
+def test_whitespace_only_is_empty_not_a_chemical():
+    assert classify_name("   ") == "EMPTY"


### PR DESCRIPTION
Addresses #372.

`kgx_export` mints an edge only when the ingredient resolves. Both call sites do
the same thing with a failure:

```python
chem_id = _resolved_ingredient_id(ingredient, ingredient_resolver)
if not chem_id:
    return None
```

Neither counts it. **14,793 rows** leave no trace in the output, no warning and
no report, so the export's node and edge totals read as complete when they are
not.

`just audit-ungrounded-ingredients` answers the same question from the corpus
side using the same resolver — no koza run, no change to the export path. It
reproduces the number exactly: 14,793 rows, 8.2%, 3,217 distinct names.

## The classification changes what the fix should be

The issue proposes emitting these under kg-microbe's `INGREDIENT_CATEGORY`.
**Most of them are not ingredients:**

| kind | names | rows |
|---|--:|--:|
| `UNRESOLVED_CHEMICAL` | 1,822 | 5,047 |
| `SOLUTION_NAME` | 1,090 | 3,225 |
| `CROSS_REFERENCE` | 304 | 1,746 |
| `PLACEHOLDER` | **1** | **4,775** |

The single placeholder is `"See source for composition"` — **a third of all
dropped rows from one string**. Emitting it under a chemical category would mint
4,775 `biolink:ChemicalEntity` nodes with that as their name, which is worse
than dropping them.

Top offenders are the same shape: `'Trace vitamins (see Medium [M190])'`,
`'Seven vitamins solution'`, `'5% Na2S・9H2O solution'`, `'Trace element
solution (see Medium [M180])'`.

Only **34%** of the loss is a grounding backlog. The rest wants linking to
solution and medium records we already hold — a different change, and the reason
this PR reports rather than emits.

## Also corrects the issue's headline

24,317 rows / 11.7% → **14,793 / 8.2%**, from #378 and #391 restoring ingredient
names that previously grounded to nothing.

## Baselined on names, not rows

One grounding decision fixes every row carrying that name, so the name count is
the size of the work and the row count is the size of the loss. `--max-names 3217`.

## Verification

- Reproduces the independently-measured 14,793 exactly.
- Resolves the whole ingredient dict rather than the bare name, since the
  resolver also reads a record's own `term` — passing just the name would
  over-report.
- 13 classifier tests, every literal a real `preferred_term` from the corpus,
  including that a cross-reference outranks the word "solution" when a string is
  both (`Trace element solution (see Medium [M180])` points at a record we hold).
- `test-fast` 1487 passed; `derived_artifacts.tsv` refreshed for the new report.

## What this does not do

Emit the rows. That decision now has the evidence it needs, and it belongs with
#373 (undeclared prefixes) and #374 (nothing ingests the export) rather than
ahead of them.