### PR TITLE
Track two curated artifacts; stop tracking date-stamped validation runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,9 +188,15 @@ reports/media_growth_review_manifest_summary.md
 # since #15 -- and understated MIM coverage, because it predates #401/#403 by six
 # hours. Regenerate with
 # `PYTHONPATH=src python scripts/batch_review_recipes.py --output reports/validation_all`.
-reports/validation_all-*.json
-reports/validation_all-*.md
-reports/validation_all-*.tsv
+# `--output` is a path prefix and the script stamps no date (:618, :662-668), so
+# the documented invocations produce undated names: `reports/validation_all.*`
+# (SKILL.md:77), `reports/validation_bacterial.*` (:73), and the bare default
+# `reports/validation.*`. Matching only the hand-dated spelling would fix the
+# instance and not the class (#412). No tracked file starts with `validation`;
+# negate below if one ever should.
+reports/validation*.json
+reports/validation*.md
+reports/validation*.tsv
 
 # Cocktail-nesting proposal worklist: a regenerable diagnostic for the #150 repair,
 # not a tracked artifact. Regenerate with `just propose-cocktail-nesting`.

--- a/.gitignore
+++ b/.gitignore
@@ -192,8 +192,10 @@ reports/media_growth_review_manifest_summary.md
 # the documented invocations produce undated names: `reports/validation_all.*`
 # (SKILL.md:77), `reports/validation_bacterial.*` (:73), and the bare default
 # `reports/validation.*`. Matching only the hand-dated spelling would fix the
-# instance and not the class (#412). No tracked file starts with `validation`;
-# negate below if one ever should.
+# instance and not the class (#412). A run worth keeping goes under
+# `reports/archive/`, which this pattern deliberately cannot reach -- a rule
+# containing `/` is anchored and `*` does not cross `/` -- and where nine
+# validation reports are already tracked (#414).
 reports/validation*.json
 reports/validation*.md
 reports/validation*.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,16 @@ reports/media_growth_review_manifest.tsv
 reports/media_growth_review_manifest.json
 reports/media_growth_review_manifest_summary.md
 
+# Date-stamped recipe-validation runs: regenerable, large (20 MB per run), and
+# they rot into false findings. The 2026-09-02 run reported two P1 criticals for
+# `medium_type: BUFFER` / `NEGATIVE_CONTROL` -- both valid MediumTypeEnum values
+# since #15 -- and understated MIM coverage, because it predates #401/#403 by six
+# hours. Regenerate with
+# `PYTHONPATH=src python scripts/batch_review_recipes.py --output reports/validation_all`.
+reports/validation_all-*.json
+reports/validation_all-*.md
+reports/validation_all-*.tsv
+
 # Cocktail-nesting proposal worklist: a regenerable diagnostic for the #150 repair,
 # not a tracked artifact. Regenerate with `just propose-cocktail-nesting`.
 data/import_tracking/reports/cocktail_nesting_proposals.tsv

--- a/prompts/claude_code_deep_research.md
+++ b/prompts/claude_code_deep_research.md
@@ -1,0 +1,135 @@
+# Claude Code task: one CultureMech deep-research curation
+
+Work from the CultureMech repository root. Read `CLAUDE.md`, any applicable
+`AGENTS.md`, the LinkML schema, and the existing target record before editing.
+
+## Mission
+
+Select exactly one high-value, unanswered culturing-media question, research it
+with the `claude_code` deep-research provider, and curate only supported findings
+into one schema-compliant `MediaRecipe` YAML record.
+
+The provider's Markdown report is a raw, auditable research artifact. It is not
+the schema-compliant result. The accepted findings must also be represented in
+the canonical YAML record and pass all relevant validation.
+
+## Non-negotiable constraints
+
+- Use only the `claude_code` provider. Do not run Falcon/Edison, OpenScientist,
+  Cyberian, or another provider, and do not fall back to one if Claude Code is
+  unavailable. This prevents separate provider-credit spending.
+- Run at most one new deep-research job. Before starting it, confirm there is no
+  existing Claude Code report for the selected medium. If one exists, select a
+  different target rather than paying for a duplicate run.
+- Do not expose, print, alter, or commit API keys or `.env` contents.
+- Do not modify the LinkML schema to accommodate research output.
+- Do not infer growth from recipe composition, a collection accession, strain
+  availability, or taxonomic plausibility. A source must explicitly connect the
+  organism or strain to growth/cultivation on the named medium or a clearly
+  identified variant.
+- Prefer primary publications and authoritative culture-collection records.
+  Record strain-level evidence when the source is strain-specific.
+- Preserve uncertainty. Never invent identifiers, ontology CURIEs, citations,
+  quotations, concentrations, conditions, or organism-medium relationships.
+
+## 1. Pick and record the question
+
+Inspect:
+
+- `data/import_tracking/reports/deep_research_priority_top100.json`
+- `data/import_tracking/reports/deep_research_priority.json`
+- `data/import_tracking/researched_media.json`
+- the candidate files under `data/normalized_yaml/`
+- existing `research/media/**/*claude_code*` reports, if present
+
+Choose the highest-priority existing recipe that has a meaningful growth-evidence
+gap, is absent from the researched manifest for equivalent work, and has no
+Claude Code report. State the exact target path and a single answerable question
+before calling the provider. Use this form:
+
+> Which explicitly documented organisms or strains grow on **<medium>**, under
+> what conditions, and does each source support this exact recipe, the parent
+> medium, or a named variant?
+
+Do not edit anything during question selection.
+
+## 2. Confirm provider fit without starting research
+
+Run:
+
+```bash
+just deep-research-provider claude_code growth_evidence
+```
+
+This is an availability/capability check, not a research job. If it reports that
+Claude Code is unavailable, stop and report the blocker. Do not switch providers.
+
+## 3. Run exactly one deep-research job
+
+Run:
+
+```bash
+just research-media claude_code <target-yaml-path>
+```
+
+Wait for completion. Do not launch a second job. Record the report and citations
+paths printed by the runner. Confirm that the report is non-empty and contains
+traceable sources. If the runner fails or returns no usable evidence, keep any
+diagnostic artifact, make no speculative YAML assertions, and stop with a clear
+status.
+
+## 4. Curate the report into the MediaRecipe schema
+
+Compare every candidate finding against the source and the existing record.
+Accept only findings with explicit evidence. Use the existing schema and nearby
+curated records as the structural authority.
+
+In particular:
+
+- Put supported organisms in `target_organisms` using the narrowest defensible
+  taxon/strain identity.
+- Distinguish the exact recipe from a parent medium and from `media_variants`.
+  If a paper changed composition or conditions materially, model or link the
+  variant; do not silently attach its evidence to the parent recipe.
+- Attach source identifiers and evidence snippets in the schema's evidence
+  objects. Snippets must be short, verbatim, and actually present in the cited
+  cached/source text.
+- Add growth conditions or metrics only when directly reported and supported.
+- Preserve existing correct data and formatting. Make the smallest useful edit.
+- Follow the repository's provenance/curation-history convention for an
+  LLM-assisted deep-research edit.
+
+The raw report stays under `research/`; the curated result stays under
+`data/normalized_yaml/`. Do not add report-only prose as new YAML fields.
+
+## 5. Validate the saved result
+
+Run all of the following against the edited file:
+
+```bash
+just validate <target-yaml-path>
+just validate-strict <target-yaml-path>
+just validate-growth --file <target-yaml-path>
+```
+
+If variant links changed, also run:
+
+```bash
+just validate-media-variant-links
+```
+
+Fix data errors, not the schema or validators. Do not run another research job to
+fix validation failures. Inspect `git diff --check` and the focused diff before
+finishing.
+
+## Completion report
+
+Report:
+
+1. the research question and why this target was selected;
+2. the provider-fit command and the single research command run;
+3. raw report/citations paths;
+4. canonical YAML path and exactly which claims were accepted or rejected;
+5. validation commands and outcomes;
+6. any unresolved evidence or identifier uncertainty.
+

--- a/reports/ingredient-role-chebi-verification-2026-08-25.md
+++ b/reports/ingredient-role-chebi-verification-2026-08-25.md
@@ -1,0 +1,20 @@
+# Ingredient-role ChEBI verification
+
+Date: 2026-08-25
+
+Source: local OAK adapter `sqlite:obo:chebi`, queried with `runoak`. A term is marked as a role only when its `rdfs:subClassOf` ancestry includes `CHEBI:50906` (`role`).
+
+| CURIE | current asserted use | actual ChEBI label | is role? | correct CURIE if different | notes |
+|---|---|---|---|---|---|
+| CHEBI:63247 | REDUCING_AGENT | reducing agent | Yes | Same as asserted | Correct. |
+| CHEBI:63248 | OXIDIZING_AGENT | oxidising agent | Yes | Same as asserted | Correct for OXIDIZING_AGENT. The original review prompt's suggestion that this denotes a reducing agent is incorrect. |
+| CHEBI:15022 | ELECTRON_DONOR | electron donor | Yes | Same as asserted | Correct; this is not magnesium(2+). |
+| CHEBI:17654 | ELECTRON_ACCEPTOR | electron acceptor | Yes | Same as asserted | Correct; this is not 5'-deoxyadenosine. |
+| CHEBI:33229 | VITAMIN_SOURCE | vitamin (role) | Yes | Same as asserted | The CURIE denotes the vitamin role, not the distinct medium-side concept "source of vitamins"; retain only if that semantic approximation is intended. |
+| CHEBI:35225 | BUFFER | buffer | Yes | Same as asserted | Correct. |
+| CHEBI:38161 | CHELATOR | chelator | Yes | Same as asserted | Correct. |
+| CHEBI:35195 | SURFACTANT | surfactant | Yes | Same as asserted | Correct. |
+| CHEBI:50407 | PH_INDICATOR | acid-base indicator | Yes | Same as asserted | Correct. |
+| CHEBI:77973 | ANTIFOAM | antifoaming agent | Yes | Same as asserted | Correct. |
+| CHEBI:23357 | COFACTOR / COFACTOR_PROVIDER | cofactor | Yes | Same as asserted | Exact for COFACTOR. For COFACTOR_PROVIDER it is only an approximation: ChEBI names the cofactor role, not a provider-of-cofactor role. |
+| CHEBI:35222 | INHIBITOR | inhibitor | Yes | Same as asserted | Correct. |


### PR DESCRIPTION
Settles five untracked files that had accumulated in the CultureMech working
tree, ahead of the MIM pin bump and KGX export. They split cleanly into curated
content and regenerable output.

## Tracked (2 files, 155 lines)

| File | Why |
|---|---|
| `prompts/claude_code_deep_research.md` | Reusable one-job deep-research task prompt. `prompts/backlog-loop-goal.md` is already tracked; this belongs beside it. |
| `reports/ingredient-role-chebi-verification-2026-08-25.md` | Verifies each ingredient-role CURIE against ChEBI ancestry under `CHEBI:50906` via local OAK. |

The ChEBI table is a curated conclusion, not output. It confirms ten roles
correct, **corrects a review prompt that wrongly read `CHEBI:63248` as a
reducing agent** (it is `oxidising agent`), and records `VITAMIN_SOURCE` and
`COFACTOR_PROVIDER` as semantic approximations — ChEBI names the *vitamin* and
*cofactor* roles, not the medium-side "source of" concepts.

## Ignored (`reports/validation*.{json,md,tsv}`)

A run is ~20 MB (13.8 MB JSON + 6.0 MB TSV). `git ls-files reports/ | grep
validation_all` returns 0 — none has ever been committed, nor committed and
later deleted.

More to the point, the local 2026-09-02 copy is **actively misleading**:

- It reports 2 P1 criticals for `medium_type: BUFFER` and `NEGATIVE_CONTROL`.
  Both have been valid `MediumTypeEnum` values since `179518e4fb` (2026-05-18),
  documented at `src/culturemech/schema/culturemech.yaml:2275,2277`.
- It puts MIM coverage at 0.8% (1,685 linked), without the retired-field
  fallback that covers 1,677 instances.

Both are exactly the bug `a0c587011b` fixed — "Derive the review script's enums
and MIM field from the repo, not from copies (#401, #402, #403)" — whose own
docstring names `BUFFER` and `NEGATIVE_CONTROL` as the two false P1 criticals
the hardcoded list produced. That fix landed **2026-09-02 19:52**, six hours
after the report was generated at **13:34**.

The report's headline recommendation is "CRITICAL: Fix 2 P1 errors in 2 recipes
before KG export". It is wrong, and KG export is the next thing due.

## Checks

- The new ignore rule shadows **0 tracked files** (`git ls-files | git check-ignore --stdin`).
- Both keepers remain trackable under it.
- All nine documented output shapes are covered. The review caught that the
  first rule matched only the hand-dated spelling sitting on disk, while
  `--output` is a path prefix with no date stamp — so `reports/validation_all.*`,
  the shape `SKILL.md:77` actually documents, slipped through. Filed as #412 and
  fixed here in `1a8c2b09f9`.
- Copied byte-identically from the working tree (`diff -q`).
- Branched from `origin/main` in an isolated worktree, because a concurrent
  Claude session is live in the main CultureMech checkout; its HEAD was not moved.

## Review findings

Two adversarial passes, both read-only. Three issues filed:

| Issue | Finding | Disposition |
|---|---|---|
| #412 | Ignore rule matched only the hand-dated spelling on disk; `--output` is a path prefix with no date stamp, so every documented invocation slipped through | **fixed here** (`1a8c2b09f9`) |
| #414 | Comment claimed no tracked file starts with `validation`; `reports/archive/` holds nine, and the comment pointed at a `!` negation instead of the idiomatic archive path | **fixed here** (`c990c19f6b`) |
| #413 | `VITAMIN_SOURCE` is the only one of eleven `*_SOURCE`/`*_PROVIDER` roles asserting ontology *identity* (`meaning: CHEBI:33229`) rather than a weak `mappings:` — exactly what the tracked ChEBI report flags | **left filed** — schema change with KGX consequences, wants its own review |

Also checked and cleared: no CI workflow or `just` recipe consumes
`reports/validation*`; all twelve role CURIEs in the ChEBI report still match the
schema exactly, so it is current rather than stale; `CHEBI:25728`
(`OSMOPROTECTANT`/`OSMOTIC_AGENT`) is a *documented* deliberate sharing with
anti-fan-out notes, not a comparable defect; no secrets in either tracked file;
all six `just` recipes the prompt cites exist; both files are ASCII, LF, and
newline-terminated.

Regenerate a report with
`PYTHONPATH=src python scripts/batch_review_recipes.py --output reports/validation_all`.
Post-#403 the numbers read differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyveZVuXAT9bytKrGKUcY6

