### PR TITLE
Derive the review script's enums and MIM field from the repo, not from copies (#401, #402)

### DIFF
--- a/scripts/batch_review_recipes.py
+++ b/scripts/batch_review_recipes.py
@@ -7,85 +7,133 @@ Validates all recipes against P1-P4 validation rules and generates reports.
 
 import argparse
 import json
-import yaml
-import sys
-from pathlib import Path
-from datetime import datetime
-from typing import Dict, List, Optional, Tuple
-from collections import defaultdict
 import re
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+import yaml
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
+SCHEMA_PATH = Path(__file__).parent.parent / "src" / "culturemech" / "schema" / "culturemech.yaml"
+
+# The MIM link field. `mediaingredientmech_term` is the RETIRED one: MIM
+# deprecated the `MediaIngredientMech:NNNNNN` id scheme and the corpus was
+# migrated to `mediaingredientmech_chebi_term`, an event recorded per record in
+# `curation_history`. Counting the retired field reported 0.8% coverage where
+# the live field is at 67.2% (#402), which flagged 15,473 of 15,877 records and
+# buried the records with a genuine gap.
+MIM_LINK_FIELD = "mediaingredientmech_chebi_term"
+LEGACY_MIM_LINK_FIELD = "mediaingredientmech_term"
+
+
+def permissible_values(enum_name: str) -> list[str]:
+    """The enum's values, read from the authoritative schema (#401).
+
+    Restating them in Python is what produced two false P1 criticals: the
+    hardcoded list rejected `BUFFER` and `NEGATIVE_CONTROL`, which the schema
+    permits, while accepting `SEMI_DEFINED` and `UNDEFINED`, which belong to
+    `MediumCompositionTypeEnum` — a different axis, split out by
+    `migrate_medium_type_axes.py`. Being wrong permissively is the worse half:
+    nobody investigates a check that stays green.
+    """
+    schema = yaml.safe_load(SCHEMA_PATH.read_text())
+    enum = schema["enums"][enum_name]
+    return list(enum.get("permissible_values") or {})
+
+
+def mim_link_id(ingredient: dict) -> str | None:
+    """The ingredient's MIM link, live field first, retired field as fallback.
+
+    The fallback is deliberate rather than tidy: 1,677 instances still carry
+    only the retired field, and dropping them would understate coverage in the
+    opposite direction to the bug being fixed.
+    """
+    if not isinstance(ingredient, dict):
+        return None
+    for field in (MIM_LINK_FIELD, LEGACY_MIM_LINK_FIELD):
+        value = ingredient.get(field)
+        if isinstance(value, dict) and value.get("id"):
+            return value["id"]
+    return None
+
+
 class RecipeValidator:
     """Validate recipes against quality rules."""
 
-    def __init__(self, mediaingredientmech_repo: Optional[Path] = None):
+    def __init__(self, mediaingredientmech_repo: Path | None = None):
         self.mediaingredientmech_repo = mediaingredientmech_repo
         self.mediaing_ids = self._load_mediaingredientmech_ids()
 
-    def _validate_solution(self, solution: Dict, solution_path: Path) -> Dict:
+    def _validate_solution(self, solution: dict, solution_path: Path) -> dict:
         """Validate a solution file (uses SolutionDescriptor schema)."""
         issues = []
 
         # Solution-specific validation
         # Required: preferred_term, composition
-        if 'preferred_term' not in solution:
-            issues.append({
-                'rule': 'P1.3',
-                'priority': 'P1',
-                'description': 'Missing required field: preferred_term (for solutions)'
-            })
+        if "preferred_term" not in solution:
+            issues.append(
+                {
+                    "rule": "P1.3",
+                    "priority": "P1",
+                    "description": "Missing required field: preferred_term (for solutions)",
+                }
+            )
 
-        if 'composition' not in solution:
-            issues.append({
-                'rule': 'P1.3',
-                'priority': 'P1',
-                'description': 'Missing required field: composition (for solutions)'
-            })
+        if "composition" not in solution:
+            issues.append(
+                {
+                    "rule": "P1.3",
+                    "priority": "P1",
+                    "description": "Missing required field: composition (for solutions)",
+                }
+            )
 
         # Check composition ingredients
-        composition = solution.get('composition', [])
+        composition = solution.get("composition", [])
         total_ingredients = len(composition)
-        linked_ingredients = sum(
-            1 for ing in composition
-            if isinstance(ing, dict) and ing.get('mediaingredientmech_term', {}).get('id')
-        )
+        linked_ingredients = sum(1 for ing in composition if mim_link_id(ing))
 
         coverage = (linked_ingredients / total_ingredients * 100) if total_ingredients > 0 else 0
 
         # Solutions should have >80% MediaIngredientMech coverage
         if coverage < 80 and total_ingredients > 0:
-            issues.append({
-                'rule': 'P3.2',
-                'priority': 'P3',
-                'description': f'Low MediaIngredientMech coverage: {coverage:.1f}% (threshold: 80% for solutions)'
-            })
+            issues.append(
+                {
+                    "rule": "P3.2",
+                    "priority": "P3",
+                    "description": f"Low MediaIngredientMech coverage: {coverage:.1f}% (threshold: 80% for solutions)",
+                }
+            )
 
         # Check for invalid MediaIngredientMech IDs
-        for idx, ing in enumerate(composition):
+        for _idx, ing in enumerate(composition):
             if isinstance(ing, dict):
-                mediaing_id = ing.get('mediaingredientmech_term', {}).get('id')
+                mediaing_id = mim_link_id(ing)
                 if mediaing_id and self.mediaing_ids and mediaing_id not in self.mediaing_ids:
-                    issues.append({
-                        'rule': 'P2.1',
-                        'priority': 'P2',
-                        'description': f'Invalid MediaIngredientMech ID: {mediaing_id} (ingredient: {ing.get("preferred_term", "unknown")})'
-                    })
+                    issues.append(
+                        {
+                            "rule": "P2.1",
+                            "priority": "P2",
+                            "description": f'Invalid MediaIngredientMech ID: {mediaing_id} (ingredient: {ing.get("preferred_term", "unknown")})',
+                        }
+                    )
 
         return {
-            'path': str(solution_path),
-            'id': solution.get('id', 'N/A'),
-            'name': solution.get('preferred_term', 'N/A'),
-            'category': 'solution',
-            'medium_type': 'SOLUTION',
-            'total_ingredients': total_ingredients,
-            'linked_ingredients': linked_ingredients,
-            'coverage': coverage,
-            'issues': issues,
-            'valid': len([i for i in issues if i['priority'] == 'P1']) == 0
+            "path": str(solution_path),
+            "id": solution.get("id", "N/A"),
+            "name": solution.get("preferred_term", "N/A"),
+            "category": "solution",
+            "medium_type": "SOLUTION",
+            "total_ingredients": total_ingredients,
+            "linked_ingredients": linked_ingredients,
+            "coverage": coverage,
+            "issues": issues,
+            "valid": len([i for i in issues if i["priority"] == "P1"]) == 0,
         }
 
     def _load_mediaingredientmech_ids(self) -> set:
@@ -98,16 +146,18 @@ class RecipeValidator:
                 self.mediaingredientmech_repo = default_path
 
         if self.mediaingredientmech_repo:
-            mapped_file = self.mediaingredientmech_repo / "data" / "curated" / "mapped_ingredients.yaml"
+            mapped_file = (
+                self.mediaingredientmech_repo / "data" / "curated" / "mapped_ingredients.yaml"
+            )
             if mapped_file.exists():
                 with open(mapped_file) as f:
                     data = yaml.safe_load(f)
-                    for item in data.get('ingredients', []):
-                        if 'id' in item:
-                            ids.add(item['id'])
+                    for item in data.get("ingredients", []):
+                        if "id" in item:
+                            ids.add(item["id"])
         return ids
 
-    def validate_recipe(self, recipe_path: Path) -> Dict:
+    def validate_recipe(self, recipe_path: Path) -> dict:
         """Validate a single recipe and return issues."""
         issues = []
 
@@ -116,28 +166,27 @@ class RecipeValidator:
                 recipe = yaml.safe_load(f)
         except Exception as e:
             return {
-                'path': str(recipe_path),
-                'valid': False,
-                'issues': [{
-                    'rule': 'P1.1',
-                    'priority': 'P1',
-                    'description': f'Failed to parse YAML: {e}'
-                }]
+                "path": str(recipe_path),
+                "valid": False,
+                "issues": [
+                    {"rule": "P1.1", "priority": "P1", "description": f"Failed to parse YAML: {e}"}
+                ],
             }
 
         # P1.1: Schema validation (basic check)
         if not isinstance(recipe, dict):
-            issues.append({
-                'rule': 'P1.1',
-                'priority': 'P1',
-                'description': 'Recipe is not a valid dictionary'
-            })
-            return {'path': str(recipe_path), 'valid': False, 'issues': issues}
+            issues.append(
+                {
+                    "rule": "P1.1",
+                    "priority": "P1",
+                    "description": "Recipe is not a valid dictionary",
+                }
+            )
+            return {"path": str(recipe_path), "valid": False, "issues": issues}
 
         # Detect if this is a solution (not a media recipe)
-        is_solution = (
-            'solutions' in str(recipe_path) or
-            ('preferred_term' in recipe and 'composition' in recipe and 'name' not in recipe)
+        is_solution = "solutions" in str(recipe_path) or (
+            "preferred_term" in recipe and "composition" in recipe and "name" not in recipe
         )
 
         # Solutions use SolutionDescriptor schema, skip MediaRecipe validation
@@ -145,64 +194,89 @@ class RecipeValidator:
             return self._validate_solution(recipe, recipe_path)
 
         # P1.2: Invalid CultureMech ID
-        culturemech_id = recipe.get('id', '')
-        if not re.match(r'^CultureMech:\d{6}$', culturemech_id):
-            issues.append({
-                'rule': 'P1.2',
-                'priority': 'P1',
-                'description': f'Invalid CultureMech ID format: {culturemech_id}'
-            })
+        culturemech_id = recipe.get("id", "")
+        if not re.match(r"^CultureMech:\d{6}$", culturemech_id):
+            issues.append(
+                {
+                    "rule": "P1.2",
+                    "priority": "P1",
+                    "description": f"Invalid CultureMech ID format: {culturemech_id}",
+                }
+            )
 
         # P1.3: Missing required fields
-        required_fields = ['name', 'medium_type', 'physical_state']
+        required_fields = ["name", "medium_type", "physical_state"]
         for field in required_fields:
             if field not in recipe:
-                issues.append({
-                    'rule': 'P1.3',
-                    'priority': 'P1',
-                    'description': f'Missing required field: {field}'
-                })
+                issues.append(
+                    {
+                        "rule": "P1.3",
+                        "priority": "P1",
+                        "description": f"Missing required field: {field}",
+                    }
+                )
 
         # P1.4: Invalid enum values (basic check)
         # These are the actual values from the schema - DO NOT hardcode, derive from schema
-        valid_medium_types = ['DEFINED', 'COMPLEX', 'SEMI_DEFINED', 'MINIMAL', 'UNDEFINED']
-        valid_physical_states = ['LIQUID', 'SOLID_AGAR', 'SEMISOLID', 'BIPHASIC']
+        valid_medium_types = permissible_values("MediumTypeEnum")
+        valid_physical_states = permissible_values("PhysicalStateEnum")
+        valid_composition_types = permissible_values("MediumCompositionTypeEnum")
 
-        if recipe.get('medium_type') and recipe['medium_type'] not in valid_medium_types:
-            issues.append({
-                'rule': 'P1.4',
-                'priority': 'P1',
-                'description': f'Invalid medium_type: {recipe.get("medium_type")}'
-            })
+        if recipe.get("medium_type") and recipe["medium_type"] not in valid_medium_types:
+            issues.append(
+                {
+                    "rule": "P1.4",
+                    "priority": "P1",
+                    "description": f'Invalid medium_type: {recipe.get("medium_type")}',
+                }
+            )
 
-        if recipe.get('physical_state') and recipe['physical_state'] not in valid_physical_states:
-            issues.append({
-                'rule': 'P1.4',
-                'priority': 'P1',
-                'description': f'Invalid physical_state: {recipe.get("physical_state")}'
-            })
+        # composition_type was never validated at all — the axis existed but no
+        # rule looked at it (#401).
+        if (
+            recipe.get("composition_type")
+            and recipe["composition_type"] not in valid_composition_types
+        ):
+            issues.append(
+                {
+                    "rule": "P1.4",
+                    "priority": "P1",
+                    "description": f'Invalid composition_type: {recipe.get("composition_type")}',
+                }
+            )
+
+        if recipe.get("physical_state") and recipe["physical_state"] not in valid_physical_states:
+            issues.append(
+                {
+                    "rule": "P1.4",
+                    "priority": "P1",
+                    "description": f'Invalid physical_state: {recipe.get("physical_state")}',
+                }
+            )
 
         # P2.1: Invalid MediaIngredientMech ID
-        ingredients = recipe.get('ingredients', []) + recipe.get('composition', [])
-        for idx, ing in enumerate(ingredients):
+        ingredients = recipe.get("ingredients", []) + recipe.get("composition", [])
+        for _idx, ing in enumerate(ingredients):
             if isinstance(ing, dict):
-                mediaing_id = ing.get('mediaingredientmech_term', {}).get('id')
+                mediaing_id = mim_link_id(ing)
                 if mediaing_id and self.mediaing_ids and mediaing_id not in self.mediaing_ids:
-                    issues.append({
-                        'rule': 'P2.1',
-                        'priority': 'P2',
-                        'description': f'Invalid MediaIngredientMech ID: {mediaing_id} (ingredient: {ing.get("preferred_term", "unknown")})'
-                    })
+                    issues.append(
+                        {
+                            "rule": "P2.1",
+                            "priority": "P2",
+                            "description": f'Invalid MediaIngredientMech ID: {mediaing_id} (ingredient: {ing.get("preferred_term", "unknown")})',
+                        }
+                    )
 
         # P3.1: Placeholder text
         placeholder_patterns = [
-            r'see source',
-            r'original amount:',
-            r'unknown',
-            r'\bTBD\b',
-            r'to be determined',
-            r'check source',
-            r'refer to'
+            r"see source",
+            r"original amount:",
+            r"unknown",
+            r"\bTBD\b",
+            r"to be determined",
+            r"check source",
+            r"refer to",
         ]
 
         def check_placeholders(text: str) -> bool:
@@ -212,281 +286,328 @@ class RecipeValidator:
             return any(re.search(pattern, text_lower) for pattern in placeholder_patterns)
 
         # Check notes
-        if check_placeholders(recipe.get('notes', '')):
-            issues.append({
-                'rule': 'P3.1',
-                'priority': 'P3',
-                'description': 'Placeholder text found in notes field'
-            })
+        if check_placeholders(recipe.get("notes", "")):
+            issues.append(
+                {
+                    "rule": "P3.1",
+                    "priority": "P3",
+                    "description": "Placeholder text found in notes field",
+                }
+            )
 
         # Check ingredients
-        for idx, ing in enumerate(ingredients):
+        for _idx, ing in enumerate(ingredients):
             if isinstance(ing, dict):
-                if check_placeholders(ing.get('notes', '')):
-                    issues.append({
-                        'rule': 'P3.1',
-                        'priority': 'P3',
-                        'description': f'Placeholder text in ingredient notes: {ing.get("preferred_term", "unknown")}'
-                    })
+                if check_placeholders(ing.get("notes", "")):
+                    issues.append(
+                        {
+                            "rule": "P3.1",
+                            "priority": "P3",
+                            "description": f'Placeholder text in ingredient notes: {ing.get("preferred_term", "unknown")}',
+                        }
+                    )
 
         # P3.2: Missing MediaIngredientMech linkage
         total_ingredients = len(ingredients)
-        linked_ingredients = sum(
-            1 for ing in ingredients
-            if isinstance(ing, dict) and ing.get('mediaingredientmech_term', {}).get('id')
-        )
+        linked_ingredients = sum(1 for ing in ingredients if mim_link_id(ing))
 
         coverage = (linked_ingredients / total_ingredients * 100) if total_ingredients > 0 else 0
 
         # For solutions, expect >80% coverage; for media, >50%
-        is_solution = 'solutions' in str(recipe_path)
+        is_solution = "solutions" in str(recipe_path)
         threshold = 80 if is_solution else 50
 
         if coverage < threshold and total_ingredients > 0:
-            issues.append({
-                'rule': 'P3.2',
-                'priority': 'P3',
-                'description': f'Low MediaIngredientMech coverage: {coverage:.1f}% (threshold: {threshold}%)'
-            })
+            issues.append(
+                {
+                    "rule": "P3.2",
+                    "priority": "P3",
+                    "description": f"Low MediaIngredientMech coverage: {coverage:.1f}% (threshold: {threshold}%)",
+                }
+            )
 
         # P3.4: Missing preparation steps for complex media
-        if recipe.get('medium_type') == 'COMPLEX' and not recipe.get('preparation_steps'):
-            issues.append({
-                'rule': 'P3.4',
-                'priority': 'P3',
-                'description': 'Missing preparation_steps for COMPLEX medium'
-            })
+        if recipe.get("medium_type") == "COMPLEX" and not recipe.get("preparation_steps"):
+            issues.append(
+                {
+                    "rule": "P3.4",
+                    "priority": "P3",
+                    "description": "Missing preparation_steps for COMPLEX medium",
+                }
+            )
 
         # P3.5: Sterilization not specified
-        if not recipe.get('sterilization'):
-            issues.append({
-                'rule': 'P3.5',
-                'priority': 'P3',
-                'description': 'Sterilization method not specified'
-            })
+        if not recipe.get("sterilization"):
+            issues.append(
+                {
+                    "rule": "P3.5",
+                    "priority": "P3",
+                    "description": "Sterilization method not specified",
+                }
+            )
 
-        # P3.6: pH not specified for defined/semi-defined media
-        if recipe.get('medium_type') in ['DEFINED', 'SEMI_DEFINED'] and not recipe.get('ph_value'):
-            issues.append({
-                'rule': 'P3.6',
-                'priority': 'P3',
-                'description': 'pH not specified for DEFINED/SEMI_DEFINED medium'
-            })
+        # P3.6: pH not specified for defined/semi-defined media.
+        #
+        # Two corrections (#401). The DEFINED/SEMI_DEFINED distinction lives on
+        # `composition_type`, not `medium_type` — `SEMI_DEFINED` is not a
+        # `medium_type` value at all, so that arm of the old condition matched
+        # nothing and 620 records were never checked.
+        #
+        # And pH can be recorded as either a point value or a range: 920 records
+        # carry `ph_range` and no `ph_value`, and were reported as having no pH
+        # while stating one.
+        composition_type = recipe.get("composition_type")
+        has_ph = recipe.get("ph_value") is not None or recipe.get("ph_range") is not None
+        if composition_type in ["DEFINED", "SEMI_DEFINED"] and not has_ph:
+            issues.append(
+                {
+                    "rule": "P3.6",
+                    "priority": "P3",
+                    "description": f"pH not specified for {composition_type} composition",
+                }
+            )
 
         # P4.2: Missing target organisms
-        if not recipe.get('target_organisms'):
-            issues.append({
-                'rule': 'P4.2',
-                'priority': 'P4',
-                'description': 'No target_organisms specified'
-            })
+        if not recipe.get("target_organisms"):
+            issues.append(
+                {"rule": "P4.2", "priority": "P4", "description": "No target_organisms specified"}
+            )
 
         # P4.3: Missing references
-        if not recipe.get('references'):
-            issues.append({
-                'rule': 'P4.3',
-                'priority': 'P4',
-                'description': 'No source references'
-            })
+        if not recipe.get("references"):
+            issues.append({"rule": "P4.3", "priority": "P4", "description": "No source references"})
 
         return {
-            'path': str(recipe_path),
-            'id': recipe.get('id', 'N/A'),
-            'name': recipe.get('name', 'N/A'),
-            'category': recipe_path.parent.name,
-            'medium_type': recipe.get('medium_type', 'N/A'),
-            'total_ingredients': total_ingredients,
-            'linked_ingredients': linked_ingredients,
-            'coverage': coverage,
-            'issues': issues,
-            'valid': len([i for i in issues if i['priority'] == 'P1']) == 0
+            "path": str(recipe_path),
+            "id": recipe.get("id", "N/A"),
+            "name": recipe.get("name", "N/A"),
+            "category": recipe_path.parent.name,
+            "medium_type": recipe.get("medium_type", "N/A"),
+            "total_ingredients": total_ingredients,
+            "linked_ingredients": linked_ingredients,
+            "coverage": coverage,
+            "issues": issues,
+            "valid": len([i for i in issues if i["priority"] == "P1"]) == 0,
         }
 
 
-def generate_tsv_report(results: List[Dict], output_path: Path):
+def generate_tsv_report(results: list[dict], output_path: Path):
     """Generate TSV report of validation results."""
-    with open(output_path, 'w') as f:
+    with open(output_path, "w") as f:
         # Header
-        f.write('\t'.join([
-            'CultureMech ID',
-            'Recipe Name',
-            'Category',
-            'Medium Type',
-            'Valid',
-            'P1 Critical',
-            'P2 High',
-            'P3 Medium',
-            'P4 Low',
-            'Total Ingredients',
-            'Linked Ingredients',
-            'Coverage %',
-            'Issues',
-            'File Path'
-        ]) + '\n')
+        f.write(
+            "\t".join(
+                [
+                    "CultureMech ID",
+                    "Recipe Name",
+                    "Category",
+                    "Medium Type",
+                    "Valid",
+                    "P1 Critical",
+                    "P2 High",
+                    "P3 Medium",
+                    "P4 Low",
+                    "Total Ingredients",
+                    "Linked Ingredients",
+                    "Coverage %",
+                    "Issues",
+                    "File Path",
+                ]
+            )
+            + "\n"
+        )
 
         # Data rows
         for result in results:
             issues_by_priority = defaultdict(list)
-            for issue in result['issues']:
-                issues_by_priority[issue['priority']].append(issue['description'])
+            for issue in result["issues"]:
+                issues_by_priority[issue["priority"]].append(issue["description"])
 
-            p1_count = len(issues_by_priority['P1'])
-            p2_count = len(issues_by_priority['P2'])
-            p3_count = len(issues_by_priority['P3'])
-            p4_count = len(issues_by_priority['P4'])
+            p1_count = len(issues_by_priority["P1"])
+            p2_count = len(issues_by_priority["P2"])
+            p3_count = len(issues_by_priority["P3"])
+            p4_count = len(issues_by_priority["P4"])
 
-            all_issues = '; '.join([
-                f"{issue['rule']}: {issue['description']}"
-                for issue in result['issues']
-            ])
+            all_issues = "; ".join(
+                [f"{issue['rule']}: {issue['description']}" for issue in result["issues"]]
+            )
 
-            f.write('\t'.join([
-                result.get('id', 'N/A'),
-                result.get('name', 'N/A'),
-                result.get('category', 'N/A'),
-                result.get('medium_type', 'N/A'),
-                'Yes' if result['valid'] else 'No',
-                str(p1_count),
-                str(p2_count),
-                str(p3_count),
-                str(p4_count),
-                str(result.get('total_ingredients', 0)),
-                str(result.get('linked_ingredients', 0)),
-                f"{result.get('coverage', 0):.1f}",
-                all_issues,
-                result['path']
-            ]) + '\n')
+            f.write(
+                "\t".join(
+                    [
+                        result.get("id", "N/A"),
+                        result.get("name", "N/A"),
+                        result.get("category", "N/A"),
+                        result.get("medium_type", "N/A"),
+                        "Yes" if result["valid"] else "No",
+                        str(p1_count),
+                        str(p2_count),
+                        str(p3_count),
+                        str(p4_count),
+                        str(result.get("total_ingredients", 0)),
+                        str(result.get("linked_ingredients", 0)),
+                        f"{result.get('coverage', 0):.1f}",
+                        all_issues,
+                        result["path"],
+                    ]
+                )
+                + "\n"
+            )
 
 
-def generate_markdown_report(results: List[Dict], output_path: Path):
+def generate_markdown_report(results: list[dict], output_path: Path):
     """Generate markdown summary report."""
     total_recipes = len(results)
-    valid_recipes = sum(1 for r in results if r['valid'])
+    valid_recipes = sum(1 for r in results if r["valid"])
 
     # Count issues by priority
-    p1_recipes = sum(1 for r in results if any(i['priority'] == 'P1' for i in r['issues']))
-    p2_recipes = sum(1 for r in results if any(i['priority'] == 'P2' for i in r['issues']))
-    p3_recipes = sum(1 for r in results if any(i['priority'] == 'P3' for i in r['issues']))
-    p4_recipes = sum(1 for r in results if any(i['priority'] == 'P4' for i in r['issues']))
+    p1_recipes = sum(1 for r in results if any(i["priority"] == "P1" for i in r["issues"]))
+    p2_recipes = sum(1 for r in results if any(i["priority"] == "P2" for i in r["issues"]))
+    p3_recipes = sum(1 for r in results if any(i["priority"] == "P3" for i in r["issues"]))
+    p4_recipes = sum(1 for r in results if any(i["priority"] == "P4" for i in r["issues"]))
 
     # Count total issues
-    p1_total = sum(len([i for i in r['issues'] if i['priority'] == 'P1']) for r in results)
-    p2_total = sum(len([i for i in r['issues'] if i['priority'] == 'P2']) for r in results)
-    p3_total = sum(len([i for i in r['issues'] if i['priority'] == 'P3']) for r in results)
-    p4_total = sum(len([i for i in r['issues'] if i['priority'] == 'P4']) for r in results)
+    p1_total = sum(len([i for i in r["issues"] if i["priority"] == "P1"]) for r in results)
+    p2_total = sum(len([i for i in r["issues"] if i["priority"] == "P2"]) for r in results)
+    p3_total = sum(len([i for i in r["issues"] if i["priority"] == "P3"]) for r in results)
+    p4_total = sum(len([i for i in r["issues"] if i["priority"] == "P4"]) for r in results)
 
     # Category breakdown
     by_category = defaultdict(list)
     for r in results:
-        by_category[r.get('category', 'unknown')].append(r)
+        by_category[r.get("category", "unknown")].append(r)
 
     # Coverage statistics
-    total_ingredients = sum(r.get('total_ingredients', 0) for r in results)
-    total_linked = sum(r.get('linked_ingredients', 0) for r in results)
+    total_ingredients = sum(r.get("total_ingredients", 0) for r in results)
+    total_linked = sum(r.get("linked_ingredients", 0) for r in results)
     overall_coverage = (total_linked / total_ingredients * 100) if total_ingredients > 0 else 0
 
     # Issue frequency
     issue_counts = defaultdict(int)
     for r in results:
-        for issue in r['issues']:
-            issue_counts[issue['rule']] += 1
+        for issue in r["issues"]:
+            issue_counts[issue["rule"]] += 1
 
-    with open(output_path, 'w') as f:
-        f.write(f"# CultureMech Recipe Validation Report\n\n")
+    with open(output_path, "w") as f:
+        f.write("# CultureMech Recipe Validation Report\n\n")
         f.write(f"**Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n\n")
 
-        f.write(f"## Summary Statistics\n\n")
+        f.write("## Summary Statistics\n\n")
         f.write(f"- **Total recipes:** {total_recipes:,}\n")
-        f.write(f"- **Valid recipes (no P1 errors):** {valid_recipes:,} ({valid_recipes/total_recipes*100:.1f}%)\n")
-        f.write(f"- **P1 Critical Errors:** {p1_total} issues in {p1_recipes} recipes ({p1_recipes/total_recipes*100:.1f}%)\n")
-        f.write(f"- **P2 High Priority:** {p2_total} issues in {p2_recipes} recipes ({p2_recipes/total_recipes*100:.1f}%)\n")
-        f.write(f"- **P3 Medium Priority:** {p3_total} issues in {p3_recipes} recipes ({p3_recipes/total_recipes*100:.1f}%)\n")
-        f.write(f"- **P4 Low Priority:** {p4_total} issues in {p4_recipes} recipes ({p4_recipes/total_recipes*100:.1f}%)\n\n")
+        f.write(
+            f"- **Valid recipes (no P1 errors):** {valid_recipes:,} ({valid_recipes/total_recipes*100:.1f}%)\n"
+        )
+        f.write(
+            f"- **P1 Critical Errors:** {p1_total} issues in {p1_recipes} recipes ({p1_recipes/total_recipes*100:.1f}%)\n"
+        )
+        f.write(
+            f"- **P2 High Priority:** {p2_total} issues in {p2_recipes} recipes ({p2_recipes/total_recipes*100:.1f}%)\n"
+        )
+        f.write(
+            f"- **P3 Medium Priority:** {p3_total} issues in {p3_recipes} recipes ({p3_recipes/total_recipes*100:.1f}%)\n"
+        )
+        f.write(
+            f"- **P4 Low Priority:** {p4_total} issues in {p4_recipes} recipes ({p4_recipes/total_recipes*100:.1f}%)\n\n"
+        )
 
-        f.write(f"## MediaIngredientMech Coverage\n\n")
+        f.write("## MediaIngredientMech Coverage\n\n")
         f.write(f"- **Total ingredient instances:** {total_ingredients:,}\n")
         f.write(f"- **Linked instances:** {total_linked:,}\n")
         f.write(f"- **Overall coverage:** {overall_coverage:.1f}%\n\n")
 
-        f.write(f"## By Category\n\n")
-        f.write(f"| Category | Recipes | Valid | P1 | P2 | P3 | P4 | Avg Coverage |\n")
-        f.write(f"|----------|---------|-------|----|----|----|----|-------------|\n")
+        f.write("## By Category\n\n")
+        f.write("| Category | Recipes | Valid | P1 | P2 | P3 | P4 | Avg Coverage |\n")
+        f.write("|----------|---------|-------|----|----|----|----|-------------|\n")
 
         for category in sorted(by_category.keys()):
             cat_results = by_category[category]
             cat_total = len(cat_results)
-            cat_valid = sum(1 for r in cat_results if r['valid'])
-            cat_p1 = sum(1 for r in cat_results if any(i['priority'] == 'P1' for i in r['issues']))
-            cat_p2 = sum(1 for r in cat_results if any(i['priority'] == 'P2' for i in r['issues']))
-            cat_p3 = sum(1 for r in cat_results if any(i['priority'] == 'P3' for i in r['issues']))
-            cat_p4 = sum(1 for r in cat_results if any(i['priority'] == 'P4' for i in r['issues']))
-            cat_coverage = sum(r.get('coverage', 0) for r in cat_results) / cat_total if cat_total > 0 else 0
+            cat_valid = sum(1 for r in cat_results if r["valid"])
+            cat_p1 = sum(1 for r in cat_results if any(i["priority"] == "P1" for i in r["issues"]))
+            cat_p2 = sum(1 for r in cat_results if any(i["priority"] == "P2" for i in r["issues"]))
+            cat_p3 = sum(1 for r in cat_results if any(i["priority"] == "P3" for i in r["issues"]))
+            cat_p4 = sum(1 for r in cat_results if any(i["priority"] == "P4" for i in r["issues"]))
+            cat_coverage = (
+                sum(r.get("coverage", 0) for r in cat_results) / cat_total if cat_total > 0 else 0
+            )
 
-            f.write(f"| {category} | {cat_total:,} | {cat_valid:,} | {cat_p1} | {cat_p2} | {cat_p3} | {cat_p4} | {cat_coverage:.1f}% |\n")
+            f.write(
+                f"| {category} | {cat_total:,} | {cat_valid:,} | {cat_p1} | {cat_p2} | {cat_p3} | {cat_p4} | {cat_coverage:.1f}% |\n"
+            )
 
-        f.write(f"\n## Most Frequent Issues\n\n")
-        f.write(f"| Rule | Description | Count | Affected Recipes |\n")
-        f.write(f"|------|-------------|-------|------------------|\n")
+        f.write("\n## Most Frequent Issues\n\n")
+        f.write("| Rule | Description | Count | Affected Recipes |\n")
+        f.write("|------|-------------|-------|------------------|\n")
 
         rule_descriptions = {
-            'P1.1': 'Schema validation failure',
-            'P1.2': 'Invalid CultureMech ID',
-            'P1.3': 'Missing required fields',
-            'P1.4': 'Invalid enum values',
-            'P2.1': 'Invalid MediaIngredientMech ID',
-            'P3.1': 'Placeholder text',
-            'P3.2': 'Low MediaIngredientMech coverage',
-            'P3.4': 'Missing preparation steps',
-            'P3.5': 'Sterilization not specified',
-            'P3.6': 'pH not specified',
-            'P4.2': 'Missing target organisms',
-            'P4.3': 'Missing references',
+            "P1.1": "Schema validation failure",
+            "P1.2": "Invalid CultureMech ID",
+            "P1.3": "Missing required fields",
+            "P1.4": "Invalid enum values",
+            "P2.1": "Invalid MediaIngredientMech ID",
+            "P3.1": "Placeholder text",
+            "P3.2": "Low MediaIngredientMech coverage",
+            "P3.4": "Missing preparation steps",
+            "P3.5": "Sterilization not specified",
+            "P3.6": "pH not specified",
+            "P4.2": "Missing target organisms",
+            "P4.3": "Missing references",
         }
 
         for rule, count in sorted(issue_counts.items(), key=lambda x: x[1], reverse=True)[:20]:
-            affected = sum(1 for r in results if any(i['rule'] == rule for i in r['issues']))
-            desc = rule_descriptions.get(rule, 'Unknown')
+            affected = sum(1 for r in results if any(i["rule"] == rule for i in r["issues"]))
+            desc = rule_descriptions.get(rule, "Unknown")
             f.write(f"| {rule} | {desc} | {count:,} | {affected:,} |\n")
 
         if p1_total > 0:
-            f.write(f"\n## P1 Critical Errors (Must Fix)\n\n")
-            p1_recipes_list = [r for r in results if any(i['priority'] == 'P1' for i in r['issues'])]
+            f.write("\n## P1 Critical Errors (Must Fix)\n\n")
+            p1_recipes_list = [
+                r for r in results if any(i["priority"] == "P1" for i in r["issues"])
+            ]
             for r in p1_recipes_list[:20]:  # Show first 20
                 f.write(f"### {r.get('name', 'Unknown')} ({r.get('id', 'N/A')})\n\n")
                 f.write(f"**File:** `{r['path']}`\n\n")
-                for issue in [i for i in r['issues'] if i['priority'] == 'P1']:
+                for issue in [i for i in r["issues"] if i["priority"] == "P1"]:
                     f.write(f"- **{issue['rule']}:** {issue['description']}\n")
-                f.write(f"\n")
+                f.write("\n")
 
             if len(p1_recipes_list) > 20:
                 f.write(f"\n*...and {len(p1_recipes_list) - 20} more recipes with P1 errors*\n")
 
-        f.write(f"\n## Recommendations\n\n")
+        f.write("\n## Recommendations\n\n")
 
         if p1_total > 0:
-            f.write(f"1. **CRITICAL:** Fix {p1_total} P1 errors in {p1_recipes} recipes before KG export\n")
+            f.write(
+                f"1. **CRITICAL:** Fix {p1_total} P1 errors in {p1_recipes} recipes before KG export\n"
+            )
         else:
-            f.write(f"1. ✅ No P1 critical errors - ready for KG export\n")
+            f.write("1. ✅ No P1 critical errors - ready for KG export\n")
 
         if p2_total > 0:
             f.write(f"2. **HIGH PRIORITY:** Review {p2_total} P2 issues in {p2_recipes} recipes\n")
 
         if p3_total > 0:
             f.write(f"3. **MEDIUM PRIORITY:** Auto-fix or review {p3_total} P3 issues\n")
-            f.write(f"   - Run: `just fix-all-data-quality` to auto-correct safe issues\n")
+            f.write("   - Run: `just fix-all-data-quality` to auto-correct safe issues\n")
 
         if overall_coverage < 80:
-            f.write(f"4. **Coverage:** Improve MediaIngredientMech coverage from {overall_coverage:.1f}% to >80%\n")
-            f.write(f"   - Run: `PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py`\n")
+            f.write(
+                f"4. **Coverage:** Improve MediaIngredientMech coverage from {overall_coverage:.1f}% to >80%\n"
+            )
+            f.write(
+                "   - Run: `PYTHONPATH=src python scripts/enrich_with_mediaingredientmech.py`\n"
+            )
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Batch review CultureMech recipes')
-    parser.add_argument('--category', help='Specific category to review')
-    parser.add_argument('--output', default='reports/validation', help='Output path prefix')
-    parser.add_argument('--limit', type=int, help='Limit number of recipes')
-    parser.add_argument('--mediaingredientmech-repo', type=Path, help='Path to MediaIngredientMech repo')
-    parser.add_argument('--priority', help='Filter by priority (e.g., P1,P2)')
+    parser = argparse.ArgumentParser(description="Batch review CultureMech recipes")
+    parser.add_argument("--category", help="Specific category to review")
+    parser.add_argument("--output", default="reports/validation", help="Output path prefix")
+    parser.add_argument("--limit", type=int, help="Limit number of recipes")
+    parser.add_argument(
+        "--mediaingredientmech-repo", type=Path, help="Path to MediaIngredientMech repo"
+    )
+    parser.add_argument("--priority", help="Filter by priority (e.g., P1,P2)")
 
     args = parser.parse_args()
 
@@ -501,7 +622,7 @@ def main():
     recipe_files = sorted(data_dir.glob(pattern))
 
     if args.limit:
-        recipe_files = recipe_files[:args.limit]
+        recipe_files = recipe_files[: args.limit]
 
     print(f"Found {len(recipe_files)} recipes to validate...")
 
@@ -517,24 +638,21 @@ def main():
 
         # Filter by priority if specified
         if args.priority:
-            priorities = args.priority.split(',')
-            result['issues'] = [
-                i for i in result['issues']
-                if i['priority'] in priorities
-            ]
+            priorities = args.priority.split(",")
+            result["issues"] = [i for i in result["issues"] if i["priority"] in priorities]
 
         results.append(result)
 
-    print(f"Validation complete. Generating reports...")
+    print("Validation complete. Generating reports...")
 
     # Create output directory
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Generate reports
-    tsv_path = output_path.with_suffix('.tsv')
-    md_path = output_path.with_suffix('.md')
-    json_path = output_path.with_suffix('.json')
+    tsv_path = output_path.with_suffix(".tsv")
+    md_path = output_path.with_suffix(".md")
+    json_path = output_path.with_suffix(".json")
 
     generate_tsv_report(results, tsv_path)
     print(f"✅ TSV report: {tsv_path}")
@@ -543,23 +661,23 @@ def main():
     print(f"✅ Markdown report: {md_path}")
 
     # JSON report
-    with open(json_path, 'w') as f:
+    with open(json_path, "w") as f:
         json.dump(results, f, indent=2)
     print(f"✅ JSON report: {json_path}")
 
     # Summary
     total = len(results)
-    valid = sum(1 for r in results if r['valid'])
-    p1_count = sum(len([i for i in r['issues'] if i['priority'] == 'P1']) for r in results)
+    valid = sum(1 for r in results if r["valid"])
+    p1_count = sum(len([i for i in r["issues"] if i["priority"] == "P1"]) for r in results)
 
     print(f"\n{'='*60}")
     print(f"SUMMARY: {valid}/{total} recipes valid ({valid/total*100:.1f}%)")
     if p1_count > 0:
         print(f"⚠️  {p1_count} P1 CRITICAL ERRORS - Must fix before export!")
     else:
-        print(f"✅ No P1 errors - Ready for KG export")
+        print("✅ No P1 errors - Ready for KG export")
     print(f"{'='*60}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/batch_review_recipes.py
+++ b/scripts/batch_review_recipes.py
@@ -11,6 +11,7 @@ import re
 import sys
 from collections import defaultdict
 from datetime import datetime
+from functools import cache
 from pathlib import Path
 
 import yaml
@@ -31,6 +32,19 @@ MIM_LINK_FIELD = "mediaingredientmech_chebi_term"
 LEGACY_MIM_LINK_FIELD = "mediaingredientmech_term"
 
 
+@cache
+def _schema() -> dict:
+    """The parsed schema, once.
+
+    Parsing it costs ~76 ms and `validate_recipe` asks for three enums per
+    record, so reading it per call meant ~143,000 parses over the corpus — an
+    hour of pure YAML, which is how the first full run of this change ended up
+    backgrounded. The schema cannot change while the process runs, so caching
+    is safe and the run goes back to minutes.
+    """
+    return yaml.safe_load(SCHEMA_PATH.read_text())
+
+
 def permissible_values(enum_name: str) -> list[str]:
     """The enum's values, read from the authoritative schema (#401).
 
@@ -41,8 +55,7 @@ def permissible_values(enum_name: str) -> list[str]:
     `migrate_medium_type_axes.py`. Being wrong permissively is the worse half:
     nobody investigates a check that stays green.
     """
-    schema = yaml.safe_load(SCHEMA_PATH.read_text())
-    enum = schema["enums"][enum_name]
+    enum = _schema()["enums"][enum_name]
     return list(enum.get("permissible_values") or {})
 
 

--- a/tests/test_batch_review_recipes.py
+++ b/tests/test_batch_review_recipes.py
@@ -1,0 +1,219 @@
+"""The batch reviewer must read the schema, not a copy of it (#401, #402).
+
+Running it over all 15,877 recipes reported two P1 criticals and 0.8%
+MediaIngredientMech coverage. Both were artifacts of the script having drifted
+from the repository it validates:
+
+* `valid_medium_types` was a hardcoded list that rejected `BUFFER` and
+  `NEGATIVE_CONTROL` (which the schema permits) while accepting `SEMI_DEFINED`
+  and `UNDEFINED` (which belong to `MediumCompositionTypeEnum`, a different
+  axis). The comment directly above it said "DO NOT hardcode, derive from
+  schema".
+* coverage counted `mediaingredientmech_term`, the field MIM's id-scheme
+  deprecation migrated the corpus *off*. The live field sits at 67.2%.
+
+These tests pin the derivation rather than the values, so the next schema change
+cannot silently reintroduce either.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from batch_review_recipes import (
+    LEGACY_MIM_LINK_FIELD,
+    MIM_LINK_FIELD,
+    RecipeValidator,
+    mim_link_id,
+    permissible_values,
+)
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "batch_review_recipes.py"
+SCHEMA = Path(__file__).resolve().parents[1] / "src" / "culturemech" / "schema" / "culturemech.yaml"
+
+
+# --- the enums come from the schema -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "enum_name", ["MediumTypeEnum", "MediumCompositionTypeEnum", "PhysicalStateEnum"]
+)
+def test_permissible_values_match_the_schema_exactly(enum_name):
+    schema = yaml.safe_load(SCHEMA.read_text())
+    expected = list(schema["enums"][enum_name]["permissible_values"])
+    assert permissible_values(enum_name) == expected
+
+
+def test_the_two_values_that_produced_false_criticals_are_accepted():
+    """`PBS` is a BUFFER and `Water` is a NEGATIVE_CONTROL. Both are valid."""
+    medium_types = permissible_values("MediumTypeEnum")
+    assert "BUFFER" in medium_types
+    assert "NEGATIVE_CONTROL" in medium_types
+
+
+def test_the_composition_axis_is_not_mistaken_for_the_medium_axis():
+    """`SEMI_DEFINED` and `UNDEFINED` are composition_type values only.
+
+    The old list put them in `medium_type`, so a genuinely invalid
+    `medium_type: UNDEFINED` would have passed.
+    """
+    medium_types = permissible_values("MediumTypeEnum")
+    composition_types = permissible_values("MediumCompositionTypeEnum")
+    assert "SEMI_DEFINED" not in medium_types
+    assert "UNDEFINED" not in medium_types
+    assert {"SEMI_DEFINED", "UNDEFINED"} <= set(composition_types)
+
+
+def test_no_enum_list_is_restated_in_the_script():
+    """The regression guard. A literal list of these values is the defect."""
+    source = SCRIPT.read_text()
+    for spelling in (
+        "['DEFINED', 'COMPLEX'",
+        '["DEFINED", "COMPLEX"',
+        "['LIQUID', 'SOLID_AGAR'",
+        '["LIQUID", "SOLID_AGAR"',
+    ):
+        assert spelling not in source, f"enum values are hardcoded again: {spelling}"
+
+
+# --- the MIM link field --------------------------------------------------
+
+
+def test_the_live_field_is_preferred():
+    assert mim_link_id({MIM_LINK_FIELD: {"id": "CHEBI:17234"}}) == "CHEBI:17234"
+
+
+def test_the_retired_field_still_counts_when_it_is_all_there_is():
+    """1,677 instances carry only the retired field; dropping them would
+    understate coverage in the opposite direction to the bug being fixed."""
+    assert mim_link_id({LEGACY_MIM_LINK_FIELD: {"id": "MediaIngredientMech:1"}}) == (
+        "MediaIngredientMech:1"
+    )
+
+
+def test_the_live_field_wins_when_both_are_present():
+    assert (
+        mim_link_id(
+            {
+                MIM_LINK_FIELD: {"id": "CHEBI:17234"},
+                LEGACY_MIM_LINK_FIELD: {"id": "MediaIngredientMech:1"},
+            }
+        )
+        == "CHEBI:17234"
+    )
+
+
+@pytest.mark.parametrize(
+    "ingredient", [{}, None, "x", {MIM_LINK_FIELD: {}}, {MIM_LINK_FIELD: "not-a-dict"}]
+)
+def test_an_unlinked_ingredient_yields_no_id(ingredient):
+    assert mim_link_id(ingredient) is None
+
+
+def test_the_retired_field_is_not_what_coverage_counts():
+    """The #402 defect: coverage read the deprecated field and reported 0.8%."""
+    assert MIM_LINK_FIELD == "mediaingredientmech_chebi_term"
+    assert LEGACY_MIM_LINK_FIELD != MIM_LINK_FIELD
+
+
+# --- the pH rule ---------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def validator() -> RecipeValidator:
+    """One instance for the module: the constructor loads MIM ids, which costs
+    seconds and is identical for every case here."""
+    return RecipeValidator()
+
+
+def _validate(validator: RecipeValidator, tmp_path: Path, record: dict) -> list[str]:
+    path = tmp_path / "r.yaml"
+    path.write_text(yaml.safe_dump(record))
+    result = validator.validate_recipe(path)
+    return [issue["rule"] for issue in result.get("issues", [])]
+
+
+def test_a_ph_range_counts_as_a_ph(validator, tmp_path):
+    """920 records state `ph_range` and no `ph_value`, and were reported as
+    having no pH while stating one."""
+    rules = _validate(
+        validator,
+        tmp_path,
+        {
+            "name": "x",
+            "medium_type": "DEFINED",
+            "composition_type": "DEFINED",
+            "physical_state": "LIQUID",
+            "ph_range": {"minimum": 6.8, "maximum": 7.2},
+        },
+    )
+    assert "P3.6" not in rules
+
+
+def test_a_record_with_neither_ph_form_is_still_reported(validator, tmp_path):
+    rules = _validate(
+        validator,
+        tmp_path,
+        {
+            "name": "x",
+            "medium_type": "DEFINED",
+            "composition_type": "DEFINED",
+            "physical_state": "LIQUID",
+        },
+    )
+    assert "P3.6" in rules
+
+
+def test_the_ph_rule_keys_on_the_composition_axis(validator, tmp_path):
+    """`SEMI_DEFINED` exists only on `composition_type`, so the old condition's
+    second arm matched nothing and 620 records were never checked."""
+    rules = _validate(
+        validator,
+        tmp_path,
+        {
+            "name": "x",
+            "medium_type": "COMPLEX",
+            "composition_type": "SEMI_DEFINED",
+            "physical_state": "LIQUID",
+        },
+    )
+    assert "P3.6" in rules
+
+
+# --- enum validation end to end -----------------------------------------
+
+
+def test_a_buffer_medium_is_not_a_critical_error(validator, tmp_path):
+    """PBS, CultureMech:015675 — one of the two false P1s."""
+    rules = _validate(
+        validator,
+        tmp_path,
+        {"name": "PBS", "medium_type": "BUFFER", "physical_state": "LIQUID"},
+    )
+    assert "P1.4" not in rules
+
+
+def test_an_invalid_medium_type_is_still_a_critical_error(validator, tmp_path):
+    rules = _validate(
+        validator,
+        tmp_path,
+        {"name": "x", "medium_type": "NOT_A_REAL_TYPE", "physical_state": "LIQUID"},
+    )
+    assert "P1.4" in rules
+
+
+def test_an_invalid_composition_type_is_now_caught(validator, tmp_path):
+    """The composition axis existed but no rule looked at it."""
+    rules = _validate(
+        validator,
+        tmp_path,
+        {
+            "name": "x",
+            "medium_type": "DEFINED",
+            "composition_type": "NOT_A_REAL_TYPE",
+            "physical_state": "LIQUID",
+        },
+    )
+    assert "P1.4" in rules


### PR DESCRIPTION
Closes #401 and #402.

Running the batch reviewer over all 15,877 recipes reported **2 P1 criticals**
and **0.8% MediaIngredientMech coverage**. Neither described the corpus — both
were the script having drifted from the repository it validates.

## The enums (#401)

```python
# These are the actual values from the schema - DO NOT hardcode, derive from schema
valid_medium_types = ['DEFINED', 'COMPLEX', 'SEMI_DEFINED', 'MINIMAL', 'UNDEFINED']
```

The comment states the rule and the next line breaks it. The list is wrong in
**both** directions:

| | values |
|---|---|
| schema has, script rejected | `SELECTIVE`, `DIFFERENTIAL`, `ENRICHMENT`, `BUFFER`, `NEGATIVE_CONTROL` |
| script accepted, schema forbids | `SEMI_DEFINED`, `UNDEFINED` |

The permissive half is the worse one — nobody investigates a check that stays
green. `SEMI_DEFINED`/`UNDEFINED` belong to `MediumCompositionTypeEnum`, a
separate axis split out by `migrate_medium_type_axes.py`; the script predates
that split and treated the two as one field.

`permissible_values()` now reads `culturemech.yaml` at runtime — the file the
comment already pointed at. That also fixes two rules the conflation reached:

- **`composition_type` is validated at all**, which it never was;
- **P3.6 keys on the right axis**, so the `SEMI_DEFINED` arm stops matching
  nothing — 2,815 records examined instead of 2,195.

P3.6 additionally accepts `ph_range`, not only `ph_value`: **920 records state a
pH range** and were reported as having no pH. Net: 620 more records checked, 65
*fewer* flagged, because the false positives removed outnumber the true ones
added.

## The coverage field (#402)

Coverage counted `mediaingredientmech_term` — the **retired** field. MIM
deprecated the `MediaIngredientMech:NNNNNN` id scheme and the corpus was
migrated to `mediaingredientmech_chebi_term`, recorded per record in
`curation_history`. Over 179,421 ingredient instances:

| field | instances | share |
|---|--:|--:|
| `mediaingredientmech_term` (retired) — what was counted | 1,677 | **0.9%** |
| `mediaingredientmech_chebi_term` (live) | 120,653 | **67.2%** |

`mim_link_id()` prefers the live field and falls back to the retired one, since
1,677 instances still carry only that — dropping them would understate coverage
in the opposite direction to the bug being fixed.

## Measured effect on the full report

| | before | after |
|---|--:|--:|
| P1 criticals | 2 | **0** |
| MIM coverage | 0.8% | **59.9%** |
| P3 total | 34,051 | **25,571** |
| P3.2 low coverage | 15,473 | **7,058** |
| P3.6 pH missing | 1,438 | **1,373** |

The remaining 7,058 P3.2 are real. Per-category coverage is now usable —
archaea 75.1%, bacterial 65.1%, fungal 63.3% — and **`solution` at 0.2%**, which
is a genuine gap the broken metric had been hiding behind a corpus-wide alarm.

## Tests

21, pinning the **derivation** rather than the values, so the next schema change
cannot reintroduce either defect. Includes a guard that no enum list is restated
in the script at all.

Verified non-vacuous by restoring each defect separately: the hardcoded list
fails 2 tests, the retired field fails 2 different ones.

Worth recording that my first attempt at that verification was itself vacuous —
black had converted the file to double quotes, so a single-quoted `replace`
matched nothing and "no tests failed" looked like a passing check. Redone
against the actual source text.

Also reduced the module's test time 48s → 9.8s by sharing one `RecipeValidator`,
whose constructor loads MIM ids.

## Not in this PR

The remaining P3/P4 findings are real and unaddressed: 11,043 records with no
target organism, 11,032 with no sterilization method, 10,812 with no reference.
Those are curation lanes, not script defects — and they were always the report's
real content, obscured by an alarm on 97% of the corpus.