### PR TITLE
Add single-record YAML curation skill

### DIFF
--- a/.claude/skills/curate-yaml-record/SKILL.md
+++ b/.claude/skills/curate-yaml-record/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: curate-yaml-record
+description: Review and curate one CultureMech medium or stock-solution YAML record for source identity, formulation accuracy, preparation detail, growth evidence, completeness, and resolvable gaps. Use when asked to audit, improve, complete, correct, or add evidence to one record; do not use for bulk ingestion, generated merge/page edits, or as permission to contact anyone or mutate GitHub.
+allowed-tools: Bash, Read, Grep, Glob, WebSearch, WebFetch, Edit, Write
+metadata:
+  category: curation
+  requires_database: false
+  requires_internet: true
+  version: 1.0.0
+---
+
+# Curate one CultureMech YAML record
+
+Produce a scientifically defensible medium or stock-solution record and an
+explicit account of what is supported, corrected, still missing, and genuinely
+unknown. Search results are leads; only inspected sources can support a claim.
+
+## Boundaries
+
+- Resolve one authoritative target under `data/normalized_yaml/`. Distinguish
+  `MediaRecipe` from `SolutionRecipe`; do not silently substitute a similarly
+  named medium, variant, or stock solution.
+- An audit or review request is read-only. Curate, improve, complete, correct,
+  or add-evidence requests authorize local edits to the named record and the
+  smallest necessary repository-owned provenance path.
+- Never edit `data/raw_yaml/`, `data/merge_yaml/merged/`, `app/data.js`, or
+  generated `pages/` as the source of a correction. Fix the normalized record,
+  source-specific input, or maintained rule that owns the value.
+- Never create or edit a GitHub issue, PR, comment, email, form, or message
+  without explicit authorization for that outbound action.
+- Preserve unrelated work. Follow `CLAUDE.md`; use a branch and a separate
+  worktree when the checkout is dirty or occupied.
+- Never infer that an absent optional property is false and never add a value
+  merely to improve coverage.
+
+## Read before judging the record
+
+Read the complete target plus:
+
+- `CLAUDE.md`;
+- `docs/CONTRIBUTING.md` and `docs/QUICK_START.md`;
+- the relevant `MediaRecipe`, `SolutionRecipe`, ingredient, evidence, and
+  curation-event classes in `src/culturemech/schema/culturemech.yaml`;
+- [references/review-checklist.md](references/review-checklist.md).
+
+Consult `docs/DATA_LAYERS.md` when ownership of a field or generated artifact
+is unclear. Check related variants, solutions, and source records; a rendered
+page or merged recipe is not independent evidence.
+
+## Workflow
+
+### 1. Establish the baseline
+
+Read the whole YAML. Record its ID, lineage token, name, record kind, source
+metadata, references, variants, composition, existing evidence, quality flags,
+and curation history. Run:
+
+```bash
+just validate-schema <record-path>
+just validate-strict <record-path>
+```
+
+Use `just validate-terms <record-path>` and `just validate-references
+<record-path>` when their caches or network dependencies are available. A green
+schema gate proves shape, not scientific correctness.
+
+### 2. Verify record and source identity first
+
+Confirm that the record denotes the intended medium or stock solution and that
+its source name, source accession, category, `record_kind`, parent/variant
+relations, and stable ID agree. IDs are permanent; never hand-pick or reuse one.
+
+For ingredients, use the packaged MediaIngredientMech label index and respect
+exact chemical form. Hydration, stereochemistry, salts, digits, formula
+punctuation, and stock-versus-final concentration can change identity or amount.
+Do not replace unresolved material with a plausible ChEBI term.
+
+### 3. Review every scientific and procedural claim
+
+Check each ingredient, solution reference, amount/unit, pH, temperature,
+salinity, atmosphere, physical state, sterilization step, preparation step,
+storage condition, target-organism assertion, application, and growth-evidence
+claim against the cited source. Distinguish an upstream recipe, primary growth
+study, database assertion, secondary review, and search-result snippet.
+
+Preserve the source's stated formulation. Do not silently convert a stock
+recipe to final-medium amounts, fill an unspecified quantity, or upgrade
+reported growth to an optimal or exclusive medium claim. Keep exact quotations
+short and attached to the narrowest supported assertion.
+
+### 4. Assess completeness and resolve supported gaps
+
+Apply the checklist and use bounded, targeted searches for consequential gaps.
+Prioritize:
+
+1. wrong medium/solution identity or source;
+2. missing, duplicated, or chemically misresolved ingredients;
+3. incorrect quantity, unit, stock dilution, or final-volume arithmetic;
+4. missing or contradictory preparation, sterilization, pH, temperature, or
+   atmosphere details;
+5. unsupported growth, application, organism, or variant claims.
+
+Do not add generic discussion text for every empty optional slot. Record a
+discussion or quality flag only for a concrete conflict or consequential task,
+including what was checked and what evidence would resolve it.
+
+### 5. Write through the guarded path
+
+Use a narrowly scoped temporary or checked-in Python mutator that loads the
+existing YAML, asserts the expected ID/path, changes only reviewed nodes,
+appends an event with
+`culturemech.curate.curation_event.record_curation_event`, and writes with
+`culturemech.validation.write_validated.write_validated_recipe`.
+
+Use `curator="claude"` when no curator identity was supplied. Do not attribute
+an agent's judgement to the user. Do not append an event when no substantive
+change was made. Inspect the object and text diff; abandon or repair any
+whole-file presentation churn before proceeding.
+
+If the correction is source-owned or generated, fix its authoritative input or
+rule and regenerate. Never patch the derived merge to make it look correct.
+
+### 6. Verify and report
+
+After an edit, run the focused checks again and then the proportional wider
+gates:
+
+```bash
+just validate-strict <record-path>
+just validate-products
+just verify-merges
+git diff --check
+git diff -- <record-path> src scripts history
+```
+
+Run `just qc` when the change or available environment warrants the full gate.
+Read the emitted YAML again and ensure every citation supports its nearest
+claim and the history entry describes the actual diff.
+
+Report corrections/additions and their sources, retained claims checked,
+remaining gaps and unsuccessful bounded searches, data-layer ownership of each
+change, and every validation result. CultureMech has no record-level REVIEWED
+status; never invent one.

--- a/.claude/skills/curate-yaml-record/references/review-checklist.md
+++ b/.claude/skills/curate-yaml-record/references/review-checklist.md
@@ -1,0 +1,43 @@
+# CultureMech record review checklist
+
+Use this for claim-level review of one `MediaRecipe` or `SolutionRecipe`. Empty
+optional fields are not automatically defects.
+
+## Evidence standard
+
+- Put evidence on the narrowest representable claim and verify identifiers and
+  source text before citing them.
+- A source recipe establishes what it says, not that every organism grows or
+  grows optimally in the formulation.
+- A search result is discovery metadata. Inspect the database record, paper,
+  or source document before using it.
+- Preserve conflicting formulations or version differences explicitly; do not
+  blend them into an unsupported synthetic recipe.
+- State bounded negative searches as “not found,” never “does not exist.”
+
+## Field-by-field audit
+
+| Area | Verify | Complete enough when |
+|---|---|---|
+| Identity | ID, lineage token, name, source accession, record kind, and category identify one medium or stock solution. | No similarly named medium, variant, or solution is being conflated. |
+| Source provenance | `sources`, `source_data`, import metadata, references, and retrieval/version detail agree. | A reader can recover the authoritative formulation and distinguish imported from curator-added content. |
+| Ingredients | Ingredient identity, exact supplied form, quantity, unit, role, and order/grouping match the source. | Every stated component is supported; unresolved ingredients remain explicit. |
+| Solutions | Referenced stock solution, amount, concentration, nesting, and preparation boundary are correct. | Stock and final-medium quantities are not conflated and references resolve. |
+| Arithmetic | Totals, dilutions, concentration conversions, and final volume are dimensionally consistent. | No conversion assumes an unstated density, stock strength, or final volume. |
+| Conditions | pH, temperature, salinity, light, atmosphere, vessel, and physical state retain source context. | Values are scoped to preparation, incubation, or storage correctly. |
+| Preparation | Step order, sterilization, cooling, post-autoclave additions, storage, and shelf life match the protocol. | Following the record would not materially change the source recipe. |
+| Organisms/growth | Taxon or strain, growth outcome, conditions, medium variant, and evidence are aligned. | Growth claims do not generalize beyond the tested organism and conditions. |
+| Classification | Medium type, nutritional class, functional role, applications, parents, and variants are source-supported. | Filing choices do not erase alternate roles or imply unsupported equivalence. |
+| Evidence | Reference identifiers resolve; snippets are exact; notes distinguish interpretation. | Every consequential curator claim is traceable to an inspected source. |
+| Discussions/flags | Each item names a concrete conflict, uncertainty, or next curation action. | No placeholder task or coverage-filling prose remains. |
+| Audit | `curation_history` describes only the actual change and preserves older entries. | Provenance is append-only and names the acting curator/process honestly. |
+
+## Data ownership
+
+- Curate authoritative records under `data/normalized_yaml/`.
+- Fix imported/source-owned claims in their maintained input or importer when a
+  direct normalized edit would be overwritten.
+- Regenerate `data/merge_yaml/merged/` and page/browser outputs; never curate
+  them directly.
+- Use the repository's ID allocator for new IDs and the packaged MIM index for
+  publication-time ingredient resolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ arguments or `CMM_AUTOMATION_DATA_DIR`, `MICROBE_MEDIA_PARAM_DIR`, and
 - New records/IDs: `create-recipe`, then `manage-identifiers`.
 - Recipe QA: `review-recipes`; broad schema/pipeline audits:
   `audit-schema-gaps`; quick diagnosis: `schema-gap-analysis`.
+- Single-record scientific curation: `curate-yaml-record`.
 - Sources: `fetch-source` or `scrape-jcm-media`.
 - Grounding: `id-label-correspondence` and `match-kg-microbe`.
 - Research: `deep-research-medium` and `research-ingredient-roles`.

--- a/scripts/validate_claude_skills.py
+++ b/scripts/validate_claude_skills.py
@@ -10,7 +10,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ROOT / ".claude" / "skills"
-REQUIRED_FRONTMATTER = {"name", "description", "version"}
+REQUIRED_FRONTMATTER = {"name", "description"}
 LOCAL_REFERENCE = re.compile(
     r"`((?:scripts|src|docs|conf|\.claude)/[^`\s]+|(?:README|NEXT_TASKS|project\.justfile)[^`\s]*)`"
 )
@@ -57,6 +57,12 @@ def validate_skills() -> list[str]:
         missing = sorted(REQUIRED_FRONTMATTER - metadata.keys())
         if missing:
             errors.append(f"{skill_file.relative_to(ROOT)}: missing {', '.join(missing)}")
+        nested_metadata = metadata.get("metadata")
+        nested_version = (
+            nested_metadata.get("version") if isinstance(nested_metadata, dict) else None
+        )
+        if not metadata.get("version") and not nested_version:
+            errors.append(f"{skill_file.relative_to(ROOT)}: missing version")
         if metadata.get("name") != directory.name:
             errors.append(
                 f"{skill_file.relative_to(ROOT)}: name must match directory {directory.name!r}"

--- a/tests/test_claude_skills.py
+++ b/tests/test_claude_skills.py
@@ -19,3 +19,22 @@ def test_stats_report_uses_discoverable_skill_layout() -> None:
     assert path.is_file()
     assert validate_claude_skills.frontmatter(path)["name"] == "stats-report"
     assert not (ROOT / ".claude" / "skills" / "stats-report.md").exists()
+
+
+def test_validator_accepts_standard_nested_skill_metadata(tmp_path, monkeypatch) -> None:
+    skill_dir = tmp_path / ".claude" / "skills" / "curate-yaml-record"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: curate-yaml-record\n"
+        "description: Curate one record.\n"
+        "metadata:\n"
+        "  version: 1.0.0\n"
+        "---\n\n"
+        "# Curate one record\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(validate_claude_skills, "ROOT", tmp_path)
+    monkeypatch.setattr(validate_claude_skills, "SKILLS_DIR", tmp_path / ".claude" / "skills")
+
+    assert validate_claude_skills.validate_skills() == []


### PR DESCRIPTION
## Summary
- add a CultureMech-specific single-record YAML curation skill and checklist
- route the skill from CLAUDE.md
- accept standard nested skill metadata while preserving the legacy layout

## Validation
- skill-creator quick validation
- targeted repository tests: 136 passed