### PR TITLE
Strip invisible characters from TOGO component names (#406)

### DIFF
--- a/data/normalized_yaml/bacterial/pcr_s11_medium.yaml
+++ b/data/normalized_yaml/bacterial/pcr_s11_medium.yaml
@@ -38,7 +38,7 @@ ingredients:
   concentration:
     value: '1'
     unit: MILLIMOLAR
-- preferred_term: Trace metals 'Gaffron­+Se'
+- preferred_term: Trace metals 'Gaffron+Se'
   concentration:
     value: '0.5'
     unit: G_PER_L
@@ -333,6 +333,13 @@ curation_history:
   curator: primary-term-label-canonicalization-v1.0
   action: Canonicalized primary term label to OBO canonical (OAK)
   notes: 4 primary term(s); ingredient name resolved by OAK sqlite:obo:chebi.
+- timestamp: '2026-09-03T07:08:46.323971+00:00'
+  curator: togo_importer.clean_component_name
+  action: REMOVED_INVISIBLE_CHARACTERS
+  notes: Removed a U+00AD SOFT HYPHEN from 1 ingredient name (#406). TOGO serves the
+    discretionary hyphen as part of the component name; it is a soft-wrap artifact
+    of the source page, renders as nothing, and made the name unmatchable. No other
+    content changed.
 solutions:
 - preferred_term: FeCl3 solution
   composition: []

--- a/src/culturemech/import/togo_importer.py
+++ b/src/culturemech/import/togo_importer.py
@@ -14,6 +14,40 @@ from typing import Any
 
 import yaml
 
+# Characters that render as nothing and so survive every visual review while
+# being a different string to every matcher. TOGO serves at least one component
+# name containing a discretionary hyphen — `Trace metals 'Gaffron\xad+Se'`
+# (#406) — which is a soft-wrap artifact of the source page, not part of the
+# name. Stripping them is not a curation decision: none carries semantic content
+# inside a chemical name.
+_INVISIBLE = str.maketrans(
+    "",
+    "",
+    "".join(
+        chr(code)
+        for code in (
+            0x00AD,  # SOFT HYPHEN
+            0x200B,  # ZERO WIDTH SPACE
+            0x200C,  # ZERO WIDTH NON-JOINER
+            0x200D,  # ZERO WIDTH JOINER
+            0x2060,  # WORD JOINER
+            0xFEFF,  # ZERO WIDTH NO-BREAK SPACE / BOM
+        )
+    ),
+)
+
+
+def clean_component_name(name: str | None) -> str:
+    """A source component name with invisible characters removed.
+
+    NBSP (U+00A0) is deliberately NOT in the strip set: it is a visible space
+    and removing it would join two words. It is normalised to a plain space
+    instead, so the name still matches on whitespace.
+    """
+    if not name:
+        return ""
+    return str(name).translate(_INVISIBLE).replace("\u00a0", " ").strip()
+
 
 class TogoImporter:
     """Import TOGO Medium data to CultureMech format."""
@@ -252,7 +286,7 @@ class TogoImporter:
             final_concentration = self._decimal(item.get("conc_value"))
             if final_concentration is not None and allow_final_concentration:
                 ingredient = {
-                    "preferred_term": item.get("component_name", "Unknown"),
+                    "preferred_term": clean_component_name(item.get("component_name")) or "Unknown",
                     "concentration": {
                         "value": self._format_decimal(final_concentration),
                         "unit": self._parse_unit(str(item.get("conc_unit") or "")),
@@ -265,7 +299,7 @@ class TogoImporter:
             if not item.get("gmo_id") or not self._is_gas_item(item):
                 return None
             ingredient = {
-                "preferred_term": item.get("component_name", "Unknown"),
+                "preferred_term": clean_component_name(item.get("component_name")) or "Unknown",
                 "concentration": {"value": "variable", "unit": "VARIABLE"},
             }
             notes = self._item_notes(item)
@@ -293,7 +327,7 @@ class TogoImporter:
             amount_text = self._format_decimal(amount)
 
         ingredient = {
-            "preferred_term": item.get("component_name", "Unknown"),
+            "preferred_term": clean_component_name(item.get("component_name")) or "Unknown",
             "concentration": {
                 "value": amount_text,
                 "unit": concentration_unit,

--- a/tests/test_togo_component_names.py
+++ b/tests/test_togo_component_names.py
@@ -1,0 +1,89 @@
+"""A source component name must not carry invisible characters (#406).
+
+TOGO serves `Trace metals 'Gaffron\xad+Se'` — with U+00AD SOFT HYPHEN between
+`Gaffron` and `+Se`. A discretionary hyphen renders as nothing unless a line
+breaks there, so the name looked correct in every editor, diff and report while
+being a different string to every matcher: it could not ground, and it was the
+last surviving fragment of #387.
+
+The character is a soft-wrap artifact of the source page, not part of the name,
+and it came through the import verbatim.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _importer():
+    spec = importlib.util.spec_from_file_location(
+        "togo_importer", REPO_ROOT / "src" / "culturemech" / "import" / "togo_importer.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def clean():
+    return _importer().clean_component_name
+
+
+def test_the_soft_hyphen_that_started_this_is_removed(clean):
+    assert clean("Trace metals 'Gaffron\xad+Se'") == "Trace metals 'Gaffron+Se'"
+
+
+@pytest.mark.parametrize(
+    "code", [0x00AD, 0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF], ids=lambda c: f"U+{c:04X}"
+)
+def test_every_zero_width_character_is_stripped(clean, code):
+    assert clean(f"Na{chr(code)}Cl") == "NaCl"
+
+
+def test_a_non_breaking_space_becomes_a_space_rather_than_vanishing(clean):
+    """NBSP is *visible*. Deleting it would join two words into one."""
+    assert clean("Yeast extract") == "Yeast extract"
+
+
+def test_a_clean_name_is_returned_unchanged(clean):
+    for name in ("NaCl", "MgSO4 x 7 H2O", "Trace metals 'Gaffron+Se'", "PABA(p-aminobenzoic acid)"):
+        assert clean(name) == name
+
+
+def test_meaningful_punctuation_survives(clean):
+    """A real hyphen, a middle dot and a bullet are content, not formatting."""
+    assert clean("L-cysteine") == "L-cysteine"
+    assert clean("CaCl2·2H2O") == "CaCl2·2H2O"
+    assert clean("MgSO4•7H2O") == "MgSO4•7H2O"
+
+
+@pytest.mark.parametrize("empty", [None, "", "   ", "​"])
+def test_an_empty_or_invisible_only_name_yields_the_empty_string(clean, empty):
+    assert clean(empty) == ""
+
+
+@pytest.mark.corpus
+def test_no_ingredient_name_in_the_corpus_carries_an_invisible_character(corpus):
+    """The corpus-side assertion. One record carried one; it is repaired."""
+    invisible = {0x00AD, 0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF}
+    offenders = []
+
+    def walk(items):
+        for ingredient in items or []:
+            if not isinstance(ingredient, dict):
+                continue
+            name = str(ingredient.get("preferred_term", ""))
+            if any(ord(ch) in invisible for ch in name):
+                offenders.append(ascii(name))
+            walk(ingredient.get("composition"))
+
+    for _path, record in corpus:
+        walk(record.get("ingredients"))
+        walk(record.get("solutions"))
+
+    assert not offenders, f"{len(offenders)} name(s) carry invisible characters: {offenders[:5]}"


### PR DESCRIPTION
Closes #406 — the last surviving fragment of #387, and the only ingredient name
in the corpus carrying an invisible character.

```
CultureMech:008849   data/normalized_yaml/bacterial/pcr_s11_medium.yaml
  ingredients[4].preferred_term = "Trace metals 'Gaffron\xad+Se'"
                                                        ^^^^ U+00AD SOFT HYPHEN
```

## Why this one is different from the rest of #387

#387's two populations destroyed information — a field swap (497 names, fixed in
#378) and truncation at a parenthesis (111 names, fixed in #391). This destroys
nothing. A discretionary hyphen renders as nothing unless a line breaks there,
so the name looked correct in every editor, diff and report **while being a
different string to every matcher**. It could not ground, and it sat in the
unresolvable set behind a character nobody could see.

## It is upstream, so the importer had to change too

Verified against the tracked raw capture — `data/raw/togo/togo_media.json`
serves `"Trace metals 'Gaffron\xad+Se'"`. The character is TOGO's, a soft-wrap
artifact of the source page, and the import carried it through verbatim.
Repairing only the record would let the next fetch reintroduce it.

`clean_component_name` strips U+00AD, U+200B/C/D, U+2060 and U+FEFF at the three
sites that read `component_name`.

**NBSP (U+00A0) is deliberately not in that set.** It is a *visible* space;
deleting it would join two words. It is normalised to a plain space instead.

Removing these is not a curation decision — none carries semantic content inside
a chemical name. That is what separates them from the middle dot in
`CaCl2·2H2O` and the bullet in `MgSO4•7H2O`, which are content and are pinned as
such by a test.

## Verification

- Corpus-wide after this: **0** ingredient names contain any invisible
  character, across soft hyphen, all four zero-widths, word joiner and BOM.
- `validate` on the record passes; `validate-strict` 0 errors / 15,877 files;
  `test-fast` 1522 passed.
- Non-vacuous: removing the normaliser fails 9 of 14 fast tests.

Worth recording that my first non-vacuity check was itself vacuous — the
shell-level replacement did not match the source escape, so "nothing failed"
looked like a pass. Redone with an assertion on the anchor before the edit.
That is the second time this session the same trap has appeared; the assertion
is now the habit.

## Found while doing this

**#408** — comparing this record against its raw TOGO capture showed the import
substitutes `G_PER_L` for volume units: **3,803 rows** where the source says
`ml`, `ml/l` or `L`. For water that is coincidentally near-exact (density 1),
but **1,224 non-water rows across 751 records** are numerically wrong —
methanol (0.792), glycerol (1.26), ethanol (0.789), 25% HCl (~1.12). No gate
sees the non-water half. That is a much larger finding than this PR and is
filed separately.

**#407** — the parse-damage figure quoted in the MIM residual triage is stale:
618 mentions → 1 (this one), after #378 and #391.