### PR TITLE
Bump the MIM label-index pin to 9f09e4fb: +720 labels, none lost

### DIFF
--- a/docs/mediaingredientmech_enrichment.md
+++ b/docs/mediaingredientmech_enrichment.md
@@ -15,9 +15,9 @@ The packaged files are:
 - `src/culturemech/data/mediaingredientmech/label_index.metadata.json`
 
 The current pin is MIM commit
-`82694054f5bbf74b5392bf8858c9962c2152a35a`: 9,115 data rows, 854,426
+`9f09e4fb97fb0e6cbbd6f25baca40b36512adb88`: 9,876 data rows, 922,191
 bytes, SHA-256
-`7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac`.
+`a36cd4683feb89e2fc2a1721dc15008d1e10c12044e89a36c27b6621a8aaf262`.
 Metadata also fixes the repository, source path, seven-column header, row count,
 and consumer-contract version. There is no moving-branch lookup in a normal
 build.

--- a/src/culturemech/data/mediaingredientmech/label_index.csv
+++ b/src/culturemech/data/mediaingredientmech/label_index.csv
@@ -11,9 +11,13 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (+)-Arabinogalactan,preferred_term,CHEBI:27569,(+)-Arabinogalactan,CHEBI:27569,MAPPED,unique
 (+)-carvone,ontology_label,CHEBI:15399,D(+)-Carvone,CHEBI:15399,MAPPED,unique
 "(+)-cis-Hexahydro-2-oxo-1H-thieno[3,4]imidazole-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+(+)-D-arabitol,synonym,CHEBI:15963,Ribitol,CHEBI:15963,MAPPED,unique
+(+)-d-glucosamine,synonym,CHEBI:5417,Glucosamine,CHEBI:5417,MAPPED,unique
 (+)-D-glucose,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
 (+)-D-glycogen,synonym,CHEBI:28087,Glycogen,CHEBI:28087,MAPPED,unique
 (+)-L-lyxitol,synonym,CHEBI:18403,Arabitol,CHEBI:18403,MAPPED,unique
+(+)-l-ornithine,synonym,CHEBI:16176,D-ornithine,CHEBI:16176,MAPPED,unique
+(+)-l-rhamnose,synonym,CHEBI:16988,D-Ribose,CHEBI:16988,MAPPED,unique
 (+)-L-tartaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 (+)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
 (+)-lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
@@ -22,6 +26,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (+)-Tetrandrine,ontology_label,CHEBI:49,Tetrandrine,CHEBI:49,MAPPED,unique
 (+)-Weinsaeure,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 (+-)-Aspartic acid,synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
+(+-)-menthol,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
 (+/-)-Verapamil hydrochloride,preferred_term,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
 (-)-(S)-proline,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
 (-)-2-pyrrolidinecarboxylic acid,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,unique
@@ -29,7 +34,9 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (-)-alpha-bisabolol,preferred_term,CHEBI:125,(-)-alpha-bisabolol,CHEBI:125,MAPPED,unique
 (-)-anisomycin,preferred_term,CHEBI:338412,(-)-anisomycin,CHEBI:338412,MAPPED,unique
 (-)-beta-caryophyllene,ontology_label,CHEBI:10357,Caryophyllene [T(-)],CHEBI:10357,MAPPED,unique
+(-)-Chloramphenicol,synonym,CHEBI:17698,Chloramphenicol,CHEBI:17698,MAPPED,unique
 (-)-D-fructose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
+(-)-d-rhamnose,synonym,CHEBI:16988,D-Ribose,CHEBI:16988,MAPPED,unique
 (-)-D-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
 (-)-epigallocatechin,ontology_label,CHEBI:42255,Epigallocatechin,CHEBI:42255,MAPPED,unique
 (-)-epigallocatechin 3-gallate,ontology_label,CHEBI:4806,(-)-Epigallocatechin gallate,CHEBI:4806,MAPPED,unique
@@ -45,6 +52,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (-)-quinic Acid,preferred_term,CHEBI:17521,(-)-quinic Acid,CHEBI:17521,MAPPED,unique
 (-)-Salsoline,ontology_label,CHEBI:112,Salsoline,CHEBI:112,MAPPED,unique
 (-)-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
+(1)  Ca(NO3)2,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 (1)  Ca(NO3)2.4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 "(1,4-beta-D-glucosyl)(n)",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
 "(1,4-beta-D-Glucosyl)n",synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
@@ -83,6 +91,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "(1R,3S,5R,6R,9R,11R,15S,16R,17R,18S,19E,21E,23E,25E,27E,29E,31E,33R,35S,36R,37S)-33-[(3-amino-3,6-dideoxy-beta-D-mannopyranosyl)oxy]-1,3,5,6,9,11,17,37-octahydroxy-15,16,18-trimethyl-13-oxo-14,39-dioxabicyclo[33.3.1]nonatriaconta-19,21,23,25,27,29,31-heptaene-36-carboxylic acid",synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
 "(1R,4E,9S)-4,11,11-trimethyl-8-methylidenebicyclo[7.2.0]undec-4-ene",synonym,CHEBI:10357,Caryophyllene [T(-)],CHEBI:10357,MAPPED,unique
 "(1R,5S)-1,2,3,4,5,6-hexahydro-8H-1,5-methanopyrido[1,2-a][1,5]diazocin-8-one",synonym,CHEBI:4055,Cytisine,CHEBI:4055,MAPPED,unique
+"(1R,5S,6S)-2-[(3S,5S)-5-DIMETHYLAMINOCARBONYLPYRROLIDIN-3-YLTHIO]-6-[(R)-1-HYDROXYETHYL]-1-METHYLCARBAPEN-2-EM-3-CARBOXYLIC ACID",synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 "(1S)-1,5-anhydro-1-[4,5-dihydroxy-2-(hydroxymethyl)-10-oxo-9,10-dihydroanthracen-9-yl]-D-glucitol",synonym,CHEBI:73222,Aloin,CHEBI:73222,MAPPED,unique
 "(1S,3R,7S,8S,8aR)-8-{2-[(2R,4R)-4-hydroxy-6-oxotetrahydro-2H-pyran-2-yl]ethyl}-3,7-dimethyl-1,2,3,7,8,8a-hexahydronaphthalen-1-yl (2S)-2-methylbutanoate",synonym,CHEBI:40303,Lovastatin,CHEBI:40303,MAPPED,unique
 "(1S,3R,7S,8S,8aR)-8-{2-[(2R,4R)-4-hydroxy-6-oxotetrahydro-2H-pyran-2-yl]ethyl}-3,7-dimethyl-1,2,3,7,8,8a-hexahydronaphthalen-1-yl 2,2-dimethylbutanoate",synonym,CHEBI:9150,Simvastatin,CHEBI:9150,MAPPED,unique
@@ -94,6 +103,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (2->1)-beta-D-fructofuranan,synonym,CHEBI:15443,Inulin,CHEBI:15443,MAPPED,unique
 (2->6)-beta-D-fructan,ontology_label,CHEBI:16703,Levan - from Erwinia herbicola,CHEBI:16703,MAPPED,unique
 (2->6)-beta-D-fructofuranan,synonym,CHEBI:16703,Levan - from Erwinia herbicola,CHEBI:16703,MAPPED,unique
+(2-aminoethyl)phosphonic acid,ontology_label,CHEBI:15573,2-Aminoethylphosphonate,CHEBI:15573,MAPPED,unique
 (2-Hydroxyethyl)trimethylammonium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
 "(2E)-1-(2,4-dihydroxyphenyl)-3-(4-hydroxyphenyl)prop-2-en-1-one",synonym,CHEBI:310312,Isoliquiritigenin,CHEBI:310312,MAPPED,unique
 (2E)-2-butenedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
@@ -129,6 +139,8 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (2R)-2-ammonio-3-sulfanylpropanoate,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,agree:same_substance
 (2R)-2-ammonio-3-sulfanylpropanoate,synonym,CHEBI:35235,L-cysteine zwitterion,CHEBI:35235,MAPPED,agree:same_substance
 "(2R,2'R)-3,3'-disulfanediylbis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+"(2R,3R)-1,4-dimercaptobutane-2,3-diol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+"(2R,3R)-1,4-disulfanylbutane-2,3-diol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 "(2R,3R)-2,3,4-trihydroxybutanal",synonym,CHEBI:27904,D-erythrose,CHEBI:27904,MAPPED,unique
 "(2R,3R)-2,3-Dihydroxybernsteinsaeure",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 "(2R,3R)-2,3-dihydroxybutanedioate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
@@ -228,7 +240,9 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "(2Z)-3,7-dimethylocta-2,6-dien-1-ol",synonym,CHEBI:29452,Nerol,CHEBI:29452,MAPPED,unique
 (2Z)-but-2-enedioic acid,synonym,CHEBI:18300,Maleic acid,CHEBI:18300,MAPPED,unique
 "(2Z,4E)-5-[(1S)-1-hydroxy-2,6,6-trimethyl-4-oxocyclohex-2-en-1-yl]-3-methylpenta-2,4-dienoic acid",synonym,CHEBI:2365,Abscisic acid,CHEBI:2365,MAPPED,unique
+"(3,4-dihydroxyphenyl)acetate",ontology_label,CHEBI:17612,"3,4-Dihydroxyphenylacetate",CHEBI:17612,MAPPED,unique
 "(3,5-dibromo-4-hydroxyphenyl)(2-ethyl-1-benzofuran-3-yl)methanone",synonym,CHEBI:3023,Benzbromarone,CHEBI:3023,MAPPED,unique
+(3-chloro-4-hydroxyphenyl)acetic acid,ontology_label,CHEBI:47106,3-Chloro-4-hydroxyphenylacetic acid,CHEBI:47106,MAPPED,unique
 "(3aR,4S,7R,7aS)-3a,7a-dimethylhexahydro-4,7-epoxy-2-benzofuran-1,3-dione",synonym,CHEBI:64213,Cantharidin,CHEBI:64213,MAPPED,unique
 "(3aR,5S,8aR,9aR)-5,8a-dimethyl-3-methylidene-3a,5,6,7,8,8a,9,9a-octahydronaphtho[2,3-b]furan-2(3H)-one",synonym,CHEBI:2540,Helenine,CHEBI:2540,MAPPED,unique
 "(3aS,4R,5S,6S,8R,9R,9aR,10R)-5-hydroxy-4,6,9,10-tetramethyl-1-oxo-6-vinyldecahydro-3a,9-propanocyclopenta[8]annulen-8-yl {[2-(diethylamino)ethyl]sulfanyl}acetate",synonym,CHEBI:44137,Tiamulin,CHEBI:44137,MAPPED,unique
@@ -257,6 +271,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "(4aS,6aR,8aR,8bR,9aS,12R,12aS,14aR,14bR)-12-(3-furyl)-6,6,8a,12a-tetramethyldecahydro-3H-oxireno[d]pyrano[4',3':3,3a][2]benzofuro[5,4-f]isochromene-3,8,10(6H,9aH)-trione",synonym,CHEBI:16226,Limonin,CHEBI:16226,MAPPED,unique
 (4R)-4-aminoisoxazolidin-3-one,synonym,CHEBI:40009,D-Cycloserine,CHEBI:40009,MAPPED,unique
 (4R)-4-hydroxy-L-proline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+"(4R,5S,6S)-3-{[(3S,5S)-5-(dimethylcarbamoyl)pyrrolidin-3-yl]thio}-6-[(1R)-1-hydroxyethyl]-4-methyl-7-oxo-1-azabicyclo[3.2.0]hept-2-ene-2-carboxylic acid",synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 "(4S)-2-methyl-1,4,5,6-tetrahydropyrimidine-4-carboxylic acid",synonym,CHEBI:27592,Ectoine,CHEBI:27592,MAPPED,unique
 "(4S)-4-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[2-[[(2S,3S)-2-[(2-aminoacetyl)amino]-3-methylpentanoyl]amino]acetyl]amino]hexanoyl]amino]-3-phenylpropanoyl]amino]-4-methylpentanoyl]amino]-3-(1H-imidazol-5-yl)propanoyl]amino]-3-hydroxypropanoyl]amino]propanoyl]amino]acetyl]amino]hexanoyl]amino]-3-phenylpropanoyl]amino]acetyl]amino]hexanoyl]amino]propanoyl]amino]-3-phenylpropanoyl]amino]-3-methylbutanoyl]amino]acetyl]amino]-5-[[(2S,3S)-1-[[(2S)-1-[[(2S)-6-amino-1-[[(1S)-1-carboxy-2-hydroxyethyl]amino]-1-oxohexan-2-yl]amino]-4-methylsulanyl-1-oxobutan-2-yl]amino]-3-methyl-1-oxopentan-2-yl]amino]-5-oxopentanoic acid",synonym,CHEBI:201898,Magainin I,CHEBI:201898,MAPPED,unique
 "(4S)-4-[[2-[[(2S)-2-[[(2S)-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-2-[[(2S)-1-[2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S,3S)-2-[[2-[[(2S)-4-amino-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-4-amino-2-[[(2S)-2-[[2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S,3S)-2-[[(2S)-6-amino-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2-[[(2S)-6-amino-2-[[(2S)-2-[[(2S)-2,6-diaminohexanoyl]amino]-3-(1H-indol-3-yl)propanoyl]amino]hexanoyl]amino]-3-methylbutanoyl]amino]-3-phenylpropanoyl]amino]hexanoyl]amino]hexanoyl]amino]-3-methylpentanoyl]amino]-4-carboxybutanoyl]amino]hexanoyl]amino]-4-methylsulanylbutanoyl]amino]acetyl]amino]-5-carbamimidamidopentanoyl]amino]-4-oxobutanoyl]amino]-3-methylpentanoyl]amino]-5-carbamimidamidopentanoyl]amino]-4-oxobutanoyl]amino]acetyl]amino]-3-methylpentanoyl]amino]-3-methylbutanoyl]amino]hexanoyl]amino]propanoyl]amino]acetyl]pyrrolidine-2-carbonyl]amino]propanoyl]amino]-3-methylpentanoyl]amino]propanoyl]amino]-3-methylbutanoyl]amino]-4-methylpentanoyl]amino]acetyl]amino]-5-[[(2S)-1-[[(2S)-6-amino-1-[[(2S)-1-[[(2S)-1-amino-4-methyl-1-oxopentan-2-yl]amino]-1-oxopropan-2-yl]amino]-1-oxohexan-2-yl]amino]-1-oxopropan-2-yl]amino]-5-oxopentanoic acid",synonym,CHEBI:201469,Cecropin B,CHEBI:201469,MAPPED,unique
@@ -298,6 +313,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (E)-3-phenyl-2-propenoic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
 (E)-4-Aminostyryl acetate,synonym,kgmicrobe.compound:e_4_aminostyryl_acetate,E 4 Aminostyryl Acetate,kgmicrobe.compound:e_4_aminostyryl_acetate,MAPPED,unique
 (E)-4-coumaric acid methyl ester,ontology_label,cas:19367-38-5,methyl-trans-p-coumarate,CHEBI:194094,MAPPED,unique
+(E)-8-Methyl-N-vanillyl-6-nonenamide,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 (E)-but-2-enoic acid,synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
 (E)-cinnamic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
 (E)-crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
@@ -321,6 +337,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (NH4)2Ni(SO4)2,preferred_term,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
 (NH4)2Ni(SO4)2,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
 (NH4)2Ni(SO4)2 x 6 H2O,preferred_term,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
+(NH4)2Ni(SO4)2 x 6 H2O (0.1% w/v),synonym,CHEBI:86149,(NH4)2Ni(SO4)2,CHEBI:86149,MAPPED,unique
 (NH4)2Ni(SO4)2 x 6 H2O (0.1% w/v),synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
 (NH4)2Ni(SO4)2.6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
 (NH4)2Ni(SO4)2·6H2O,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
@@ -333,9 +350,18 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (NH4)3 citrate,preferred_term,CHEBI:63037,(NH4)3 citrate,CHEBI:63037,MAPPED,unique
 (NH4)6Mo7O24,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
 (NH4)6Mo7O24 x 4 H2O,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+(NH4)6Mo7O24.4H2O,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
+(NH4)6Mo7O4,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)6Mo7O4 x 24 H2O,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)6MoO24·4H2O,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)6MoO7O24,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)6MoO7O24 x 4 H2O,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
 (NH4)Cl,synonym,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
 (NH4)H2PO4,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
 (NH4)HCO3,synonym,CHEBI:184335,NH4HCO3,CHEBI:184335,MAPPED,unique
+(NH4)Mo7O24·4H2O,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)MoO7O24,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
+(NH4)MoO7O24 x 4 H2O,synonym,cas:12054-85-2,ammonium molybdate tetrahydrate,CHEBI:91249,MAPPED,unique
 (NH4)NO3,preferred_term,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
 (p-hydroxyphenyl)acetic acid,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
 (R)-(+)-Lipoate,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
@@ -362,6 +388,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "(R,R)-3,3'-dithiobis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
 "(R,R)-Tartaric acid",synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 "(R,R)-Tartrate",synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
+"(R,R,R)-alpha-tocopherol",ontology_label,CHEBI:18145,alpha-Tocopherol,CHEBI:18145,MAPPED,unique
 "(R,S)-Aspartic acid",synonym,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,unique
 "(R-(R*,R*))-2,3-dihydroxybutanedioic acid, disodium salt",synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
 "(R-(R*,R*))-3,3'-Dithiobis(2-aminopropanoic acid)",synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
@@ -431,6 +458,8 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 (trimethylammoniumyl)acetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
 (Z)-Octadec-9-enoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
 -Asp-,synonym,CHEBI:75228,D,CHEBI:75228,REJECTED,unique
+.MgSO4,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+.MgSO4,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 .MgSO4,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 .MgSO4 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 .MgSO4 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
@@ -468,6 +497,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "1,2,3-trichloropropane",preferred_term,CHEBI:34036,"1,2,3-trichloropropane",CHEBI:34036,MAPPED,unique
 "1,2,3-Trihydroxypropane",synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
 "1,2,3-Trihydroxypropane",synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+"1,2--Dichloropropane (10 mg/ml in methanol)",synonym,CHEBI:82163,"1,2-Dichloropropane",CHEBI:82163,MAPPED,unique
 "1,2-benzacenaphthylene",synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
 "1,2-Benzenediol",synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
 "1,2-benzisothiazol-3(2H)-one 1,1-dioxide",synonym,CHEBI:32111,Saccharin,CHEBI:32111,MAPPED,unique
@@ -482,6 +512,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "1,2-dithiolane-3-valeric acid",synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
 "1,2-ethanedicarboxylic acid",synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
 "1,2-ETHANEDIOL",synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
+"1,2-propandiol",synonym,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
 "1,2-Propanediol",preferred_term,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
 "1,3,4-trihydroxybutan-2-one",synonym,CHEBI:23958,L-(+)-Erythrulose,CHEBI:23958,MAPPED,unique
 "1,3,5/2,4,6-cyclohexanehexol",synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
@@ -499,6 +530,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "1,3-Propanediol",preferred_term,CHEBI:16109,"1,3-Propanediol",CHEBI:16109,MAPPED,unique
 "1,3-Xylene",synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
 "1,4,7,10,13,16-hexaoxacyclooctadecane",synonym,CHEBI:32397,18-Crown-6,CHEBI:32397,MAPPED,unique
+"1,4--dithiothreitol (DTT)",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 "1,4-B-D-Galactobiose",preferred_term,cas:2152-98-9,"1,4-B-D-Galactobiose",CHEBI:36226,MAPPED,unique
 "1,4-Butanediamine",synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
 "1,4-Butanediol",preferred_term,CHEBI:41189,"1,4-Butanediol",CHEBI:41189,MAPPED,unique
@@ -540,6 +572,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 1-aminocyclopropane-1-carboxylate,preferred_term,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
 1-Aminocyclopropane-1-carboxylic acid,synonym,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
 1-aminocyclopropanecarboxylic acid,ontology_label,CHEBI:18053,1-aminocyclopropane-1-carboxylate,CHEBI:18053,MAPPED,unique
+1-beta-D-Galactopyranosyl-4-alpha-D-glucopyranose,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 1-beta-D-Galactopyranosyl-4-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 1-beta-D-Glucopyranosyl-4-D-glucopyranose,synonym,CHEBI:17057,Cellobiose,CHEBI:17057,MAPPED,unique
 1-beta-D-Ribofuranosylcytosine,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
@@ -547,6 +580,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 1-beta-D-ribofuranosyluracil,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
 1-butanecarboxylic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
 1-butanoic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
+1-Butanol,synonym,CHEBI:28885,Butanol,CHEBI:28885,MAPPED,unique
 1-butanol+CO2,preferred_term,kgmicrobe.ingredient:1_butanol_co2,1-butanol+CO2,kgmicrobe.ingredient:1_butanol_co2,MAPPED,unique
 1-butyric acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
 "1-carboxy-N,N,N-trimethylmethanaminium inner salt",synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
@@ -653,7 +687,9 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "2,3,5-Triphenyltetrazolium chloride",preferred_term,CHEBI:78019,"2,3,5-Triphenyltetrazolium chloride",CHEBI:78019,MAPPED,unique
 "2,3,9,10-tetramethoxy-5,6-dihydroisoquino[3,2-a]isoquinolinium",synonym,CHEBI:16096,Palmatine,CHEBI:16096,MAPPED,unique
 "2,3-butanediol",preferred_term,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"2,3-butanone",synonym,CHEBI:16583,Diacetyl,CHEBI:16583,MAPPED,unique
 "2,3-Butylene glycol",synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
+"2,3-DIHYDROXY-1,4-DITHIOBUTANE",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 "2,3-DIHYDROXY-BENZOIC ACID",synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
 "2,3-dihydroxybenzoic acid",preferred_term,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
 "2,3-Dihydroxybutane",synonym,CHEBI:62064,"2,3-butanediol",CHEBI:62064,MAPPED,unique
@@ -663,11 +699,14 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "2,3-dimethylsuccinic acid",ontology_label,CHEBI:167506,2-dimethylsuccinic Acid,CHEBI:167506,MAPPED,unique
 "2,3-dioxido-1,4-dioxy-2,3-disulfy-[4]catenate(2-)",synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
 "2,4(1H,3H)-pyrimidinedione",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
+"2,4-D",ontology_label,CHEBI:28854,"2,4-Dichlorophenoxyacetic acid",CHEBI:28854,MAPPED,unique
 "2,4-diamino-4-oxobutanoic acid",synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
 "2,4-diamino-6,7-di-iso-propylpteridine phosphate",preferred_term,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
 "2,4-diamino-6,7-diisopropylpteridine",ontology_label,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unresolved:partial_chemistry
 "2,4-diamino-6,7-diisopropylpteridine",ontology_label,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unresolved:partial_chemistry
+"2,4-Dichlorophenoxyacetic acid",preferred_term,CHEBI:28854,"2,4-Dichlorophenoxyacetic acid",CHEBI:28854,MAPPED,unique
 "2,4-dihydroxy-5-methylpyrimidine",synonym,CHEBI:17821,Thymine,CHEBI:17821,MAPPED,unique
+"2,4-Dihydroxybenzoic acid",preferred_term,CHEBI:42094,"2,4-Dihydroxybenzoic acid",CHEBI:42094,MAPPED,unique
 "2,4-Dinitrophenol",preferred_term,CHEBI:42017,"2,4-Dinitrophenol",CHEBI:42017,MAPPED,unique
 "2,4-Dioxopyrimidine",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
 "2,4-Pyrimidinedione",synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
@@ -679,6 +718,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "2,6-diacetyl-3,7,9-trihydroxy-8,9b-dimethyldibenzo[b,d]furan-1(9bH)-one",synonym,CHEBI:38319,Usnic Acid,CHEBI:38319,MAPPED,unique
 "2,6-diaminoheptanedioic acid",synonym,CHEBI:23673,Diaminopimelic acid,CHEBI:23673,MAPPED,unique
 "2,6-diaminopimelic acid",ontology_label,CHEBI:23673,Diaminopimelic acid,CHEBI:23673,MAPPED,unique
+"2,6-dichloro-4-nitroaniline",ontology_label,CHEBI:27864,Dichloran (0.2% in ethanol),CHEBI:27864,MAPPED,unique
 "2,6-dihydroxybenzoic acid",preferred_term,cas:303-07-1,"2,6-dihydroxybenzoic acid",cas:303-07-1,MAPPED,unique
 "2,6-dihydroxypurine",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
 "2,6-dioxo-1,2,3,6-tetrahydropurine",synonym,CHEBI:17712,Xanthine,CHEBI:17712,MAPPED,unique
@@ -719,11 +759,13 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 2-acetamido-2-deoxy-D-galactopyranose,synonym,CHEBI:28037,N-Acetyl-D-galactosamine,CHEBI:28037,MAPPED,unique
 2-acetamido-2-deoxy-D-glucopyranose,synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
 2-acetamido-2-deoxy-D-glucopyranose 6-(dihydrogen phosphate),synonym,CHEBI:15784,N-Acetyl-D-glucosamine 6-phosphate sodium salt,CHEBI:15784,MAPPED,unique
+2-Acetamido-2-deoxy-D-glucose,synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
 2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-aldehydo-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
 2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-aldehydo-D-glucose,synonym,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
 2-acetamido-3-O-[(1R)-1-carboxyethyl]-2-deoxy-D-glucose,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
 2-acetamidopentanedioic acid,synonym,CHEBI:172431,N-Acetyl-glutamic acid,CHEBI:172431,MAPPED,unique
 2-Acetylpyrrole,preferred_term,CHEBI:59981,2-Acetylpyrrole,CHEBI:59981,MAPPED,unique
+2-aminethanol,synonym,CHEBI:16000,Ethanolamine,CHEBI:16000,MAPPED,unique
 "2-amino-1,5-dihydro-1-methyl-4H-Imidazol-4-one",synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
 "2-amino-1,9-dihydro-6H-purin-6-one",synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
 "2-amino-1,9-dihydro-9-beta-D-ribofuranosyl-6H-purin-6-one",synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
@@ -767,6 +809,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 2-aminoethanol,synonym,CHEBI:16000,Ethanolamine,CHEBI:16000,MAPPED,unique
 2-aminoethyl dihydrogen phosphate,synonym,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
 2-aminoethyl sulfonate,synonym,CHEBI:15891,Taurine,CHEBI:15891,MAPPED,unique
+2-Aminoethylphosphonate,preferred_term,CHEBI:15573,2-Aminoethylphosphonate,CHEBI:15573,MAPPED,unique
 2-aminopentanedioic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
 2-aminopentanoic Acid,preferred_term,CHEBI:19475,2-aminopentanoic Acid,CHEBI:19475,MAPPED,unique
 2-Aminosuccinamic acid,synonym,CHEBI:17196,L-Asparagine,CHEBI:17196,MAPPED,unique
@@ -778,8 +821,10 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 2-butoxy-N-[2-(diethylamino)ethyl]quinoline-4-carboxamide,synonym,CHEBI:247956,Dibucaine,CHEBI:247956,MAPPED,unique
 2-carboxyfuran,synonym,CHEBI:30845,2-Furoic acid,CHEBI:30845,MAPPED,unique
 2-Carene-3-One,preferred_term,UNMAPPED_0196,2-Carene-3-One,,UNMAPPED,unique
+"2-chloro-4(ethylamino)-6-(isopropylamino)-1,3,5-triazine",synonym,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
 "2-chloro-4-ethylamino-6-isopropylamino-1,3,5-triazine",synonym,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
 "2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",preferred_term,CHEBI:15930,"2-chloro-4ethylamino-6-isopropylamino-1,3,5-triazine",CHEBI:15930,MAPPED,unique
+2-Chlorobenzoic acid,preferred_term,CHEBI:30793,2-Chlorobenzoic acid,CHEBI:30793,MAPPED,unique
 2-dehydro-D-gluconate,preferred_term,CHEBI:16808,2-dehydro-D-gluconate,CHEBI:16808,MAPPED,resolved:owned
 2-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_2-dehydro-d-gluconate,Potassium 2-dehydro-D-gluconate,CHEBI:16808,MAPPED,resolved:owned
 2-dehydro-D-gluconate,ontology_label,kgmicrobe.compound:potassium_2-ketogluconate,Potassium 2-ketogluconate,CHEBI:16808,MAPPED,resolved:owned
@@ -848,10 +893,12 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 2-imino-1-methylimidazolidin-4-one,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
 2-Keto-D-gluconic acid hemicalcium salt hydrate,preferred_term,cas:1040352-40-6,2-Keto-D-gluconic acid hemicalcium salt hydrate,CHEBI:27469,MAPPED,unique
 2-Keto-D-gluconic acid hemicalcium salt monohydrate,preferred_term,cas:3470-37-9,2-Keto-D-gluconic acid hemicalcium salt monohydrate,CHEBI:27469,MAPPED,unique
+2-Ketogluconate (2-dehydro-D-gluconate),synonym,CHEBI:16808,2-dehydro-D-gluconate,CHEBI:16808,MAPPED,unique
 2-Ketoglutaric acid,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
 2-ketopropionic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
 2-Mercaptoethanesulfonate,preferred_term,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 2-Mercaptoethanesulfonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
+2-Mercaptoethanesulfonic acid (Coenzyme M),synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 2-mercaptoethanesulphonic acid,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 2-Mercaptoethanol,preferred_term,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
 2-Mercaptopyridine N-oxide sodium salt,preferred_term,CHEBI:201738,2-Mercaptopyridine N-oxide sodium salt,CHEBI:201738,MAPPED,unique
@@ -902,6 +949,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 2-naphthyl Dihydrogen Phosphate,preferred_term,CHEBI:91043,2-naphthyl Dihydrogen Phosphate,CHEBI:91043,MAPPED,unique
 2-naphthyl Tetradecanoate,preferred_term,CHEBI:90249,2-naphthyl Tetradecanoate,CHEBI:90249,MAPPED,unique
 2-nitroimidazole,ontology_label,CHEBI:67135,Azomycin,CHEBI:67135,MAPPED,unique
+2-Nitrophenol,preferred_term,CHEBI:16260,2-Nitrophenol,CHEBI:16260,MAPPED,unique
 2-nitrophenyl beta-D-galactoside,ontology_label,CHEBI:90144,O-nitrophenyl-beta-D-galactopyranosid,CHEBI:90144,MAPPED,unique
 2-O-alpha-L-rhamnosyl-alpha-L-rhamnosyl-3-hydroxydecanoyl-3-hydroxydecanoic acid,ontology_label,CHEBI:62570,Rhamnolipid,CHEBI:62570,MAPPED,unique
 2-octadecanoylglycerol,synonym,CHEBI:75456,Glycerol monostearate,CHEBI:75456,MAPPED,unique
@@ -972,13 +1020,16 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "3,4,5-Trihydroxybenzoic acid",synonym,CHEBI:30778,Gallic Acid,CHEBI:30778,MAPPED,unique
 "3,4,5-trimethoxybenzoate",preferred_term,CHEBI:58989,"3,4,5-trimethoxybenzoate",CHEBI:58989,MAPPED,unique
 "3,4,5-trimethoxybenzoic acid",ontology_label,CHEBI:454991,Eudesmic Acid,CHEBI:454991,MAPPED,unique
+"3,4,5-Trimethoxycinnamic acid",preferred_term,CHEBI:566519,"3,4,5-Trimethoxycinnamic acid",CHEBI:566519,MAPPED,unique
 "3,4-dihydroxy-5-methoxybenzoic acid",synonym,CHEBI:28647,3-O-methylgallate,CHEBI:28647,MAPPED,unique
 "3,4-dihydroxybenzaldehyde",ontology_label,CHEBI:50205,Protocatechualdehyde,CHEBI:50205,MAPPED,unique
 "3,4-dihydroxybenzoate",ontology_label,CHEBI:36241,Protocatechuate,CHEBI:36241,MAPPED,unique
 "3,4-dihydroxybenzoic acid",ontology_label,CHEBI:36062,Protocatechuic Acid,CHEBI:36062,MAPPED,unique
+"3,4-Dihydroxyphenylacetate",preferred_term,CHEBI:17612,"3,4-Dihydroxyphenylacetate",CHEBI:17612,MAPPED,unique
 "3,4-dimethoxybenzoic acid",ontology_label,CHEBI:296881,Veratric Acid,CHEBI:296881,MAPPED,unique
 "3,5,7-trihydroxy-2-(3,4,5-trihydroxyphenyl)-4H-chromen-4-one",synonym,CHEBI:18152,Myricetin,CHEBI:18152,MAPPED,unique
 "3,5-dihydroxy-2-[3-(4-hydroxyphenyl)propanoyl]phenyl beta-D-glucopyranoside",synonym,CHEBI:8113,Phloridzin,CHEBI:8113,MAPPED,unique
+"3,5-Dihydroxybenzoic acid",preferred_term,CHEBI:39912,"3,5-Dihydroxybenzoic acid",CHEBI:39912,MAPPED,unique
 "3,5-Dinitrosalicylic acid",preferred_term,CHEBI:53648,"3,5-Dinitrosalicylic acid",CHEBI:53648,MAPPED,unique
 "3,7,11-trimethyldodeca-1,6,10-trien-3-ol",synonym,CHEBI:7524,Nerolidol,CHEBI:7524,MAPPED,unique
 "3,7,11-trimethyldodeca-2,6,10-trien-1-ol",synonym,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
@@ -1033,6 +1084,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 3-aminobutyrate,preferred_term,CHEBI:87997,3-aminobutyrate,CHEBI:87997,MAPPED,unique
 3-aminobutyric acid,preferred_term,CHEBI:37081,3-aminobutyric acid,CHEBI:37081,MAPPED,unique
 3-aminoisobutyric acid,ontology_label,CHEBI:27389,DL-3-Aminoisobutyric acid,CHEBI:27389,MAPPED,unique
+3-Aminophenol,preferred_term,CHEBI:28924,3-Aminophenol,CHEBI:28924,MAPPED,unique
 3-aminopropanoic acid,synonym,CHEBI:16958,Beta-alanine,CHEBI:16958,MAPPED,unique
 3-Aminopropionitrile Fumarate,preferred_term,CHEBI:91084,3-Aminopropionitrile Fumarate,CHEBI:91084,MAPPED,unique
 3-beta-d-glucan,preferred_term,CHEBI:37671,3-beta-d-glucan,CHEBI:37671,MAPPED,unique
@@ -1043,7 +1095,9 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 3-carboxylpyridine,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
 3-carboxyphenol,synonym,CHEBI:30764,3-Hydroxybenzoic acid,CHEBI:30764,MAPPED,unique
 3-carboxypyridine,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+3-Chloro-4-hydroxyphenylacetic acid,preferred_term,CHEBI:47106,3-Chloro-4-hydroxyphenylacetic acid,CHEBI:47106,MAPPED,unique
 3-Chloro-L-tyrosine,preferred_term,CHEBI:53678,3-Chloro-L-tyrosine,CHEBI:53678,MAPPED,unique
+3-Chloroacrylic acid,preferred_term,CHEBI:19982,3-Chloroacrylic acid,CHEBI:19982,MAPPED,unique
 3-dehydro-D-gluconate,preferred_term,CHEBI:85256,3-dehydro-D-gluconate,CHEBI:85256,MAPPED,unique
 3-fucosyllactose,ontology_label,cas:41312-47-4,3'-fucosyllactose,CHEBI:90065,MAPPED,unique
 3-hydroxy 2-butanone,synonym,CHEBI:15688,Acetoin,CHEBI:15688,MAPPED,unique
@@ -1072,6 +1126,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 3-Hydroxyhexanoic acid,preferred_term,CHEBI:37035,3-Hydroxyhexanoic acid,CHEBI:37035,MAPPED,unique
 3-hydroxyisobutyric acid,ontology_label,cas:1219589-99-7,DL-3-Hydroxyisobutyric acid sodium salt,CHEBI:18064,MAPPED,unique
 3-hydroxypentanoic acid,ontology_label,CHEBI:139272,rac-3-Hydroxypentanoic Acid,CHEBI:139272,MAPPED,unique
+3-Hydroxypropanal,preferred_term,CHEBI:17871,3-Hydroxypropanal,CHEBI:17871,MAPPED,unique
 3-hydroxypropanoate,synonym,CHEBI:16510,3-Hydroxypropionate,CHEBI:16510,MAPPED,unique
 3-Hydroxypropionate,preferred_term,CHEBI:16510,3-Hydroxypropionate,CHEBI:16510,MAPPED,unique
 3-hydroxysalicylic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
@@ -1103,6 +1158,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 3-morpholin-4-ylpropane-1-sulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
 3-morpholinopropanesulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
 3-nitropropanoate,preferred_term,CHEBI:59899,3-nitropropanoate,CHEBI:59899,MAPPED,unique
+3-nitropropanoic acid,synonym,CHEBI:59899,3-nitropropanoate,CHEBI:59899,MAPPED,unique
 3-O-methyl Alpha-D-glucopyranoside,preferred_term,kgmicrobe.compound:3-o-methyl_alpha-d-glucopyranoside,3-O-methyl Alpha-D-glucopyranoside,kgmicrobe.compound:3-o-methyl_alpha-d-glucopyranoside,MAPPED,unique
 3-O-Methyl-D-glucopyranose,preferred_term,cas:13224-94-7,3-O-Methyl-D-glucopyranose,cas:13224-94-7,MAPPED,unique
 3-O-methyl-D-glucose,ontology_label,CHEBI:73918,3-O-methyl-glucose,CHEBI:73918,MAPPED,unique
@@ -1148,6 +1204,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "4,5-bis(hydroxymethyl)-2-methylpyridin-3-ol hydrochloride",synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 4-(1H-indol-3-yl)butanoic acid,synonym,CHEBI:33070,Indole-3-butyric acid,CHEBI:33070,MAPPED,unique
 4-(2-Hydroxyethyl)-1-piperazineethane sulfonic acid,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+4-(2-hydroxyethyl)-1-piperazineethanesulfonic acid,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
 4-(2-hydroxyethyl)-2-methoxyphenol,synonym,CHEBI:173769,homovanillyl alcohol,CHEBI:173769,MAPPED,unique
 4-(alpha-D-glucosido)-D-glucose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 4-(AMINOMETHYL)-5-(HYDROXYMETHYL)-2-METHYLPYRIDIN-3-OL,synonym,CHEBI:16410,Pyridoxamine,CHEBI:16410,MAPPED,unique
@@ -1177,6 +1234,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "4-amino-2-hydroxy-N,N,N-trimethyl-4-oxobutan-1-aminium chloride",synonym,kgmicrobe.compound:carnitine_hydrochloride,Carnitine Hydrochloride,CHEBI:17126,MAPPED,unique
 4-amino-2-hydroxybenzoic acid,synonym,CHEBI:27565,para-aminosalicylic acid,CHEBI:27565,MAPPED,unique
 4-amino-2-hydroxypyrimidine,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
+4-Amino-5-hydroxymethyl-2-methylpyrimidine,preferred_term,CHEBI:16892,4-Amino-5-hydroxymethyl-2-methylpyrimidine,CHEBI:16892,MAPPED,unique
 4-Amino-benzoic acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-amino-N-(2-quinoxalinyl)benzenesulfonamide,ontology_label,cas:59-40-5,Sulfaquinoxaline,CHEBI:94719,MAPPED,unique
 "4-amino-N-(5-methyl-1,2-oxazol-3-yl)benzenesulfonamide",synonym,CHEBI:9332,Sulfamethoxazole,CHEBI:9332,MAPPED,unique
@@ -1185,6 +1243,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 4-Aminobenzoate,preferred_term,CHEBI:17836,4-Aminobenzoate,CHEBI:17836,MAPPED,unique
 4-Aminobenzoesaeure,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-Aminobenzoic Acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+4-aminobenzoic acid zwitterion,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-Aminobutanoic acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
 4-aminobutyrate,preferred_term,CHEBI:30566,4-aminobutyrate,CHEBI:30566,MAPPED,unique
 4-Aminobutyric acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
@@ -1192,7 +1251,9 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 4-aminosalicylic acid,ontology_label,CHEBI:27565,para-aminosalicylic acid,CHEBI:27565,MAPPED,unique
 4-aminovalerate,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
 4-aminovaleric acid,synonym,CHEBI:15887,5-Aminovaleric acid,CHEBI:15887,MAPPED,unique
+4-ammoniobenzoate,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-Anisaldehyde,preferred_term,CHEBI:28235,4-Anisaldehyde,CHEBI:28235,MAPPED,unique
+4-azaniumylbenzoate,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-azaoctamethylenediamine,synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
 "4-azaoctane-1,8-diamine",synonym,CHEBI:16610,spermidine,CHEBI:16610,MAPPED,unique
 4-azido-L-phenylalanine,preferred_term,CHEBI:228211,4-azido-L-phenylalanine,CHEBI:228211,MAPPED,unique
@@ -1204,6 +1265,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 4-Carboxyphenylamine,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 4-coumarate,preferred_term,CHEBI:32373,4-coumarate,CHEBI:32373,MAPPED,unique
 4-coumaric acid methyl ester,ontology_label,CHEBI:86904,methyl-cis-p-coumarate,CHEBI:86904,MAPPED,unique
+4-Cresol,preferred_term,CHEBI:17847,4-Cresol,CHEBI:17847,MAPPED,unique
 4-Deoxypyridoxine,preferred_term,CHEBI:65083,4-Deoxypyridoxine,CHEBI:65083,MAPPED,unique
 4-Diamino-6,preferred_term,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,4-Diamino-6,,REJECTED,unique
 4-Diamino-6,synonym,kgmicrobe.compound:24-diamino-67-di-iso-propylpteridine_phosphate,"2,4-diamino-6,7-di-iso-propylpteridine phosphate",CHEBI:73908,MAPPED,unique
@@ -1274,6 +1336,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 4-nitrophenyl-beta-D-galactoside,ontology_label,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
 4-O-alpha-D-glucopyranosyl-alpha-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 4-O-alpha-D-glucopyranosyl-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+4-O-beta-D-galactopyranosyl-alpha-D-glucopyranose,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 4-O-beta-D-galactopyranosyl-beta-D-fructofuranose,synonym,CHEBI:6359,Lactulose,CHEBI:6359,MAPPED,unique
 4-O-beta-D-galactopyranosyl-beta-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 4-O-beta-D-galactopyranosyl-D-glucitol,synonym,CHEBI:75323,Lactitol,CHEBI:75323,MAPPED,unique
@@ -1303,6 +1366,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "5,6,7-trihydroxy-2-phenyl-4H-chromen-4-one",synonym,CHEBI:2979,Baicalein,CHEBI:2979,MAPPED,unique
 "5,6-dihydro-5-azathymidine",preferred_term,mesh:C014480,"5,6-dihydro-5-azathymidine",mesh:C014480,MAPPED,unique
 "5,6-Dihydro-5-fluorouracil",ontology_label,CHEBI:80624,"5-Fluorodihydropyrimidine-2,4-dione",CHEBI:80624,MAPPED,unique
+"5,6-dihydro-9,10-dimethoxy-1,3-benzodioxolo[5,6-a]benzo[g]quinolizinium",synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 "5,6-dihydroxy-2-(4-hydroxyphenyl)-4-oxo-4H-chromen-7-yl beta-D-glucopyranosiduronic acid",synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
 "5,6-dihydroxy-2-(4-hydroxyphenyl)-4-oxo-4H-chromen-7-yl beta-D-glucopyranosiduronic acid",synonym,CHEBI:66870,Na2S2O4,CHEBI:66870,REJECTED,unique
 "5,7,4'-Trimethoxyisoflavone",preferred_term,cas:1162-82-9,"5,7,4'-Trimethoxyisoflavone",cas:1162-82-9,MAPPED,unique
@@ -1364,6 +1428,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 5-hydroxyoctanoic acid,synonym,CHEBI:180039,5-Hydroxyoctanoate,CHEBI:180039,MAPPED,unique
 5-hydroxysalicylic acid,synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
 5-Keto-D-Gluconic Acid potassium salt,preferred_term,cas:91446-96-7,5-Keto-D-Gluconic Acid potassium salt,CHEBI:17426,MAPPED,unique
+5-Ketogluconate (5-dehydro-D-gluconate),synonym,cas:91446-96-7,5-Keto-D-Gluconic Acid potassium salt,CHEBI:17426,MAPPED,unique
 5-L-Glutamyl-L-cysteinylglycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
 5-MeBza-Cba,synonym,UNMAPPED_0179,5-methylbenzimidazolyl cobamide,,UNMAPPED,unique
 5-methoxybenzimidazolyl cobamide,preferred_term,UNMAPPED_0180,5-methoxybenzimidazolyl cobamide,,UNMAPPED,unique
@@ -1438,6 +1503,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "7,2'-Dihydroxyflavone",preferred_term,cas:77298-66-9,"7,2'-Dihydroxyflavone",CHEBI:94071,MAPPED,unique
 "7,2'-Dimethoxyflavone",preferred_term,UNMAPPED_0199,"7,2'-Dimethoxyflavone",,UNMAPPED,unique
 "7,4'-Dimethoxyisoflavone",preferred_term,UNMAPPED_0189,"7,4'-Dimethoxyisoflavone",,UNMAPPED,unique
+"7,8,13,13a-tetradehydro-9,10-dimethoxy-2,3-[methylenebis(oxy)]berbinium",synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 "7,8-dihydroxy-6-methoxy-2H-chromen-2-one",synonym,CHEBI:5169,Fraxetin,CHEBI:5169,MAPPED,unique
 "7,8-dimethyl-10-(D-ribo-2,3,4,5-tetrahydroxypentyl)benzo[g]pteridine-2,4(3H,10H)-dione",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 "7,8-dimethyl-10-(D-ribo-2,3,4,5-tetrahydroxypentyl)isoalloxazine",synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
@@ -1466,6 +1532,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 8-hydroxy-nitroquinoline,preferred_term,CHEBI:67121,8-hydroxy-nitroquinoline,CHEBI:67121,MAPPED,unique
 "8-methoxy-6-nitro-2H-phenanthro[3,4-d][1,3]dioxole-5-carboxylic acid",synonym,CHEBI:2825,Aristolochic Acid,CHEBI:2825,MAPPED,unique
 84 g/L NaHCO3 solution,preferred_term,kgmicrobe.ingredient:84_gl_nahco3_solution,84 g/L NaHCO3 solution,CHEBI:32139,MAPPED,unique
+"9,10-dimethoxy-2,3-(methylenedioxy)-7,8,13,13a-tetradehydroberbinium",synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 "9,10-dimethoxy-5,6-dihydro[1,3]dioxolo[4,5-g]isoquino[3,2-a]isoquinolin-7-ium",synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 9-(2-deoxy-beta-D-erythro-pentofuranosyl)-9H-purin-6-ol,synonym,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
 9-(beta-D-ribofuranosyl)-9H-purin-6-ol,synonym,CHEBI:17596,Inosine,CHEBI:17596,MAPPED,unique
@@ -1489,6 +1556,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 "[(2R,3S,4R,5R)-5-(6-amino-9H-purin-9-yl)-4-hydroxy-3-(phosphonooxy)tetrahydrofuran-2-yl]methyl (3R)-3-hydroxy-4-({3-oxo-3-[(2-sulfanylethyl)amino]propyl}amino)-2,2-dimethyl-4-oxobutyl dihydrogen diphosphate",synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
 [(2S)-2-amino-2-carboxyethyl]-hydroxyimino-oxidoazanium,synonym,CHEBI:221124,alanosine,CHEBI:221124,MAPPED,unique
 [(aminoacetyl)amino]acetic acid,synonym,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
+"[1,1′-Biphenyl]-2-ol",preferred_term,CHEBI:17043,"[1,1′-Biphenyl]-2-ol",CHEBI:17043,MAPPED,unique
 "[1,4]naphthoquinon",synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED,unique
 "[2-[1-[5,7-dihydroxy-3-(3,4,5-trihydroxybenzoyl)oxy-3,4-dihydro-2H-chromen-2-yl]-3,4,5-trihydroxy-6-oxobenzo[7]annulen-8-yl]-5,7-dihydroxy-3,4-dihydro-2H-chromen-3-yl] 3,4,5-trihydroxybenzoate",synonym,cas:30462-35-2,Theaflavin Digallate,CHEBI:185495,MAPPED,unique
 "[2-hydroxy-2-[3-hydroxy-4-[(4E,6E,12E,14Z)-10-hydroxy-3,15-dimethoxy-7,9,11,13-tetramethyl-16-oxo-1-oxacyclohexadeca-4,6,12,14-tetraen-2-yl]pentan-2-yl]-5-methyl-6-propan-2-yloxan-4-yl] (E)-4-[(2-hydroxy-5-oxocyclopenten-1-yl)amino]-4-oxobut-2-enoate",synonym,CHEBI:199416,Bafilomycin B1,CHEBI:199416,MAPPED,unique
@@ -1500,6 +1568,7 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 [4)-beta-D-GlcpN(1->]n,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
 [4-(prop-1-en-2-yl)cyclohex-1-en-1-yl]methanol,synonym,CHEBI:15420,Perillyl Alcohol,CHEBI:15420,MAPPED,unique
 [AlCl3],synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
+[AsO(OH)2](-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 [B(OH)3],synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 [CaCl2],synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
 [CeCl3],synonym,CHEBI:35458,CeCl3,CHEBI:35458,MAPPED,unique
@@ -1523,6 +1592,8 @@ label,match_type,identifier,preferred_term,ontology_id,mapping_status,ambiguity
 [SiO2],synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
 [SO2(OH)2],synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 [WO2(OH)2],synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+"\""Metals 44\""",synonym,MICRO:0000456,Metals ''44'' (see below),MICRO:0000456,MAPPED,unique
+`Lab-Lemco’ powder,synonym,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
 A+ Trace Components,preferred_term,kgmicrobe.ingredient:a_trace_components,A+ Trace Components,kgmicrobe.ingredient:a_trace_components,MAPPED,unique
 A+ Trace Components (sterilize before adding),synonym,kgmicrobe.ingredient:a_trace_components,A+ Trace Components,kgmicrobe.ingredient:a_trace_components,MAPPED,unique
 a-Cyclodextrin,preferred_term,CHEBI:40585,a-Cyclodextrin,CHEBI:40585,MAPPED,unique
@@ -1552,19 +1623,25 @@ Acetate,preferred_term,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
 acetate,ontology_label,CHEBI:30089,Acetate (carbon source),CHEBI:30089,REJECTED,unique
 Acetate (carbon source),preferred_term,CHEBI:30089,Acetate (carbon source),CHEBI:30089,REJECTED,unique
 Acetate (carbon source),synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+acetate ester,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+acetate esters,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
 ACETATE ION,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
 Acetate-replacing factor,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+acetates,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
 Acetic acid,preferred_term,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
 acetic acid magnesium salt,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
 "acetic acid, ammonium salt",synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
 "Acetic acid, magnesium salt (2:1)",synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
 "acetic acid, sodium salt",synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
+Acetic ester,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
 Acetoacetate,preferred_term,CHEBI:13705,Acetoacetate,CHEBI:13705,MAPPED,unique
 Acetoin,preferred_term,CHEBI:15688,Acetoin,CHEBI:15688,MAPPED,unique
 Acetomycin,preferred_term,CHEBI:209246,Acetomycin,CHEBI:209246,MAPPED,unique
 acetone,preferred_term,CHEBI:15347,acetone,CHEBI:15347,MAPPED,unique
 Acetosyringone,preferred_term,CHEBI:2404,Acetosyringone,CHEBI:2404,MAPPED,unique
 Acetovanillone,preferred_term,CHEBI:2781,Acetovanillone,CHEBI:2781,MAPPED,unique
+Acetyl ester,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
+acetyl esters,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
 acetyl xylan,synonym,CHEBI:134431,Acetylated xylan,CHEBI:134431,MAPPED,unique
 Acetyl-Dihydro-7-Epikhivorin,preferred_term,UNMAPPED_0197,Acetyl-Dihydro-7-Epikhivorin,,UNMAPPED,unique
 Acetyl-Glu,synonym,CHEBI:172431,N-Acetyl-glutamic acid,CHEBI:172431,MAPPED,unique
@@ -1632,6 +1709,7 @@ Actinohivin,preferred_term,kgmicrobe.compound:actinohivin,Actinohivin,kgmicrobe.
 Actinomycetin,preferred_term,kgmicrobe.compound:actinomycetin,Actinomycetin,kgmicrobe.compound:actinomycetin,MAPPED,unique
 actinomycin,ontology_label,kgmicrobe.compound:actinomycin_a,Actinomycin A,CHEBI:15369,MAPPED,unique
 Actinomycin A,preferred_term,kgmicrobe.compound:actinomycin_a,Actinomycin A,CHEBI:15369,MAPPED,unique
+actinomycin B,synonym,CHEBI:27666,Actinomycin D,CHEBI:27666,MAPPED,unique
 Actinomycin D,preferred_term,CHEBI:27666,Actinomycin D,CHEBI:27666,MAPPED,unique
 Actinomycin X,preferred_term,mesh:C041783,Actinomycin X,mesh:C041783,MAPPED,unique
 Actinotiocin,preferred_term,mesh:C006403,Actinotiocin,mesh:C006403,MAPPED,unique
@@ -1660,6 +1738,8 @@ Adipate,preferred_term,CHEBI:17128,Adipate,CHEBI:17128,MAPPED,unique
 adipate(2-),ontology_label,CHEBI:17128,Adipate,CHEBI:17128,MAPPED,unique
 Adipic acid,preferred_term,CHEBI:30832,Adipic acid,CHEBI:30832,MAPPED,unique
 Aepfelsaeure,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+aerobic catabolization: acetate,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+aerobic catabolization: dihydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 Aescin,ontology_label,CHEBI:2500,Escin,CHEBI:2500,MAPPED,unique
 Aesculetin,preferred_term,cas:305-01-1,Aesculetin,cas:305-01-1,MAPPED,unique
 Aethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
@@ -1667,10 +1747,20 @@ Aethylalkohol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
 Aetzkali,synonym,CHEBI:32035,KOH,CHEBI:32035,MAPPED,unique
 Aetznatron,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
 Agar,preferred_term,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar  (if needed),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (BD),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+agar (BD-Difco),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (Difco),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (if needed),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (if needed)*,synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (Molecular Genetics),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar (Purified),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
+Agar* (if needed),synonym,CHEBI:2509,Agar,CHEBI:2509,MAPPED,unique
 Agarose,preferred_term,CHEBI:2511,Agarose,CHEBI:2511,MAPPED,unique
 Agave,preferred_term,FOODON:00005198,Agave,FOODON:00005198,MAPPED,unique
 Agelasine,preferred_term,UNMAPPED_0198,Agelasine,,UNMAPPED,unique
 agua,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Air,preferred_term,ENVO:00002005,Air,ENVO:00002005,MAPPED,unique
 air-dried garden soil,preferred_term,ENVO:00002263,air-dried garden soil,ENVO:00002263,MAPPED,unique
 Al2(SO4)3 x 18 H2O,preferred_term,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
 Al2(SO4)3.18H2O,synonym,CHEBI:74779,Al2(SO4)3 x 18 H2O,CHEBI:74779,MAPPED,unique
@@ -1690,6 +1780,7 @@ alcohol etilico,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
 alcool ethylique,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
 aldehydo-D-gluco-hexose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 aldehydo-D-gluco-hexose,synonym,CHEBI:17234,glucose,CHEBI:17234,REJECTED,unique
+aldehydo-D-glucose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
 aldehydo-D-lyxose,ontology_label,CHEBI:62318,D-(-)-lyxose,CHEBI:16789,REJECTED,unique
 aldehydo-N-acetylmuramic acid,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
 aldehydo-N-acetylmuramic acid,synonym,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
@@ -1716,6 +1807,7 @@ Allopurinol,preferred_term,CHEBI:40279,Allopurinol,CHEBI:40279,MAPPED,unique
 Allura Red AC,preferred_term,CHEBI:172687,Allura Red AC,CHEBI:172687,MAPPED,unique
 Aloin,preferred_term,CHEBI:73222,Aloin,CHEBI:73222,MAPPED,unique
 "alpha,alpha',alpha''-trimethylaminetricarboxylic acid",synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+"alpha,alpha-Trehalose",preferred_term,CHEBI:16551,"alpha,alpha-Trehalose",CHEBI:16551,MAPPED,unique
 "alpha-(5,6-dimethylbenzimidazolyl)cobamide",synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 alpha-Amino-1H-imidazole-4-propionic acid,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
 alpha-Amino-beta-(3-indolyl)-propionic acid,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
@@ -1741,6 +1833,7 @@ alpha-D-Glcp-(1->4)-alpha-D-Glcp,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,
 alpha-D-Glcp-(1->4)-D-Glcp,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 alpha-D-glucopyranose,synonym,CHEBI:17925,alpha-D-Glucose,CHEBI:17925,MAPPED,unique
 alpha-D-glucopyranosyl-(1->3)-D-fructose,synonym,CHEBI:32528,D-(+)-Turanose,CHEBI:32528,MAPPED,unique
+alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranose,synonym,CHEBI:17306,maltose,CHEBI:17306,REJECTED,unique
 alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:27445,Maltohexaose,CHEBI:27445,MAPPED,unique
 alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-alpha-D-glucopyranosyl-(1->4)-D-glucose,synonym,CHEBI:28460,Maltotetraose,CHEBI:28460,MAPPED,unique
@@ -1766,6 +1859,7 @@ alpha-isobutyric acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,uni
 alpha-ketoglutamate,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
 alpha-ketoglutarate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
 alpha-ketoglutaric acid,preferred_term,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
+alpha-ketoglutaric acid (100 mM).,synonym,CHEBI:30915,alpha-ketoglutaric acid,CHEBI:30915,MAPPED,unique
 alpha-ketopropionic acid,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
 alpha-L-arabinofuranosyl-(1->5)-alpha-L-arabinofuranosyl-(1->5)-alpha-L-arabinofuranose,synonym,cas:89315-59-3,Arabinotriose,CHEBI:62799,MAPPED,unique
 alpha-L-Araf-(1->5)-alpha-L-Araf-(1->5)-alpha-L-Araf,ontology_label,cas:89315-59-3,Arabinotriose,CHEBI:62799,MAPPED,unique
@@ -1775,6 +1869,7 @@ alpha-Lactose,preferred_term,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,uniq
 Alpha-lactose monohydrate,ontology_label,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 alpha-lipoic acid,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
 alpha-Liponsaeure,synonym,CHEBI:16494,(DL)-alpha-Lipoic acid,CHEBI:16494,MAPPED,unique
+Alpha-maltose,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 alpha-methyl butyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
 alpha-Methylbutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
 alpha-Methylguanidino acetic acid,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
@@ -1784,6 +1879,7 @@ alpha-naphthoquinone,synonym,CHEBI:27418,"1,4-Naphthoquinone",CHEBI:27418,MAPPED
 alpha-Oxopropionsaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
 alpha-phylloquinone,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
 alpha-Pinene,synonym,CHEBI:17187,pinene,CHEBI:17187,MAPPED,unique
+alpha-Tocopherol,preferred_term,CHEBI:18145,alpha-Tocopherol,CHEBI:18145,MAPPED,unique
 Alpha-Toxicarol (Dl),preferred_term,CHEBI:9643,Alpha-Toxicarol (Dl),CHEBI:9643,MAPPED,unique
 Althiomycin,preferred_term,CHEBI:157683,Althiomycin,CHEBI:157683,MAPPED,unique
 aluminium chloride hexahydrate,synonym,CHEBI:30115,AlCl3 x 6 H2O,CHEBI:30115,MAPPED,unique
@@ -1861,6 +1957,7 @@ Ammonium ferric citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,
 Ammonium ferrous sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Ammonium heptamolybdate tetrahydrate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
 ammonium hydrogen citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
+ammonium hydroxide,ontology_label,CHEBI:18219,NH4OH,CHEBI:18219,MAPPED,unique
 ammonium iron(2+) sulfate--water (1/6),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 ammonium iron(II) sulfate heptahydrate,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 ammonium iron(II) sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
@@ -1886,6 +1983,7 @@ ammonium orthomolybdate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAP
 Ammonium orthophosphate dihydrogen,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
 ammonium oxalate,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
 ammonium persulfate,preferred_term,CHEBI:156543,ammonium persulfate,CHEBI:156543,MAPPED,unique
+Ammonium phosphate,synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
 Ammonium saltpeter,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
 Ammonium Sulfamate,preferred_term,CHEBI:81950,Ammonium Sulfamate,CHEBI:81950,MAPPED,unique
 Ammonium Sulfate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
@@ -1908,10 +2006,12 @@ Amphotericin,preferred_term,UNMAPPED_0325,Amphotericin,,UNMAPPED,unique
 Amphotericin A,preferred_term,mesh:C041989,Amphotericin A,mesh:C041989,MAPPED,unique
 Amphotericin B,preferred_term,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,resolved:owned
 amphotericin B,synonym,UNMAPPED_0325,Amphotericin,,UNMAPPED,resolved:owned
+Amphotericin B (5 mg/ml DMSO),synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
 Amphotericine B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
 amphotericinum B,synonym,CHEBI:2682,Amphotericin B,CHEBI:2682,MAPPED,unique
 ampicilina,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
 Ampicillin,preferred_term,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
+Ampicillin (50 mg/ml),synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
 ampicillin acid,synonym,CHEBI:28971,Ampicillin,CHEBI:28971,MAPPED,unique
 ampicillin natrium,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
 Ampicillin sodium,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
@@ -1926,8 +2026,11 @@ amylopectin from maize,preferred_term,kgmicrobe.ingredient:amylopectin_from_maiz
 amylose,ontology_label,CHEBI:28102,Amylose from potato,CHEBI:28102,MAPPED,unique
 Amylose from potato,preferred_term,CHEBI:28102,Amylose from potato,CHEBI:28102,MAPPED,unique
 amylum,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+an acetyl ester,synonym,CHEBI:32029,K-acetate,CHEBI:32029,MAPPED,unique
 Anabasine Hydrochloride,preferred_term,cas:53912-89-3,Anabasine Hydrochloride,NCIT:C216370,MAPPED,unique
 Anaerobe Basal Broth CM0957,preferred_term,UNMAPPED_0327,Anaerobe Basal Broth CM0957,,UNMAPPED,unique
+anaerobic catabolization: acetate,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
+Anaerobic water,preferred_term,ENVO:01000173,Anaerobic water,ENVO:01000173,MAPPED,unique
 Andirobin,preferred_term,cas:6488-63-7,Andirobin,cas:6488-63-7,MAPPED,unique
 Andrographolide,preferred_term,CHEBI:65408,Andrographolide,CHEBI:65408,MAPPED,unique
 Anethole,preferred_term,CHEBI:2716,Anethole,CHEBI:2716,MAPPED,unique
@@ -1939,6 +2042,7 @@ Anhydrotetracycline hydrochloride,preferred_term,CHEBI:201752,Anhydrotetracyclin
 anhydrous calcium chloride,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,conflict:different_substances
 anhydrous calcium chloride,synonym,kgmicrobe.compound:cacl2_x_7_h2o,CaCl2 x 7 H2O,CHEBI:3312,MAPPED,conflict:different_substances
 anhydrous gypsum,synonym,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
+Anhydrous lactose,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 anhydrous manganese chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
 anhydrous sodium acetate,synonym,CHEBI:32138,Sodium acetate·3H2O,CHEBI:32138,REJECTED,unique
 anhydrous sodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
@@ -1946,6 +2050,7 @@ Anhydrous sodium sulfite,synonym,CHEBI:86477,Na2SO3 x 5 H2O,CHEBI:86477,MAPPED,u
 animal manure,ontology_label,kgmicrobe.ingredient:dry_cow-manure,Dry cow-manure,ENVO:00003031,MAPPED,unique
 Anisodamine Hydrobromide,ontology_label,cas:17659-49-3,Anisodamine Hydrobromide (),NCIT:C221850,MAPPED,unique
 Anisodamine Hydrobromide (),preferred_term,cas:17659-49-3,Anisodamine Hydrobromide (),NCIT:C221850,MAPPED,unique
+anoxic water,ontology_label,ENVO:01000173,Anaerobic water,ENVO:01000173,MAPPED,unique
 Anthracene,preferred_term,CHEBI:35298,Anthracene,CHEBI:35298,MAPPED,unique
 Anthracycline Antibiotic,preferred_term,CHEBI:49322,Anthracycline Antibiotic,CHEBI:49322,MAPPED,unique
 anthranilamide,preferred_term,CHEBI:193638,anthranilamide,CHEBI:193638,MAPPED,unique
@@ -1954,6 +2059,7 @@ anthranilic acid,preferred_term,CHEBI:30754,anthranilic acid,CHEBI:30754,MAPPED,
 "anthraquinone-2,6-disulfonate",synonym,cas:853-68-9,AQDS,cas:853-68-9,MAPPED,unique
 anti-pellagra vitamin,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
 Antiberiberi factor,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Antibiotic SM 7338,synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 Antimonate,preferred_term,CHEBI:30295,Antimonate,CHEBI:30295,MAPPED,unique
 antimonate(3-),ontology_label,CHEBI:30295,Antimonate,CHEBI:30295,MAPPED,unique
 Antimycin A,preferred_term,CHEBI:2762,Antimycin A,CHEBI:2762,MAPPED,unique
@@ -1968,6 +2074,7 @@ Apiole,preferred_term,CHEBI:70353,Apiole,CHEBI:70353,MAPPED,unique
 apo-yersiniabactin,preferred_term,UNMAPPED_0239,apo-yersiniabactin,,UNMAPPED,unique
 apocynin,ontology_label,CHEBI:2781,Acetovanillone,CHEBI:2781,MAPPED,unique
 apple acid,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+Apple Juice,preferred_term,FOODON:00001059,Apple Juice,FOODON:00001059,MAPPED,unique
 Apramycin,preferred_term,CHEBI:2790,Apramycin,CHEBI:2790,MAPPED,unique
 Apramycin sulfate,ontology_label,cas:65710-07-8,Apramycin sulfate salt,CHEBI:190734,MAPPED,unique
 Apramycin sulfate salt,preferred_term,cas:65710-07-8,Apramycin sulfate salt,CHEBI:190734,MAPPED,unique
@@ -2013,15 +2120,21 @@ aromatic molecular entity,synonym,CHEBI:33655,Aromatic compound,CHEBI:33655,MAPP
 Arsenate,preferred_term,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 Arsenate ion,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 arsenate(3-),ontology_label,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+arsenite,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+arsenite(1-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 arsorate,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 Artepaulin,preferred_term,cas:13902-54-0,Artepaulin,cas:13902-54-0,MAPPED,unique
 Artificial Sea Salt,preferred_term,MICRO:0001647,Artificial Sea Salt,MICRO:0001647,MAPPED,unique
+Artificial seawater,preferred_term,MICRO:0001715,Artificial seawater,MICRO:0001715,MAPPED,unique
+Artificial seawater (see below),synonym,MICRO:0001715,Artificial seawater,MICRO:0001715,MAPPED,unique
+Artificial seawater (see Medium No. 736 ),synonym,MICRO:0001715,Artificial seawater,MICRO:0001715,MAPPED,unique
 Ascoltin,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
 Ascomycin,preferred_term,CHEBI:29582,Ascomycin,CHEBI:29582,MAPPED,unique
 Ascophyllum,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
 Ascorbate,preferred_term,CHEBI:22651,Ascorbate,CHEBI:22651,MAPPED,unique
 ascorbate de sodium,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 Ascorbic acid,preferred_term,CHEBI:22652,Ascorbic acid,CHEBI:22652,MAPPED,unique
+Ascorbic acid (Sigma),synonym,CHEBI:22652,Ascorbic acid,CHEBI:22652,MAPPED,unique
 ascorbic acid sodium salt,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 Ascorbicap,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
 Ascorbinsaeure,synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
@@ -2042,6 +2155,7 @@ ASPARTIC ACID,synonym,cas:1115-63-5,L-Aspartic acid potassium salt,CHEBI:17053,M
 ASPARTIC ACID,synonym,cas:323194-76-9,L-Aspartic acid sodium salt monohydrate,CHEBI:17053,MAPPED,conflict:different_substances
 aspartic acid,ontology_label,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,conflict:different_substances
 aspyrone,synonym,CHEBI:18101,4-Hydroxyphenyl acetic acid,CHEBI:18101,MAPPED,unique
+assimilation: citrate,synonym,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,unique
 Astaxanthin,preferred_term,CHEBI:40968,Astaxanthin,CHEBI:40968,MAPPED,unique
 Astromicin,preferred_term,CHEBI:37923,Astromicin,CHEBI:37923,MAPPED,unique
 asuccin,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
@@ -2058,6 +2172,7 @@ Auraptene,preferred_term,CHEBI:134355,Auraptene,CHEBI:134355,MAPPED,unique
 Aureothricin,preferred_term,CHEBI:156452,Aureothricin,CHEBI:156452,MAPPED,unique
 Auryxia,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 Austrapen,synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
+autoclaved,synonym,cas:9049-37-0,Polygalacturonic acid sodium salt,CHEBI:62969,MAPPED,unique
 "autoclaved, Galactan from Potato",synonym,UNMAPPED_0238,Galactan from Potato,,UNMAPPED,unique
 "autoclaved, Glucomannan (konjac)",synonym,cas:11078-31-2,Glucomannan (konjac),CHEBI:17020,MAPPED,unique
 "autoclaved, Glycogen",synonym,CHEBI:28087,Glycogen,CHEBI:28087,MAPPED,unique
@@ -2083,6 +2198,7 @@ azepan-2-one,synonym,CHEBI:28579,Caprolactam,CHEBI:28579,MAPPED,unique
 Azetat,synonym,CHEBI:30089,Acetate,CHEBI:30089,MAPPED,unique
 azetidin-2-one,ontology_label,CHEBI:327119,2-Azetidinone,CHEBI:327119,MAPPED,unique
 Azithromycin,preferred_term,CHEBI:2955,Azithromycin,CHEBI:2955,MAPPED,unique
+azlocillin,preferred_term,CHEBI:2956,azlocillin,CHEBI:2956,MAPPED,unique
 azlocillin sodium,ontology_label,CHEBI:51864,Azlocillin sodium salt,CHEBI:51864,MAPPED,unique
 Azlocillin sodium salt,preferred_term,CHEBI:51864,Azlocillin sodium salt,CHEBI:51864,MAPPED,unique
 Azomycin,preferred_term,CHEBI:67135,Azomycin,CHEBI:67135,MAPPED,unique
@@ -2119,9 +2235,12 @@ Bacto Bitone,preferred_term,UNMAPPED_0330,Bacto Bitone,,UNMAPPED,unique
 Bacto brain heart infusion,preferred_term,MICRO:0000193,Bacto brain heart infusion,MICRO:0000193,MAPPED,unique
 Bacto Casitone (Difco),synonym,MICRO:0000606,Casitone,MICRO:0000606,MAPPED,unique
 Bacto Heart Infusion Broth,preferred_term,UNMAPPED_0332,Bacto Heart Infusion Broth,,UNMAPPED,unique
+Bacto Heart Infusion Broth (Difco),synonym,UNMAPPED_0332,Bacto Heart Infusion Broth,,UNMAPPED,unique
 Bacto m TGE broth,preferred_term,UNMAPPED_0333,Bacto m TGE broth,,UNMAPPED,unique
+Bacto m TGE broth (BD-Difco),synonym,UNMAPPED_0333,Bacto m TGE broth,,UNMAPPED,unique
 Bacto Malt Extract (Difco),synonym,FOODON:03301056,Malt extract,FOODON:03301056,MAPPED,unique
 Bacto Middlebrook 7H10 agar,preferred_term,UNMAPPED_0115,Bacto Middlebrook 7H10 agar,,UNMAPPED,unique
+Bacto Middlebrook 7H10 agar (Difco 262710),synonym,UNMAPPED_0115,Bacto Middlebrook 7H10 agar,,UNMAPPED,unique
 Bacto Panton,preferred_term,UNMAPPED_0334,Bacto Panton,,UNMAPPED,unique
 Bacto peptone,preferred_term,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
 Bacto Peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
@@ -2175,6 +2294,7 @@ Bathocuproinedisulfonic acid disodium salt,synonym,cas:52698-84-7,Bathocuproine 
 Bathophenanthrolinedisulfonic acid disodium salt hydrate,preferred_term,kgmicrobe.compound:bathophenanthrolinedisulfonic_acid_disodium_salt_hydrate,Bathophenanthrolinedisulfonic acid disodium salt hydrate,CHEBI:78157,MAPPED,unique
 BC Lignin Sorghum,preferred_term,UNMAPPED_0169,BC Lignin Sorghum,,UNMAPPED,unique
 BCYE agar,preferred_term,UNMAPPED_0113,BCYE agar,,UNMAPPED,unique
+BCYE agar (BD-Difco),synonym,UNMAPPED_0113,BCYE agar,,UNMAPPED,unique
 Bedaquiline,preferred_term,CHEBI:72292,Bedaquiline,CHEBI:72292,MAPPED,unique
 Beef,preferred_term,NCIT:C71932,Beef,NCIT:C71932,MAPPED,unique
 beef (ground),ontology_label,FOODON:00001282,Ground beef,FOODON:00001282,MAPPED,unique
@@ -2192,6 +2312,7 @@ Beef Heart Infusion,preferred_term,kgmicrobe.ingredient:beef_heart_infusion,Beef
 Beflavin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 Beflavine,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 Beijerinck's Solution,preferred_term,kgmicrobe.ingredient:beijerincks_solution,Beijerinck's Solution,kgmicrobe.ingredient:beijerincks_solution,MAPPED,unique
+Benzaldehyde,preferred_term,CHEBI:17169,Benzaldehyde,CHEBI:17169,MAPPED,unique
 Benzalkonium Chloride,preferred_term,CHEBI:3020,Benzalkonium Chloride,CHEBI:3020,MAPPED,unique
 Benzbromarone,preferred_term,CHEBI:3023,Benzbromarone,CHEBI:3023,MAPPED,unique
 Benzene,preferred_term,CHEBI:16716,Benzene,CHEBI:16716,MAPPED,unique
@@ -2209,12 +2330,15 @@ Benzoate,preferred_term,CHEBI:16150,Benzoate,CHEBI:16150,MAPPED,unique
 benzoic acid,preferred_term,CHEBI:30746,benzoic acid,CHEBI:30746,MAPPED,unique
 "Benzoic acid, sodium salt",synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
 Benzoin,preferred_term,CHEBI:17682,Benzoin,CHEBI:17682,MAPPED,unique
+Benzothiazole,preferred_term,CHEBI:45993,Benzothiazole,CHEBI:45993,MAPPED,unique
 Benzyl Alcohol,preferred_term,CHEBI:17987,Benzyl Alcohol,CHEBI:17987,MAPPED,unique
 Benzyl cyanide,synonym,CHEBI:25979,Benzylcyanide,CHEBI:25979,MAPPED,unique
 Benzyl isothiocyanate,preferred_term,CHEBI:17484,Benzyl isothiocyanate,CHEBI:17484,MAPPED,unique
 Benzylcyanide,preferred_term,CHEBI:25979,Benzylcyanide,CHEBI:25979,MAPPED,unique
 Benzylhydrazine Hydrochloride,preferred_term,cas:3287-99-8,Benzylhydrazine Hydrochloride,cas:3287-99-8,MAPPED,unique
 benzylpenicillin sodium,ontology_label,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
+berbaman,synonym,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
+Berberin,synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 Berberine,preferred_term,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 Berberine chloride (TN),ontology_label,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 Bergapten,preferred_term,CHEBI:18293,Bergapten,CHEBI:18293,MAPPED,unique
@@ -2258,13 +2382,16 @@ beta-D-galactopyranosyl-(1->3)-2-acetamido-2-deoxy-beta-D-glucopyranosyl-(1->3)-
 beta-D-galactopyranosyl-(1->4)-2-acetamido-2-deoxy-beta-D-glucopyranosyl-(1->3)-beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:60239,Lacto-N-neotetraose,CHEBI:60239,MAPPED,unique
 beta-D-galactopyranosyl-(1->4)-alpha-D-glucopyranose,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 beta-D-galactopyranosyl-(1->4)-beta-D-glucopyranose,synonym,CHEBI:36218,Beta-Lactose,CHEBI:36218,MAPPED,unique
+beta-D-galactopyranosyl-(1->4)-beta-D-glucose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 beta-D-galactopyranosyl-(1->4)-D-galactopyranose,ontology_label,cas:2152-98-9,"1,4-B-D-Galactobiose",CHEBI:36226,MAPPED,unique
 beta-D-galactopyranosyl-(1->4)-D-glucopyranose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 Beta-D-galactoside,preferred_term,CHEBI:28034,Beta-D-galactoside,CHEBI:28034,MAPPED,unique
+beta-D-Galp-(1->4)-alpha-D-Glcp,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
 beta-D-Galp-(1->4)-beta-D-Glcp,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 beta-D-Galp-(1->4)-D-Glcp,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 beta-D-Glcp-(1->6)-beta-D-Glcp,ontology_label,CHEBI:71422,Beta-gentiobiose,CHEBI:71422,MAPPED,unique
 beta-D-glucan,ontology_label,CHEBI:28793,b-Glucan from Oat,CHEBI:28793,MAPPED,unique
+"beta-D-glucopyranose, 4-O-beta-D-galactopyranosyl-",synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 beta-D-glucopyranosyl-(1->3)-D-glucopyranose,synonym,CHEBI:18411,Laminaribiose,CHEBI:18411,MAPPED,unique
 beta-D-glucopyranosyl-(1->4)-beta-D-glucoopyranosyl-(1->4)-beta-D-glucoopyranosyl-(1->4)-D-glucoopyranose,synonym,CHEBI:62974,Cellotetraose,CHEBI:62974,MAPPED,unique
 beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranosyl-(1->4)-beta-D-glucopyranose,synonym,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
@@ -2277,6 +2404,7 @@ beta-D-glucopyranuronamide,synonym,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPE
 Beta-d-glucose,preferred_term,CHEBI:15903,Beta-d-glucose,CHEBI:15903,MAPPED,unique
 beta-D-glucuronamide,ontology_label,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,unique
 Beta-D-glucuronic Acid,preferred_term,CHEBI:28860,Beta-D-glucuronic Acid,CHEBI:28860,MAPPED,unique
+beta-D-Lactose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 beta-D-mannopyranosyl-(1->4)-D-mannopyranose,synonym,CHEBI:25164,Mannobiose,CHEBI:25164,MAPPED,unique
 beta-D-mannopyranosyl-(1->4)-D-mannose,synonym,CHEBI:25164,Mannobiose,CHEBI:25164,MAPPED,unique
 beta-D-xylopyranosyl-(1->4)-beta-D-xylopyranosyl-(1->4)-beta-D-xylopyranosyl-(1->4)-D-xylopyranose,synonym,CHEBI:62972,Xylotetraose,CHEBI:62972,MAPPED,unique
@@ -2312,11 +2440,13 @@ Betaine,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPE
 Betaine hydrochloride,preferred_term,cas:590-46-5,Betaine hydrochloride,CHEBI:17750,MAPPED,unique
 Betaine x H2O,preferred_term,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
 Betanin,preferred_term,CHEBI:3080,Betanin,CHEBI:3080,MAPPED,unique
-BG-11 Medium,preferred_term,UNMAPPED_0061,BG-11 Medium,,UNMAPPED,unique
+BG 11 medium,ontology_label,MICRO:0001348,BG-11 Medium,MICRO:0001348,MAPPED,unique
+BG-11 Medium,preferred_term,MICRO:0001348,BG-11 Medium,MICRO:0001348,MAPPED,unique
 BG-11 Trace Metals Solution,preferred_term,kgmicrobe.ingredient:bg-11_trace_metals_solution,BG-11 Trace Metals Solution,kgmicrobe.ingredient:bg-11_trace_metals_solution,MAPPED,unique
 BH(OH)2,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
 BHC,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
 BHI,preferred_term,kgmicrobe.ingredient:bhi,BHI,kgmicrobe.ingredient:bhi,MAPPED,unique
+Bicarbonate,preferred_term,CHEBI:17544,Bicarbonate,CHEBI:17544,MAPPED,unique
 bicarbonate of soda,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
 Bicine,preferred_term,CHEBI:40957,Bicine,CHEBI:40957,REJECTED,unique
 Bicine,synonym,CHEBI:40957,BICINE buffer,CHEBI:40957,MAPPED,unique
@@ -2337,12 +2467,14 @@ Biocoline,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
 Bioecolians,preferred_term,UNMAPPED_0207,Bioecolians,,UNMAPPED,unique
 Bios I,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
 Biotin,preferred_term,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Biotin (1 μg/μL),synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 Biotin (Vitamin B7),synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 Biotin Vitamin Solution,preferred_term,kgmicrobe.ingredient:biotin_vitamin_solution,Biotin Vitamin Solution,MICRO:0000460,MAPPED,unique
 biotina,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 Biotine,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 biotinum,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 Biphenyl,preferred_term,CHEBI:17097,Biphenyl,CHEBI:17097,MAPPED,unique
+biphenyl-2-ol,ontology_label,CHEBI:17043,"[1,1′-Biphenyl]-2-ol",CHEBI:17043,MAPPED,unique
 "biphenyl-4,4'-diol",ontology_label,CHEBI:34367,"4,4'-dihydroxybiphenyl",CHEBI:34367,MAPPED,unique
 Bipotassium chromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
 bis(2-cyanoethan-1-aminium) (2E)-but-2-enedioate,synonym,CHEBI:91084,3-Aminopropionitrile Fumarate,CHEBI:91084,MAPPED,unique
@@ -2376,7 +2508,9 @@ Blasticidin S,preferred_term,CHEBI:15353,Blasticidin S,CHEBI:15353,MAPPED,unique
 Bleomycin,preferred_term,CHEBI:22907,Bleomycin,CHEBI:22907,MAPPED,unique
 Bleomycin sulfate,preferred_term,CHEBI:34582,Bleomycin sulfate,CHEBI:34582,MAPPED,unique
 bleu de methylene,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Blood,preferred_term,UBERON:0000178,Blood,UBERON:0000178,MAPPED,unique
 Blood Agar Base,preferred_term,UNMAPPED_0339,Blood Agar Base,,UNMAPPED,unique
+Blood agar base (BD-Difco),synonym,UNMAPPED_0339,Blood Agar Base,,UNMAPPED,unique
 Blood agar No 2,preferred_term,UNMAPPED_0340,Blood agar No 2,,UNMAPPED,unique
 blood serum,ontology_label,UBERON:0001977,Serum,UBERON:0001977,MAPPED,unique
 Bluensomycin,preferred_term,CHEBI:81193,Bluensomycin,CHEBI:81193,MAPPED,resolved:owned
@@ -2385,7 +2519,9 @@ boiled in 10% ethanol,synonym,UNMAPPED_0247,b-glucan from Barley,,UNMAPPED,uniqu
 Bold 1NV Medium,preferred_term,UNMAPPED_0051,Bold 1NV Medium,,UNMAPPED,unique
 Bold Trace Stock,preferred_term,kgmicrobe.ingredient:bold_trace_stock,Bold Trace Stock,kgmicrobe.ingredient:bold_trace_stock,MAPPED,unique
 Boldine,preferred_term,CHEBI:3148,Boldine,CHEBI:3148,MAPPED,unique
+Borate,preferred_term,CHEBI:22908,Borate,CHEBI:22908,MAPPED,unique
 borax,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Bordet-Gengou Agar Base (BD 248200),synonym,UNMAPPED_0341,Bordet-Gengou-Agar-Base,,UNMAPPED,unique
 Bordet-Gengou-Agar-Base,preferred_term,UNMAPPED_0341,Bordet-Gengou-Agar-Base,,UNMAPPED,unique
 Boric acid,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 Borneol,preferred_term,CHEBI:28093,Borneol,CHEBI:28093,MAPPED,unique
@@ -2403,23 +2539,31 @@ brain,ontology_label,UNMAPPED_0170,Calf brains,UBERON:0000955,UNMAPPED,unique
 Brain heart infusion,preferred_term,MICRO:0000193,Brain heart infusion,MICRO:0000193,MAPPED,unique
 brain heart infusion,ontology_label,MICRO:0000193,Bacto brain heart infusion,MICRO:0000193,MAPPED,unique
 brain heart infusion,ontology_label,MICRO:0000193,Brain heart infusion broth,MICRO:0000193,MAPPED,unique
+brain heart infusion agar,ontology_label,MICRO:0000566,brain–heart infusion agar,MICRO:0000566,MAPPED,unique
 Brain heart infusion broth,preferred_term,MICRO:0000193,Brain heart infusion broth,MICRO:0000193,MAPPED,unique
+brain–heart infusion agar,preferred_term,MICRO:0000566,brain–heart infusion agar,MICRO:0000566,MAPPED,unique
 Brazilein,preferred_term,CHEBI:69196,Brazilein,CHEBI:69196,MAPPED,unique
 Brenzcatechin,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
 Brenztraubensaeure,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
 Brewer anaerobic agar,preferred_term,UNMAPPED_0116,Brewer anaerobic agar,,UNMAPPED,unique
+Brewer anaerobic agar (BD-Difco),synonym,UNMAPPED_0116,Brewer anaerobic agar,,UNMAPPED,unique
 Bristol Medium,preferred_term,UNMAPPED_0023,Bristol Medium,,UNMAPPED,unique
 Bromide salt of sodium,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
 Bromnatrium,synonym,CHEBI:63004,NaBr,CHEBI:63004,MAPPED,unique
 Bromocresol purple,preferred_term,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
 "bromocresol purple""",synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
+Bromophenol blue,preferred_term,CHEBI:59424,Bromophenol blue,CHEBI:59424,MAPPED,unique
+Bromophenol blue (0.5% in 0.2N KOH),synonym,CHEBI:59424,Bromophenol blue,CHEBI:59424,MAPPED,unique
 Bromosuccinate,preferred_term,CHEBI:73706,Bromosuccinate,CHEBI:73706,MAPPED,unique
 Bromothymol blue,preferred_term,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
 bromothymol sulfone phthalein,synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
 Bromthymol blue,synonym,CHEBI:86155,Bromothymol blue,CHEBI:86155,MAPPED,unique
 Bronopol,ontology_label,CHEBI:31306,"2-bromo-2-nitro-1,3-propanediol",CHEBI:31306,MAPPED,unique
 Brucella agar,preferred_term,MICRO:0000595,Brucella agar,MICRO:0000595,MAPPED,unique
+Brucella agar (BD-BBL),synonym,MICRO:0000595,Brucella agar,MICRO:0000595,MAPPED,unique
 Brucella Broth,preferred_term,UNMAPPED_0348,Brucella Broth,,UNMAPPED,unique
+Brucella Broth (BD 211088),synonym,UNMAPPED_0348,Brucella Broth,,UNMAPPED,unique
+Brucella broth (BD-BBL),synonym,UNMAPPED_0348,Brucella Broth,,UNMAPPED,unique
 Brucine,preferred_term,CHEBI:3193,Brucine,CHEBI:3193,MAPPED,unique
 Bryamycin,synonym,CHEBI:29693,Thiostrepton,CHEBI:29693,MAPPED,unique
 BTS,synonym,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
@@ -2481,12 +2625,15 @@ Ca(NO3)2 · 4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 Ca(NO3)2.4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 Ca(NO3)2x4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 Ca(NO3)2·4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
+Ca(NO3)2•4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 Ca(NO3)2•4H2O(CAS: 13477-34-4),synonym,UNMAPPED_0049,Ca,,UNMAPPED,unique
 Ca(NO3)2・4H2O,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 Ca-folinate,preferred_term,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
 Ca-pantothenate,preferred_term,CHEBI:31345,Ca-pantothenate,CHEBI:31345,REJECTED,unique
 Ca-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
+Ca3(PO4)2,synonym,CHEBI:9679,Tricalcium phosphate,CHEBI:9679,MAPPED,unique
 CaCl .6H O,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
+CaCl 2,synonym,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
 CaCl 2 X 2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
 CaCl2,preferred_term,CHEBI:3312,CaCl2,CHEBI:3312,MAPPED,unique
 CaCl2  x 2 H2O,synonym,CHEBI:86158,CaCl2 x 2 H2O,CHEBI:86158,MAPPED,unique
@@ -2563,6 +2710,9 @@ caffeic acid,preferred_term,CHEBI:36281,caffeic acid,CHEBI:36281,MAPPED,unique
 Caffeine,preferred_term,CHEBI:27732,Caffeine,CHEBI:27732,MAPPED,unique
 Caffeine Hydrobromide,preferred_term,cas:5743-18-0,Caffeine Hydrobromide,cas:5743-18-0,MAPPED,unique
 CaHPO4,preferred_term,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+calciol,ontology_label,CHEBI:28940,Vitamin D3,CHEBI:28940,MAPPED,unique
+Calcium,preferred_term,CHEBI:22984,Calcium,CHEBI:22984,MAPPED,unique
+calcium atom,ontology_label,CHEBI:22984,Calcium,CHEBI:22984,MAPPED,unique
 "calcium bis[(3R,5S,6E)-7-{4-(4-fluorophenyl)-6-isopropyl-2-[methyl(methylsulfonyl)amino]pyrimidin-5-yl}-3,5-dihydroxyhept-6-enoate]",synonym,CHEBI:77249,Rosuvastatin calcium,CHEBI:77249,MAPPED,unique
 "calcium bis{(3R,5R)-7-[3-(anilinocarbonyl)-5-(4-fluorophenyl)-2-isopropyl-4-phenyl-1H-pyrrol-1-yl]-3,5-dihydroxyheptanoate} trihydrate",synonym,CHEBI:2911,Atorvastatin calcium salt trihydrate,CHEBI:2911,MAPPED,unique
 Calcium Carbonate,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
@@ -2591,6 +2741,8 @@ Calcium dinitrate tetrahydrate,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,
 Calcium folinate,synonym,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
 calcium hydrogen phosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
 calcium hydrogenphosphate,synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
+Calcium lactate,preferred_term,FOODON:03413044,Calcium lactate,FOODON:03413044,MAPPED,unique
+Calcium malate,preferred_term,FOODON:03413045,Calcium malate,FOODON:03413045,MAPPED,unique
 calcium nitrate,ontology_label,CHEBI:64205,Ca(NO3)2,CHEBI:64205,MAPPED,unique
 Calcium nitrate tetrahydrate,synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
 calcium nitrate--water (1/4),synonym,CHEBI:86159,Ca(NO3)2 x 4 H2O,CHEBI:86159,MAPPED,unique
@@ -2611,6 +2763,7 @@ Calciumcarbonat,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
 Calcium pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 Calf brains,preferred_term,UNMAPPED_0170,Calf brains,UBERON:0000955,UNMAPPED,unique
 calf serum,ontology_label,MICRO:0001709,Bovine calf serum,MICRO:0001709,MAPPED,unique
+Calf serum (Gibco),synonym,MICRO:0001709,Bovine calf serum,MICRO:0001709,MAPPED,unique
 Calprotectin,preferred_term,NCIT:C105971,Calprotectin,NCIT:C105971,MAPPED,unique
 Calprotectin S1,preferred_term,UNMAPPED_0229,Calprotectin S1,,UNMAPPED,unique
 Calprotectin S1S2,preferred_term,UNMAPPED_0230,Calprotectin S1S2,,UNMAPPED,unique
@@ -2625,6 +2778,7 @@ Cane sugar,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
 Cantharidin,preferred_term,CHEBI:64213,Cantharidin,CHEBI:64213,MAPPED,unique
 Capecitabine,preferred_term,CHEBI:31348,Capecitabine,CHEBI:31348,MAPPED,unique
 Capreomycin,preferred_term,CHEBI:3371,Capreomycin,CHEBI:3371,MAPPED,unique
+Capric acid (decanoic acid),synonym,CHEBI:30813,Decanoic acid,CHEBI:30813,MAPPED,unique
 Caproic acid,preferred_term,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
 Caprolactam,preferred_term,CHEBI:28579,Caprolactam,CHEBI:28579,MAPPED,unique
 Capronic acid,synonym,CHEBI:30776,Caproic acid,CHEBI:30776,MAPPED,unique
@@ -2662,11 +2816,13 @@ Carboximethylcellulosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:23403
 carboxyethane,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
 Carboxymethyl cellulose,preferred_term,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carboxymethyl cellulose (sodium salt),synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+"Carboxymethyl cellulose, sodium salt",synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carboxymethylcellulose,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carboxymethylcellulose sodium,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 carboxymethylcellulose sodium salt,ontology_label,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carboxymethylcellulosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carcinomycin,preferred_term,kgmicrobe.compound:carcinomycin,Carcinomycin,kgmicrobe.compound:carcinomycin,MAPPED,unique
+Carmellose,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 carmellosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 carmelosa,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 Carminate,preferred_term,CHEBI:149531,Carminate,CHEBI:149531,MAPPED,unique
@@ -2689,6 +2845,8 @@ casamino acids,ontology_label,mesh:C017721,Casamino acids (vitamin assay),mesh:C
 Casamino Acids (0.01 %,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
 Casamino acids (vit. assay),synonym,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
 Casamino acids (vitamin assay),preferred_term,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
+"Casamino acids, vitamin assay (BD-Difco)",synonym,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
+"Casamino acids, vitamin assay (Difco)",synonym,mesh:C017721,Casamino acids (vitamin assay),mesh:C017721,MAPPED,unique
 Casaminoacids,synonym,FOODON:03315719,Casamino acids,FOODON:03315719,MAPPED,unique
 Casein,preferred_term,FOODON:03420180,Casein,FOODON:03420180,MAPPED,unique
 Casein Enzymic Hydrolysate,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
@@ -2725,8 +2883,10 @@ CaSO4•2H2O(Mallinckroft 4300),synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MA
 CaSO4•2H2Osaturated solution,preferred_term,kgmicrobe.ingredient:caso42h2osaturated_solution,CaSO4•2H2Osaturated solution,kgmicrobe.ingredient:caso42h2osaturated_solution,MAPPED,unique
 CaSO4•2H2Osaturated solution (Mallinckroft 4300),synonym,kgmicrobe.ingredient:caso42h2osaturated_solution,CaSO4•2H2Osaturated solution,kgmicrobe.ingredient:caso42h2osaturated_solution,MAPPED,unique
 CaSO4・2H2O,synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
+CaSO4・7H2O,synonym,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
 CaSO4・7H2O,synonym,CHEBI:31346,CaSO4 x 7 H2O,CHEBI:31346,MAPPED,unique
 Catalase,preferred_term,NCIT:C61062,Catalase,NCIT:C61062,MAPPED,unique
+Catalase (Sigma C--10),synonym,NCIT:C61062,Catalase,NCIT:C61062,MAPPED,unique
 catechol,ontology_label,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
 catechol-3-carboxylic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
 catena-poly[(oxidoarsenate-mu-oxido)]sodium,synonym,CHEBI:29678,Sodium m-arsenite,CHEBI:29678,MAPPED,unique
@@ -2786,7 +2946,9 @@ Cellostatin,preferred_term,kgmicrobe.compound:cellostatin,Cellostatin,kgmicrobe.
 Cellotetraose,preferred_term,CHEBI:62974,Cellotetraose,CHEBI:62974,MAPPED,unique
 Cellotriose,preferred_term,CHEBI:3528,Cellotriose,CHEBI:3528,MAPPED,unique
 Cellulose,preferred_term,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
+Cellulose (Avicel or MN 300),synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,unique
 Cellulose MN 300,preferred_term,UNMAPPED_0354,Cellulose MN 300,,UNMAPPED,unique
+Cellulose powder,preferred_term,FOODON:03310367,Cellulose powder,FOODON:03310367,MAPPED,unique
 Celluloseglycolic acid,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 CeNO33 x 6 H2O,preferred_term,UNMAPPED_0355,CeNO33 x 6 H2O,,UNMAPPED,unique
 Cephalexin,preferred_term,CHEBI:3534,Cephalexin,CHEBI:3534,MAPPED,unique
@@ -2851,6 +3013,7 @@ chitin,ontology_label,UNMAPPED_0248,Chitin from shrimp shells,CHEBI:17029,UNMAPP
 Chitin from shrimp shells,preferred_term,UNMAPPED_0248,Chitin from shrimp shells,CHEBI:17029,UNMAPPED,unique
 Chitosan,preferred_term,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
 Chloramphenicol,preferred_term,CHEBI:17698,Chloramphenicol,CHEBI:17698,MAPPED,unique
+chloramphenicol (if needed),synonym,CHEBI:17698,Chloramphenicol,CHEBI:17698,MAPPED,unique
 chlorane,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
 Chlorate de sodium,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
 Chlorate salt of sodium,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
@@ -2858,6 +3021,7 @@ chlorhexidine acetate,ontology_label,kgmicrobe.compound:chlorhexidine_diacetate_
 Chlorhexidine diacetate salt hydrate,preferred_term,kgmicrobe.compound:chlorhexidine_diacetate_salt_hydrate,Chlorhexidine diacetate salt hydrate,CHEBI:81711,MAPPED,unique
 "Chloric acid, sodium salt",synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
 Chloridazon,preferred_term,CHEBI:81838,Chloridazon,CHEBI:81838,MAPPED,unique
+chloride,ontology_label,CHEBI:17996,Cl-,CHEBI:17996,MAPPED,unique
 Chloride de choline,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
 chlorido(protoporphyrinato)iron(III),synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 chloridohydrogen,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
@@ -2878,6 +3042,7 @@ chlorure de methylthioninium,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED
 chlorure de sodium,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
 chlorure de zinc,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 Chlorwasserstoff,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+chocolate agar,preferred_term,MICRO:0000591,chocolate agar,MICRO:0000591,MAPPED,unique
 Cholest-5-en-3beta-ol,synonym,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,unique
 Cholesterin,synonym,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,unique
 cholesterol,preferred_term,CHEBI:16113,cholesterol,CHEBI:16113,MAPPED,resolved:owned
@@ -2942,6 +3107,7 @@ Cinnamic acid,preferred_term,CHEBI:27386,Cinnamic acid,CHEBI:27386,MAPPED,unique
 Cinnamycin,preferred_term,CHEBI:141991,Cinnamycin,CHEBI:141991,MAPPED,unique
 Cinoxacin,preferred_term,CHEBI:3716,Cinoxacin,CHEBI:3716,MAPPED,unique
 Ciprofloxacin,preferred_term,CHEBI:100241,Ciprofloxacin,CHEBI:100241,MAPPED,unique
+ciprofloxacin (if needed),synonym,CHEBI:100241,Ciprofloxacin,CHEBI:100241,MAPPED,unique
 Ciprofloxacin Hydrochloride,preferred_term,CHEBI:59936,Ciprofloxacin Hydrochloride,CHEBI:59936,MAPPED,unique
 ciprofloxacin hydrochloride hydrate,ontology_label,CHEBI:59936,Ciprofloxacin Hydrochloride,CHEBI:59936,MAPPED,unique
 "cis-(+)-Tetrahydro-2-oxothieno[3,4]imidazoline-4-valeric acid",synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
@@ -2966,6 +3132,7 @@ citramalate(2-),ontology_label,CHEBI:13997,Citramalate,CHEBI:13997,MAPPED,unique
 citramalic acid,ontology_label,cas:1030365-02-6,potassium citramalate monohydrate,CHEBI:15584,MAPPED,unique
 Citrate,preferred_term,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,resolved:owned
 Citrate,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,resolved:owned
+citrate(1-),synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
 citrate(3-),ontology_label,CHEBI:16947,Citrate,CHEBI:16947,MAPPED,unique
 Citric acid,preferred_term,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,resolved:owned
 Citric Acid,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,resolved:owned
@@ -2979,10 +3146,13 @@ Citric acid x H2O,preferred_term,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPE
 Citric acid·H2O,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
 Citric Acid•H2O,preferred_term,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,unique
 Citric Acid•H2O(Fisher A 104),synonym,CHEBI:30769,Citric Acid•H2O,CHEBI:30769,MAPPED,unique
+Citric Acid•H2O(Fisher A 104),synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
 Citronensaeure,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
 "Citronensaeure,Trinatrium-Salz-Dihydrat",synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
 CITRULLINE,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
+Cl-,preferred_term,CHEBI:17996,Cl-,CHEBI:17996,MAPPED,unique
 Cladomycin,preferred_term,kgmicrobe.compound:cladomycin,Cladomycin,kgmicrobe.compound:cladomycin,MAPPED,unique
+Clarified rumen fluid,preferred_term,MICRO:0000520,Clarified rumen fluid,MICRO:0000520,MAPPED,unique
 Clarithromycin,preferred_term,CHEBI:3732,Clarithromycin,CHEBI:3732,MAPPED,unique
 Clavulanic Acid,preferred_term,CHEBI:48947,Clavulanic Acid,CHEBI:48947,MAPPED,unique
 Cleland's reagent,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
@@ -3002,6 +3172,8 @@ CMC,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 CMC + PY + Horse Serum,preferred_term,kgmicrobe.ingredient:cmc_py_horse_serum,CMC + PY + Horse Serum,kgmicrobe.ingredient:cmc_py_horse_serum,MAPPED,unique
 CMC-Na,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 CMRL 1066,preferred_term,UNMAPPED_0359,CMRL 1066,,UNMAPPED,unique
+CMRL 1066 (Gibco 330--1540),synonym,UNMAPPED_0359,CMRL 1066,,UNMAPPED,unique
+CMRL-1066 (ATCC 20-2206),synonym,UNMAPPED_0359,CMRL 1066,,UNMAPPED,unique
 CN-Cbl,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
 CN-Cbl,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
 Co Carboxylase,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
@@ -3027,8 +3199,10 @@ CoA-SH,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
 CoASH,synonym,CHEBI:15346,Coenzyme A,CHEBI:15346,MAPPED,unique
 Cob(III)alamin,synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 COBALAMIN,synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+Cobalamin (1 μg/μL),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 Cobalamin (B12),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 Cobalamin (III),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
+cobalamin(1+),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 cobalamin(III),synonym,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 Cobalamine,preferred_term,CHEBI:30411,Cobalamine,CHEBI:30411,MAPPED,unique
 Cobalt (2+) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
@@ -3047,9 +3221,11 @@ Cobalt dichloride hexahydrate,synonym,CHEBI:53503,Cobalt chloride hexahydrate,CH
 cobalt dinitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
 cobalt dinitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
 Cobalt monosulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+Cobalt monosulfate heptahydrate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
 Cobalt nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
 Cobalt nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
 Cobalt sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+Cobalt sulfate heptahydrate,synonym,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
 cobalt(2+) chloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
 cobalt(2+) chloride,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
 cobalt(2+) chloride,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
@@ -3061,6 +3237,7 @@ Cobalt(2+) nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,
 cobalt(2+) nitrate--water (1/6),synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
 cobalt(2+) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
 cobalt(2+) sulfate heptahydrate,ontology_label,CHEBI:91244,CoSO4 x 7 H2O,CHEBI:91244,MAPPED,unique
+cobalt(2+) sulfate--water (1/7),synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
 cobalt(II) chloride,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
 cobalt(II) chloride,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
 cobalt(II) chloride,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
@@ -3070,10 +3247,12 @@ Cobalt(II) chloride--water (1/7),synonym,CHEBI:53503,Cobalt chloride hexahydrate
 Cobalt(II) nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
 Cobalt(II) nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
 Cobalt(II) sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cobalt(II) sulfate heptahydrate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
 Cobalt-NTA,preferred_term,UNMAPPED_0154,Cobalt-NTA,,UNMAPPED,unique
 Cobaltous nitrate,synonym,CHEBI:86209,Co(NO3)2,CHEBI:86209,MAPPED,unique
 Cobaltous nitrate hexahydrate,synonym,CHEBI:86214,Co(NO3)2 x 6 H2O,CHEBI:86214,MAPPED,unique
 Cobaltous sulfate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
+cobaltous sulfate heptahydrate,synonym,CHEBI:53470,CoSO4,CHEBI:53470,MAPPED,unique
 cocarboxilasa,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
 cocarboxylase,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
 cocarboxylase chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
@@ -3104,6 +3283,7 @@ CoCl2 × 6H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_su
 CoCl2 × 6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
 CoCl2 ∙ 6 H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,conflict:different_substances
 CoCl2 ∙ 6 H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
+CoCl2.6H2O,synonym,CHEBI:35696,CoCl2,CHEBI:35696,MAPPED,unique
 CoCl2·6H2O,synonym,kgmicrobe.compound:cocl2_x_2_h2o,CoCl2 x 2 H2O,CHEBI:35696,MAPPED,conflict:different_substances
 CoCl2·6H2O,synonym,kgmicrobe.compound:cocl2_x_4_h2o,CoCl2 x 4 H2O,CHEBI:35696,MAPPED,conflict:different_substances
 CoCl2·6H2O,synonym,CHEBI:53503,CoCl2 x 6 H2O,CHEBI:53503,REJECTED,conflict:different_substances
@@ -3135,6 +3315,8 @@ Collinomycin,preferred_term,kgmicrobe.compound:collinomycin,Collinomycin,kgmicro
 Colloidal chitin,preferred_term,UNMAPPED_0361,Colloidal chitin,,UNMAPPED,unique
 Columbia agar base,preferred_term,MICRO:0000536,Columbia agar base,MICRO:0000536,MAPPED,unique
 Columbia blood agar base,preferred_term,UNMAPPED_0118,Columbia blood agar base,,UNMAPPED,unique
+Columbia blood agar base (BD-Difco),synonym,UNMAPPED_0118,Columbia blood agar base,,UNMAPPED,unique
+Columbia blood agar base (Oxoid CM331),synonym,UNMAPPED_0118,Columbia blood agar base,,UNMAPPED,unique
 CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 common salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
 Complan,preferred_term,UNMAPPED_0363,Complan,,UNMAPPED,unique
@@ -3146,8 +3328,11 @@ coniferol,ontology_label,CHEBI:17745,coniferyl alcohol,CHEBI:17745,MAPPED,unique
 coniferyl alcohol,preferred_term,CHEBI:17745,coniferyl alcohol,CHEBI:17745,MAPPED,unique
 coniferyl aldehyde,preferred_term,CHEBI:16547,coniferyl aldehyde,CHEBI:16547,MAPPED,unique
 Cooked meat medium,preferred_term,FOODON:03305103,Cooked meat medium,FOODON:03305103,MAPPED,unique
+Cooked meat medium (Oxoid),synonym,FOODON:03305103,Cooked meat medium,FOODON:03305103,MAPPED,unique
+Copper,preferred_term,CHEBI:28694,Copper,CHEBI:28694,MAPPED,unique
 copper (II) chloride dihydrate,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
 Copper (II) sulfate pentahydrate,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+copper atom,ontology_label,CHEBI:28694,Copper,CHEBI:28694,MAPPED,unique
 Copper bichloride,synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
 Copper chloride (CuCl),synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
 Copper chloride (CuCl2),synonym,CHEBI:49553,CuCl2,CHEBI:49553,MAPPED,unique
@@ -3198,6 +3383,8 @@ Copper-NTA,preferred_term,UNMAPPED_0151,Copper-NTA,,UNMAPPED,unique
 Coppertrace,synonym,CHEBI:86318,CuCl2 x 2 H2O,CHEBI:86318,MAPPED,unique
 Corn meal,preferred_term,FOODON:03310257,Corn meal,FOODON:03310257,MAPPED,unique
 Corn meal agar,preferred_term,UNMAPPED_0130,Corn meal agar,,UNMAPPED,unique
+Corn meal agar (BD-Difco),synonym,UNMAPPED_0130,Corn meal agar,,UNMAPPED,unique
+Corn meal agar (Nissui),synonym,UNMAPPED_0130,Corn meal agar,,UNMAPPED,unique
 Corn Oil,preferred_term,CHEBI:195250,Corn Oil,CHEBI:195250,MAPPED,unique
 Corn Starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Corn Steep Liquor + Glucose + Fumarate,preferred_term,kgmicrobe.ingredient:corn_steep_liquor_glucose_fumarate,Corn Steep Liquor + Glucose + Fumarate,kgmicrobe.ingredient:corn_steep_liquor_glucose_fumarate,MAPPED,unique
@@ -3225,6 +3412,7 @@ Creatine,preferred_term,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
 Creatine anhydride,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
 creatinina,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
 Creatinine,preferred_term,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
+Cresol,preferred_term,CHEBI:25399,Cresol,CHEBI:25399,MAPPED,unique
 Cresol red,preferred_term,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
 Cresolsulfophthalein,synonym,CHEBI:86218,Cresol red,CHEBI:86218,MAPPED,unique
 Crinamine,preferred_term,CHEBI:3914,Crinamine,CHEBI:3914,MAPPED,unique
@@ -3234,6 +3422,7 @@ croscarmellosum,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED
 croscarmelosa,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
 crotonate,synonym,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
 Crotonic acid,preferred_term,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
+Crotonic acid (ALDRICH 113018),synonym,CHEBI:41131,Crotonic acid,CHEBI:41131,MAPPED,unique
 Crude Oil,preferred_term,ENVO:00002984,Crude Oil,ENVO:00002984,MAPPED,unique
 Cryptotanshinone,preferred_term,CHEBI:149838,Cryptotanshinone,CHEBI:149838,MAPPED,unique
 Crystal Violet,preferred_term,CHEBI:41688,Crystal Violet,CHEBI:41688,MAPPED,unique
@@ -3287,6 +3476,7 @@ Cuprous chloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
 Curamycin A,preferred_term,CHEBI:71987,Curamycin A,CHEBI:71987,MAPPED,unique
 Curcumin,preferred_term,CHEBI:3962,Curcumin,CHEBI:3962,MAPPED,unique
 Curdlan,preferred_term,cas:54724-00-4,Curdlan,mesh:C038459,MAPPED,unique
+CuSO .5H O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
 CuSO4,preferred_term,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
 CuSO4 . 2H2O,synonym,CHEBI:23414,CuSO4,CHEBI:23414,MAPPED,unique
 CuSO4 . 2H2O,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
@@ -3307,6 +3497,7 @@ CuSO4 x H2O,synonym,CHEBI:23414,CuSO4 x 2 H2O,CHEBI:23414,MAPPED,unique
 CuSO4 x H2O,synonym,CHEBI:23414,CuSO4 x 4 H2O,CHEBI:23414,MAPPED,unique
 CuSO4 · 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
 CuSO4 ⋅ 5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
+CuSO4*5 H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
 CuSO4.5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
 CuSO4.6H2O,synonym,CHEBI:91246,CuSO4 x 6 H2O,CHEBI:91246,MAPPED,unique
 CuSO4·5H2O,synonym,CHEBI:31440,CuSO4 x 5 H2O,CHEBI:31440,MAPPED,unique
@@ -3323,6 +3514,7 @@ Cyanocobalamine,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved
 Cyanocobalamine,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
 Cyanocobalamin in,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
 Cyanocobalamin in,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
+Cyanuric acid,preferred_term,CHEBI:38028,Cyanuric acid,CHEBI:38028,MAPPED,unique
 Cyclodextrin,preferred_term,CHEBI:23456,Cyclodextrin,CHEBI:23456,MAPPED,unique
 cycloheptaamylose,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
 cycloheptaglucan,synonym,CHEBI:495055,Cyclomaltoheptaose,CHEBI:495055,MAPPED,unique
@@ -3343,10 +3535,12 @@ Cycloviracin B2,preferred_term,CHEBI:202116,Cycloviracin B2,CHEBI:202116,MAPPED,
 Cyd,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
 Cystargin,preferred_term,mesh:C058276,Cystargin,mesh:C058276,MAPPED,unique
 Cystein,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+Cystein-HCl,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 Cystein-HCl x 2 H2O (5% (w/v)),synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 Cystein-HCl x 2 H2O (5% (w/v)),synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
 Cysteine,preferred_term,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,resolved:owned
 CYSTEINE,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,resolved:owned
+cysteine . HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 Cysteine hydrochloride,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 Cysteine monohydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 Cysteine-HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
@@ -3354,6 +3548,7 @@ Cysteine-HCl x H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,u
 Cysteine-HCl·H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 Cysteine-HCl∙H2O,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
 Cysteine-HCl⋅H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+Cysteine.HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 Cystine,preferred_term,CHEBI:17376,Cystine,CHEBI:17376,MAPPED,unique
 Cyt,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
 Cytidin,synonym,CHEBI:17562,Cytidine,CHEBI:17562,MAPPED,unique
@@ -3397,6 +3592,7 @@ D-(-)-Pantolactone,preferred_term,CHEBI:16719,D-(-)-Pantolactone,CHEBI:16719,MAP
 D-(-)-sorbitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
 D-(-)-tagatose,preferred_term,CHEBI:4249,D-(-)-tagatose,CHEBI:4249,MAPPED,unique
 D-2-Aminobutyric acid,preferred_term,CHEBI:28797,D-2-Aminobutyric acid,CHEBI:28797,MAPPED,unique
+D-adonitol (D-ribitol),synonym,CHEBI:15963,Ribitol,CHEBI:15963,MAPPED,unique
 D-Alanine,preferred_term,CHEBI:15570,D-Alanine,CHEBI:15570,MAPPED,unique
 D-alpha-aminobutyric acid,ontology_label,CHEBI:28797,D-2-Aminobutyric acid,CHEBI:28797,MAPPED,unique
 D-apiose,preferred_term,CHEBI:16689,D-apiose,CHEBI:16689,MAPPED,unique
@@ -3447,6 +3643,7 @@ D-glucaric acid,ontology_label,cas:576-42-1,D-Saccharic acid potassium salt,CHEB
 D-Glucitol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
 D-gluco-hexose,synonym,CHEBI:17634,D-Glucose,CHEBI:17634,MAPPED,unique
 D-gluconate,preferred_term,CHEBI:18391,D-gluconate,CHEBI:18391,MAPPED,unique
+D-Gluconic acid,preferred_term,CHEBI:33198,D-Gluconic acid,CHEBI:33198,MAPPED,unique
 "D-Gluconic acid, monosodium salt",synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
 "D-glucono-1,5-lactone",ontology_label,CHEBI:16217,D-(+)-Gluconic acid gamma-lactone,CHEBI:16217,MAPPED,unique
 D-glucopyranose,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
@@ -3501,6 +3698,7 @@ D-mannose 6-(dihydrogen phosphate),synonym,cas:70442-25-0,D-Mannose 6-phosphate 
 D-mannose 6-phosphate,ontology_label,CHEBI:17369,Mannose-6-Phosphate,CHEBI:17369,MAPPED,conflict:different_substances
 D-mannose 6-phosphate,ontology_label,cas:70442-25-0,D-Mannose 6-phosphate sodium salt,CHEBI:17369,MAPPED,conflict:different_substances
 D-Mannose 6-phosphate sodium salt,preferred_term,cas:70442-25-0,D-Mannose 6-phosphate sodium salt,CHEBI:17369,MAPPED,unique
+D-melezitose (melezitose),synonym,cas:207511-10-2,D-(+)-Melezitose hydrate,CHEBI:6731,MAPPED,unique
 D-Melibiose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
 D-melibiose (melibiose),synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
 D-mellibiose,synonym,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
@@ -3531,6 +3729,7 @@ D-threonine,preferred_term,CHEBI:16398,D-threonine,CHEBI:16398,MAPPED,unique
 D-Trehalose,synonym,CHEBI:27082,Trehalose,CHEBI:27082,MAPPED,unique
 D-Trehalose dihydrate,preferred_term,CHEBI:232797,D-Trehalose dihydrate,CHEBI:232797,MAPPED,unique
 D-tryptophan,preferred_term,CHEBI:16296,D-tryptophan,CHEBI:16296,MAPPED,unique
+D-turanose (turanose),synonym,CHEBI:32528,D-(+)-Turanose,CHEBI:32528,MAPPED,unique
 D-valine,preferred_term,CHEBI:27477,D-valine,CHEBI:27477,MAPPED,unique
 D-XYLITOL,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
 D-Xylose,preferred_term,CHEBI:65327,D-Xylose,CHEBI:65327,MAPPED,unique
@@ -3563,8 +3762,13 @@ Decaplanin,preferred_term,mesh:C076135,Decaplanin,mesh:C076135,MAPPED,unique
 Decoyinine,preferred_term,CHEBI:191094,Decoyinine,CHEBI:191094,MAPPED,unique
 decyl alcohol,preferred_term,CHEBI:28903,decyl alcohol,CHEBI:28903,MAPPED,unique
 Defibrinated horse blood,preferred_term,MICRO:0001572,Defibrinated horse blood,MICRO:0001572,MAPPED,unique
+defibrinated horse blood (TCS Biologicals),synonym,MICRO:0001572,Defibrinated horse blood,MICRO:0001572,MAPPED,unique
 Defibrinated rabbit blood,synonym,MICRO:0001229,Rabbit blood,MICRO:0001229,MAPPED,unique
 Defibrinated sheep blood,preferred_term,MICRO:0001570,Defibrinated sheep blood,MICRO:0001570,MAPPED,unique
+degradation: 4-nitrophenyl beta-D-galactopyranoside,synonym,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
+degradation: aromatic compound,synonym,CHEBI:33655,Aromatic compound,CHEBI:33655,MAPPED,unique
+degradation: elastin,synonym,CHEBI:4767,Elastin,CHEBI:4767,MAPPED,unique
+degradation: hydrocarbon,synonym,CHEBI:24632,Hydrocarbon,CHEBI:24632,MAPPED,unique
 degradation: starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Dehydrated ethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
 dehydrated RCM medium,preferred_term,UNMAPPED_0372,dehydrated RCM medium,,UNMAPPED,unique
@@ -3581,6 +3785,7 @@ Delta-Nonalactone,preferred_term,CHEBI:171747,Delta-Nonalactone,CHEBI:171747,MAP
 Delta-Undecalactone,preferred_term,CHEBI:171846,Delta-Undecalactone,CHEBI:171846,MAPPED,unique
 delta-ureidonorvaline,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
 Deoxycholic acid,preferred_term,CHEBI:28834,Deoxycholic acid,CHEBI:28834,MAPPED,unique
+deoxyhemoglobin,ontology_label,CHEBI:5656,Hemoglobin,CHEBI:5656,MAPPED,unique
 Deoxyinosine,synonym,CHEBI:28997,2'-Deoxyinosine,CHEBI:28997,MAPPED,unique
 deoxyribonucleic acid,ontology_label,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
 deoxyribonucleic acid,ontology_label,kgmicrobe.ingredient:fish-sperm_dna,Deoxyribonucleic acid from herring sperm,CHEBI:16991,REJECTED,unique
@@ -3588,6 +3793,7 @@ Deoxyribonucleic acid from herring sperm,preferred_term,kgmicrobe.ingredient:fis
 Deoxyribonucleic acid from herring sperm,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
 deoxyribonucleic acids,synonym,kgmicrobe.ingredient:fish-sperm_dna,Fish-Sperm DNA,CHEBI:16991,MAPPED,unique
 deoxyribonucleic acids,synonym,kgmicrobe.ingredient:fish-sperm_dna,Deoxyribonucleic acid from herring sperm,CHEBI:16991,REJECTED,unique
+Deoxyribose,synonym,CHEBI:28816,2-Deoxy-D-Ribose,CHEBI:28816,MAPPED,unique
 "Deoxysappanone B 7,3'-Dimethyl Ether",preferred_term,UNMAPPED_0200,"Deoxysappanone B 7,3'-Dimethyl Ether",,UNMAPPED,unique
 Deoxythymidine,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
 Deoxyuridine,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
@@ -3630,10 +3836,12 @@ diammonium [(sulfonatoperoxy)sulfonyl]oxidanide,synonym,CHEBI:156543,ammonium pe
 Diammonium Citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
 Diammonium hydrogen citrate,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
 diammonium hydrogen phosphate,ontology_label,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
+diammonium L-tartrate,ontology_label,CHEBI:63075,Diammonium tartrate,CHEBI:63075,MAPPED,unique
 Diammonium molybdate,preferred_term,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
 Diammonium nickel disulfate hexahydrate,synonym,CHEBI:86149,(NH4)2Ni(SO4)2 x 6 H2O,CHEBI:86149,MAPPED,unique
 Diammonium oxalate,synonym,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
 diammonium sulfate,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+Diammonium tartrate,preferred_term,CHEBI:63075,Diammonium tartrate,CHEBI:63075,MAPPED,unique
 diammonium tetraoxomolybdate,synonym,CHEBI:91249,Diammonium molybdate,CHEBI:91249,MAPPED,unique
 diamond green B,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
 diazanium hydrogen phosphate,synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
@@ -3649,6 +3857,7 @@ dibenzofuran,synonym,CHEBI:28145,Dibenzofuran,CHEBI:28145,MAPPED,unique
 Dibenzothiophene,preferred_term,CHEBI:23681,Dibenzothiophene,CHEBI:23681,MAPPED,unique
 Dibucaine,preferred_term,CHEBI:247956,Dibucaine,CHEBI:247956,MAPPED,unique
 Diced potato,preferred_term,UNMAPPED_0375,Diced potato,,UNMAPPED,unique
+Dichloran (0.2% in ethanol),preferred_term,CHEBI:27864,Dichloran (0.2% in ethanol),CHEBI:27864,MAPPED,unique
 Dichloran-Glycerol-agar base,preferred_term,UNMAPPED_0376,Dichloran-Glycerol-agar base,,UNMAPPED,unique
 dichloro-lambda(2)-plumbane,synonym,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPPED,unique
 dichlorocadmium--water (2/5),synonym,CHEBI:63938,Cadmium chloride hemipentahydrate,CHEBI:63938,MAPPED,unique
@@ -3669,6 +3878,7 @@ Dicopac,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_
 Dicopper dichloride,synonym,CHEBI:53472,CuCl,CHEBI:53472,MAPPED,unique
 dideuterium oxide,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
 diethyl ether,preferred_term,CHEBI:35702,diethyl ether,CHEBI:35702,MAPPED,unique
+Diethyl phosphonate,preferred_term,CHEBI:41962,Diethyl phosphonate,CHEBI:41962,MAPPED,unique
 diethylamine NONOate,ontology_label,cas:372965-00-9,DEANONOate,CHEBI:77707,MAPPED,unique
 Difco 0001,preferred_term,UNMAPPED_0377,Difco 0001,,UNMAPPED,unique
 Difco Bacto- Tryptone,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unique
@@ -3687,6 +3897,7 @@ Dihydrofumaric acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
 dihydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 Dihydrogen ammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
 dihydrogen arsenite,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+dihydrogen citrate,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
 dihydrogen oxide,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 dihydrogen peroxide,synonym,CHEBI:16240,Hydrogen peroxide,CHEBI:16240,MAPPED,unique
 dihydrogen tetraoxosulfate,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
@@ -3697,6 +3908,7 @@ dihydrogen(sulfide),synonym,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,uniq
 Dihydrostreptomycin,preferred_term,CHEBI:38291,Dihydrostreptomycin,CHEBI:38291,MAPPED,unique
 dihydroxidodioxidosulfur,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 dihydroxidodioxidotungsten,synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+dihydroxidooxidoarsenate(1-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
 dihydroxidooxidoselenium,synonym,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
 Dihydroxyacetone,preferred_term,CHEBI:16016,Dihydroxyacetone,CHEBI:16016,MAPPED,unique
 dihydroxyborane,synonym,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
@@ -3708,6 +3920,7 @@ dimethyl ether,ontology_label,cas:5728-44-9,Apigenin Dimethyl Ether,CHEBI:28887,
 Dimethyl sulfide,preferred_term,CHEBI:17437,Dimethyl sulfide,CHEBI:17437,MAPPED,unique
 dimethyl sulfone,preferred_term,CHEBI:9349,dimethyl sulfone,CHEBI:9349,MAPPED,unique
 Dimethyl sulfoxide,preferred_term,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
+dimethyl sulfoxide (DMSO),synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
 dimethyl sulfur oxide,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
 dimethyl sulphoxide,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
 Dimethylacetic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
@@ -3772,6 +3985,7 @@ disodium (S)-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
 "disodium 6beta-(2-carboxylato-2-phenylacetamido)-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:34609,Carbenicillin disodium salt,CHEBI:34609,MAPPED,unique
 "disodium 6beta-{[(2R)-2-carboxylato-2-thiophen-3-ylacetyl]amino}-2,2-dimethylpenam-3alpha-carboxylate",synonym,CHEBI:35017,Ticarcillin disodium salt,CHEBI:35017,MAPPED,unique
 Disodium acid arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+disodium acid orthophosphate,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
 disodium arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 Disodium beta-glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
 disodium butanedioate,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
@@ -3792,6 +4006,7 @@ Disodium glycerol 2-phosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,
 Disodium glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
 disodium hydrogen arsorate--water (1/7),synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 Disodium hydrogen phosphate,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+disodium hydrogen phosphate dihydrate,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 disodium hydrogen phosphate heptahydrate,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 disodium hydrogenarsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 disodium hydrogenphosphate,ontology_label,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
@@ -3799,8 +4014,8 @@ disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2
 disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 disodium hydrogenphosphate,ontology_label,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 disodium hydrogenphosphate,ontology_label,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,conflict:different_substances
-disodium hydrogenphosphate dihydrate,ontology_label,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
-disodium hydrogenphosphate dodecahydrate,ontology_label,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
+disodium hydrogenphosphate dihydrate,ontology_label,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
+disodium hydrogenphosphate dodecahydrate,ontology_label,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
 "Disodium indigo-5,5-disulfonate",synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
 Disodium L-(+)-tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
 Disodium L-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
@@ -3811,11 +4026,14 @@ Disodium metabisulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 Disodium molybdate,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
 Disodium molybdate dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Disodium monohydrogen arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
+disodium monohydrogen phosphate,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
 disodium monosulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
+disodium orthophosphate,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,unique
 Disodium oxalate,preferred_term,CHEBI:132764,Disodium oxalate,CHEBI:132764,MAPPED,unique
 disodium oxido(oxo)-kappa(4)-sulfanesulfonate,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 disodium oxosilanediolate,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
 Disodium Phosphate,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Disodium phosphate dihydrate,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 Disodium phosphate heptahydrate (0.02 M stock),preferred_term,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 disodium phosphorofluoridate,synonym,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
 Disodium pyrosulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
@@ -3829,8 +4047,12 @@ disodium selenium trioxide,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
 Disodium succinate,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
 disodium succinate (anh.),synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
 disodium succinate hexahydrate,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+Disodium succinate x 6 H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
 disodium succinate.6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
+Disodium succinate·6H2O,synonym,CHEBI:63675,Sodium succinate,CHEBI:63675,MAPPED,unique
+Disodium succinate・6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,CHEBI:63686,MAPPED,unique
 disodium sulfate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+disodium sulfate decahydrate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 disodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
 disodium sulfide--water (1/9),synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 disodium sulfite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
@@ -3840,6 +4062,7 @@ disodium sulphate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 disodium tartrate,synonym,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
 disodium tetraborate,synonym,CHEBI:38892,Na2B4O7,CHEBI:38892,MAPPED,unique
 disodium tetraborate decahydrate,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Disodium tetraoxotungstate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Disodium thiosulfate,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
 disodium thiosulfate pentahydrate,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
 disodium thiosulphate pentahydrate,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
@@ -3852,16 +4075,21 @@ disodium;6-hydroxy-5-[(2-methoxy-5-methyl-4-sulonatophenyl)diazenyl]naphthalene-
 DISTAMYCIN A,ontology_label,CHEBI:41958,Stallimycin,CHEBI:41958,MAPPED,unique
 Distiled water,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 Distilled water,preferred_term,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Distilled water (for liquid medium),synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+Distilled water (for solid medium),synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 "Disulfurous acid, disodium salt",synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 Dithionit,synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
 Dithionite,preferred_term,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
 DITHIONITE,synonym,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
 dithionite(2-),ontology_label,CHEBI:42160,Dithionite,CHEBI:42160,MAPPED,unique
 Dithiothreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+Dithiothreitol (0.25 M),synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+Dithiothreitol (DTT),synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 Dithiotreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 diuron,ontology_label,CHEBI:116509,DCMU,CHEBI:116509,MAPPED,unique
 Diydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 DL vitamins,preferred_term,kgmicrobe.ingredient:dl_vitamins,DL vitamins,kgmicrobe.ingredient:dl_vitamins,MAPPED,unique
+DL vitamins (see below),synonym,kgmicrobe.ingredient:dl_vitamins,DL vitamins,kgmicrobe.ingredient:dl_vitamins,MAPPED,unique
 DL-2-Aminoadipic acid,preferred_term,CHEBI:37023,DL-2-Aminoadipic acid,CHEBI:37023,MAPPED,unique
 DL-2-Aminobutyric acid,preferred_term,CHEBI:35621,DL-2-Aminobutyric acid,CHEBI:35621,MAPPED,unique
 DL-2-gamma-aminobutyrate,preferred_term,UNMAPPED_0710,DL-2-gamma-aminobutyrate,,REJECTED,unique
@@ -3881,6 +4109,7 @@ DL-aspartic acid,preferred_term,CHEBI:22660,DL-aspartic acid,CHEBI:22660,MAPPED,
 DL-Calcium pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 DL-carnitine,preferred_term,CHEBI:17126,DL-carnitine,CHEBI:17126,MAPPED,unique
 DL-Dithiothreitol,preferred_term,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+DL-Dithiothreitol (DTT),synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 DL-glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 DL-Glutamic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
 DL-Glutaminic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
@@ -3894,6 +4123,7 @@ DL-kavain,ontology_label,CHEBI:156288,Kawain,CHEBI:156288,MAPPED,unique
 DL-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
 DL-Malate,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
 DL-Malic acid,preferred_term,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
+DL-menthol,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
 DL-methionine,preferred_term,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
 DL-mevalonic acid,preferred_term,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
 DL-Na-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
@@ -3929,17 +4159,21 @@ Doxorubicin,preferred_term,CHEBI:28748,Doxorubicin,CHEBI:28748,MAPPED,unique
 Doxorubicin hydrochloride,preferred_term,CHEBI:31522,Doxorubicin hydrochloride,CHEBI:31522,MAPPED,unique
 Doxycycline,preferred_term,CHEBI:50845,Doxycycline,CHEBI:50845,MAPPED,unique
 Doxycycline hyclate,preferred_term,CHEBI:34730,Doxycycline hyclate,CHEBI:34730,MAPPED,unique
+dried bovine hemoglobin,ontology_label,MICRO:0001599,Dried Bovine Hemoglobin (BD 212392),MICRO:0001599,MAPPED,unique
+Dried Bovine Hemoglobin (BD 212392),preferred_term,MICRO:0001599,Dried Bovine Hemoglobin (BD 212392),MICRO:0001599,MAPPED,unique
 Dried sodium sulfite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
 Dried yeast extract S (Wako),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 Dry cow-manure,preferred_term,kgmicrobe.ingredient:dry_cow-manure,Dry cow-manure,ENVO:00003031,MAPPED,unique
 dThd,synonym,CHEBI:17748,Thymidine,CHEBI:17748,MAPPED,unique
 DTL,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 DTT,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+DTT (DL-Dithiothreitol),synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 dU,synonym,CHEBI:16450,2'-Deoxyuridine,CHEBI:16450,MAPPED,unique
 duartin,ontology_label,cas:52305-04-1,Duartin (-),mesh:C087989,MAPPED,unique
 Duartin (-),preferred_term,cas:52305-04-1,Duartin (-),mesh:C087989,MAPPED,unique
 Dulbecco's Phosphate-Buffered Saline,ontology_label,kgmicrobe.ingredient:pbs,PBS,NCIT:C178908,MAPPED,unique
 dulcite,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
+Dulcitol (galactitol),synonym,CHEBI:16813,Galactitol,CHEBI:16813,MAPPED,unique
 Durhamycin,preferred_term,kgmicrobe.compound:durhamycin,Durhamycin,kgmicrobe.compound:durhamycin,MAPPED,unique
 Dv_base_medium,preferred_term,UNMAPPED_0305,Dv_base_medium,,UNMAPPED,unique
 Dv_base_Y_medium,preferred_term,UNMAPPED_0278,Dv_base_Y_medium,,UNMAPPED,unique
@@ -4028,12 +4262,14 @@ EDTA Stock,preferred_term,kgmicrobe.ingredient:edta_stock,EDTA Stock,kgmicrobe.i
 EDTA tetrasodium tetrahydrate salt,preferred_term,cas:13235-36-4,EDTA tetrasodium tetrahydrate salt,CHEBI:4735,MAPPED,unique
 EDTA trisodium,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
 EDTA trisodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA(Disodium salt),synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA-2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA-3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
 EDTA.Na .2H O,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTANa,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA·2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA·3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+EDTA•2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA・2Na,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 EDTA・3Na,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
 Egg yolk,preferred_term,FOODON:03315772,Egg yolk,FOODON:03315772,MAPPED,unique
@@ -4109,6 +4345,7 @@ Ethyl chrysanthemumate,ontology_label,cas:97-41-6,"Chrysanthemic Acid, Ethyl Est
 Ethyl decanoate,preferred_term,CHEBI:87430,Ethyl decanoate,CHEBI:87430,MAPPED,unique
 ethyl hex-2-enoate,synonym,CHEBI:16411,3-Indolyl acetic acid,CHEBI:16411,MAPPED,unique
 ethyl methyl sulfide,preferred_term,CHEBI:231886,ethyl methyl sulfide,CHEBI:231886,MAPPED,unique
+Ethyl octanoate,preferred_term,CHEBI:87426,Ethyl octanoate,CHEBI:87426,MAPPED,unique
 ethylacetic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
 Ethylene glycol,preferred_term,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
 ethylene tetrachloride,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
@@ -4124,6 +4361,7 @@ ethylenediaminetetraacetic acid,ontology_label,cas:13235-36-4,EDTA tetrasodium t
 ethylenediaminetetraacetic acid,ontology_label,CHEBI:4735,EDTA (acid form),CHEBI:4735,REJECTED,conflict:different_substances
 ethylenediaminetetraacetic acid disodium salt dihydrate,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 ethylenediaminetetraacetic acid trisodium salt,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
+Ethylenediamintetraacetic acid (EDTA),synonym,cas:13235-36-4,EDTA tetrasodium tetrahydrate salt,CHEBI:4735,MAPPED,unique
 Ethylenesuccinic acid,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
 ethylformic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
 Ethylic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
@@ -4134,6 +4372,8 @@ EtOH,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
 Eudesmic Acid,preferred_term,CHEBI:454991,Eudesmic Acid,CHEBI:454991,MAPPED,unique
 Eugenol,preferred_term,CHEBI:4917,Eugenol,CHEBI:4917,MAPPED,unique
 Euglena Medium,preferred_term,UNMAPPED_0064,Euglena Medium,,UNMAPPED,unique
+Eugon agar,ontology_label,MICRO:0001358,Eugon agar (BD-Difco),MICRO:0001358,MAPPED,unique
+Eugon agar (BD-Difco),preferred_term,MICRO:0001358,Eugon agar (BD-Difco),MICRO:0001358,MAPPED,unique
 Euphol,preferred_term,CHEBI:4940,Euphol,CHEBI:4940,MAPPED,unique
 Eurocidin,preferred_term,kgmicrobe.compound:eurocidin,Eurocidin,kgmicrobe.compound:eurocidin,MAPPED,unique
 europium chloride,synonym,cas:10025-76-0,Europium(III) chloride,cas:10025-76-0,MAPPED,unique
@@ -4145,11 +4385,14 @@ FA 18:1,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
 Factor A,synonym,UNMAPPED_0182,2-methyladeninyl cobamide,,UNMAPPED,unique
 Factor IIIm,synonym,UNMAPPED_0180,5-methoxybenzimidazolyl cobamide,,UNMAPPED,unique
 FAD,preferred_term,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
+farm soil,preferred_term,ENVO:00005749,farm soil,ENVO:00005749,MAPPED,unique
 farnesol,ontology_label,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
 Fastidious Anaerobe Agar,preferred_term,UNMAPPED_0120,Fastidious Anaerobe Agar,,UNMAPPED,unique
 Fastidious Anaerobe Basal Broth,preferred_term,UNMAPPED_0381,Fastidious Anaerobe Basal Broth,,UNMAPPED,unique
 Fastidious Anaerobe Broth With Meat Granules,preferred_term,kgmicrobe.ingredient:fastidious_anaerobe_broth_with_meat_granules,Fastidious Anaerobe Broth With Meat Granules,kgmicrobe.ingredient:fastidious_anaerobe_broth_with_meat_granules,MAPPED,unique
 Fatty acid,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fatty acid mixture,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fatty acid mixture (see below),synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
 Fatty acid mixture (see Medium No. 266),preferred_term,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
 fatty acids,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
 FBS,synonym,NCIT:C113696,Fetal bovine serum,NCIT:C113696,MAPPED,unique
@@ -4162,11 +4405,15 @@ Fe(0),synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
 Fe(3+)-citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 Fe(II)SO4,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
 Fe(III) citrate,preferred_term,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Fe(III)-citrate (19% Fe),synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 Fe(III)-EDTA,preferred_term,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Fe(III)-EDTA (0.66% [wt/vol] in water),synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
 Fe(III)-oxyhydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 Fe(III)PO4 x 4 H2O,preferred_term,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
 Fe(III)·EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
+Fe(III)・EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
 Fe(NH3)citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+Fe(NH4)2(SO4)2,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)2(SO4)2 . 6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)2(SO4)2 . 7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 Fe(NH4)2(SO4)2 x 6 H2O,preferred_term,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
@@ -4176,14 +4423,19 @@ Fe(NH4)2(SO4)2 x 6 H2O (2% v/v),synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI
 Fe(NH4)2(SO4)2 x 6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)2(SO4)2 x 7 H2O,preferred_term,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 Fe(NH4)2(SO4)2 x 7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
+Fe(NH4)2(SO4)2.6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)2(SO4)2x7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 Fe(NH4)2(SO4)2·6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)2(SO4)2·7H2O,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 Fe(NH4)2(SO4)2・6H2O,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Fe(NH4)citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
+Fe(SO4)3 x n H2O,synonym,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,unique
 Fe2(SO4)3 x n H2O,preferred_term,CHEBI:53438,Fe2(SO4)3 x n H2O,CHEBI:53438,MAPPED,resolved:owned
 Fe2(SO4)3 x n H2O,synonym,UNMAPPED_0385,FeSO43 x n H2O,,UNMAPPED,resolved:owned
+Fe2+,synonym,CHEBI:29033,Ferrous Ion,CHEBI:29033,MAPPED,unique
+Fe3+,synonym,CHEBI:29034,Ferric Iron,CHEBI:29034,MAPPED,unique
 Fe4(PO4)2,preferred_term,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+FeCl 2,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
 FeCl 2 x 4 H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
 FeCl2,preferred_term,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,unique
 FeCl2 . 4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
@@ -4206,13 +4458,23 @@ FeCl2⋅6H2O,synonym,kgmicrobe.compound:fecl2_x_6_h2o,FeCl2 x 6 H2O,CHEBI:30812,
 FeCl2⋅6H2O,synonym,kgmicrobe.compound:fecl2_x_7_h2o,FeCl2 x 7 H2O,CHEBI:30812,MAPPED,conflict:different_substances
 FeCl2・4H2O,synonym,CHEBI:86249,FeCl2 x 4 H2O,CHEBI:86249,MAPPED,unique
 FeCl3,preferred_term,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
+FeCl3 (25mM),synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
+FeCl3 . 6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 FeCl3 x 4 H2O,preferred_term,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,unique
 FeCl3 x 6 H2O,preferred_term,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x 6 H2O (0.1% w/v in 0.2 N HCl),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x 6 H2O (0.5%),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x 6 H2O (w/v=1%),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x 6 H2O NaEDTA,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x 6 H2O solution (2%),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3 x6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
+FeCl3*6 H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 FeCl3.6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 FeCl3·4H2O,synonym,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:30808,MAPPED,unique
 FeCl3·6H2O,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 Fen,synonym,CHEBI:82664,Iron powder,CHEBI:82664,MAPPED,unique
 FeNa-EDTA,synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+FeNa.EDTA,synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
 fenazona,synonym,CHEBI:31225,Antipyrine,CHEBI:31225,MAPPED,unique
 FePO4,preferred_term,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
 FePO4.4H2O,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
@@ -4221,10 +4483,12 @@ fermentation: glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 Fermented Rumen Extract,preferred_term,kgmicrobe.ingredient:fermented_rumen_extract,Fermented Rumen Extract,kgmicrobe.ingredient:fermented_rumen_extract,MAPPED,unique
 Feromax,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
 Feroritard,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Ferric ammmonium citrate,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
 Ferric ammonium citrate,preferred_term,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
 ferric chloride,synonym,CHEBI:30808,FeCl3,CHEBI:30808,MAPPED,unique
 Ferric chloride hexahydrate,synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 Ferric citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
+"Ferric citrate (0.1%, w/v)",synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 Ferric citrate monohydrate,preferred_term,CHEBI:144434,Ferric citrate monohydrate,CHEBI:144434,MAPPED,unique
 ferric diphosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
 Ferric EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
@@ -4232,6 +4496,7 @@ ferric hydroxide oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,uni
 Ferric Iron,preferred_term,CHEBI:29034,Ferric Iron,CHEBI:29034,MAPPED,unique
 Ferric iron citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 ferric malate solution,preferred_term,kgmicrobe.ingredient:ferric_malate_solution,ferric malate solution,kgmicrobe.ingredient:ferric_malate_solution,MAPPED,unique
+Ferric nitrilotriacetate,preferred_term,CHEBI:132238,Ferric nitrilotriacetate,CHEBI:132238,MAPPED,unique
 Ferric orthophosphate,synonym,CHEBI:131371,FePO4,CHEBI:131371,MAPPED,unique
 ferric orthophosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
 ferric oxide,ontology_label,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
@@ -4249,6 +4514,8 @@ Ferrihydrite,preferred_term,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 ferriprotoporphyrin IX chloride,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 FerriSeltz,synonym,CHEBI:31604,Ferric ammonium citrate,CHEBI:31604,MAPPED,unique
 Ferro-Gradumet,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
+Ferrous ammonium sulfate,preferred_term,CHEBI:76243,Ferrous ammonium sulfate,CHEBI:76243,MAPPED,unique
+ferrous ammonium sulfate (anhydrous),ontology_label,CHEBI:76243,Ferrous ammonium sulfate,CHEBI:76243,MAPPED,unique
 ferrous ammonium sulfate heptahydrate,synonym,CHEBI:131378,Fe(NH4)2(SO4)2 x 7 H2O,CHEBI:131378,MAPPED,unique
 ferrous ammonium sulfate hexahydrate,synonym,CHEBI:76181,Fe(NH4)2(SO4)2 x 6 H2O,CHEBI:76181,MAPPED,unique
 Ferrous chloride,synonym,CHEBI:30812,FeCl2,CHEBI:30812,MAPPED,unique
@@ -4271,6 +4538,8 @@ ferrum,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
 Ferulate,preferred_term,CHEBI:17620,Ferulate,CHEBI:17620,MAPPED,unique
 Ferulic Acid,preferred_term,CHEBI:193350,Ferulic Acid,CHEBI:193350,MAPPED,unique
 FeSO .7H O,synonym,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
+FeSO .7H O,synonym,CHEBI:75832,FeSO4 x 5 H2O,CHEBI:75832,MAPPED,unique
+FeSO .7H O,synonym,CHEBI:75832,FeSO4 x 6 H2O,CHEBI:75832,MAPPED,unique
 FeSO4,preferred_term,CHEBI:75832,FeSO4,CHEBI:75832,MAPPED,unique
 FeSO4 . 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
 FeSO4 7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
@@ -4310,8 +4579,10 @@ FeSO4・7H2O,synonym,CHEBI:75836,FeSO4 x 7 H2O,CHEBI:75836,MAPPED,unique
 FeSO4・H2O,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
 Fespan,synonym,CHEBI:75834,FeSO4 x H2O,CHEBI:75834,MAPPED,unique
 Fetal bovine serum,preferred_term,NCIT:C113696,Fetal bovine serum,NCIT:C113696,MAPPED,unique
+Fetal Bovine Serum (ATCC 30-2020),synonym,NCIT:C113696,Fetal bovine serum,NCIT:C113696,MAPPED,unique
 Fettsaeure,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
 Fettsaeuren,synonym,CHEBI:35366,Fatty acid mixture (see Medium No. 266),CHEBI:35366,MAPPED,unique
+Fe·EDTA,synonym,CHEBI:30729,Fe(III)-EDTA,CHEBI:30729,MAPPED,unique
 Fibersol-2-AG,preferred_term,UNMAPPED_0211,Fibersol-2-AG,,UNMAPPED,unique
 Fiboflavin,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 Fibrin,preferred_term,CHEBI:5054,Fibrin,CHEBI:5054,MAPPED,unique
@@ -4344,12 +4615,14 @@ Flavomycin,preferred_term,CHEBI:28908,Flavomycin,CHEBI:28908,MAPPED,unique
 Flavone,preferred_term,CHEBI:42491,Flavone,CHEBI:42491,MAPPED,unique
 Flaxain,synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 Fleroxacin,preferred_term,CHEBI:31810,Fleroxacin,CHEBI:31810,MAPPED,unique
+flucloxacillin,preferred_term,CHEBI:5098,flucloxacillin,CHEBI:5098,MAPPED,unique
 Fluoranthene,preferred_term,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
 fluoranthene,synonym,CHEBI:33083,Fluoranthene,CHEBI:33083,MAPPED,unique
 Fluorene,preferred_term,CHEBI:28266,Fluorene,CHEBI:28266,MAPPED,unique
 Fluorescein,preferred_term,NCIT:C61766,Fluorescein,NCIT:C61766,MAPPED,unique
 Folate,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 Folic acid,preferred_term,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+Folic acid (5 μg/μL),synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 Folicet,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 Folinic acid,preferred_term,CHEBI:15640,Folinic acid,CHEBI:15640,MAPPED,unique
 Folinic acid (citrovorum),synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
@@ -4378,6 +4651,7 @@ Framycetin,preferred_term,CHEBI:7508,Framycetin,CHEBI:7508,MAPPED,unique
 Fraxetin,preferred_term,CHEBI:5169,Fraxetin,CHEBI:5169,MAPPED,unique
 FREE CYSTEINE,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
 Fresh Baker's Yeast Extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
+Fresh Baker’s Yeast Extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 Fresh egg mixture,preferred_term,UNMAPPED_0387,Fresh egg mixture,,UNMAPPED,unique
 Fru,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
 Fruchtzucker,synonym,CHEBI:28757,Fructose,CHEBI:28757,MAPPED,unique
@@ -4446,7 +4720,9 @@ Gallate + Formate,preferred_term,kgmicrobe.ingredient:gallate_formate,Gallate + 
 Gallic Acid,preferred_term,CHEBI:30778,Gallic Acid,CHEBI:30778,MAPPED,unique
 Gallium(III)chloride,preferred_term,cas:13450-90-3,Gallium(III)chloride,cas:13450-90-3,MAPPED,unique
 GAM agar,preferred_term,UNMAPPED_0121,GAM agar,,UNMAPPED,unique
+GAM agar (Nissui),synonym,UNMAPPED_0121,GAM agar,,UNMAPPED,unique
 GAM broth,preferred_term,UNMAPPED_0388,GAM broth,,UNMAPPED,unique
+GAM broth (Nissui),synonym,UNMAPPED_0388,GAM broth,,UNMAPPED,unique
 GAM Broth mod. powder,preferred_term,UNMAPPED_0389,GAM Broth mod. powder,,UNMAPPED,unique
 GAM Broth powder,preferred_term,UNMAPPED_0390,GAM Broth powder,,UNMAPPED,unique
 Gambogic Acid,preferred_term,CHEBI:67521,Gambogic Acid,CHEBI:67521,MAPPED,unique
@@ -4472,10 +4748,15 @@ Gelatin Hydrolyzed,preferred_term,UNMAPPED_0731,Gelatin Hydrolyzed,,REJECTED,uni
 Gelatin peptone,synonym,MICRO:0000178,Bacto peptone,MICRO:0000178,MAPPED,unique
 Gelatine,preferred_term,CHEBI:5291,Gelatine,CHEBI:5291,MAPPED,unique
 Gellan Gum,synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+Gellan gum (if needed),synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+Gellan Gum (Phytagel),synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
 Gelrite,preferred_term,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+gelrite (Gellan Gum),synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
+Gelrite (if needed),synonym,CHEBI:85248,Gelrite,CHEBI:85248,MAPPED,unique
 geneticin,ontology_label,CHEBI:42768,Geneticin G418,CHEBI:42768,MAPPED,unique
 Geneticin G418,preferred_term,CHEBI:42768,Geneticin G418,CHEBI:42768,MAPPED,unique
 Gentamicin,preferred_term,CHEBI:17833,Gentamicin,CHEBI:17833,MAPPED,unique
+gentamicin (if needed),synonym,CHEBI:17833,Gentamicin,CHEBI:17833,MAPPED,unique
 Gentamicin C2b,preferred_term,CHEBI:81283,Gentamicin C2b,CHEBI:81283,MAPPED,unique
 gentamicin sulfate,ontology_label,CHEBI:5312,Gentamicin sulfate salt,CHEBI:5312,MAPPED,unique
 Gentamicin sulfate salt,preferred_term,CHEBI:5312,Gentamicin sulfate salt,CHEBI:5312,MAPPED,unique
@@ -4491,6 +4772,8 @@ Ginger,preferred_term,NCIT:C66725,Ginger,NCIT:C66725,MAPPED,unique
 Ginkgolide A,preferred_term,CHEBI:5355,Ginkgolide A,CHEBI:5355,MAPPED,unique
 Ginkgotoxin,preferred_term,CHEBI:166575,Ginkgotoxin,CHEBI:166575,MAPPED,unique
 Gjerstad humics,preferred_term,UNMAPPED_0145,Gjerstad humics,,UNMAPPED,unique
+Glauber's salt,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+Glaubersalz,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 Glc,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 Glc(b1-4)Glc(b1-4)Glc(b1-4)Glc(b1-4)Glc(b1-4)b-Glc,synonym,CHEBI:49533,Cellohexaose,CHEBI:49533,MAPPED,unique
 Glc-OH,synonym,CHEBI:17634,Dextrose,CHEBI:17634,REJECTED,unique
@@ -4498,6 +4781,7 @@ Glc-ol,synonym,CHEBI:17924,D-Sorbitol,CHEBI:17924,MAPPED,unique
 Glca1-4Glca,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 Glcalpha1-4Glca,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
 Glcalpha1-4Glcalpha,synonym,CHEBI:17306,Maltose,CHEBI:17306,MAPPED,unique
+GlcNAc,synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
 Glebomycin,preferred_term,NCIT:C90636,Glebomycin,NCIT:C90636,MAPPED,unique
 Glicerofosfato de colina,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 Glu-Glu,ontology_label,CHEBI:5390,Glutamyl-glutamic Acid,CHEBI:5390,MAPPED,unique
@@ -4527,6 +4811,8 @@ Glucuronamide,preferred_term,cas:3789-97-7,Glucuronamide,CHEBI:32323,MAPPED,uniq
 Glucuronate,preferred_term,CHEBI:24297,Glucuronate,CHEBI:24297,MAPPED,unique
 Glukose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 Glutamate,preferred_term,CHEBI:29987,Glutamate,CHEBI:29987,MAPPED,unique
+Glutamate monosodium salt,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+Glutamate Sodium,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 glutamate(2-),ontology_label,CHEBI:29987,Glutamate,CHEBI:29987,MAPPED,unique
 Glutamic acid,preferred_term,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,resolved:owned
 GLUTAMIC ACID,synonym,CHEBI:16015,L-Glutamic acid,CHEBI:16015,MAPPED,resolved:owned
@@ -4534,9 +4820,11 @@ GLUTAMIC ACID,synonym,cas:6382-01-0,L-Glutamic acid monopotassium salt monohydra
 Glutamic Acid,ontology_label,kgmicrobe.compound:hydro_methylpteroylglutamylglutamic_acid,Hydro Methylpteroylglutamylglutamic Acid,NCIT:C1115,MAPPED,resolved:owned
 Glutamic acid 5-amide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
 Glutamic acid amide,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
+"Glutamic acid, monosodium salt",synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 GLUTAMINE,synonym,CHEBI:18050,L-Glutamine,CHEBI:18050,MAPPED,unique
 Glutaminic acid,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
 Glutaminsaeure,synonym,CHEBI:18237,Glutamic acid,CHEBI:18237,MAPPED,unique
+Glutammato monosodico,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 Glutamyl-glutamic Acid,preferred_term,CHEBI:5390,Glutamyl-glutamic Acid,CHEBI:5390,MAPPED,unique
 Glutaraldehyde,preferred_term,CHEBI:64276,Glutaraldehyde,CHEBI:64276,MAPPED,unique
 Glutarate,preferred_term,CHEBI:24329,Glutarate,CHEBI:24329,MAPPED,unique
@@ -4581,6 +4869,7 @@ Glycerol phosphate disodium salt hydrate,preferred_term,cas:55073-41-1,Glycerol 
 Glycerol-3-phosphatidylcholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 glycerol-3-phosphocholine,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 Glycerol-asparagine agar,preferred_term,UNMAPPED_0122,Glycerol-asparagine agar,,UNMAPPED,unique
+glycerolum,synonym,CHEBI:15978,Glycerol 3-phosphate,CHEBI:15978,MAPPED,unique
 Glycerophosphate de choline,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 Glycine,preferred_term,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
 Glycine 1%,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
@@ -4601,6 +4890,7 @@ glycolaldehyde,preferred_term,CHEBI:17071,glycolaldehyde,CHEBI:17071,MAPPED,uniq
 Glycolate,preferred_term,CHEBI:29805,Glycolate,CHEBI:29805,MAPPED,unique
 Glycolic Acid,preferred_term,CHEBI:17497,Glycolic Acid,CHEBI:17497,MAPPED,unique
 Glycolic acid cellulose ether,synonym,CHEBI:234035,Carboxymethyl cellulose,CHEBI:234035,MAPPED,unique
+glycyl alcohol,synonym,CHEBI:15978,Glycerol 3-phosphate,CHEBI:15978,MAPPED,unique
 Glycyl L-aspartic Acid,preferred_term,CHEBI:73804,Glycyl L-aspartic Acid,CHEBI:73804,MAPPED,unique
 Glycyl-Aspartate,ontology_label,cas:79731-35-4,Gly-DL-Asp,CHEBI:193741,MAPPED,unique
 Glycyl-glycine,preferred_term,CHEBI:17201,Glycyl-glycine,CHEBI:17201,MAPPED,unique
@@ -4624,6 +4914,7 @@ Glyoxyldiureide,synonym,CHEBI:15676,Allantoin,CHEBI:15676,MAPPED,unique
 Glyzerin,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
 Glyzerin,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
 Glyzin,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
+goethite,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 gold (III) chloride hydrate,preferred_term,cas:27988-77-8,gold (III) chloride hydrate,CHEBI:30076,MAPPED,unique
 gold trichloride,ontology_label,cas:27988-77-8,gold (III) chloride hydrate,CHEBI:30076,MAPPED,unique
 Gossypetin,preferred_term,CHEBI:16400,Gossypetin,CHEBI:16400,MAPPED,unique
@@ -4641,7 +4932,9 @@ Green House Soil,preferred_term,kgmicrobe.ingredient:green_house_soil,Green Hous
 Grisamine,preferred_term,kgmicrobe.compound:grisamine,Grisamine,kgmicrobe.compound:grisamine,MAPPED,unique
 Griseolutein A,preferred_term,mesh:C018306,Griseolutein A,mesh:C018306,MAPPED,unique
 Griseolutein B,preferred_term,mesh:C018307,Griseolutein B,mesh:C018307,MAPPED,unique
+Gro,synonym,CHEBI:15978,Glycerol 3-phosphate,CHEBI:15978,MAPPED,unique
 Ground beef,preferred_term,FOODON:00001282,Ground beef,FOODON:00001282,MAPPED,unique
+growth: goethite,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 GSH,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
 Gua,synonym,CHEBI:16235,Guanine,CHEBI:16235,MAPPED,unique
 Guaiacol,preferred_term,CHEBI:28591,Guaiacol,CHEBI:28591,MAPPED,unique
@@ -4660,6 +4953,7 @@ Gum arabic from acacia tree,preferred_term,cas:9000-01-5,Gum arabic from acacia 
 Guo,synonym,CHEBI:16750,Guanosine,CHEBI:16750,MAPPED,unique
 GYP-sodium acetate-mineral salts broth,preferred_term,UNMAPPED_0397,GYP-sodium acetate-mineral salts broth,,UNMAPPED,unique
 GYPS,preferred_term,kgmicrobe.ingredient:gyps,GYPS,kgmicrobe.ingredient:gyps,MAPPED,unique
+H BO,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 H(2),synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 H(2)O,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 H-COOH,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
@@ -4672,6 +4966,8 @@ H2+tetramethylammonium,preferred_term,kgmicrobe.ingredient:h2_tetramethylammoniu
 H2+trimethylamine,preferred_term,kgmicrobe.ingredient:h2_trimethylamine,H2+trimethylamine,kgmicrobe.ingredient:h2_trimethylamine,MAPPED,unique
 H2_CO2,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 H2_methanol,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
+H2AsO3(-),synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+H2cit,synonym,CHEBI:31404,Citric acid x H2O,CHEBI:31404,MAPPED,unique
 H2mal,synonym,CHEBI:6650,DL-Malic acid,CHEBI:6650,MAPPED,unique
 H2N(CH2)4NH2,synonym,CHEBI:17148,Putrescine,CHEBI:17148,MAPPED,unique
 H2N-CH2-COOH,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
@@ -4679,6 +4975,7 @@ H2NC(O)NH2,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
 H2O,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 H2SeO3,preferred_term,CHEBI:26642,H2SeO3,CHEBI:26642,MAPPED,unique
 H2SO4,preferred_term,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+H2SO4 (0.1 N),synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 H2WO4,preferred_term,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
 H3BO,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 H3BO2,preferred_term,CHEBI:38267,H3BO2,CHEBI:38267,MAPPED,unique
@@ -4686,6 +4983,7 @@ H3BO3,preferred_term,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 H3BO3(Baker 0084),synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
 H3cit,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
 H3nta,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
+H3PO4,preferred_term,CHEBI:26078,H3PO4,CHEBI:26078,MAPPED,unique
 H3tea,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
 Haemin,preferred_term,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 Halomicin,preferred_term,kgmicrobe.compound:halomicin,Halomicin,kgmicrobe.compound:halomicin,MAPPED,unique
@@ -4704,26 +5002,47 @@ Hasp,synonym,CHEBI:22653,Asparagine,CHEBI:22653,MAPPED,unique
 HBO3,preferred_term,UNMAPPED_0398,HBO3,,UNMAPPED,unique
 HCH,synonym,CHEBI:24536,Hexachlorocyclo-hexane,CHEBI:24536,MAPPED,unique
 HCl,preferred_term,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (25% or 7.7 M),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (25% v/ v),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (25%),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+"HCl (25%, 7.7 M)",synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+"HCl (25%, v/v)",synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (25%; 7.7 M),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (32%),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+HCl (35%),synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
 HCl.,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
 HCO2H,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
 HCOOH,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
 Hcys,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
+heart infusion agar,ontology_label,MICRO:0000567,Heart Infusion Agar (BD 211065),MICRO:0000567,MAPPED,unique
+Heart Infusion Agar (BD 211065),preferred_term,MICRO:0000567,Heart Infusion Agar (BD 211065),MICRO:0000567,MAPPED,unique
+Heart Infusion Agar (Difco),synonym,MICRO:0000567,Heart Infusion Agar (BD 211065),MICRO:0000567,MAPPED,unique
+Heart infusion agar (Eiken),synonym,MICRO:0000567,Heart Infusion Agar (BD 211065),MICRO:0000567,MAPPED,unique
 Heart Infusion Broth,preferred_term,UNMAPPED_0399,Heart Infusion Broth,,UNMAPPED,unique
+Heart Infusion Broth (BD 238400),synonym,UNMAPPED_0399,Heart Infusion Broth,,UNMAPPED,unique
+Heart infusion broth (BD-Difco),synonym,UNMAPPED_0399,Heart Infusion Broth,,UNMAPPED,unique
+Heart infusion broth (Eiken),synonym,UNMAPPED_0399,Heart Infusion Broth,,UNMAPPED,unique
 heavy water,synonym,CHEBI:41981,deuterated water,CHEBI:41981,MAPPED,unique
 Hecogenin,preferred_term,CHEBI:5633,Hecogenin,CHEBI:5633,MAPPED,unique
 Helenine,preferred_term,CHEBI:2540,Helenine,CHEBI:2540,MAPPED,unique
 Hemicalcium D-(+)- pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 Hemicalcium D-+-pantothenate,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 Hemin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+Hemin (0.1% in 0.05 N NaOH),synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+hemin (ICN),synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 Hemin chloride,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 hemin IX,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
+hemin solution,ontology_label,MICRO:0001598,Hemin solution (see below),MICRO:0001598,MAPPED,unique
+Hemin solution (see below),preferred_term,MICRO:0001598,Hemin solution (see below),MICRO:0001598,MAPPED,unique
 Hemine,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 Hemodal,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
+Hemoglobin,preferred_term,CHEBI:5656,Hemoglobin,CHEBI:5656,MAPPED,unique
 Henicosane,preferred_term,CHEBI:32931,Henicosane,CHEBI:32931,MAPPED,unique
 Hepacholine,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
 heparin sodium,ontology_label,kgmicrobe.ingredient:heparin_sodium_salt_from_porcine_intestinal_mucosa,Heparin sodium salt from porcine intestinal mucosa,CHEBI:230519,MAPPED,unique
 Heparin sodium salt from porcine intestinal mucosa,preferred_term,kgmicrobe.ingredient:heparin_sodium_salt_from_porcine_intestinal_mucosa,Heparin sodium salt from porcine intestinal mucosa,CHEBI:230519,MAPPED,unique
 HEPES,preferred_term,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
+HEPES (10mM),synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
 HEPES buffer,synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
 HEPES buffer(CAS: 7365-45-9),synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
 HEPES buffer(Sigma H-3375),synonym,CHEBI:42334,HEPES,CHEBI:42334,MAPPED,unique
@@ -4758,8 +5077,10 @@ Hgly,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
 hierro,synonym,CHEBI:18248,Iron,CHEBI:18248,MAPPED,unique
 Hipolypepton,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Hipolypepton (Nihon seiyaku),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Hipolypepton*,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Hippurate,synonym,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
 Hippuric acid,preferred_term,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
+Hippuric acid (N-benzoylglycine),synonym,CHEBI:18089,Hippuric acid,CHEBI:18089,MAPPED,unique
 Histamine,preferred_term,CHEBI:18295,Histamine,CHEBI:18295,MAPPED,unique
 Histidin,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
 histidina,synonym,CHEBI:27570,DL-Histidine,CHEBI:27570,MAPPED,unique
@@ -4772,7 +5093,8 @@ Hmet,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
 HO-CH2-CH2-OH,synonym,CHEBI:30742,Ethylene glycol,CHEBI:30742,MAPPED,unique
 HOAc,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
 HOH,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
-Homo-PIPES,preferred_term,UNMAPPED_0401,Homo-PIPES,,UNMAPPED,unique
+Homo-PIPES,synonym,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
+Homo-PIPES (SIGMA),synonym,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
 "homopiperazine-1,4-bis(2-ethanesulfonic acid), HOMO-PIPES",synonym,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
 HOMOPIPES,preferred_term,cas:202185-84-0,HOMOPIPES,cas:202185-84-0,MAPPED,unique
 homovanillic acid,preferred_term,CHEBI:545959,homovanillic acid,CHEBI:545959,MAPPED,unique
@@ -4780,7 +5102,13 @@ homovanillyl alcohol,preferred_term,CHEBI:173769,homovanillyl alcohol,CHEBI:1737
 HOOC-CH2-CH2-COOH,synonym,CHEBI:15741,Succinic acid,CHEBI:15741,MAPPED,unique
 Hopanoid,preferred_term,CHEBI:51963,Hopanoid,CHEBI:51963,MAPPED,unique
 Horikoshi-I medium,preferred_term,UNMAPPED_0402,Horikoshi-I medium,,UNMAPPED,unique
+Horse blood,preferred_term,MICRO:0001234,Horse blood,MICRO:0001234,MAPPED,unique
 Horse serum,preferred_term,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Horse Serum (Gibco)*,synonym,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Horse serum (Invitrogen),synonym,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Horse Serum (not inactivated),synonym,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Horse serum (Oxoid),synonym,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
+Horse Serum (RM1239),synonym,MICRO:0001235,Horse serum,MICRO:0001235,MAPPED,unique
 Hortesin,preferred_term,kgmicrobe.compound:hortesin,Hortesin,kgmicrobe.compound:hortesin,MAPPED,unique
 Hpro,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
 HS-CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
@@ -4789,6 +5117,7 @@ HSDB 7729,synonym,CHEBI:86154,Bromocresol purple,CHEBI:86154,MAPPED,unique
 Htrp,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
 Hunter's Trace Stock Solution,preferred_term,kgmicrobe.ingredient:hunters_trace_stock_solution,Hunter's Trace Stock Solution,kgmicrobe.ingredient:hunters_trace_stock_solution,MAPPED,unique
 Huperzine A,preferred_term,CHEBI:78330,Huperzine A,CHEBI:78330,MAPPED,unique
+Hy--Case Amino (Sigma),synonym,UNMAPPED_0404,Hy-Case Amino,,UNMAPPED,unique
 Hy-Case Amino,preferred_term,UNMAPPED_0404,Hy-Case Amino,,UNMAPPED,unique
 Hyaluronic acid sodium,ontology_label,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
 Hyaluronic acid sodium salt from Streptococcus equi,preferred_term,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
@@ -4814,12 +5143,17 @@ Hydrogen sulfide,preferred_term,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,
 hydrogen sulfite sodium,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 hydrogen tetraoxosulfate(2-),synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 hydrogen tetraoxosulfate(VI),synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
+hydrogencarbonate,ontology_label,CHEBI:17544,Bicarbonate,CHEBI:17544,MAPPED,unique
 Hydrogenchlorid,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
+hydrolysis: 4-nitrophenyl beta-D-galactopyranoside,synonym,CHEBI:355715,4-nitrophenyl beta-D-galactopyranoside,CHEBI:355715,MAPPED,unique
 hydrolysis: cationic chitosan,synonym,CHEBI:16261,Chitosan,CHEBI:16261,MAPPED,unique
+hydrolysis: crab shell chitin,synonym,CHEBI:17029,Chitin,CHEBI:17029,MAPPED,unique
+hydrolysis: esculin,synonym,CHEBI:4853,Esculin Monohydrate,CHEBI:4853,MAPPED,unique
 hydrolysis: urea,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
 Hydroquinone,preferred_term,CHEBI:17594,Hydroquinone,CHEBI:17594,MAPPED,unique
 Hydroquinonecarboxylic acid,synonym,CHEBI:17189,Gentisic acid,CHEBI:17189,MAPPED,unique
 hydrous ferric oxide,preferred_term,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
+hydroxocobalamin hydrochloride,preferred_term,NCIT:C217966,hydroxocobalamin hydrochloride,NCIT:C217966,MAPPED,unique
 hydroxy(4-hydroxyphenyl)acetic acid,synonym,cas:184901-84-6,4-Hydroxymandelic acid monohydrate,CHEBI:16388,MAPPED,unique
 hydroxy(phenyl)acetic acid,synonym,CHEBI:35825,Mandelic acid,CHEBI:35825,MAPPED,unique
 Hydroxy-L-Proline,preferred_term,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
@@ -4895,6 +5229,7 @@ INS No. 264,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
 Inulin,preferred_term,CHEBI:15443,Inulin,CHEBI:15443,MAPPED,unique
 Iodide,preferred_term,CHEBI:16382,Iodide,CHEBI:16382,MAPPED,unique
 Iodonitrotetrazolium chloride,preferred_term,CHEBI:75421,Iodonitrotetrazolium chloride,CHEBI:75421,MAPPED,unique
+IPTG,preferred_term,CHEBI:61448,IPTG,CHEBI:61448,MAPPED,unique
 Irgasan,preferred_term,CHEBI:164200,Irgasan,CHEBI:164200,MAPPED,unique
 Irigenin,preferred_term,CHEBI:81409,Irigenin,CHEBI:81409,MAPPED,unique
 Iron,preferred_term,CHEBI:18248,Iron,CHEBI:18248,MAPPED,resolved:owned
@@ -4973,6 +5308,7 @@ iron(III) chloride,synonym,kgmicrobe.compound:fecl3_x_4_h2o,FeCl3 x 4 H2O,CHEBI:
 Iron(III) citrate,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 iron(III) citrate monohydrate,ontology_label,CHEBI:144434,Ferric citrate monohydrate,CHEBI:144434,MAPPED,unique
 Iron(III) diphosphate,synonym,CHEBI:132767,Fe4(PO4)2,CHEBI:132767,MAPPED,unique
+iron(III) nitrilotriacetate,ontology_label,CHEBI:132238,Ferric nitrilotriacetate,CHEBI:132238,MAPPED,unique
 iron(III) orthophosphate tetrahydrate,synonym,CHEBI:131372,Fe(III)PO4 x 4 H2O,CHEBI:131372,MAPPED,unique
 iron(III) oxide,synonym,CHEBI:50819,hydrous ferric oxide,CHEBI:50819,MAPPED,unique
 iron(III) oxyhydroxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
@@ -5005,6 +5341,7 @@ Isocitrate,preferred_term,CHEBI:16087,Isocitrate,CHEBI:16087,MAPPED,unique
 isocitrate(3-),ontology_label,CHEBI:16087,Isocitrate,CHEBI:16087,MAPPED,unique
 "Isocitric acid, DL-",ontology_label,kgmicrobe.compound:dl-isocitric_acid_trisodium_salt_hydrate,DL-Isocitric acid trisodium salt hydrate,CHEBI:172950,MAPPED,unique
 Isocorydine,ontology_label,CHEBI:6000,S-Isocorydine (),CHEBI:6000,MAPPED,unique
+Isodecenoic acid vanillylamide,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 Isoleucine,synonym,CHEBI:17191,L-Isoleucine,CHEBI:17191,MAPPED,unique
 Isoliquiritigenin,preferred_term,CHEBI:310312,Isoliquiritigenin,CHEBI:310312,MAPPED,unique
 Isomaltose,preferred_term,CHEBI:28189,Isomaltose,CHEBI:28189,MAPPED,unique
@@ -5019,6 +5356,7 @@ Isopropanol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
 Isopropionate,preferred_term,kgmicrobe.compound:isopropionate,Isopropionate,kgmicrobe.compound:isopropionate,MAPPED,unique
 isopropyl 3-keto-N-acetyl-a-D-glucosamine,preferred_term,UNMAPPED_0234,isopropyl 3-keto-N-acetyl-a-D-glucosamine,,UNMAPPED,unique
 Isopropyl alcohol,preferred_term,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
+isopropyl beta-D-thiogalactopyranoside,ontology_label,CHEBI:61448,IPTG,CHEBI:61448,MAPPED,unique
 isopropylacetic acid,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
 Isopropylalkohol,synonym,CHEBI:17824,Isopropyl alcohol,CHEBI:17824,MAPPED,unique
 isopropylformic acid,synonym,CHEBI:16135,Isobutyric acid,CHEBI:16135,MAPPED,unique
@@ -5034,6 +5372,8 @@ Isovaleriansaeure,synonym,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
 Isovaleric acid,preferred_term,CHEBI:28484,Isovaleric acid,CHEBI:28484,MAPPED,unique
 Isovanillin,preferred_term,CHEBI:193161,Isovanillin,CHEBI:193161,MAPPED,unique
 Isovitalex,preferred_term,kgmicrobe.ingredient:isovitalex,Isovitalex,kgmicrobe.ingredient:isovitalex,MAPPED,unique
+IsoVitaleX (BD 211876),synonym,kgmicrobe.ingredient:isovitalex,Isovitalex,kgmicrobe.ingredient:isovitalex,MAPPED,unique
+isovitalex (BD Biosciences),synonym,kgmicrobe.ingredient:isovitalex,Isovitalex,kgmicrobe.ingredient:isovitalex,MAPPED,unique
 Isovitexin,preferred_term,CHEBI:18330,Isovitexin,CHEBI:18330,MAPPED,unique
 ISP 7 Medium,preferred_term,UNMAPPED_0408,ISP 7 Medium,,UNMAPPED,unique
 Itaconate,preferred_term,CHEBI:17240,Itaconate,CHEBI:17240,MAPPED,unique
@@ -5063,6 +5403,7 @@ K2HPO4・3H2O,synonym,kgmicrobe.compound:k2hpo4_x_3_h2o,K2HPO4 x 3 H2O,CHEBI:131
 K2S4O6,preferred_term,CHEBI:86466,K2S4O6,CHEBI:86466,MAPPED,unique
 K2SO4,preferred_term,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
 K2SO4 x 7 H2O,preferred_term,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
+K2SO4·7H2O,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
 K2SO4·7H2O,synonym,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
 K2SO4・7H2O,synonym,CHEBI:32036,K2SO4 x 7 H2O,CHEBI:32036,MAPPED,unique
 KAl(SO4)2,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
@@ -5083,6 +5424,7 @@ Kaliumsulfat,synonym,CHEBI:32036,K2SO4,CHEBI:32036,MAPPED,unique
 Kalziumkarbonat,synonym,CHEBI:3311,CaCO3,CHEBI:3311,MAPPED,unique
 Kalziumsulfat,synonym,CHEBI:31346,CaSO4,CHEBI:31346,MAPPED,unique
 Kanamycin,preferred_term,CHEBI:6104,Kanamycin,CHEBI:6104,MAPPED,unique
+kanamycin (if needed),synonym,CHEBI:6104,Kanamycin,CHEBI:6104,MAPPED,unique
 Kanamycin A sulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
 Kanamycin acid sulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
 Kanamycin monosulfate,synonym,CHEBI:6109,Kanamycin sulfate,CHEBI:6109,MAPPED,unique
@@ -5112,11 +5454,14 @@ KH PO,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 KH2HPO4,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
 KH2PO3,preferred_term,cas:13977-65-6,KH2PO3,CHEBI:44976,MAPPED,unique
 KH2PO4,preferred_term,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+KH2PO4 (0.4 g/l),synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+KH2PO4 (7% w/v),synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 KH2PO4(Sigma P 0662),synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 KHAYASIN,ontology_label,UNMAPPED_0191,Khayasin C,CHEBI:185858,UNMAPPED,unique
 Khayasin C,preferred_term,UNMAPPED_0191,Khayasin C,CHEBI:185858,UNMAPPED,unique
 KHCO3,preferred_term,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
 KI,preferred_term,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
+KI (0.01% w/v),synonym,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
 Kieselsaeureanhydrid,synonym,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
 kijanimicin,preferred_term,CHEBI:220048,kijanimicin,CHEBI:220048,MAPPED,unique
 KJ,synonym,CHEBI:8346,KI,CHEBI:8346,MAPPED,unique
@@ -5139,6 +5484,7 @@ Kreatin,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
 Kreatinin,synonym,CHEBI:16737,Creatinine,CHEBI:16737,MAPPED,unique
 KRX-0502,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 KSCN,preferred_term,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
+L(+) Sodium glutamate,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 L(+)-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
 L(+)-Tartaric acid,preferred_term,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 L-(+)-alpha-Aminoisovaleric acid,synonym,CHEBI:16414,L-Valine,CHEBI:16414,MAPPED,unique
@@ -5158,10 +5504,12 @@ L-(-)-sorbose,preferred_term,CHEBI:17266,L-(-)-sorbose,CHEBI:17266,MAPPED,unique
 L-(-)-Threonine,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
 L-(-)-tryptophan,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,unique
 L--Cysteine HCl H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
+L--cysteine・HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 L--Cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 L--cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 L--Cysteine・HCL・H2O,synonym,CHEBI:91248,L-Cysteine hydrochloride monohydrate,CHEBI:91248,REJECTED,unique
 "L-1,2-dithiolane 3-valeric acid",synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
+"L-1,4-dithiothreitol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 L-15 medium,preferred_term,UNMAPPED_0414,L-15 medium,,UNMAPPED,unique
 L-15 powder,preferred_term,UNMAPPED_0415,L-15 powder,,UNMAPPED,unique
 "L-2,6-Diaminocaproic acid",synonym,CHEBI:18019,L-Lysine,CHEBI:18019,MAPPED,unique
@@ -5237,6 +5585,8 @@ L-cysteic acid,ontology_label,cas:23537-25-9,L-Cysteic acid monohydrate,CHEBI:17
 L-Cysteic acid monohydrate,preferred_term,cas:23537-25-9,L-Cysteic acid monohydrate,CHEBI:17285,MAPPED,unique
 L-Cystein,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
 L-Cysteine,preferred_term,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-cysteine (Sigma),synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
+L-Cysteine . HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 L-Cysteine HCl,preferred_term,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 L-Cysteine HCl monohydrate,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 L-Cysteine HCl x H2O,preferred_term,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
@@ -5257,6 +5607,7 @@ L-Cysteine monohydrochloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPP
 L-Cysteine x HCl x H2O solution,preferred_term,kgmicrobe.ingredient:l-cysteine_x_hcl_x_h2o_solution,L-Cysteine x HCl x H2O solution,CHEBI:91247,MAPPED,unique
 L-cysteine zwitterion,preferred_term,CHEBI:35235,L-cysteine zwitterion,CHEBI:35235,MAPPED,resolved:owned
 L-cysteine zwitterion,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,resolved:owned
+L-cysteine · HCl,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,unique
 L-Cysteine-HCl x H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 L-Cysteine-HCl·H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
 L-Cysteine・HCl・H2O,synonym,CHEBI:91248,L-Cysteine HCl x H2O,CHEBI:91248,MAPPED,unique
@@ -5266,7 +5617,9 @@ L-Cysteiniumchloride,synonym,CHEBI:91247,L-Cysteine HCl,CHEBI:91247,MAPPED,uniqu
 L-Cystine,preferred_term,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
 L-Deoxyalliin,preferred_term,CHEBI:74077,L-Deoxyalliin,CHEBI:74077,MAPPED,unique
 L-Dicysteine,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
+L-dithiothreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 L-dopa,ontology_label,CHEBI:15765,Levodopa,CHEBI:15765,MAPPED,unique
+L-DTT,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 L-fructose,preferred_term,CHEBI:28120,L-fructose,CHEBI:28120,MAPPED,unique
 L-Fuc,synonym,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
 L-Fucose,preferred_term,CHEBI:18287,L-Fucose,CHEBI:18287,MAPPED,unique
@@ -5355,6 +5708,7 @@ L-Tartaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
 L-tartrate,synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
 L-threarate,synonym,CHEBI:63017,Na-tartrate,CHEBI:63017,REJECTED,unique
 L-threaric acid,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
+"L-threo-1,4-dimercapto-2,3-butanediol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 L-threo-4-hydroxyproline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
 "L-threo-hex-2-enono-1,4-lactone",synonym,CHEBI:29073,L-Ascorbic acid,CHEBI:29073,MAPPED,unique
 L-Threonin,synonym,CHEBI:16857,L-Threonine,CHEBI:16857,MAPPED,unique
@@ -5375,7 +5729,9 @@ L-Zystein,synonym,CHEBI:17561,L-Cysteine,CHEBI:17561,MAPPED,unique
 L-α-Phosphatidylcholine,synonym,CHEBI:86658,L-alpha-Phosphatidylcholine,CHEBI:86658,MAPPED,unique
 L-α-Phosphatidylinositol from Glycine max (soybean),preferred_term,cas:97281-52-2,L-α-Phosphatidylinositol from Glycine max (soybean),CHEBI:28874,MAPPED,unique
 Lab Lemco powder,preferred_term,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
+Lab--Lemco powder (Oxoid),synonym,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
 Lab-Lemco beef extract,synonym,FOODON:03302088,Beef extract,FOODON:03302088,MAPPED,unique
+Lab-Lemco powder,synonym,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
 Lac,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 Lacidipine,preferred_term,CHEBI:135737,Lacidipine,CHEBI:135737,MAPPED,unique
 Lactalbumin hydrolysate,preferred_term,MICRO:0001365,Lactalbumin hydrolysate,MICRO:0001365,MAPPED,unique
@@ -5391,11 +5747,15 @@ Lacto-N-fucopentaose-2,ontology_label,CHEBI:89932,Lacto-N-fucopentaose II,CHEBI:
 Lacto-N-neotetraose,preferred_term,CHEBI:60239,Lacto-N-neotetraose,CHEBI:60239,MAPPED,unique
 Lacto-N-tetraose,preferred_term,cas:14116-68-8,Lacto-N-tetraose,CHEBI:30248,MAPPED,unique
 Lactobacilli MRS broth,preferred_term,UNMAPPED_0421,Lactobacilli MRS broth,,UNMAPPED,unique
+Lactobacilli MRS Broth (BD 288130),synonym,UNMAPPED_0421,Lactobacilli MRS broth,,UNMAPPED,unique
+Lactobacilli MRS broth (BD-Difco),synonym,UNMAPPED_0421,Lactobacilli MRS broth,,UNMAPPED,unique
 Lactobacillus MRS broth,preferred_term,UNMAPPED_0422,Lactobacillus MRS broth,,UNMAPPED,unique
+Lactobacillus MRS broth (BD-Difco),synonym,UNMAPPED_0422,Lactobacillus MRS broth,,UNMAPPED,unique
 Lactodifucotetraose,ontology_label,CHEBI:89917,Difucosyllactose,CHEBI:89917,MAPPED,unique
 Lactone,preferred_term,CHEBI:25000,Lactone,CHEBI:25000,MAPPED,unique
 Lactose,preferred_term,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,resolved:owned
 lactose,synonym,CHEBI:36218,Beta-Lactose,CHEBI:36218,MAPPED,resolved:owned
+Lactose monohydrate,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 Lactulose,preferred_term,CHEBI:6359,Lactulose,CHEBI:6359,MAPPED,unique
 Laevulose,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,unique
 Laktobiose,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
@@ -5410,6 +5770,7 @@ Lanthanum (III) chloride,preferred_term,cas:20211-76-1,Lanthanum (III) chloride,
 lanthanum trichloride,ontology_label,cas:20211-76-1,Lanthanum (III) chloride,CHEBI:231515,MAPPED,unique
 Lapachol,preferred_term,CHEBI:6377,Lapachol,CHEBI:6377,MAPPED,unique
 Larchwood xylan,preferred_term,UNMAPPED_0424,Larchwood xylan,,UNMAPPED,unique
+Larchwood xylan (Sigma),synonym,UNMAPPED_0424,Larchwood xylan,,UNMAPPED,unique
 Lauric acid,preferred_term,CHEBI:30805,Lauric acid,CHEBI:30805,MAPPED,unique
 "Lauric acid, sodium salt",synonym,CHEBI:131839,Na-laurate,CHEBI:131839,MAPPED,unique
 Lawsone,preferred_term,CHEBI:44401,Lawsone,CHEBI:44401,MAPPED,unique
@@ -5424,11 +5785,13 @@ lead(II) chloride,ontology_label,CHEBI:88212,lead (II) chloride,CHEBI:88212,MAPP
 lead(II) nitrate,synonym,CHEBI:37187,Lead (II) nitrate,CHEBI:37187,MAPPED,unique
 Lecithin,preferred_term,CHEBI:61995,Lecithin,CHEBI:61995,MAPPED,unique
 Legionella agar enrichment,preferred_term,kgmicrobe.ingredient:legionella_agar_enrichment,Legionella agar enrichment,kgmicrobe.ingredient:legionella_agar_enrichment,MAPPED,unique
+Legionella agar enrichment (BD-Difco),synonym,kgmicrobe.ingredient:legionella_agar_enrichment,Legionella agar enrichment,kgmicrobe.ingredient:legionella_agar_enrichment,MAPPED,unique
 Leimzucker,synonym,CHEBI:15428,Glycine,CHEBI:15428,MAPPED,unique
 Lemon,preferred_term,NCIT:C72005,Lemon,NCIT:C72005,MAPPED,unique
 Lentilan from mushroom,preferred_term,CHEBI:31770,Lentilan from mushroom,CHEBI:31770,MAPPED,unique
 lentinan,ontology_label,CHEBI:31770,Lentilan from mushroom,CHEBI:31770,MAPPED,unique
 Leptospira Medium Base EMJH,preferred_term,UNMAPPED_0426,Leptospira Medium Base EMJH,,UNMAPPED,unique
+Leptospira Medium Base EMJH (Difco),synonym,UNMAPPED_0426,Leptospira Medium Base EMJH,,UNMAPPED,unique
 Leucine,synonym,CHEBI:15603,L-Leucine,CHEBI:15603,MAPPED,unique
 Leucodin,preferred_term,CHEBI:4441,Leucodin,CHEBI:4441,MAPPED,unique
 Leucovorin calcium,synonym,CHEBI:31340,Ca-folinate,CHEBI:31340,MAPPED,unique
@@ -5444,6 +5807,7 @@ Levulinic Acid,preferred_term,CHEBI:45630,Levulinic Acid,CHEBI:45630,MAPPED,uniq
 Lichenan (icelandic moss),preferred_term,kgmicrobe.ingredient:lichenan_icelandic_moss,Lichenan (icelandic moss),CHEBI:6452,MAPPED,unique
 lichenin,ontology_label,kgmicrobe.ingredient:lichenan_icelandic_moss,Lichenan (icelandic moss),CHEBI:6452,MAPPED,unique
 LiCl,preferred_term,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
+LiCl.H O,synonym,CHEBI:48607,LiCl,CHEBI:48607,MAPPED,unique
 Lignin,preferred_term,CHEBI:6457,Lignin,CHEBI:6457,MAPPED,unique
 Lignin alkali,preferred_term,cas:8068-05-1,Lignin alkali,cas:8068-05-1,MAPPED,unique
 Limocrocin,preferred_term,mesh:C079132,Limocrocin,mesh:C079132,MAPPED,unique
@@ -5475,6 +5839,8 @@ liver extract,ontology_label,MICRO:0001363,Liver extract concentrate,MICRO:00013
 liver extract,ontology_label,MICRO:0001363,Liver extract infusion,MICRO:0001363,MAPPED,unique
 Liver extract concentrate,preferred_term,MICRO:0001363,Liver extract concentrate,MICRO:0001363,MAPPED,unique
 Liver extract infusion,preferred_term,MICRO:0001363,Liver extract infusion,MICRO:0001363,MAPPED,unique
+liver powder,preferred_term,FOODON:03000441,liver powder,FOODON:03000441,MAPPED,unique
+liver powder supplement,ontology_label,FOODON:03000441,liver powder,FOODON:03000441,MAPPED,unique
 LL-37,preferred_term,CHEBI:81664,LL-37,CHEBI:81664,MAPPED,unique
 LL17-29,preferred_term,UNMAPPED_0172,LL17-29,,UNMAPPED,unique
 Locust bean gum,preferred_term,cas:9000-40-2,Locust bean gum,FOODON:03413132,MAPPED,unique
@@ -5483,6 +5849,7 @@ Lomefloxacin hydrochloride,preferred_term,CHEBI:6518,Lomefloxacin hydrochloride,
 Lomofungin,preferred_term,CHEBI:224243,Lomofungin,CHEBI:224243,MAPPED,unique
 Loratadine,preferred_term,CHEBI:6538,Loratadine,CHEBI:6538,MAPPED,unique
 Lovastatin,preferred_term,CHEBI:40303,Lovastatin,CHEBI:40303,MAPPED,unique
+LSM-15166,synonym,CHEBI:30745,Phenyl acetic acid,CHEBI:30745,MAPPED,unique
 Lucimycin,preferred_term,CHEBI:135874,Lucimycin,CHEBI:135874,MAPPED,unique
 Lumazine,preferred_term,CHEBI:16489,Lumazine,CHEBI:16489,MAPPED,unique
 Lumichrome,preferred_term,CHEBI:17781,Lumichrome,CHEBI:17781,MAPPED,unique
@@ -5512,8 +5879,10 @@ Macro Component 1 for J Medium,preferred_term,kgmicrobe.ingredient:macro_compone
 Macro Component 2 for J medium,preferred_term,kgmicrobe.ingredient:macro_component_2_for_j_medium,Macro Component 2 for J medium,kgmicrobe.ingredient:macro_component_2_for_j_medium,MAPPED,unique
 Macrolide Antibiotic,preferred_term,CHEBI:25105,Macrolide Antibiotic,CHEBI:25105,MAPPED,unique
 Magainin I,preferred_term,CHEBI:201898,Magainin I,CHEBI:201898,MAPPED,unique
+Magnesium,preferred_term,CHEBI:25107,Magnesium,CHEBI:25107,MAPPED,unique
 magnesium 3-carboxy-3-hydroxypentanedioate,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
 Magnesium acetate,preferred_term,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
+magnesium atom,ontology_label,CHEBI:25107,Magnesium,CHEBI:25107,MAPPED,unique
 magnesium carbonate,ontology_label,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
 Magnesium chloride,preferred_term,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 Magnesium chloride anhydrous,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
@@ -5534,16 +5903,19 @@ magnesium dichloride hexahydrate,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,M
 magnesium dichloride hexahydrate,ontology_label,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 magnesium dichloride monohydrate,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
 magnesium dichloride--water (1/1),synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
+magnesium dichloride--water (1/2),synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 magnesium dichloride--water (1/6),synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 magnesium dichloride--water (1/6),synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 Magnesium hydrogen citrate,synonym,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
 magnesium nitrate,ontology_label,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
 magnesium nitrate hexahydrate,preferred_term,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+magnesium oxide,ontology_label,CHEBI:31794,MgO,CHEBI:31794,MAPPED,unique
 Magnesium sulfate,preferred_term,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
 magnesium sulfate,ontology_label,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,unique
 Magnesium sulfate (1:1),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
 magnesium sulfate (1:1) heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 magnesium sulfate (1:1) heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+magnesium sulfate anhydrous,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 Magnesium sulfate heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
@@ -5551,11 +5923,14 @@ magnesium sulfate heptahydrate,ontology_label,CHEBI:31795,MgSO4·7H2O,CHEBI:3179
 magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 magnesium sulfate--water (1/7),synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
+magnesium sulphate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 magnesium sulphate heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 magnesium sulphate heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 Magnesium(2+),preferred_term,CHEBI:18420,Magnesium(2+),CHEBI:18420,MAPPED,unique
+magnesium(II) sulfate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 Magnesiumchlorid,synonym,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,unique
 Magnesiumsulfat,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+Maize meal,synonym,FOODON:03310257,Corn meal,FOODON:03310257,MAPPED,unique
 Malachite green,preferred_term,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
 malachite green chloride,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
 malachite green chloride salt,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
@@ -5610,6 +5985,7 @@ Mangandichlorid,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
 Mangandioxid,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
 Manganese,preferred_term,NCIT:C624,Manganese,NCIT:C624,MAPPED,unique
 Manganese (II) chloride tetrahydrate,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+Manganese (II) sulfate monohydrate,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
 Manganese bichloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
 manganese binoxide,synonym,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
 Manganese chloride,synonym,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
@@ -5695,8 +6071,13 @@ Mannose-6-Phosphate,preferred_term,CHEBI:17369,Mannose-6-Phosphate,CHEBI:17369,M
 Mannotriose,preferred_term,CHEBI:146181,Mannotriose,CHEBI:146181,MAPPED,unique
 Margaric acid,synonym,CHEBI:32365,heptadecanoic acid,CHEBI:32365,MAPPED,unique
 Marine agar 2216,preferred_term,kgmicrobe.ingredient:marine_agar_2216,Marine agar 2216,kgmicrobe.ingredient:marine_agar_2216,MAPPED,unique
+Marine agar 2216 (BD-Difco),synonym,kgmicrobe.ingredient:marine_agar_2216,Marine agar 2216,kgmicrobe.ingredient:marine_agar_2216,MAPPED,unique
 Marine Broth,preferred_term,UNMAPPED_0433,Marine Broth,,UNMAPPED,unique
+Marine Broth  (MB) 2216  (Difco),synonym,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
 Marine broth 2216,preferred_term,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
+Marine Broth 2216 (BD 279110),synonym,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
+Marine Broth 2216 (BD--Difco),synonym,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
+Marine broth 2216 (BD-Difco),synonym,kgmicrobe.ingredient:marine_broth_2216,Marine broth 2216,kgmicrobe.ingredient:marine_broth_2216,MAPPED,unique
 Marinostatin,preferred_term,CHEBI:221095,Marinostatin,CHEBI:221095,MAPPED,unique
 Marmite,preferred_term,mesh:C008328,Marmite,mesh:C008328,MAPPED,unique
 mascagnite,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
@@ -5730,7 +6111,9 @@ melezitose,ontology_label,cas:207511-10-2,D-(+)-Melezitose hydrate,CHEBI:6731,MA
 Melibiose,preferred_term,CHEBI:28053,Melibiose,CHEBI:28053,MAPPED,unique
 Melitose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
 Melitriose,synonym,CHEBI:16634,Raffinose,CHEBI:16634,MAPPED,unique
+MEM,synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 MEM alpha Modification,preferred_term,UNMAPPED_0437,MEM alpha Modification,,UNMAPPED,unique
+MEM alpha Modification (BioWest),synonym,UNMAPPED_0437,MEM alpha Modification,,UNMAPPED,unique
 MEM-Medium,preferred_term,UNMAPPED_0438,MEM-Medium,,UNMAPPED,unique
 menadion,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
 Menadione,preferred_term,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,resolved:owned
@@ -5746,6 +6129,7 @@ MeNH2,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
 Menthol,preferred_term,cas:1490-04-6,Menthol,CHEBI:25187,MAPPED,unique
 MeOH,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
 Mephyton,synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+MEPM,synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 "Mercaptoacetic acid, sodium salt",synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
 Mercaptoethanol,synonym,CHEBI:41218,2-Mercaptoethanol,CHEBI:41218,MAPPED,unique
 mercury (II) chloride,preferred_term,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
@@ -5753,7 +6137,9 @@ mercury dichloride,ontology_label,CHEBI:31823,mercury (II) chloride,CHEBI:31823,
 mercury(2+) chloride,synonym,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
 mercury(II) chloride,synonym,CHEBI:31823,mercury (II) chloride,CHEBI:31823,MAPPED,unique
 Meropenem,preferred_term,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
+meropenem anhydrous,synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 meropenem trihydrate,ontology_label,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
+meropenemum,synonym,CHEBI:6770,Meropenem,CHEBI:6770,MAPPED,unique
 MES,preferred_term,CHEBI:39010,MES,CHEBI:39010,MAPPED,resolved:owned
 MES,ontology_label,kgmicrobe.ingredient:mes_buffer,MES buffer,CHEBI:39010,MAPPED,resolved:owned
 MES (2-[N-Morpholino]ethane sulfonic acid),synonym,CHEBI:39005,MES [2-(N-morpholino) ethane sulfonic acid],CHEBI:39005,MAPPED,unique
@@ -5772,6 +6158,7 @@ meso-xylitol,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
 meta-xylene,synonym,CHEBI:28488,m-Xylene,CHEBI:28488,MAPPED,unique
 metacetonic acid,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
 Metall salt sol. 44,preferred_term,kgmicrobe.ingredient:metall_salt_sol_44,Metall salt sol. 44,kgmicrobe.ingredient:metall_salt_sol_44,MAPPED,unique
+Metals ''44'' (see below),preferred_term,MICRO:0000456,Metals ''44'' (see below),MICRO:0000456,MAPPED,unique
 Methacycline,preferred_term,CHEBI:6805,Methacycline,CHEBI:6805,MAPPED,unique
 Methanamine,synonym,CHEBI:16830,Methylamine,CHEBI:16830,MAPPED,unique
 "Methanamine, hydrochloride (1:1)",synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
@@ -5781,6 +6168,9 @@ Methanecarboxylic acid,synonym,CHEBI:15366,Acetic acid,CHEBI:15366,MAPPED,unique
 methanedione,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
 Methanoic acid,synonym,CHEBI:30751,Formic acid,CHEBI:30751,MAPPED,unique
 Methanol,preferred_term,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Methanol (10%),synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Methanol*,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
+Methanol**,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
 Methanol-utilizing bacteria medium B,preferred_term,UNMAPPED_0443,Methanol-utilizing bacteria medium B,,UNMAPPED,unique
 Methicillin,preferred_term,CHEBI:6827,Methicillin,CHEBI:6827,MAPPED,unique
 Methionin,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
@@ -5801,6 +6191,7 @@ methyl 3-(4-hydroxyphenyl)propanoate,synonym,CHEBI:176565,Methyl 3-(4-hydroxyphe
 Methyl 3-(4-hydroxyphenyl)propionate,preferred_term,CHEBI:176565,Methyl 3-(4-hydroxyphenyl)propionate,CHEBI:176565,MAPPED,unique
 methyl 3-keto-a-D-glucopyranoside,preferred_term,UNMAPPED_0233,methyl 3-keto-a-D-glucopyranoside,,UNMAPPED,unique
 Methyl 6-Hydroxyangolensate,preferred_term,CHEBI:181871,Methyl 6-Hydroxyangolensate,CHEBI:181871,MAPPED,unique
+"methyl 7-chloro-6,7,8-trideoxy-6-({[(2S,4R)-1-methyl-4-propylpyrrolidin-2-yl]carbonyl}amino)-1-thio-D-glycero-alpha-D-galacto-octopyranoside",synonym,CHEBI:3745,Clindamycin,CHEBI:3745,MAPPED,unique
 Methyl alcohol,synonym,CHEBI:17790,Methanol,CHEBI:17790,MAPPED,unique
 methyl alpha-D-galactoside,ontology_label,CHEBI:55507,1-o-methyl Alpha-galactopyranoside,CHEBI:55507,MAPPED,unique
 Methyl alpha-D-glucopyranoside,preferred_term,CHEBI:320061,Methyl alpha-D-glucopyranoside,CHEBI:320061,MAPPED,unique
@@ -5832,6 +6223,7 @@ Methylamine-HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 Methylammonium chloride,synonym,CHEBI:59337,Methylamine hydrochloride,CHEBI:59337,MAPPED,unique
 methylbenzene,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
 Methylcarbinol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+methylcobalamin,preferred_term,CHEBI:28115,methylcobalamin,CHEBI:28115,MAPPED,unique
 Methylenblau,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
 Methylene blue,preferred_term,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
 methylene chloride,preferred_term,CHEBI:15767,methylene chloride,CHEBI:15767,MAPPED,unique
@@ -5839,10 +6231,12 @@ methylethylacetic acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,M
 Methylglycocyamine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
 methylglyoxal,preferred_term,CHEBI:17158,methylglyoxal,CHEBI:17158,MAPPED,unique
 methylisothiazolinone,ontology_label,CHEBI:53620,2-methyl-4-isothizaolin-3-one,CHEBI:53620,MAPPED,unique
+Methylphosphonic acid,preferred_term,CHEBI:45129,Methylphosphonic acid,CHEBI:45129,MAPPED,unique
 methylsulfinylmethane,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
 methylthioninii chloridum,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
 Methylthioninium chloride,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
 Methylxanthoxylin,preferred_term,cas:23121-32-6,Methylxanthoxylin,CHEBI:169463,MAPPED,unique
+Meticillin,synonym,CHEBI:6827,Methicillin,CHEBI:6827,MAPPED,unique
 metionina,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
 Metronidazole,preferred_term,CHEBI:6909,Metronidazole,CHEBI:6909,MAPPED,unique
 mevalonic acid,ontology_label,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
@@ -5854,8 +6248,11 @@ Mg(II) acetate,synonym,CHEBI:62964,Magnesium acetate,CHEBI:62964,MAPPED,unique
 Mg(NO3)2 x 6 H2O,synonym,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
 Mg-citrate,preferred_term,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
 Mg2SO4,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+Mg2SO4,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,unique
 MG[18:1(omega-9)],synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+MgCl 2,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl*6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
+MgCl*6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2,preferred_term,CHEBI:6636,MgCl2,CHEBI:6636,MAPPED,unique
 MgCl2  x 6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2  x 7 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
@@ -5864,9 +6261,11 @@ MgCl2  x 7 H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:dif
 MgCl2  x 76 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
 MgCl2  x 76 H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
 MgCl2  x 76 H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2 . 6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl2 . 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2 x 2 H2O,preferred_term,CHEBI:131394,MgCl2 x 2 H2O,CHEBI:131394,MAPPED,unique
 MgCl2 x 6 H2O,preferred_term,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2 x 6 H2O (200 g/l stock solution),synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl2 x 6 H2O (200 g/l stock solution),synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2 X 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
 MgCl2 X 6H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
@@ -5885,7 +6284,9 @@ MgCl2.H2O,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
 MgCl2x 6 H2O,preferred_term,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,resolved:owned
 MgCl2x 6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,resolved:owned
 MgCl2x 6 H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,resolved:owned
+MgCl2x 6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl2x 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
+MgCl2x6H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl2x6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2x7H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
 MgCl2x7H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
@@ -5893,6 +6294,7 @@ MgCl2x7H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:differe
 MgCl2 x 6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,conflict:different_substances
 MgCl2 x 6H2O,synonym,kgmicrobe.compound:mgcl2_x_7_h2o,MgCl2 x 7 H2O,CHEBI:6636,MAPPED,conflict:different_substances
 MgCl2 x 6H2O,synonym,CHEBI:86345,MgCl2x 6 H2O,CHEBI:6636,REJECTED,conflict:different_substances
+MgCl2·6 H2O,synonym,CHEBI:86345,Magnesium chloride,CHEBI:86345,MAPPED,unique
 MgCl2·6 H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2·6H2O,synonym,CHEBI:86345,MgCl2 x 6 H2O,CHEBI:86345,MAPPED,unique
 MgCl2·H2O,synonym,CHEBI:86355,MgCl2 x H2O,CHEBI:86355,MAPPED,unique
@@ -5903,16 +6305,23 @@ MgCO,synonym,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
 MgCO3,preferred_term,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
 MgCO3(MCIB CB486),synonym,CHEBI:31793,MgCO3,CHEBI:31793,MAPPED,unique
 MgNO32 x 6 H2O,synonym,cas:13446-18-9,magnesium nitrate hexahydrate,CHEBI:64736,MAPPED,unique
+MgO,preferred_term,CHEBI:31794,MgO,CHEBI:31794,MAPPED,unique
+MgSO,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 MgSO .7H O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MgSO .7H O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,unique
+MgSO .7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO 4,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO 4,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 MgSO 4 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO 4 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 MgSO x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO2,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO2,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 MgSO2 x 7 H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO2 x 7 H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO2·7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
 MgSO4 . 7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
 MgSO4 . 7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
@@ -5926,6 +6335,7 @@ MgSO4 x 6 H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,resolved:owne
 MgSO4 x 6H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
 MgSO4 x 6H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
 MgSO4 x 6H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
+MgSO4 x 7 H20,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4 x 7 H20,synonym,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 MgSO4 x 7 H2O,preferred_term,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4 x 7 H2O (0.1% w/v),synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:different_substances
@@ -5959,36 +6369,49 @@ MgSO4 ·7H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,conflict:d
 MgSO4 ·7H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,conflict:different_substances
 MgSO4 ·7H2O,synonym,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,conflict:different_substances
 MgSO4 × 7 H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
+MgSO4 × 7 H2O,synonym,CHEBI:32599,MgSO4 x 6 H2O,CHEBI:32599,MAPPED,unique
 MgSO4.7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4.7H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 MgSO47H2O,preferred_term,CHEBI:31795,MgSO47H2O,CHEBI:31795,REJECTED,unique
 MgSO47H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4x7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4x7H2O,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MgSO4·6H2O,synonym,CHEBI:32599,Magnesium sulfate,CHEBI:32599,MAPPED,unique
 MgSO4·7H2O,preferred_term,CHEBI:31795,MgSO4·7H2O,CHEBI:31795,REJECTED,unique
 MgSO4·7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4·H2O,preferred_term,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 MgSO4·H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4•7H2O,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 MgSO4•7H2O (Sigma 230391),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O (Sigma 230391),synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 MgSO4•7H2O(CAS: 10034-99-8),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O(CAS: 10034-99-8),synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 MgSO4•7H2O(Sigma 230391),synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
+MgSO4•7H2O(Sigma 230391),synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
+MH agar,preferred_term,MICRO:0001328,MH agar,MICRO:0001328,MAPPED,unique
 MHPP,synonym,CHEBI:176565,Methyl 3-(4-hydroxyphenyl)propionate,CHEBI:176565,MAPPED,unique
+micronutrient,ontology_label,CHEBI:27027,Micronutrients,CHEBI:27027,MAPPED,unique
 micronutrient solution,preferred_term,kgmicrobe.ingredient:micronutrient_solution,micronutrient solution,kgmicrobe.ingredient:micronutrient_solution,MAPPED,unique
+Micronutrients,preferred_term,CHEBI:27027,Micronutrients,CHEBI:27027,MAPPED,unique
 Microstop,synonym,CHEBI:63076,(NH4)2 citrate,CHEBI:63076,MAPPED,unique
 Middlebrook 7H10 agar,preferred_term,NCIT:C85509,Middlebrook 7H10 agar,NCIT:C85509,MAPPED,unique
+Middlebrook 7H10 Agar (Difco),synonym,NCIT:C85509,Middlebrook 7H10 agar,NCIT:C85509,MAPPED,unique
 Middlebrook 7H10 Growth Medium,ontology_label,NCIT:C85509,Middlebrook 7H10 agar,NCIT:C85509,MAPPED,unique
 Midecamycin,preferred_term,CHEBI:31845,Midecamycin,CHEBI:31845,MAPPED,unique
 miharamycin A,preferred_term,CHEBI:216282,miharamycin A,CHEBI:216282,MAPPED,unique
 Milchzucker,synonym,CHEBI:17716,Lactose,CHEBI:17716,MAPPED,unique
 Milk,preferred_term,UBERON:0001913,Milk,UBERON:0001913,MAPPED,unique
+Milk sugar,synonym,CHEBI:189432,alpha-Lactose,CHEBI:189432,MAPPED,unique
+mineral,ontology_label,CHEBI:46662,Minerals,CHEBI:46662,MAPPED,unique
 Mineral 3B solution,preferred_term,kgmicrobe.ingredient:mineral_3b_solution,Mineral 3B solution,kgmicrobe.ingredient:mineral_3b_solution,MAPPED,unique
 Mineral 3B solution minus Nitrogen,preferred_term,kgmicrobe.ingredient:mineral_3b_solution_minus_nitrogen,Mineral 3B solution minus Nitrogen,kgmicrobe.ingredient:mineral_3b_solution_minus_nitrogen,MAPPED,unique
 Mineral 3B solution minus phosphorus,preferred_term,kgmicrobe.ingredient:mineral_3b_solution_minus_phosphorus,Mineral 3B solution minus phosphorus,kgmicrobe.ingredient:mineral_3b_solution_minus_phosphorus,MAPPED,unique
 Mineral salts base,preferred_term,kgmicrobe.ingredient:mineral_salts_base,Mineral salts base,kgmicrobe.ingredient:mineral_salts_base,MAPPED,unique
 Mineral salts medium base,preferred_term,UNMAPPED_0609,Mineral salts medium base,,UNMAPPED,unique
+Mineral solution (see Medium No. 976,synonym,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,Mineral solution see Medium No. 976,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,MAPPED,unique
 Mineral solution see Medium No. 976,preferred_term,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,Mineral solution see Medium No. 976,kgmicrobe.ingredient:mineral_solution_see_medium_no_976,MAPPED,unique
 Mineral water,preferred_term,FOODON:03301328,Mineral water,FOODON:03301328,MAPPED,unique
+Minerals,preferred_term,CHEBI:46662,Minerals,CHEBI:46662,MAPPED,unique
 Minimycin,preferred_term,mesh:C002363,Minimycin,mesh:C002363,MAPPED,unique
 Minocycline,preferred_term,CHEBI:50694,Minocycline,CHEBI:50694,MAPPED,unique
 Minocycline hydrochloride,preferred_term,CHEBI:50697,Minocycline hydrochloride,CHEBI:50697,MAPPED,unique
@@ -6000,11 +6423,13 @@ MnCl2,preferred_term,CHEBI:63041,MnCl2,CHEBI:63041,MAPPED,unique
 MnCl2 . 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2 x 2 H2O,preferred_term,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
 MnCl2 x 4 H2O,preferred_term,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
+MnCl2 x 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2 · 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2 × 4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2 ∙ 4 H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2.4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2·2H2O,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
+MnCl2·4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2∙4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2⋅4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl2・4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
@@ -6012,6 +6437,7 @@ MnCl2．2H2O,synonym,CHEBI:131395,MnCl2 x 2 H2O,CHEBI:131395,MAPPED,unique
 MnCl2･4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl4 x 4 H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnCl4 x 6 H2O,preferred_term,UNMAPPED_0450,MnCl4 x 6 H2O,,UNMAPPED,unique
+MnCl4・4H2O,synonym,CHEBI:86368,MnCl2 x 4 H2O,CHEBI:86368,MAPPED,unique
 MnII x EDTA,preferred_term,UNMAPPED_0451,MnII x EDTA,,UNMAPPED,unique
 MnO2,preferred_term,CHEBI:136511,MnO2,CHEBI:136511,MAPPED,unique
 MnSO4,preferred_term,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
@@ -6036,6 +6462,7 @@ MnSO4 x 7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:dif
 MnSO4 x H2O,preferred_term,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,resolved:owned
 MnSO4 x H2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,resolved:owned
 MnSO4 x n H2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+MnSO4 x n H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,unique
 MnSO4 · 4 H2O,synonym,CHEBI:86358,MnSO4 x 4 H2O,CHEBI:86358,MAPPED,unique
 MnSO4 · H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
 MnSO4 ⋅ H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
@@ -6053,6 +6480,7 @@ MnSO4·7H2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,conflict:differ
 MnSO4·7H2O,synonym,CHEBI:86364,MnSO4 x 1 H2O,CHEBI:86364,REJECTED,conflict:different_substances
 MnSO4·H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
 MnSO4·nH2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,unique
+MnSO4·nH2O,synonym,CHEBI:86360,MnSO4 x 7 H2O,CHEBI:86360,MAPPED,unique
 MnSO4⋅H2O,synonym,CHEBI:86364,MnSO4 x H2O,CHEBI:86364,MAPPED,unique
 MnSO4・5H2O,synonym,CHEBI:131524,MnSO4 x 5 H2O,CHEBI:131524,MAPPED,unique
 MnSO4・xH2O,synonym,CHEBI:86360,MnSO4,CHEBI:86360,MAPPED,conflict:different_substances
@@ -6063,10 +6491,13 @@ Modified COMBO Medium,preferred_term,UNMAPPED_0111,Modified COMBO Medium,,UNMAPP
 Modified Cooked Meat Medium,preferred_term,kgmicrobe.ingredient:modified_cooked_meat_medium,Modified Cooked Meat Medium,kgmicrobe.ingredient:modified_cooked_meat_medium,MAPPED,unique
 Modified P-IV chelated Micronutrient Solution,preferred_term,kgmicrobe.ingredient:modified_p-iv_chelated_micronutrient_solution,Modified P-IV chelated Micronutrient Solution,kgmicrobe.ingredient:modified_p-iv_chelated_micronutrient_solution,MAPPED,unique
 Modified trace vitamins,preferred_term,kgmicrobe.ingredient:modified_trace_vitamins,Modified trace vitamins,kgmicrobe.ingredient:modified_trace_vitamins,MAPPED,unique
+Modified trace vitamins (see below),synonym,kgmicrobe.ingredient:modified_trace_vitamins,Modified trace vitamins,kgmicrobe.ingredient:modified_trace_vitamins,MAPPED,unique
 Modified Wolfe's Minerals,preferred_term,kgmicrobe.ingredient:modified_wolfes_minerals,Modified Wolfe's Minerals,kgmicrobe.ingredient:modified_wolfes_minerals,MAPPED,unique
 molecular hydrogen,synonym,CHEBI:18276,Hydrogen gas,CHEBI:18276,MAPPED,unique
 molecular nitrogen,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
 MoLS4,preferred_term,UNMAPPED_0292,MoLS4,,UNMAPPED,unique
+Molybdenum,preferred_term,CHEBI:28685,Molybdenum,CHEBI:28685,MAPPED,unique
+molybdenum atom,ontology_label,CHEBI:28685,Molybdenum,CHEBI:28685,MAPPED,unique
 molybdenum trioxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
 molybdenum(6+) oxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
 molybdenum(VI) oxide,synonym,CHEBI:30627,MoO3,CHEBI:30627,MAPPED,unique
@@ -6100,6 +6531,7 @@ Monopotassium dihydrogen phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED
 Monopotassium monophosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 Monopotassium orthophosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 Monopotassium phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
+Monosodioglutammato,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 Monosodium 2-hydroxypropanoate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
 "monosodium D-(-)-6-(2-amino-2-phenylacetamido)-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo(3.2.0)heptane-2-carboxylate",synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
 Monosodium D-gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
@@ -6118,14 +6550,25 @@ MOPS,preferred_term,CHEBI:39074,MOPS,CHEBI:39074,MAPPED,resolved:owned
 MOPS,ontology_label,kgmicrobe.ingredient:mops_2m_ph7,MOPS_2M_pH7,CHEBI:39074,MAPPED,resolved:owned
 MOPS (3-(N-morpholino) propane-sulfonic acid),synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
 MOPS buffer,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
+MOPS buffer (SIGMA),synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
 MOPS_2M_pH7,preferred_term,kgmicrobe.ingredient:mops_2m_ph7,MOPS_2M_pH7,CHEBI:39074,MAPPED,unique
 Morin,preferred_term,CHEBI:75092,Morin,CHEBI:75092,MAPPED,unique
 Morpholinopropane sulfonic acid,synonym,CHEBI:44115,3-(N-morpholino)propanesulfonic acid,CHEBI:44115,MAPPED,unique
 Moxifloxacin,preferred_term,CHEBI:63611,Moxifloxacin,CHEBI:63611,MAPPED,unique
 MoYLS4,preferred_term,UNMAPPED_0264,MoYLS4,,UNMAPPED,unique
 MreB Perturbing Compound A22,preferred_term,cas:22816-60-0,MreB Perturbing Compound A22,cas:22816-60-0,MAPPED,unique
+MRS agar,ontology_label,MICRO:0000554,MRS agar (Oxoid),MICRO:0000554,MAPPED,unique
+MRS agar (Oxoid),preferred_term,MICRO:0000554,MRS agar (Oxoid),MICRO:0000554,MAPPED,unique
 MRS broth,preferred_term,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS broth (BD-Difco),synonym,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS broth (Criterion),synonym,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS broth (Difco),synonym,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS broth (Oxoid),synonym,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
+MRS broth (Sigma),synonym,UNMAPPED_0453,MRS broth,,UNMAPPED,unique
 MRS medium,preferred_term,UNMAPPED_0454,MRS medium,,UNMAPPED,unique
+MRS medium (Difco),synonym,UNMAPPED_0454,MRS medium,,UNMAPPED,unique
+MRS medium (Scharlau Chemie),synonym,UNMAPPED_0454,MRS medium,,UNMAPPED,unique
+MSG,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 Mucic acid,preferred_term,CHEBI:30852,Mucic acid,CHEBI:30852,MAPPED,unique
 Mucin,preferred_term,NCIT:C16883,Mucin,NCIT:C16883,MAPPED,unique
 Mucin from porcine stomach type III,preferred_term,cas:84082-64-4,Mucin from porcine stomach type III,cas:84082-64-4,MAPPED,unique
@@ -6133,12 +6576,14 @@ Mucin from porcine stomach type III,preferred_term,cas:84082-64-4,Mucin from por
 "Mucin from porcine stomach,Type II",preferred_term,cas:84082-64-4,"Mucin from porcine stomach,Type II",cas:84082-64-4,MAPPED,unique
 "Mucin, Bovine Submaxillary Gland, type I-S",preferred_term,cas:84195-52-8,"Mucin, Bovine Submaxillary Gland, type I-S",cas:84195-52-8,MAPPED,unique
 Mueller Hinton II agar,preferred_term,UNMAPPED_0128,Mueller Hinton II agar,,UNMAPPED,unique
+Mueller Hinton II agar (BD-BBL),synonym,UNMAPPED_0128,Mueller Hinton II agar,,UNMAPPED,unique
 Murashige & Skoog medium,preferred_term,UNMAPPED_0455,Murashige & Skoog medium,,UNMAPPED,unique
 Murashige-Skoog basal salts,preferred_term,kgmicrobe.ingredient:murashige-skoog_basal_salts,Murashige-Skoog basal salts,kgmicrobe.ingredient:murashige-skoog_basal_salts,MAPPED,unique
 muriate of potash,synonym,CHEBI:32588,KCl,CHEBI:32588,MAPPED,unique
 MWC Metal Solution,preferred_term,kgmicrobe.ingredient:mwc_metal_solution,MWC Metal Solution,kgmicrobe.ingredient:mwc_metal_solution,MAPPED,unique
 Mycobacidin,preferred_term,mesh:C010250,Mycobacidin,mesh:C010250,MAPPED,unique
-Mycobactine J,preferred_term,UNMAPPED_0456,Mycobactine J,,UNMAPPED,unique
+Mycobactin J,preferred_term,CHEBI:205364,Mycobactin J,CHEBI:205364,MAPPED,unique
+Mycobactine J,synonym,CHEBI:205364,Mycobactin J,CHEBI:205364,MAPPED,unique
 myo-Inositol,preferred_term,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
 myo-inositol,ontology_label,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
 Myoinositol,synonym,CHEBI:17268,myo-Inositol,CHEBI:17268,MAPPED,unique
@@ -6209,11 +6654,14 @@ N-(3-oxohexanoyl)homoserine lactone,ontology_label,CHEBI:29640,N-(3-oxohexanoyl)
 N-(aminoiminomethyl)-N-methylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
 N-(carbamoylmethyl)taurine,synonym,CHEBI:39060,N-(2-acetamido)-2-aminoethanesulfonic acid,CHEBI:39060,MAPPED,unique
 N-(N-gamma-L-Glutamyl-L-cysteinyl)glycine,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+N-(tri(hydroxymethyl)methyl)glycine,synonym,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
 "N-({(5S)-3-[3-fluoro-4-(morpholin-4-yl)phenyl]-2-oxo-1,3-oxazolidin-5-yl}methyl)acetamide",synonym,CHEBI:63607,Linezolid,CHEBI:63607,MAPPED,unique
+N--Acetyl--D--glucosamine (Sigma),synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
 "N-[(2S,3R)-3-hydroxy-1-(hydroxyamino)-1-oxobutan-2-yl]-4-({4-[(morpholin-4-yl)methyl]phenyl}ethynyl)benzamide",synonym,CHEBI:134107,CHIR-090,CHEBI:134107,MAPPED,unique
 "N-[(4-{[(2-amino-4-oxo-1,4-dihydropteridin-6-yl)methyl]amino}phenyl)carbonyl]-L-glutamic acid",synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 "N-[(7S)-10-hydroxy-1,2,3-trimethoxy-9-oxo-6,7-dihydro-5H-benzo[a]heptalen-7-yl]acetamide",synonym,CHEBI:183909,Colchiceine,CHEBI:183909,MAPPED,unique
 N-[(E)-AMINO(IMINO)METHYL]-N-METHYLGLYCINE,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
+"N-[2-hydroxy-1,1-bis(hydroxymethyl)ethyl]glycine",synonym,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
 "N-[4-({[2-amino-5-formyl-4-oxo-3,4,5,6,7,8-hexahydropteridin-6-yl]methyl}amino)benzoyl]-L-glutamic acid",synonym,CHEBI:15640,Folinic acid,CHEBI:15640,MAPPED,unique
 N-[amino(imino)methyl]-N-methylglycine,synonym,CHEBI:16919,Creatine,CHEBI:16919,MAPPED,unique
 N-[tris(hydroxymethyl)methyl]-3-amino-2-hydroxypropanesulfonic acid,synonym,cas:68399-81-5,TAPSO,cas:68399-81-5,MAPPED,unique
@@ -6232,8 +6680,10 @@ n-Acetyl-lysine,preferred_term,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,un
 n-Acetyl-muramic acid,preferred_term,CHEBI:47965,n-Acetyl-muramic acid,CHEBI:47966,REJECTED,unique
 n-Acetyl-muramic acid,synonym,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
 N-acetyl-neuraminic Acid,synonym,CHEBI:17012,N-acetylneuraminic acid,CHEBI:17012,MAPPED,unique
+N-Acetylchitosamine,synonym,CHEBI:8006,N-Acetyl-D-glucosamine,CHEBI:8006,MAPPED,unique
 N-acetylgalactosamine,preferred_term,CHEBI:28800,N-acetylgalactosamine,CHEBI:28800,MAPPED,unique
 N-Acetylglucosamine,preferred_term,CHEBI:59640,N-Acetylglucosamine,CHEBI:59640,MAPPED,unique
+N-acetylglucosamine (Sigma),synonym,CHEBI:59640,N-Acetylglucosamine,CHEBI:59640,MAPPED,unique
 N-acetylglucosamines,synonym,CHEBI:59640,N-Acetylglucosamine,CHEBI:59640,MAPPED,unique
 N-Acetylglutamine,synonym,CHEBI:73685,n-Acetyl-glutamine,CHEBI:73685,MAPPED,unique
 N-acetylmuramic acid,preferred_term,CHEBI:47965,N-acetylmuramic acid,CHEBI:47965,MAPPED,unique
@@ -6275,12 +6725,17 @@ N-N Dimethyl glycine,preferred_term,CHEBI:17724,N-N Dimethyl glycine,CHEBI:17724
 n-octadecanoic acid,synonym,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
 n-Pentanoate,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
 n-pentanoic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
+n-propyl chloride,synonym,CHEBI:747004,1-chloropropane,CHEBI:747004,MAPPED,unique
 N-pteroyl-L-glutamic acid,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 N-trimethylethanolamine,synonym,CHEBI:15354,Choline,CHEBI:15354,MAPPED,unique
+N-tris(hydroxymethyl)methylglycine,synonym,CHEBI:16325,Lithocholic acid,CHEBI:16325,MAPPED,unique
 n-Valeric acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
 N-Z amine,preferred_term,UNMAPPED_0457,N-Z amine,,UNMAPPED,unique
+N-Z-Amine,synonym,UNMAPPED_0457,N-Z amine,,UNMAPPED,unique
+N-Z-Amine A,synonym,UNMAPPED_0458,N-Z-Amine® A,,UNMAPPED,unique
 N-Z-Amine® A,preferred_term,UNMAPPED_0458,N-Z-Amine® A,,UNMAPPED,unique
 N-Z-Case,preferred_term,UNMAPPED_0459,N-Z-Case,,UNMAPPED,unique
+N-Z-Case (Wako),synonym,UNMAPPED_0459,N-Z-Case,,UNMAPPED,unique
 "N-{[(1S,4S,7S,8S,11R,14S,17R,20S)-7-{[N(2)-({(3R,9S,12S,15S,21S,22S)-21-[(N(2)-{[(6R,9S,10S,15aS)-10-({[(3R,6S,12S,15S)-12-[(2S)-butan-2-yl]-6-isobutyl-15-{[(2Z)-2-(L-isoleucylamino)but-2-enoyl]amino}-9-methylene-5,8,11,14-tetraoxo-1-thia-4,7,10,13-tetraazacyclohexadecan-3-yl]carbonyl}amino)-9-methyl-1,4,11-trioxododecahydro-1H,9H-pyrrolo[2,1-i][1,4,7,10]thiatriazacyclotridecin-6-yl]carbonyl}-L-lysyl)amino]-12-isobutyl-15,22-dimethyl-9-[2-(methylsulfanyl)ethyl]-5,8,11,14,17,20-hexaoxo-1-thia-4,7,10,13,16,19-hexaazacyclodocosan-3-yl}carbonyl)-L-asparaginyl-L-methionyl-L-lysyl]amino}-14-(1H-imidazol-5-ylmethyl)-4,8,20-trimethyl-3,6,12,15,21-pentaoxo-9,19-dithia-2,5,13,16,22-pentaazabicyclo[9.9.2]docos-17-yl]carbonyl}-L-seryl-L-isoleucyl-L-histidyl-N-(3-{[(1S)-5-amino-1-carboxypentyl]amino}-3-oxoprop-1-en-2-yl)-L-valinamide",synonym,CHEBI:71629,Nisin,CHEBI:71629,MAPPED,unique
 N2,synonym,CHEBI:17997,Nitrogen gas,CHEBI:17997,MAPPED,unique
 N2-Acetyl-L-lysine,synonym,CHEBI:35704,n-Acetyl-lysine,CHEBI:35704,MAPPED,unique
@@ -6289,6 +6744,7 @@ N5-(Aminocarbonyl)ornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,
 N5-carbamoylornithine,synonym,CHEBI:16349,L-Citrulline,CHEBI:16349,MAPPED,unique
 Na Acetate,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
 Na CO,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na CO,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
 NA EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 Na gluconate,synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
 Na glutamate,preferred_term,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
@@ -6310,6 +6766,7 @@ Na-ascorbate,preferred_term,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 Na-benzoate,preferred_term,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
 Na-butyrate,preferred_term,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
 Na-caproate,preferred_term,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
+Na-caseinate,preferred_term,MICRO:0001611,Na-caseinate,MICRO:0001611,MAPPED,unique
 Na-crotonate,preferred_term,CHEBI:35899,Na-crotonate,CHEBI:35899,MAPPED,unique
 Na-DL-lactate,synonym,CHEBI:75228,Sodium lactate,CHEBI:75228,MAPPED,unique
 Na-DL-malate,synonym,CHEBI:91261,Sodium malate,CHEBI:91261,MAPPED,unique
@@ -6362,21 +6819,28 @@ Na2-fumarate,preferred_term,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
 Na2-glutamate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
 Na2-glyoxalate,preferred_term,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
 Na2-ß-glycerolphosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Na2-ß-glycerophosphate,synonym,cas:154804-51-0,Beta-Glycerophosphate disodium salt hydrate,CHEBI:17270,MAPPED,unique
 Na2B4O7,preferred_term,CHEBI:38892,Na2B4O7,CHEBI:38892,MAPPED,unique
 Na2B4O7 . 10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7 x 10 H2O,preferred_term,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2B4O7 ·  10 H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7 · 10 H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7·10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7⋅10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7・10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
 Na2B4O7．10H2O,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:131366,MAPPED,unique
+Na2citrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na2citrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
 Na2citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na2CO,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
 Na2CO3,preferred_term,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
 Na2CO3 anhydrous,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3 anhydrous,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
 Na2CO3(Baker 3604),synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3(Baker 3604),synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
 Na2CO3-CO2 buffer,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+Na2CO3-CO2 buffer,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
 Na2EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 Na2EDTA . 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 Na2EDTA · 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
@@ -6385,99 +6849,102 @@ Na2EDTA· 2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 Na2EDTA·2H2O,preferred_term,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 Na2EDTA•2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 Na2EDTA•2H2O(Sigma ED255),synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
-Na2Glycerophosphate.5H2O,preferred_term,UNMAPPED_0081,Na2Glycerophosphate.5H2O,,UNMAPPED,unique
-Na2Glycerophosphate.5H2O(CAS:  13408-09-8),synonym,UNMAPPED_0081,Na2Glycerophosphate.5H2O,,UNMAPPED,unique
-Na2glycerophosphate•5H2O,preferred_term,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,resolved:owned
-Na2Glycerophosphate•5H2O,preferred_term,UNMAPPED_0101,Na2Glycerophosphate•5H2O,,UNMAPPED,resolved:owned
-Na2glycerophosphate•5H2O(CAS: 13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unresolved:no_chemistry
-Na2Glycerophosphate•5H2O(CAS: 13408-09-8),synonym,UNMAPPED_0101,Na2Glycerophosphate•5H2O,,UNMAPPED,unresolved:no_chemistry
+Na2Glycerophosphate.5H2O,synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2Glycerophosphate.5H2O(CAS:  13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2glycerophosphate•5H2O,preferred_term,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2Glycerophosphate•5H2O,synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2Glycerophosphate•5H2O(CAS: 13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
+Na2glycerophosphate•5H2O(CAS: 13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
 Na2glycerophosphate•5H2O(CAS:  13408-09-8),synonym,cas:13408-09-8,Na2glycerophosphate•5H2O,CHEBI:15978,MAPPED,unique
 Na2H2EDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 Na2H2EDTA.2H2O,synonym,CHEBI:64758,Na2EDTA·2H2O,CHEBI:64758,MAPPED,unique
 Na2H2PO4,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
+Na2HAsO4,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 Na2HAsO4 x 7 H2O,preferred_term,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 Na2HPO4,preferred_term,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,unique
 Na2HPO4 . 12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 . 12H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 . 12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 x 12 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,preferred_term,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
 Na2HPO4 x 12 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 12 H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
 Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 2 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,preferred_term,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
 Na2HPO4 x 2 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
+Na2HPO4 x 2 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
 Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 2H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x 2H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x 2H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x 3 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 3 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
-Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 3 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
 Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 3 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 6 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 6 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
-Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 6 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
 Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 6 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 7 H2O,preferred_term,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 7 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,resolved:owned
-Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
-Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,resolved:owned
+Na2HPO4 x 7 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,resolved:owned
 Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x 7 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,resolved:owned
 Na2HPO4 x H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x2 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4 x2 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 x2 H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4 × 12 H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4 × 12 H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
+Na2HPO4 × 12 H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4-KH2PO4 buffer,preferred_term,kgmicrobe.ingredient:na2hpo4-kh2po4_buffer,Na2HPO4-KH2PO4 buffer,kgmicrobe.ingredient:na2hpo4-kh2po4_buffer,MAPPED,unique
 Na2HPO4-NaH2PO4 buffer,preferred_term,kgmicrobe.ingredient:na2hpo4-nah2po4_buffer,Na2HPO4-NaH2PO4 buffer,kgmicrobe.ingredient:na2hpo4-nah2po4_buffer,MAPPED,unique
 Na2HPO4.12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.12H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4.12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4.7H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4.7H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4.7H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4·12H2O,synonym,CHEBI:34683,Na2HPO4,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_12_h2o,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
-Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,conflict:different_substances
+Na2HPO4·12H2O,synonym,CHEBI:91259,Na2HPO4 x 12 H2O,CHEBI:91259,MAPPED,conflict:different_substances
 Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_3_h2o,Na2HPO4 x 3 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,conflict:different_substances
 Na2HPO4·12H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,conflict:different_substances
-Na2HPO4·2H2O,synonym,kgmicrobe.compound:na2hpo4_x_2_h2o,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
+Na2HPO4·2H2O,synonym,CHEBI:91258,Na2HPO4 x 2 H2O,CHEBI:91258,MAPPED,unique
 Na2HPO4·6H2O,synonym,kgmicrobe.compound:na2hpo4_x_6_h2o,Na2HPO4 x 6 H2O,CHEBI:34683,MAPPED,unique
 Na2HPO4•7H2O,synonym,kgmicrobe.compound:na2hpo4_x_7_h2o,Na2HPO4 x 7 H2O,CHEBI:34683,MAPPED,unique
 Na2Mo4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MO4.2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Na2MoO4,preferred_term,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
+Na2MoO4 (0.01 M),synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
 Na2MoO4 . 2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
 Na2MoO4 . 2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
 Na2MoO4 . H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different_substances
@@ -6518,6 +6985,7 @@ Na2MoO4・2H2O,synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,conflict:different
 Na2MoO4・2H2O,synonym,CHEBI:75213,Na2MoO4·2H2O,CHEBI:75213,REJECTED,conflict:different_substances
 Na2MoO7 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Na2MoO7O4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+Na2MoO7・2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Na2MoSO4,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Na2MoSO4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Na2S,preferred_term,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
@@ -6528,9 +6996,12 @@ Na2S x 9 H2O(24% w/v),synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S x 9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S x H2O,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
 Na2S ∙ 9 H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
+Na2S-9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S.9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S2O3,preferred_term,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
+Na2S2O3 (if needed),synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
 Na2S2O3 . 5H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+Na2S2O3 x 5 H20,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
 Na2S2O3 x 5 H2O,preferred_term,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
 Na2S2O3 x 5 H2O (10% solution),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
 Na2S2O3 x 5 H2O(24 % w/v),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
@@ -6544,14 +7015,22 @@ Na2S2O4,synonym,CHEBI:66870,Sodium dithionite,CHEBI:66870,MAPPED,unique
 Na2S2O5,preferred_term,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 Na2S2SO3,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
 Na2Se2O3,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Na2Se3 x 5 H2O,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
 Na2SeO3,preferred_term,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Na2SeO3 . 5H2O,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
 Na2SeO3 . 5H2O,synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
 Na2SeO3 x 5 H2O,preferred_term,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
+Na2SeO3 x 5 H2O (0.01% w/v),synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
 Na2SeO3 x 5 H2O (0.01% w/v),synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
 Na2SeO3·5H2O,preferred_term,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
 Na2SeO3·5H2O,synonym,CHEBI:131361,Na2SeO3 x 5 H2O,CHEBI:131361,MAPPED,unique
 Na2SeO3・5H2O,synonym,CHEBI:131361,Na2SeO3·5H2O,CHEBI:131361,REJECTED,unique
 Na2SeO4,preferred_term,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+Na2SeO4 x 10 H2O,synonym,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
+Na2SeO·5H2O,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
+Na2SiO3,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
+Na2SiO3 x 5 H2O,synonym,CHEBI:60720,Na-silicate,CHEBI:60720,MAPPED,unique
+Na2SiO3 x 9 H20,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
 Na2SiO3 x 9 H2O,preferred_term,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
 Na2SiO3.9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
 Na2SiO3·9H2O,synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
@@ -6569,20 +7048,25 @@ Na2S·9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S⋅9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2S・9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Na2WO2 x 2 H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO2.2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4,preferred_term,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
+Na2WO4 (10 mM),synonym,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
 Na2WO4 . 2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4 x 2 H2O,preferred_term,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4 x 2 H2O (0.1% w/v),synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4 x 2H2O,synonym,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
 Na2WO4 × 2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4*2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4.2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4·2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Na2WO4•2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na2WO4・2H2O,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Na3-citrate,synonym,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,unique
 Na3-citrate x 2 H2O,preferred_term,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na3-citrate x 2 H2O (0.6 g/l stock solution),synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na3-EDTA,preferred_term,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
 Na3-NTA x H2O,preferred_term,UNMAPPED_0475,Na3-NTA x H2O,,UNMAPPED,unique
+Na3Citrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na3Citrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
 Na3Citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Na3VO4,preferred_term,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
@@ -6597,8 +7081,12 @@ NaCl(Fisher S271-500),synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
 NaClO3,preferred_term,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
 NaClO4,synonym,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,unique
 NaCO3,synonym,CHEBI:29377,Na2CO3,CHEBI:29377,MAPPED,unique
+NaCO3,synonym,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
+NAD,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+NAD (Sigma),synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
 NAD(+),synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
 NAD+,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+NaEDTA,synonym,CHEBI:64734,Na2-EDTA,CHEBI:64734,MAPPED,unique
 NaF,preferred_term,CHEBI:28741,NaF,CHEBI:28741,MAPPED,unique
 nafcillin sodium monohydrate,ontology_label,CHEBI:51919,Nafcillin sodium salt monohydrate,CHEBI:51919,MAPPED,unique
 Nafcillin sodium salt monohydrate,preferred_term,CHEBI:51919,Nafcillin sodium salt monohydrate,CHEBI:51919,MAPPED,unique
@@ -6625,12 +7113,20 @@ NaH2PO4・H2O,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:3
 NaHAsO4.7H2O,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 NaHCO,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
 NaHCO3,preferred_term,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3 (1 M),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3 (10% (w/v)),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+"NaHCO3 (10%, w/v)",synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3 (3% (w/v)),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+"NaHCO3 (5%, w/v)",synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+NaHCO3 (7.5% w/v in water),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
 NaHCO3(Fisher S 233),synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
 NaHSO3,preferred_term,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 nalidixic acid,ontology_label,cas:3374-05-8,Nalidixic acid sodium salt,CHEBI:100147,MAPPED,unique
 Nalidixic acid sodium salt,preferred_term,cas:3374-05-8,Nalidixic acid sodium salt,CHEBI:100147,MAPPED,unique
 NaMoO4,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 NaMoO4 x 2 H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+NaMoO4 · 2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
+NaMoO4.2H2O,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 NaNO,preferred_term,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
 NaNO2,preferred_term,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
 NaNO3,preferred_term,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
@@ -6638,6 +7134,8 @@ NaNO3(autoclave before adding)(Fisher BP360-500),synonym,NCIT:C54713,NaNO,NCIT:C
 NaNO3(CAS: 7631-99-4),synonym,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
 NaNO3(Fisher BP360-500),synonym,NCIT:C54713,NaNO,NCIT:C54713,MAPPED,unique
 NaOH,preferred_term,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+NaOH (0.38 M),synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
+NaOH (1N),synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
 naphtalene,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
 naphtaline,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
 Naphthalen,synonym,CHEBI:16482,Naphthalene,CHEBI:16482,MAPPED,unique
@@ -6656,11 +7154,13 @@ Naringenin,preferred_term,CHEBI:50202,Naringenin,CHEBI:50202,MAPPED,unique
 Naringin,preferred_term,CHEBI:28819,Naringin,CHEBI:28819,MAPPED,unique
 NaS2O3,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
 NaS2O3 x 5 H2O,synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
+NaSeO3·5H2O,synonym,CHEBI:48843,Na2SeO3,CHEBI:48843,MAPPED,unique
 NaSiO3 x 9 H2O,preferred_term,UNMAPPED_0477,NaSiO3 x 9 H2O,,UNMAPPED,unique
 NaSO4,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 Natamycin,preferred_term,CHEBI:7488,Natamycin,CHEBI:7488,MAPPED,unique
 natrii ascorbas,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 natrii chloridum,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Natrium L-hydrogenglutamat,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 Natrium nitrit,synonym,CHEBI:78870,NaNO2,CHEBI:78870,MAPPED,unique
 Natrium octanoat,synonym,CHEBI:132100,Sodium octanoate,CHEBI:132100,MAPPED,unique
 Natrium pyrophosphat,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
@@ -6669,6 +7169,7 @@ Natriumazetat,synonym,CHEBI:32954,Na-acetate,CHEBI:32954,MAPPED,unique
 Natriumbisulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 Natriumchlorat,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
 Natriumchlorid,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
+Natriumglutaminat,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 Natriumhydrogenkarbonat,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
 Natriumhydrogensulfit,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 Natriumhydroxid,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
@@ -6684,6 +7185,7 @@ Natriumsulfid,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
 Natural blue 2,synonym,CHEBI:31695,Indigocarmine,CHEBI:31695,MAPPED,unique
 Natural sea water,preferred_term,kgmicrobe.ingredient:natural_sea_water,Natural sea water,ENVO:00002149,MAPPED,unique
 Natural sea-salt,preferred_term,UNMAPPED_0050,Natural sea-salt,,UNMAPPED,unique
+Natural seawater,synonym,MICRO:0001773,Filtered Seawater,MICRO:0001773,MAPPED,unique
 "Natural seawater (filtered, 95% strength)",synonym,MICRO:0001773,Filtered Seawater,MICRO:0001773,MAPPED,unique
 NaVO3,preferred_term,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
 NaVO3 x H2O,preferred_term,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
@@ -6706,6 +7208,7 @@ Netilmicin,synonym,CHEBI:7528,Netilmycin,CHEBI:7528,MAPPED,unique
 Netilmycin,preferred_term,CHEBI:7528,Netilmycin,CHEBI:7528,MAPPED,unique
 Netropsin,preferred_term,mesh:D009429,Netropsin,mesh:D009429,MAPPED,unique
 Neutral red,preferred_term,CHEBI:86370,Neutral red,CHEBI:86370,MAPPED,unique
+NH4+,synonym,CHEBI:28938,Ammonium,CHEBI:28938,MAPPED,unique
 NH4-oxalate,preferred_term,CHEBI:91241,NH4-oxalate,CHEBI:91241,MAPPED,unique
 NH42CO3,preferred_term,CHEBI:229630,NH42CO3,CHEBI:229630,MAPPED,unique
 NH4Cl,preferred_term,CHEBI:31206,NH4Cl,CHEBI:31206,MAPPED,unique
@@ -6720,6 +7223,7 @@ NH4NO,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
 NH4NO3,synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
 NH4NO3(CAS: 6484-52-2),synonym,CHEBI:63038,(NH4)NO3,CHEBI:63038,MAPPED,unique
 NH4OAc,synonym,CHEBI:62947,Ammonium acetate,CHEBI:62947,MAPPED,unique
+NH4OH,preferred_term,CHEBI:18219,NH4OH,CHEBI:18219,MAPPED,unique
 Niacin,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
 Niacinamide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Niacor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
@@ -6740,6 +7244,7 @@ nickel dichloride,ontology_label,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,
 nickel dichloride,ontology_label,kgmicrobe.compound:nicl2_x_5_h2o,NiCl2 x 5 H2O,CHEBI:34887,MAPPED,conflict:different_substances
 Nickel dichloride hexahydrate,synonym,CHEBI:53542,Nickel (II) chloride hexahydrate,CHEBI:53542,MAPPED,unique
 Nickel monosulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+Nickel Sulfate,preferred_term,CHEBI:53001,Nickel Sulfate,CHEBI:53001,MAPPED,unique
 nickel sulfate heptahydrate,ontology_label,CHEBI:53504,NiSO4 x 7 H2O,CHEBI:53504,MAPPED,unique
 Nickel sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
 nickel sulfate hexahydrate,ontology_label,CHEBI:53437,NiSO4 x 6 H2O,CHEBI:53437,REJECTED,unique
@@ -6764,6 +7269,8 @@ nickel(II) sulphate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydr
 Nickel-NTA,preferred_term,UNMAPPED_0152,Nickel-NTA,,UNMAPPED,unique
 Nickelous sulfate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
 nickelous sulphate hexahydrate,synonym,CHEBI:53437,Nickel (II) sulfate hexahydrate,CHEBI:53437,MAPPED,unique
+NiCl 2,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
+NiCl 2 x 6 H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
 NiCl2,preferred_term,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,unique
 NiCl2 . 6H2O,synonym,CHEBI:34887,NiCl2,CHEBI:34887,MAPPED,conflict:different_substances
 NiCl2 . 6H2O,synonym,kgmicrobe.compound:nicl2_x_2_h2o,NiCl2 x 2 H2O,CHEBI:34887,MAPPED,conflict:different_substances
@@ -6841,10 +7348,14 @@ NiCl2・H2O,synonym,CHEBI:53542,NiCl2 x 6 H2O,CHEBI:53542,REJECTED,conflict:diff
 Nicotinamid,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 nicotinamida,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Nicotinamide,preferred_term,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
+Nicotinamide (Niacinamide),synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Nicotinamide adenine dinucleotide,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+nicotinamide adenine dinucleotide (NAD),synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
 Nicotinamide N-oxide,preferred_term,CHEBI:89640,Nicotinamide N-oxide,CHEBI:89640,MAPPED,unique
 nicotinamidum,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Nicotinate,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
+nicotine,ontology_label,CHEBI:18723,Nicotine (Fluka),CHEBI:18723,MAPPED,unique
+Nicotine (Fluka),preferred_term,CHEBI:18723,Nicotine (Fluka),CHEBI:18723,MAPPED,unique
 nicotine acid amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Nicotine amide,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Nicotinic acid,preferred_term,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
@@ -6943,7 +7454,14 @@ Nucleocidin,preferred_term,CHEBI:166872,Nucleocidin,CHEBI:166872,MAPPED,unique
 nukacin ISK-1,synonym,kgmicrobe.compound:bacteriocin_isk_1,Bacteriocin Isk 1,kgmicrobe.compound:bacteriocin_isk_1,MAPPED,unique
 Nutriacholic Acid,preferred_term,CHEBI:82679,Nutriacholic Acid,CHEBI:82679,MAPPED,unique
 Nutrient agar,preferred_term,UNMAPPED_0481,Nutrient agar,,UNMAPPED,unique
+Nutrient agar (Oxoid CM3),synonym,UNMAPPED_0481,Nutrient agar,,UNMAPPED,unique
 nutrient broth,ontology_label,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient Broth (BD cat 234000),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient broth (BD Difco),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient broth (BD-Difco),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient Broth (Difco),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient broth (NB) (Difco),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
+Nutrient Broth (OXOID),synonym,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
 Nutrient broth No. 2,preferred_term,MICRO:0000082,Nutrient broth No. 2,MICRO:0000082,MAPPED,unique
 Nystatin,preferred_term,CHEBI:7660,Nystatin,CHEBI:7660,MAPPED,unique
 O Carbamyl D Serine,preferred_term,mesh:C000366,O Carbamyl D Serine,mesh:C000366,MAPPED,unique
@@ -6959,14 +7477,20 @@ o-hydroxyphenol,synonym,CHEBI:18135,Pyrocatechol,CHEBI:18135,MAPPED,unique
 O-methyl-D-glucuronoxylan,preferred_term,UNMAPPED_0227,O-methyl-D-glucuronoxylan,,UNMAPPED,unique
 O-methyl-nonaethyleneglycol,synonym,CHEBI:132112,Na2S2O3,CHEBI:132112,MAPPED,unique
 O-nitrophenyl-beta-D-galactopyranosid,preferred_term,CHEBI:90144,O-nitrophenyl-beta-D-galactopyranosid,CHEBI:90144,MAPPED,unique
+O-nitrophenyl-beta-D-galactopyranoside,synonym,CHEBI:90144,O-nitrophenyl-beta-D-galactopyranosid,CHEBI:90144,MAPPED,unique
+O-Phospho-L-serine,preferred_term,CHEBI:15811,O-Phospho-L-serine,CHEBI:15811,MAPPED,unique
 O-phosphoethanolamine,ontology_label,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
 O-Phosphoryl-Ethanolamine,preferred_term,CHEBI:17553,O-Phosphoryl-Ethanolamine,CHEBI:17553,MAPPED,unique
 o-pyrocatechuic acid,synonym,CHEBI:18026,"2,3-dihydroxybenzoic acid",CHEBI:18026,MAPPED,unique
 OADC Enrichment,preferred_term,kgmicrobe.ingredient:oadc_enrichment,OADC Enrichment,kgmicrobe.ingredient:oadc_enrichment,MAPPED,unique
+OADC Enrichment (Difco),synonym,kgmicrobe.ingredient:oadc_enrichment,OADC Enrichment,kgmicrobe.ingredient:oadc_enrichment,MAPPED,unique
+Oat flakes,preferred_term,FOODON:03306272,Oat flakes,FOODON:03306272,MAPPED,unique
 oat flour,ontology_label,FOODON:03301312,Oat flour B-glucan,FOODON:03301312,MAPPED,unique
 Oat flour B-glucan,preferred_term,FOODON:03301312,Oat flour B-glucan,FOODON:03301312,MAPPED,unique
 Oatmeal,preferred_term,NCIT:C29298,Oatmeal,NCIT:C29298,MAPPED,unique
+Oatmeal (Quaker White Oats),synonym,NCIT:C29298,Oatmeal,NCIT:C29298,MAPPED,unique
 Oatmeal agar,preferred_term,UNMAPPED_0129,Oatmeal agar,,UNMAPPED,unique
+Oatmeal agar (BD-Difco),synonym,UNMAPPED_0129,Oatmeal agar,,UNMAPPED,unique
 Oatmeal Powder,ontology_label,NCIT:C29298,Oatmeal,NCIT:C29298,MAPPED,unique
 oct-1-en-3-ol,ontology_label,CHEBI:34118,1-octen-3-ol,CHEBI:34118,MAPPED,unique
 Octadec-9-enoic acid,synonym,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
@@ -6989,6 +7513,7 @@ olean-12-en-3beta-ol,synonym,CHEBI:10352,Beta-Amyrin,CHEBI:10352,MAPPED,unique
 Oleandomycin,preferred_term,CHEBI:16869,Oleandomycin,CHEBI:16869,MAPPED,unique
 Oleic acid,preferred_term,CHEBI:16196,Oleic acid,CHEBI:16196,MAPPED,unique
 oleoylglycerol,synonym,CHEBI:75937,Glycerol mono-oleate,CHEBI:75937,MAPPED,unique
+Olive oil,preferred_term,FOODON:03301826,Olive oil,FOODON:03301826,MAPPED,unique
 omega-aminobutyric acid,synonym,CHEBI:16865,gamma-Aminobutyric acid,CHEBI:16865,MAPPED,unique
 Optional ingredient,synonym,CHEBI:15824,D-Fructose,CHEBI:15824,MAPPED,conflict:different_substances
 Optional ingredient,synonym,CHEBI:18246,Cellulose,CHEBI:18246,MAPPED,conflict:different_substances
@@ -7002,14 +7527,17 @@ Organic Peat,preferred_term,UNMAPPED_0099,Organic Peat,,UNMAPPED,unique
 Original amount: (NH4)2HPO4(Fisher A686),synonym,CHEBI:63051,(NH4)2HPO4,CHEBI:63051,MAPPED,unique
 Original amount: (NH4)2SO4(Fisher A 702),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
 Ornithine,preferred_term,CHEBI:18257,Ornithine,CHEBI:18257,MAPPED,unique
+Orotate,preferred_term,CHEBI:30839,Orotate,CHEBI:30839,MAPPED,unique
 Orotic acid,preferred_term,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
 "Orotic acid, sodium salt",synonym,CHEBI:132101,Na-orotate,CHEBI:132101,MAPPED,unique
 Orotsaeure,synonym,CHEBI:16742,Orotic acid,CHEBI:16742,MAPPED,unique
 orthoboric acid,synonym,CHEBI:33118,H3BO3,CHEBI:33118,MAPPED,unique
+Orthophosphate,preferred_term,CHEBI:18367,Orthophosphate,CHEBI:18367,MAPPED,unique
 "Orthophosphoric acid, monopotassium salt",synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 Osmitrol,synonym,CHEBI:16899,D-Mannitol,CHEBI:16899,MAPPED,unique
 Ossamycin,preferred_term,CHEBI:77735,Ossamycin,CHEBI:77735,MAPPED,unique
-Ox-bile,preferred_term,UNMAPPED_0485,Ox-bile,,UNMAPPED,unique
+ox bile,ontology_label,MICRO:0000610,Ox-bile,MICRO:0000610,MAPPED,unique
+Ox-bile,preferred_term,MICRO:0000610,Ox-bile,MICRO:0000610,MAPPED,unique
 Oxacillin,preferred_term,CHEBI:7809,Oxacillin,CHEBI:7809,MAPPED,unique
 oxacillin sodium,ontology_label,CHEBI:52134,Oxacillin sodium salt,CHEBI:52134,MAPPED,unique
 Oxacillin sodium salt,preferred_term,CHEBI:52134,Oxacillin sodium salt,CHEBI:52134,MAPPED,unique
@@ -7022,7 +7550,10 @@ Oxaloacetic acid,preferred_term,CHEBI:30744,Oxaloacetic acid,CHEBI:30744,MAPPED,
 Oxamicetin,preferred_term,CHEBI:220394,Oxamicetin,CHEBI:220394,MAPPED,unique
 Oxedrine,preferred_term,CHEBI:29081,Oxedrine,CHEBI:29081,MAPPED,unique
 Oxgall,preferred_term,UNMAPPED_0486,Oxgall,,UNMAPPED,unique
+Oxgall (BD-Difco),synonym,UNMAPPED_0486,Oxgall,,UNMAPPED,unique
 oxidane,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+oxidation in darkness: sulfur compounds,synonym,CHEBI:26835,Sulfur compounds,CHEBI:26835,MAPPED,unique
+oxidation: pyrite,synonym,CHEBI:86471,Pyrite,CHEBI:86471,MAPPED,unique
 oxidized L-cysteine,synonym,CHEBI:16283,L-Cystine,CHEBI:16283,MAPPED,unique
 oxidodinitrogen(N--N),synonym,CHEBI:17045,nitrous oxide,CHEBI:17045,MAPPED,unique
 oxidoperoxidonitrate(1-),synonym,CHEBI:25941,peroxynitrite,CHEBI:25941,MAPPED,unique
@@ -7044,11 +7575,14 @@ p-Amino Benzoic Acid,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,
 p-Aminobenzoate,synonym,CHEBI:17836,4-Aminobenzoate,CHEBI:17836,MAPPED,unique
 p-Aminobenzoesaeure,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 p-Aminobenzoic acid,preferred_term,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
+p-aminobenzoic acid (0.3 μg/μL),synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 p-carboxyaniline,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 p-carboxyphenylamine,synonym,CHEBI:30753,p-Aminobenzoic acid,CHEBI:30753,MAPPED,unique
 p-Coumaric acid,preferred_term,CHEBI:32374,p-Coumaric acid,CHEBI:32374,MAPPED,unique
+p-cresol,ontology_label,CHEBI:17847,4-Cresol,CHEBI:17847,MAPPED,unique
 p-Hydroxybenzoate,preferred_term,CHEBI:17879,p-Hydroxybenzoate,CHEBI:17879,MAPPED,unique
 P-HYDROXYBENZOIC ACID,synonym,CHEBI:30763,4-Hydroxybenzoic acid,CHEBI:30763,MAPPED,unique
+p-Hydroxybenzyl alcohol,preferred_term,CHEBI:67410,p-Hydroxybenzyl alcohol,CHEBI:67410,MAPPED,unique
 P-II Metal Solution,preferred_term,kgmicrobe.ingredient:p-ii_metal_solution,P-II Metal Solution,kgmicrobe.ingredient:p-ii_metal_solution,MAPPED,unique
 P-IV Metal Solution,preferred_term,kgmicrobe.ingredient:p-iv_metal_solution,P-IV Metal Solution,kgmicrobe.ingredient:p-iv_metal_solution,MAPPED,unique
 p-lacto-N-neo-hexaose,preferred_term,cas:64309-00-8,p-lacto-N-neo-hexaose,cas:64309-00-8,MAPPED,unique
@@ -7063,6 +7597,7 @@ Paclitaxel,preferred_term,CHEBI:45863,Paclitaxel,CHEBI:45863,MAPPED,unique
 Pactamycin,preferred_term,mesh:D010142,Pactamycin,mesh:D010142,MAPPED,unique
 Paeonol,preferred_term,CHEBI:69581,Paeonol,CHEBI:69581,MAPPED,unique
 Palatinose,preferred_term,CHEBI:18394,Palatinose,CHEBI:18394,MAPPED,unique
+Palatinose (6-O-alpha-D-glucopyranosyl-D-fruc,synonym,CHEBI:18394,Palatinose,CHEBI:18394,MAPPED,unique
 palatinose hydrate,preferred_term,cas:343336-76-5,palatinose hydrate,CHEBI:18394,MAPPED,unique
 Palladium chloride,synonym,CHEBI:53434,Palladium(II) chloride,CHEBI:53434,MAPPED,unique
 Palladium(II) chloride,preferred_term,CHEBI:53434,Palladium(II) chloride,CHEBI:53434,MAPPED,unique
@@ -7073,6 +7608,8 @@ Pamamycin,preferred_term,mesh:C024500,Pamamycin,mesh:C024500,MAPPED,unique
 Pancreatic Digest of Casein,synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unresolved:no_chemistry
 Pancreatic digest of casein,synonym,MICRO:0000182,Tryptone,MICRO:0000182,MAPPED,unresolved:no_chemistry
 Pancreatic Digest of Casein (Hardy C6530),synonym,FOODON:03315719,Casein peptone,FOODON:03315719,MAPPED,unique
+pancreatic digest of gelatin,ontology_label,MICRO:0000466,Pancreatic Digest of Gelatin (Hardy C6540),MICRO:0000466,MAPPED,unique
+Pancreatic Digest of Gelatin (Hardy C6540),preferred_term,MICRO:0000466,Pancreatic Digest of Gelatin (Hardy C6540),MICRO:0000466,MAPPED,unique
 Panhematin,synonym,CHEBI:50385,Haemin,CHEBI:50385,MAPPED,unique
 Pantothenate,preferred_term,CHEBI:16454,Pantothenate,CHEBI:16454,MAPPED,unique
 Pantothenic acid,preferred_term,CHEBI:7916,Pantothenic acid,CHEBI:7916,MAPPED,unique
@@ -7112,6 +7649,7 @@ Pelargonic acid,synonym,CHEBI:29019,Nonanoic acid,CHEBI:29019,MAPPED,unique
 pellagra preventive factor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
 Penicillin,preferred_term,CHEBI:17334,Penicillin,CHEBI:17334,MAPPED,unique
 Penicillin g,preferred_term,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
+Penicillin G (Parke),synonym,CHEBI:51765,Penicillin g,CHEBI:51765,MAPPED,unique
 penicillins,synonym,CHEBI:17334,Penicillin,CHEBI:17334,MAPPED,unique
 Pentachlorophenol,preferred_term,CHEBI:17642,Pentachlorophenol,CHEBI:17642,MAPPED,unique
 pentan-1-ol,ontology_label,CHEBI:44884,1-Pentanol,CHEBI:44884,MAPPED,unique
@@ -7163,6 +7701,7 @@ peroxynitrite,preferred_term,CHEBI:25941,peroxynitrite,CHEBI:25941,MAPPED,unique
 petroleum,ontology_label,ENVO:00002984,Crude Oil,ENVO:00002984,MAPPED,unique
 Peucenin,preferred_term,cas:578-72-3,Peucenin,cas:578-72-3,MAPPED,unique
 PGA,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
+PHA,synonym,CHEBI:78037,Poly-beta-hydroxyalkanoate,CHEBI:78037,MAPPED,unique
 Phenanthrene,preferred_term,CHEBI:28851,Phenanthrene,CHEBI:28851,MAPPED,unique
 Phenazine ethosulfate,preferred_term,cas:10510-77-7,Phenazine ethosulfate,cas:10510-77-7,MAPPED,unique
 Phenazine methosulfate,preferred_term,CHEBI:8055,Phenazine methosulfate,CHEBI:8055,MAPPED,unique
@@ -7174,9 +7713,12 @@ Phenethylamine Hydrochloride,synonym,CHEBI:18397,2-phenylethylamine,CHEBI:18397,
 Phenic acid,synonym,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
 Phenol,preferred_term,CHEBI:15882,Phenol,CHEBI:15882,MAPPED,unique
 Phenol red,preferred_term,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+Phenol red (0.04%),synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
+Phenol red (0.1% aqueous),synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
 Phenolsulfonphthalein,synonym,CHEBI:31991,Phenol red,CHEBI:31991,MAPPED,unique
 Phenoxyacetic acid,preferred_term,CHEBI:8075,Phenoxyacetic acid,CHEBI:8075,MAPPED,unique
 Phenoxymethylpenicillin,preferred_term,CHEBI:27446,Phenoxymethylpenicillin,CHEBI:27446,MAPPED,unique
+Phenyl acetate,preferred_term,CHEBI:8082,Phenyl acetate,CHEBI:8082,MAPPED,unique
 Phenyl acetic acid,preferred_term,CHEBI:30745,Phenyl acetic acid,CHEBI:30745,MAPPED,unique
 Phenyl propionic acid,preferred_term,CHEBI:28631,Phenyl propionic acid,CHEBI:28631,MAPPED,unique
 Phenylacetate,preferred_term,CHEBI:18401,Phenylacetate,CHEBI:18401,MAPPED,unique
@@ -7202,14 +7744,17 @@ Phosphate Buffer,ontology_label,kgmicrobe.ingredient:potassium_phosphate_buffer,
 Phosphate Buffer,ontology_label,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
 Phosphate Buffer,ontology_label,kgmicrobe.ingredient:sodium_potassium_phosphate_buffer,Sodium Potassium phosphate buffer,NCIT:C29321,MAPPED,resolved:owned
 Phosphate Buffer Stock Solution,preferred_term,kgmicrobe.ingredient:phosphate_buffer_stock_solution,Phosphate Buffer Stock Solution,NCIT:C29321,MAPPED,unique
+phosphate(3-),ontology_label,CHEBI:18367,Orthophosphate,CHEBI:18367,MAPPED,unique
 Phosphate-buffered saline,synonym,kgmicrobe.ingredient:pbs,PBS,NCIT:C178908,MAPPED,unique
 phosphatidylinositol,ontology_label,cas:97281-52-2,L-α-Phosphatidylinositol from Glycine max (soybean),CHEBI:28874,MAPPED,unique
 Phosphocholine,preferred_term,CHEBI:18132,Phosphocholine,CHEBI:18132,MAPPED,unique
 Phosphomycin disodium salt,preferred_term,cas:26016-99-9,Phosphomycin disodium salt,cas:26016-99-9,MAPPED,unique
 phosphonic acid,ontology_label,cas:13977-65-6,KH2PO3,CHEBI:44976,MAPPED,unique
+phosphoric acid,ontology_label,CHEBI:26078,H3PO4,CHEBI:26078,MAPPED,unique
 Phosphoric acid mono-(4-formyl-5-hydroxy-6-methyl-pyridin-3-ylmethyl) ester,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
 "phosphoric acid, calcium salt (1:1)",synonym,CHEBI:32596,CaHPO4,CHEBI:32596,MAPPED,unique
 "Phosphoric acid, dipotassium salt",synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+"Phosphoric acid, disodium salt, dihydrate",synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 "Phosphoric acid, monoammonium salt",synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,unique
 "Phosphoric acid, monopotassium salt",synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
 "phosphoric acid, monosodium salt",synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
@@ -7251,6 +7796,7 @@ Piperine,preferred_term,CHEBI:28821,Piperine,CHEBI:28821,MAPPED,unique
 PIPES,preferred_term,CHEBI:39033,PIPES,CHEBI:39033,MAPPED,resolved:owned
 PIPES,ontology_label,kgmicrobe.ingredient:pipes_buffer,PIPES buffer,CHEBI:39033,MAPPED,resolved:owned
 PIPES buffer,preferred_term,kgmicrobe.ingredient:pipes_buffer,PIPES buffer,CHEBI:39033,MAPPED,unique
+PIPES buffer (Sigma),synonym,kgmicrobe.ingredient:pipes_buffer,PIPES buffer,CHEBI:39033,MAPPED,unique
 PIPES sesquisodium salt,preferred_term,cas:100037-69-2,PIPES sesquisodium salt,cas:100037-69-2,MAPPED,unique
 Piplartine,preferred_term,CHEBI:8241,Piplartine,CHEBI:8241,MAPPED,unique
 piridossina,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
@@ -7284,15 +7830,18 @@ poly(L-lysine),synonym,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,uni
 poly(L-lysine),synonym,CHEBI:61490,Poly L Lysine Polymer,CHEBI:61490,REJECTED,unique
 poly(L-lysine) polymer,preferred_term,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,unique
 poly(L-lysine) polymer,synonym,CHEBI:61490,Poly L Lysine Polymer,CHEBI:61490,REJECTED,unique
+poly(vinyl alcohol) macromolecule,ontology_label,CHEBI:17246,Polyvinyl alcohol,CHEBI:17246,MAPPED,unique
 poly-3-hydroxy butyrate,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
 poly-3-hydroxybutyrate,synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
 Poly-beta-hydroxyalkanoate,preferred_term,CHEBI:78037,Poly-beta-hydroxyalkanoate,CHEBI:78037,MAPPED,unique
 poly-ß-hydroxybutyric acid,preferred_term,UNMAPPED_0493,poly-ß-hydroxybutyric acid,,UNMAPPED,unique
 poly[(1->4)-alpha-D-GalpA],synonym,CHEBI:17309,Pectin,CHEBI:17309,MAPPED,unique
+Poly[(R)-3-hydroxybutyric acid],synonym,UNMAPPED_0494,Poly[R-3-hydroxybutyric acid],,UNMAPPED,unique
 "poly[oxy(1-methyl-3-oxopropane-1,3-diyl)]",synonym,CHEBI:53389,Poly(3-hydroxybutyrate),CHEBI:53389,MAPPED,unique
 Poly[R-3-hydroxybutyric acid],preferred_term,UNMAPPED_0494,Poly[R-3-hydroxybutyric acid],,UNMAPPED,unique
 Polychlorobiphenyl,preferred_term,CHEBI:53156,Polychlorobiphenyl,CHEBI:53156,MAPPED,unique
 Polyethylene glycol,preferred_term,CHEBI:46793,Polyethylene glycol,CHEBI:46793,MAPPED,unique
+Polyethylene glycol (Mw 106-20000),synonym,CHEBI:46793,Polyethylene glycol,CHEBI:46793,MAPPED,unique
 Polyethylene glycol hexadecyl ether,synonym,cas:9004-95-9,Cetomacrogol 1000,mesh:D002592,MAPPED,unique
 Polyethylene oxide sorbitan mono-oleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
 polygalacturonic acid,preferred_term,CHEBI:62969,polygalacturonic acid,CHEBI:62969,MAPPED,resolved:owned
@@ -7312,8 +7861,10 @@ Polyoxyethylene sorbitan monostearate,synonym,CHEBI:53425,Tween 60,CHEBI:53425,M
 Polyoxyethylene sorbitan oleate,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
 Polypepton,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Polypepton (Nihon Pharm. Co.),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypepton (Nihon Seiyaku),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Polypeptone,preferred_term,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 polypeptone,synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
+Polypeptone (BBL),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Polypeptone Peptone (BD 211910),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 Polypeptone peptone (BD-BBL),synonym,FOODON:03315306,Polypeptone,FOODON:03315306,MAPPED,unique
 polysaccharide,ontology_label,CHEBI:18154,Polysaccharides,CHEBI:18154,MAPPED,unique
@@ -7324,6 +7875,7 @@ polysorbate 60,ontology_label,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
 Polysorbate 80,synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
 Polysorbates,ontology_label,mesh:D011136,Tween,mesh:D011136,MAPPED,unique
 polysulfur,synonym,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
+Polyvinyl alcohol,preferred_term,CHEBI:17246,Polyvinyl alcohol,CHEBI:17246,MAPPED,unique
 Porcine serum,preferred_term,MICRO:0001238,Porcine serum,MICRO:0001238,MAPPED,unique
 Porfiromycin,preferred_term,CHEBI:208611,Porfiromycin,CHEBI:208611,MAPPED,unique
 Porphyran,preferred_term,mesh:C038549,Porphyran,mesh:C038549,MAPPED,unique
@@ -7350,6 +7902,7 @@ Potassium aluminum alum,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
 Potassium aluminum chloride,preferred_term,cas:74978-20-4,Potassium aluminum chloride,NCIT:C83530,MAPPED,unique
 potassium aluminum disulfate,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
 Potassium aluminum disulfate dodecahydrate,synonym,CHEBI:86465,AlK(SO4)2 x 12 H2O,CHEBI:86465,MAPPED,unique
+Potassium Aspartate,preferred_term,NCIT:C87343,Potassium Aspartate,NCIT:C87343,MAPPED,unique
 potassium bicarbonate,synonym,CHEBI:81862,KHCO3,CHEBI:81862,MAPPED,unique
 Potassium Bromide,synonym,CHEBI:32030,KBr,CHEBI:32030,MAPPED,unique
 potassium carbonate,synonym,CHEBI:131526,K2CO3,CHEBI:131526,MAPPED,unique
@@ -7358,6 +7911,7 @@ Potassium chromate,synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
 Potassium chromate(VI),synonym,CHEBI:75249,K2CrO4,CHEBI:75249,MAPPED,unique
 potassium citramalate monohydrate,preferred_term,cas:1030365-02-6,potassium citramalate monohydrate,CHEBI:15584,MAPPED,unique
 Potassium dibasic phosphate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
+Potassium dibasic phosphate trihydrate,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
 Potassium dichromate,preferred_term,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
 potassium dichromate(2-),synonym,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
 potassium dichromate(VI),synonym,CHEBI:53444,Potassium dichromate,CHEBI:53444,MAPPED,unique
@@ -7381,6 +7935,10 @@ Potassium Phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,conflict:diffe
 potassium phosphate,ontology_label,cas:16788-57-1,Potassium phosphate dibasic trihydrate,mesh:C013216,MAPPED,conflict:different_substances
 Potassium phosphate (dibasic),synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
 Potassium phosphate buffer,preferred_term,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+"Potassium phosphate buffer (0.01 M, pH 7.2)",synonym,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+"Potassium phosphate buffer (0.02 M, pH 7.0)",synonym,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+"Potassium phosphate buffer (1 M, pH 7.1)",synonym,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
+Potassium phosphate buffer* (see below),synonym,kgmicrobe.ingredient:potassium_phosphate_buffer,Potassium phosphate buffer,NCIT:C29321,MAPPED,unique
 Potassium phosphate dibasic,synonym,CHEBI:131527,K2HPO4,CHEBI:131527,MAPPED,unique
 Potassium phosphate dibasic trihydrate,preferred_term,cas:16788-57-1,Potassium phosphate dibasic trihydrate,mesh:C013216,MAPPED,unique
 Potassium phosphate monobasic,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
@@ -7400,6 +7958,9 @@ potassium thiocyanate,synonym,CHEBI:30951,KSCN,CHEBI:30951,MAPPED,unique
 Potato flour,preferred_term,FOODON:03302378,Potato flour,FOODON:03302378,MAPPED,unique
 PP factor,synonym,CHEBI:15940,Nicotinic acid,CHEBI:15940,MAPPED,unique
 PPLO broth,preferred_term,UNMAPPED_0497,PPLO broth,,UNMAPPED,unique
+PPLO broth (BD-Difco),synonym,UNMAPPED_0497,PPLO broth,,UNMAPPED,unique
+PPLO broth (Difco),synonym,UNMAPPED_0497,PPLO broth,,UNMAPPED,unique
+PPLO medium,preferred_term,MICRO:0000094,PPLO medium,MICRO:0000094,MAPPED,unique
 Pradimicin,preferred_term,CHEBI:83230,Pradimicin,CHEBI:83230,MAPPED,unique
 Pravastatin,preferred_term,CHEBI:63618,Pravastatin,CHEBI:63618,MAPPED,unique
 Pravastatin lactone,preferred_term,CHEBI:145933,Pravastatin lactone,CHEBI:145933,MAPPED,unique
@@ -7415,9 +7976,28 @@ Primary ammonium phosphate,synonym,CHEBI:62982,NH4H2PO4,CHEBI:62982,MAPPED,uniqu
 Primocarcin,preferred_term,kgmicrobe.compound:primocarcin,Primocarcin,kgmicrobe.compound:primocarcin,MAPPED,unique
 Pristinamycin,preferred_term,CHEBI:85274,Pristinamycin,CHEBI:85274,MAPPED,unique
 Probumin Universal Grade,preferred_term,UNMAPPED_0499,Probumin Universal Grade,,UNMAPPED,unique
+Probumin Universal Grade (Millipore),synonym,UNMAPPED_0499,Probumin Universal Grade,,UNMAPPED,unique
 Procaine hydrochloride,preferred_term,CHEBI:8431,Procaine hydrochloride,CHEBI:8431,MAPPED,unique
+produces: actinomycin A,synonym,kgmicrobe.compound:actinomycin_a,Actinomycin A,CHEBI:15369,MAPPED,unique
+produces: alanosine,synonym,CHEBI:221124,alanosine,CHEBI:221124,MAPPED,unique
+produces: angustmycin,synonym,CHEBI:8612,Angustmycin,CHEBI:8612,MAPPED,unique
+produces: cephamycin A,synonym,kgmicrobe.compound:cephamycin_a,Cephamycin A,CHEBI:55429,MAPPED,unique
 produces: DL-lactate,synonym,CHEBI:24996,Lactate,CHEBI:24996,MAPPED,unique
 produces: ethanol,synonym,CHEBI:16236,Ethanol,CHEBI:16236,MAPPED,unique
+produces: ferroverdin,synonym,CHEBI:219729,ferroverdin,CHEBI:219729,MAPPED,unique
+produces: hydrogen sulfide,synonym,CHEBI:16136,Hydrogen sulfide,CHEBI:16136,MAPPED,unique
+produces: indole,synonym,CHEBI:16881,Indole,CHEBI:16881,MAPPED,unique
+produces: kijanimicin,synonym,CHEBI:220048,kijanimicin,CHEBI:220048,MAPPED,unique
+produces: methane from acetate,synonym,CHEBI:16183,methane,CHEBI:16183,MAPPED,unique
+produces: methane from formate,synonym,CHEBI:16183,methane,CHEBI:16183,MAPPED,unique
+produces: miharamycin A,synonym,CHEBI:216282,miharamycin A,CHEBI:216282,MAPPED,unique
+produces: monazomycin,synonym,CHEBI:201539,monazomycin,CHEBI:201539,MAPPED,unique
+produces: nocamycin,synonym,CHEBI:219652,nocamycin,CHEBI:219652,MAPPED,unique
+produces: poly(L-lysine) polymer,synonym,CHEBI:61490,poly(L-lysine) polymer,CHEBI:61490,MAPPED,unique
+produces: ristocetin B,synonym,kgmicrobe.compound:ristocetin_b,Ristocetin B,CHEBI:85129,MAPPED,unique
+produces: rubradirin,synonym,CHEBI:223718,rubradirin,CHEBI:223718,MAPPED,unique
+produces: siderophore,synonym,CHEBI:26672,Siderophore,CHEBI:26672,MAPPED,unique
+produces: stallimycin,synonym,CHEBI:41958,Stallimycin,CHEBI:41958,MAPPED,unique
 Prolin,synonym,CHEBI:26271,Proline,CHEBI:26271,MAPPED,unique
 Proline,preferred_term,CHEBI:26271,Proline,CHEBI:26271,MAPPED,resolved:owned
 PROLINE,synonym,CHEBI:17203,L-Proline,CHEBI:17203,MAPPED,resolved:owned
@@ -7431,10 +8011,12 @@ Propandiamine,preferred_term,CHEBI:15725,Propandiamine,CHEBI:15725,MAPPED,unique
 "propane-1,2-diol",ontology_label,CHEBI:16997,"1,2-Propanediol",CHEBI:16997,MAPPED,unique
 "Propane-1,3-diamine",synonym,CHEBI:15725,Propandiamine,CHEBI:15725,MAPPED,unique
 "propane-1,3-diol",ontology_label,CHEBI:16109,"1,3-Propanediol",CHEBI:16109,MAPPED,unique
+Propane-1-ol,synonym,CHEBI:28831,Propan-1-ol,CHEBI:28831,MAPPED,unique
 propanecarboxylic acid,synonym,CHEBI:30772,Butyric acid,CHEBI:30772,MAPPED,unique
 Propanedioic acid,synonym,CHEBI:30794,Malonic acid,CHEBI:30794,MAPPED,unique
 Propanetriol,synonym,CHEBI:17754,Glycerol,CHEBI:17754,MAPPED,unique
 Propanetriol,synonym,CHEBI:17754,glycerol,CHEBI:17754,REJECTED,unique
+Propanoate,synonym,CHEBI:17272,Propionate,CHEBI:17272,MAPPED,unique
 PROPANOIC ACID,synonym,CHEBI:30768,Propionic acid,CHEBI:30768,MAPPED,unique
 "Propanoic acid, sodium salt",synonym,CHEBI:132106,Na-propionate,CHEBI:132106,MAPPED,unique
 Propanol,synonym,CHEBI:28831,Propan-1-ol,CHEBI:28831,MAPPED,unique
@@ -7454,6 +8036,7 @@ Proteose,preferred_term,kgmicrobe.compound:proteose,Proteose,kgmicrobe.compound:
 Proteose Peptone,preferred_term,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
 Proteose peptone,synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
 Proteose peptone (BD Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
+Proteose peptone (BD Difico),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
 Proteose peptone (BD--Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
 Proteose peptone (BD-Difco),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
 Proteose Peptone (Difco no. 3),synonym,MICRO:0000180,Proteose Peptone,MICRO:0000180,MAPPED,unique
@@ -7539,8 +8122,13 @@ Pyridoxal HCl,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,u
 Pyridoxal hydrochloride,preferred_term,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
 Pyridoxal phosphate,preferred_term,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
 PYRIDOXAL-5'-PHOSPHATE,synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
+pyridoxal-HCl (Sigma Aldrich),synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+pyridoxal-phosphate (Sigma Aldrich),synonym,CHEBI:18405,Pyridoxal phosphate,CHEBI:18405,MAPPED,unique
 Pyridoxal·HCl,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
+Pyridoxal・HCl,synonym,CHEBI:131529,Pyridoxal hydrochloride,CHEBI:131529,MAPPED,unique
 Pyridoxamine,preferred_term,CHEBI:16410,Pyridoxamine,CHEBI:16410,MAPPED,unique
+Pyridoxamine (15 μg/μL),synonym,CHEBI:16410,Pyridoxamine,CHEBI:16410,MAPPED,unique
+Pyridoxamine . 2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
 pyridoxamine 2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
 Pyridoxamine dichlorohydrate,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
 Pyridoxamine Dihydrochloride,preferred_term,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
@@ -7548,15 +8136,23 @@ Pyridoxamine HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MA
 Pyridoxamine hydrochloride,preferred_term,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
 pyridoxamine monohydrochloride,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
 Pyridoxamine-HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxamine.2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
 Pyridoxamine·2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
 Pyridoxamine·HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
+Pyridoxamine・2HCl,synonym,CHEBI:131532,Pyridoxamine Dihydrochloride,CHEBI:131532,MAPPED,unique
+Pyridoxamine・HCl,synonym,CHEBI:131531,Pyridoxamine hydrochloride,CHEBI:131531,MAPPED,unique
 Pyridoxin,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
 pyridoxina,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
 Pyridoxine,preferred_term,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
+Pyridoxine . HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 Pyridoxine dihydrochloride,preferred_term,CHEBI:189426,Pyridoxine dihydrochloride,CHEBI:189426,MAPPED,unique
 Pyridoxine HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 Pyridoxine hydrochloride,preferred_term,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 Pyridoxine-HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine-HCl (Vitamin B6),synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine-HCl (VitaminB6),synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine-hydrochloride,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
+Pyridoxine.HCL,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 Pyridoxine·HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 Pyridoxine・HCl,synonym,CHEBI:30961,Pyridoxine hydrochloride,CHEBI:30961,MAPPED,unique
 pyridoxinum,synonym,CHEBI:16709,Pyridoxine,CHEBI:16709,MAPPED,unique
@@ -7588,6 +8184,7 @@ Pyruvate,preferred_term,CHEBI:15361,Pyruvate,CHEBI:15361,MAPPED,unique
 Pyruvic acid,preferred_term,CHEBI:32816,Pyruvic acid,CHEBI:32816,MAPPED,unique
 Pyruvic acid sodium salt,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
 "pyruvic acid, sodium salt",synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
+QSY9 succinimidyl ester(1+),synonym,kgmicrobe.ingredient:l-cysteine_x_hcl_x_h2o_solution,L-Cysteine x HCl x H2O solution,CHEBI:91247,MAPPED,unique
 Quassin,preferred_term,CHEBI:8692,Quassin,CHEBI:8692,MAPPED,unique
 Quebrachitol,preferred_term,CHEBI:111,Quebrachitol,CHEBI:111,MAPPED,unique
 Quercetin,preferred_term,CHEBI:16243,Quercetin,CHEBI:16243,MAPPED,unique
@@ -7595,13 +8192,18 @@ Quercinitol,synonym,CHEBI:17268,m-Inositol,CHEBI:17268,REJECTED,unique
 Quinate,preferred_term,CHEBI:26490,Quinate,CHEBI:26490,MAPPED,unique
 Quinic acid,preferred_term,CHEBI:26493,Quinic acid,CHEBI:26493,MAPPED,unique
 Quinine Hdrochloride,preferred_term,cas:6119-47-7,Quinine Hdrochloride,cas:6119-47-7,MAPPED,unique
+Quinoline,preferred_term,CHEBI:17362,Quinoline,CHEBI:17362,MAPPED,unique
 R agar,preferred_term,UNMAPPED_0132,R agar,,UNMAPPED,unique
 R-(+)-Lipoic acid,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
 R-744,synonym,CHEBI:16526,Carbon dioxide gas,CHEBI:16526,MAPPED,unique
 R-LA,synonym,CHEBI:30314,Thioctic acid,CHEBI:30314,MAPPED,unique
 R2A agar,preferred_term,MICRO:0000543,R2A agar,MICRO:0000543,MAPPED,unique
+R2A agar (BD--Difco),synonym,MICRO:0000543,R2A agar,MICRO:0000543,MAPPED,unique
+R2A agar (BD-Difco),synonym,MICRO:0000543,R2A agar,MICRO:0000543,MAPPED,unique
+R2A agar (DB-Difco),synonym,MICRO:0000543,R2A agar,MICRO:0000543,MAPPED,unique
 Rabbit blood,preferred_term,MICRO:0001229,Rabbit blood,MICRO:0001229,MAPPED,unique
 Rabbit serum,preferred_term,MICRO:0002392,Rabbit serum,MICRO:0002392,MAPPED,unique
+"rac-(1R,2S,5R)-5-methyl-2-(propan-2-yl)cyclohexan-1-ol",synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
 "rac-1,2-dichloropropane",ontology_label,CHEBI:82163,"1,2-Dichloropropane",CHEBI:82163,MAPPED,unique
 "rac-2-(3,4-dimethoxyphenyl)-5-{[2-(3,4-dimethoxyphenyl)ethyl](methyl)amino}-2-isopropylpentanenitrile hydrochloride",synonym,CHEBI:53188,(+/-)-Verapamil hydrochloride,CHEBI:53188,MAPPED,unique
 "rac-3,5-dihydroxy-3-methylpentanoic acid",synonym,CHEBI:25351,DL-mevalonic acid,CHEBI:25351,MAPPED,unique
@@ -7610,6 +8212,10 @@ rac-3-Hydroxypentanoic Acid,preferred_term,CHEBI:139272,rac-3-Hydroxypentanoic A
 rac-4-hydroxy-3-(3-oxo-1-phenylbutyl)-2H-1-benzopyran-2-one,synonym,CHEBI:10033,Warfarin,CHEBI:10033,MAPPED,unique
 "rac-9-fluoro-3-methyl-10-(4-methylpiperazin-1-yl)-7-oxo-2,3-dihydro-7H-[1,4]oxazino[2,3,4-ij]quinoline-6-carboxylic acid",synonym,CHEBI:7731,Ofloxacin,CHEBI:7731,MAPPED,unique
 rac-Dithiothreitol,synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
+rac-menthol,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+racementhol,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+racementholum,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
+racementol,synonym,CHEBI:15409,Levomenthol,CHEBI:15409,MAPPED,unique
 Racemethionine,synonym,CHEBI:16811,DL-methionine,CHEBI:16811,MAPPED,unique
 racemomycin,ontology_label,kgmicrobe.compound:racemomycin_e,Racemomycin E,mesh:C019594,MAPPED,unique
 Racemomycin E,preferred_term,kgmicrobe.compound:racemomycin_e,Racemomycin E,mesh:C019594,MAPPED,unique
@@ -7625,14 +8231,26 @@ Red Arabinan from sugar-beet,preferred_term,UNMAPPED_0166,Red Arabinan from suga
 reduced coenzyme M,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 reduced CoM,synonym,CHEBI:17905,2-Mercaptoethanesulfonate,CHEBI:17905,MAPPED,unique
 Reduced glutathione,synonym,CHEBI:16856,Glutathione,CHEBI:16856,MAPPED,unique
+Reducing Agent,preferred_term,CHEBI:63247,Reducing Agent,CHEBI:63247,MAPPED,unique
+reduction: 3-O-methylgallate,synonym,CHEBI:28647,3-O-methylgallate,CHEBI:28647,MAPPED,unique
 reduction: amorphous fe(iii) oxyhydroxid,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 reduction: amorphous iron (iii) oxide,synonym,CHEBI:192761,Ferrihydrite,CHEBI:192761,MAPPED,unique
 reduction: arsenate detoxification,synonym,CHEBI:29125,Arsenate,CHEBI:29125,MAPPED,unique
+reduction: glutathione oxidized,synonym,CHEBI:17858,Glutathione oxidized,CHEBI:17858,MAPPED,unique
 Reinforced clostridial medium,preferred_term,UNMAPPED_0507,Reinforced clostridial medium,,UNMAPPED,unique
+Reinforced clostridial medium (BD-Difco),synonym,UNMAPPED_0507,Reinforced clostridial medium,,UNMAPPED,unique
+Reinforced Clostridial medium (Oxoid CM149),synonym,UNMAPPED_0507,Reinforced clostridial medium,,UNMAPPED,unique
+Reinforced clostridial medium (Oxoid),synonym,UNMAPPED_0507,Reinforced clostridial medium,,UNMAPPED,unique
 "rel-(2R,3R)-1,4-disulfanylbutane-2,3-diol",synonym,CHEBI:18320,DL-Dithiothreitol,CHEBI:18320,MAPPED,unique
 "rel-(2R,3R,4R,5S)-hexane-1,2,3,4,5,6-hexol",synonym,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
 Renilla luciferyl sulfate anion,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
 Resazurin,preferred_term,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+"Resazurin (0,1%)",synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resazurin (0.02%),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resazurin (0.025%),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resazurin (0.1% w/v in water),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resazurin (0.1%),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Resazurin (1 mg/L),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
 resazurin sodium salt,synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
 Resistomycin,preferred_term,CHEBI:29671,Resistomycin,CHEBI:29671,MAPPED,unique
 Resveratrol,preferred_term,CHEBI:27881,Resveratrol,CHEBI:27881,MAPPED,unique
@@ -7653,6 +8271,11 @@ Rib,synonym,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
 Ribitol,preferred_term,CHEBI:15963,Ribitol,CHEBI:15963,MAPPED,unique
 ribo-pentose,synonym,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
 Riboflavin,preferred_term,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavin (0.05 μg/mL),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavin (0.2 mg/ml),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavin (see below),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavin (Vitamin B2),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
+Riboflavin (Vitamine B2),synonym,CHEBI:17015,Riboflavin,CHEBI:17015,MAPPED,unique
 "Riboflavin 5'-(trihydrogen diphosphate), 5'-5'-ester with adenosine",synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
 Riboflavin 5'-adenosine diphosphate,synonym,CHEBI:16238,FAD,CHEBI:16238,MAPPED,unique
 Riboflavin solution see Medium No. 462,preferred_term,UNMAPPED_0508,Riboflavin solution see Medium No. 462,,UNMAPPED,unique
@@ -7664,6 +8287,8 @@ ribonucleic acids,synonym,kgmicrobe.ingredient:ribonucleic_acid_from_torula_yeas
 Ribose,preferred_term,CHEBI:33942,Ribose,CHEBI:33942,MAPPED,unique
 ribosylthymidine,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
 ribothymidine,synonym,CHEBI:45996,5-methyluridine,CHEBI:45996,MAPPED,unique
+Rice starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+rice straw,preferred_term,ENVO:00003870,rice straw,ENVO:00003870,MAPPED,unique
 Rice starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Rifabutin,preferred_term,CHEBI:45367,Rifabutin,CHEBI:45367,MAPPED,unique
 rifamcin,synonym,CHEBI:28077,Rifampicin,CHEBI:28077,MAPPED,unique
@@ -7699,8 +8324,11 @@ Rumen fluid,preferred_term,UBERON:0010228,Rumen fluid,UBERON:0010228,MAPPED,uniq
 ruminal fluid,ontology_label,UBERON:0010228,Rumen fluid,UBERON:0010228,MAPPED,unique
 Rutilantinone,preferred_term,cas:21288-61-9,Rutilantinone,cas:21288-61-9,MAPPED,unique
 Rutin,preferred_term,CHEBI:28527,Rutin,CHEBI:28527,MAPPED,unique
+rye bran,ontology_label,FOODON:03311582,Rye-bran,FOODON:03311582,MAPPED,unique
 rye flour,ontology_label,FOODON:03302492,Arabinoxylan (Rye Flour),FOODON:03302492,MAPPED,unique
 Rye grass,preferred_term,UNMAPPED_0511,Rye grass,,UNMAPPED,unique
+Rye--bran,synonym,FOODON:03311582,Rye-bran,FOODON:03311582,MAPPED,unique
+Rye-bran,preferred_term,FOODON:03311582,Rye-bran,FOODON:03311582,MAPPED,unique
 S(O)Me2,synonym,CHEBI:28262,Dimethyl sulfoxide,CHEBI:28262,MAPPED,unique
 "S,S-dimethyl-beta-propiothetin",ontology_label,CHEBI:16457,Dimethylsulfoniopropionate hydrochloride,CHEBI:16457,MAPPED,unique
 S-(5′-Adenosyl)-L-homocysteine,synonym,cas:9789-92-0,S-adenosyl Homocysteine,cas:9789-92-0,MAPPED,unique
@@ -7717,7 +8345,9 @@ Saccharomyces cerevisiae,ontology_label,cas:9036-88-8,Mannan from Saccharomyces 
 Saccharose,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
 Sacharose,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
 Safrole,preferred_term,CHEBI:8994,Safrole,CHEBI:8994,MAPPED,unique
+Sake,preferred_term,FOODON:03301670,Sake,FOODON:03301670,MAPPED,unique
 Salicin,preferred_term,CHEBI:17814,Salicin,CHEBI:17814,MAPPED,unique
+Salicylate,preferred_term,CHEBI:30762,Salicylate,CHEBI:30762,MAPPED,unique
 Salicylic acid,preferred_term,CHEBI:16914,Salicylic acid,CHEBI:16914,MAPPED,unique
 Salidroside,preferred_term,CHEBI:9009,Salidroside,CHEBI:9009,MAPPED,unique
 saline water,ontology_label,ENVO:00002010,Salt water,ENVO:00002010,MAPPED,unique
@@ -7730,6 +8360,7 @@ Salt Solution II,preferred_term,kgmicrobe.ingredient:salt_solution_ii,Salt Solut
 Salt water,preferred_term,ENVO:00002010,Salt water,ENVO:00002010,MAPPED,unique
 saltpetre,synonym,CHEBI:63043,KNO3,CHEBI:63043,MAPPED,unique
 Salts solution,preferred_term,kgmicrobe.ingredient:salts_solution,Salts solution,kgmicrobe.ingredient:salts_solution,MAPPED,unique
+Salts solution***,synonym,kgmicrobe.ingredient:salts_solution,Salts solution,kgmicrobe.ingredient:salts_solution,MAPPED,unique
 Salvinorin A,preferred_term,CHEBI:67900,Salvinorin A,CHEBI:67900,MAPPED,unique
 Sandramycin,preferred_term,CHEBI:221703,Sandramycin,CHEBI:221703,MAPPED,unique
 Sarcidin,preferred_term,kgmicrobe.compound:sarcidin,Sarcidin,kgmicrobe.compound:sarcidin,MAPPED,unique
@@ -7759,6 +8390,7 @@ sea salt,ontology_label,MICRO:0001647,Artificial Sea Salt,MICRO:0001647,MAPPED,u
 Sea Salt,ontology_label,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unresolved:no_chemistry
 Sea salts,preferred_term,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unique
 sea salts (Sigma),synonym,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unique
+Sea salts (Sigma-Aldrich),synonym,NCIT:C75874,Sea salts,NCIT:C75874,MAPPED,unique
 Sea water,preferred_term,ENVO:00002149,Sea water,ENVO:00002149,REJECTED,resolved:owned
 Sea water,synonym,ENVO:00002149,Seawater,ENVO:00002149,MAPPED,resolved:owned
 sea water,ontology_label,kgmicrobe.ingredient:natural_sea_water,Natural sea water,ENVO:00002149,MAPPED,resolved:owned
@@ -7789,6 +8421,7 @@ Serine hydroxamate,preferred_term,CHEBI:75494,Serine hydroxamate,CHEBI:75494,MAP
 Serotonin,preferred_term,CHEBI:28790,Serotonin,CHEBI:28790,MAPPED,unique
 Serum,preferred_term,UBERON:0001977,Serum,UBERON:0001977,MAPPED,unique
 Setamycin,preferred_term,mesh:C032953,Setamycin,mesh:C032953,MAPPED,unique
+Sheep blood,preferred_term,MICRO:0001230,Sheep blood,MICRO:0001230,MAPPED,unique
 Shikimate,synonym,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
 Shikimic Acid,preferred_term,CHEBI:16119,Shikimic Acid,CHEBI:16119,MAPPED,unique
 Showdomycin,preferred_term,CHEBI:226519,Showdomycin,CHEBI:226519,MAPPED,unique
@@ -7818,11 +8451,16 @@ sinapinaldehyde,preferred_term,CHEBI:27949,sinapinaldehyde,CHEBI:27949,MAPPED,un
 Sinomenine,preferred_term,CHEBI:9163,Sinomenine,CHEBI:9163,MAPPED,unique
 SiO2,preferred_term,CHEBI:30563,SiO2,CHEBI:30563,MAPPED,unique
 Sisomicin sulfate salt,preferred_term,cas:53179-09-2,Sisomicin sulfate salt,CHEBI:35175,MAPPED,unique
+Skim milk,synonym,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
+Skim milk (BD-Difco),synonym,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
 skim milk food product,ontology_label,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
+Skim milk powder,preferred_term,MICRO:0001241,Skim milk powder,MICRO:0001241,MAPPED,unique
 Skimmed milk,preferred_term,FOODON:03301484,Skimmed milk,FOODON:03301484,MAPPED,unique
 Skirrow supplement,preferred_term,kgmicrobe.ingredient:skirrow_supplement,Skirrow supplement,kgmicrobe.ingredient:skirrow_supplement,MAPPED,unique
 SLA,synonym,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
 Sludge,preferred_term,ENVO:00002044,Sludge,ENVO:00002044,MAPPED,unique
+Sludge fluid,preferred_term,MICRO:0000521,Sludge fluid,MICRO:0000521,MAPPED,unique
+Sludge fluid (see below),synonym,MICRO:0000521,Sludge fluid,MICRO:0000521,MAPPED,unique
 sn-3-GPC,synonym,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 sn-glycero-3-phosphocholine,preferred_term,CHEBI:16870,sn-glycero-3-phosphocholine,CHEBI:16870,MAPPED,unique
 sn-glycerol 3-(dihydrogen phosphate),synonym,cas:17989-41-2,sn-Glycerol 3-phosphate lithium salt,CHEBI:15978,MAPPED,conflict:different_substances
@@ -7839,9 +8477,11 @@ SnCl2.2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
 SnCl2·2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
 soda lye,synonym,CHEBI:32145,NaOH,CHEBI:32145,MAPPED,unique
 Sodim deoxycholate monohydrate,synonym,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,unique
+Sodium,synonym,CHEBI:29101,Sodium(+),CHEBI:29101,MAPPED,unique
 sodium (2E)-3-(4-hydroxy-3-methoxyphenyl)prop-2-enoate,synonym,CHEBI:114954,Sodium ferulate,CHEBI:114954,MAPPED,unique
 "sodium (2R)-2-[(1S)-1,2-dihydroxyethyl]-4-hydroxy-5-oxo-2,5-dihydrofuran-3-olate",synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 "sodium (2R,3S,4R,5R)-2,3,4,5,6-pentahydroxyhexanoate",synonym,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
+sodium (2S)-2-ammoniopentanedioate,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 sodium (2S)-2-azaniumylpentanedioate,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
 "sodium (2S,5R,6R)-6-{[(2R)-2-amino-2-phenylacetyl]amino}-3,3-dimethyl-7-oxo-4-thia-1-azabicyclo[3.2.0]heptane-2-carboxylate",synonym,CHEBI:34535,Na-ampicillin,CHEBI:34535,MAPPED,unique
 "sodium (6R,7R)-3-(acetoxymethyl)-8-oxo-7-[(2-thienylacetyl)amino]-5-thia-1-azabicyclo[4.2.0]oct-2-ene-2-carboxylate",synonym,CHEBI:3542,Cephalothin sodium salt,CHEBI:3542,MAPPED,unique
@@ -7928,6 +8568,7 @@ sodium carbonate,ontology_label,CHEBI:29377,Sodium carbonate solution,CHEBI:2937
 sodium carbonate,ontology_label,cas:5968-11-6,sodium carbonate monohydrate,CHEBI:29377,MAPPED,conflict:different_substances
 sodium carbonate monohydrate,preferred_term,cas:5968-11-6,sodium carbonate monohydrate,CHEBI:29377,MAPPED,unique
 Sodium carbonate solution,preferred_term,CHEBI:29377,Sodium carbonate solution,CHEBI:29377,MAPPED,unique
+sodium caseinate,ontology_label,MICRO:0001611,Na-caseinate,MICRO:0001611,MAPPED,unique
 sodium chlorate,synonym,CHEBI:65242,NaClO3,CHEBI:65242,MAPPED,unique
 Sodium Chloride,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
 Sodium Chlorite,preferred_term,CHEBI:78667,Sodium Chlorite,CHEBI:78667,MAPPED,unique
@@ -7949,6 +8590,7 @@ Sodium D-Lactate,preferred_term,cas:920-49-0,Sodium D-Lactate,cas:920-49-0,MAPPE
 sodium Deoxycholate,preferred_term,CHEBI:9177,sodium Deoxycholate,CHEBI:9177,MAPPED,resolved:owned
 sodium deoxycholate,ontology_label,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,resolved:owned
 Sodium deoxycholate monohydrate,preferred_term,cas:145224-92-6,Sodium deoxycholate monohydrate,CHEBI:9177,MAPPED,unique
+Sodium dihydrogen phosphate,synonym,CHEBI:37583,Sodium phosphate dibasic,CHEBI:37583,MAPPED,unique
 Sodium dihydrogen phosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
 sodium dihydrogen phosphate--water (1/1),synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
 sodium dihydrogenphosphate,ontology_label,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,conflict:different_substances
@@ -7977,19 +8619,25 @@ Sodium Fluoride,synonym,CHEBI:28741,NaF,CHEBI:28741,MAPPED,unique
 Sodium Fluoroacetate,preferred_term,CHEBI:38699,Sodium Fluoroacetate,CHEBI:38699,MAPPED,unique
 Sodium Fluorophosphate,preferred_term,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
 Sodium Formate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
+Sodium formate (Wako),synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
 sodium formiate,synonym,CHEBI:62965,Na-formate,CHEBI:62965,MAPPED,unique
 Sodium fumarate,synonym,CHEBI:115156,Na2-fumarate,CHEBI:115156,MAPPED,unique
 sodium gallate,synonym,CHEBI:115197,Na-gallate,CHEBI:115197,MAPPED,unique
 Sodium gluconate,preferred_term,CHEBI:84997,Sodium gluconate,CHEBI:84997,MAPPED,unique
 Sodium glutamate,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
 Sodium glutamate monohydrate,preferred_term,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+Sodium glutamate·H2O,synonym,CHEBI:64220,Na glutamate,CHEBI:64220,MAPPED,unique
 sodium glutarate,ontology_label,cas:13521-83-0,Disodium Glutarate,mesh:C000730144,MAPPED,unique
 sodium glycerol 2-phosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
+Sodium glycerophosphate,preferred_term,NCIT:C120561,Sodium glycerophosphate,NCIT:C120561,MAPPED,unique
 sodium glyoxalate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
 sodium glyoxylate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
 sodium hexanoate,synonym,CHEBI:114126,Na-caproate,CHEBI:114126,MAPPED,unique
 Sodium hydrogen arsenate heptahydrate,synonym,CHEBI:91257,Na2HAsO4 x 7 H2O,CHEBI:91257,MAPPED,unique
 sodium hydrogen carbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unique
+Sodium hydrogen glutamate,synonym,CHEBI:232425,Sodium glutamate monohydrate,CHEBI:232425,MAPPED,unique
+sodium hydrogen orthophosphate dihydrate,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
+sodium hydrogen phosphate--water (1/2),synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 sodium hydrogen sulfite,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 Sodium hydrogencarbonate,synonym,CHEBI:32139,NaHCO3,CHEBI:32139,MAPPED,unresolved:partial_chemistry
 sodium hydrogencarbonate,ontology_label,kgmicrobe.ingredient:84_gl_nahco3_solution,84 g/L NaHCO3 solution,CHEBI:32139,MAPPED,unresolved:partial_chemistry
@@ -8042,6 +8690,7 @@ sodium molybdate heptahydrate,synonym,CHEBI:86473,Na2MoO4 x 7 H2O,CHEBI:86473,MA
 Sodium molybdate(VI),synonym,CHEBI:75215,Na2MoO4,CHEBI:75215,MAPPED,unique
 Sodium molybdate(VI) dihydrate,synonym,CHEBI:75213,Na2MoO4 x 2 H2O,CHEBI:75213,MAPPED,unique
 Sodium monofluorophosphate,synonym,CHEBI:86431,Sodium Fluorophosphate,CHEBI:86431,MAPPED,unique
+sodium monohydrogen phosphate dihydrat,synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 sodium monosulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
 sodium monosulfide.9H2O,synonym,CHEBI:76209,Na2S x 9 H2O,CHEBI:76209,MAPPED,unique
 Sodium n-butyrate,synonym,CHEBI:64103,Na-butyrate,CHEBI:64103,MAPPED,unique
@@ -8071,6 +8720,7 @@ sodium oxido(dioxo)vanadium--water (1/1),synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:
 sodium oxoacetate,synonym,CHEBI:91251,Na2-glyoxalate,CHEBI:91251,MAPPED,unique
 sodium oxosilanebis(olate)--water (1/9),synonym,CHEBI:132108,Na2SiO3 x 9 H2O,CHEBI:132108,MAPPED,unique
 Sodium palmitate,preferred_term,CHEBI:234557,Sodium palmitate,CHEBI:234557,MAPPED,unique
+Sodium Pantothenate,preferred_term,NCIT:C220851,Sodium Pantothenate,NCIT:C220851,MAPPED,unique
 Sodium pectate,synonym,cas:9049-37-0,Polygalacturonic acid sodium salt,CHEBI:62969,MAPPED,unique
 Sodium perchlorate,preferred_term,CHEBI:132103,Sodium perchlorate,CHEBI:132103,MAPPED,resolved:owned
 sodium perchlorate,ontology_label,cas:7791-07-3,Sodium perchlorate monohydrate,CHEBI:132103,MAPPED,resolved:owned
@@ -8080,6 +8730,10 @@ Sodium Persulfate,preferred_term,cas:7775-27-1,Sodium Persulfate,mesh:C024625,MA
 sodium pervanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
 sodium phosphate,ontology_label,UNMAPPED_0615,Sodium phosphate monobasic (phosphorus source),CHEBI:37586,UNMAPPED,unique
 Sodium phosphate buffer,preferred_term,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
+"Sodium phosphate buffer (10 mM, pH 7.1)",synonym,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
+Sodium phosphate buffer (10 mM; pH7.1),synonym,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
+"Sodium phosphate buffer (25 mM, pH 3.4)",synonym,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
+Sodium phosphate buffer (25 mM; pH 3.4),synonym,kgmicrobe.ingredient:sodium_phosphate_buffer,Sodium phosphate buffer,NCIT:C29321,MAPPED,unique
 Sodium phosphate dibasic,preferred_term,CHEBI:37583,Sodium phosphate dibasic,CHEBI:37583,MAPPED,unique
 Sodium phosphate monobasic,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
 Sodium phosphate monobasic (phosphorus source),preferred_term,UNMAPPED_0615,Sodium phosphate monobasic (phosphorus source),CHEBI:37586,UNMAPPED,unique
@@ -8087,6 +8741,7 @@ sodium phosphate monobasic anhydrous,synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAP
 sodium phosphate monobasic anhydrous,synonym,kgmicrobe.compound:nah2po4_x_2_h2o,NaH2PO4 x 2 H2O,CHEBI:37585,MAPPED,conflict:different_substances
 Sodium phosphate monobasic monohydrate,preferred_term,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
 Sodium phosphate monohydrate,synonym,CHEBI:114249,Sodium phosphate monobasic monohydrate,CHEBI:114249,MAPPED,unique
+"Sodium phosphate, dibasic, dihydrate",synonym,kgmicrobe.ingredient:disodium_phosphate_heptahydrate_~28002_m_stock~29,Disodium phosphate heptahydrate (0.02 M stock),CHEBI:34683,MAPPED,unique
 "sodium phosphate, monobasic",synonym,CHEBI:37585,NaH2PO4,CHEBI:37585,MAPPED,unique
 Sodium phosphite dibasic pentahydrate,preferred_term,cas:13517-23-2,Sodium phosphite dibasic pentahydrate,CHEBI:36361,MAPPED,unique
 Sodium polymannuronate,synonym,CHEBI:53311,Sodium alginate,CHEBI:53311,MAPPED,unique
@@ -8102,6 +8757,7 @@ Sodium pyrosulfite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 sodium pyrosulphite,synonym,CHEBI:114786,Na2S2O5,CHEBI:114786,MAPPED,unique
 Sodium Pyruvate,synonym,CHEBI:50144,Na-pyruvate,CHEBI:50144,MAPPED,unique
 Sodium resazurin,synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
+Sodium resazurin (0.1% w/v),synonym,CHEBI:8806,Resazurin,CHEBI:8806,MAPPED,unique
 Sodium salicylate,preferred_term,CHEBI:9180,Sodium salicylate,CHEBI:9180,MAPPED,unique
 sodium salt,ontology_label,cas:128596-80-5,3'-sialyllactose sodium salt,CHEBI:26714,MAPPED,conflict:different_substances
 sodium salt,ontology_label,cas:157574-76-0,6'-O-sialyllactose sodium salt,CHEBI:26714,MAPPED,conflict:different_substances
@@ -8128,6 +8784,7 @@ sodium succinate.6H2O,synonym,CHEBI:63686,Sodium succinate dibasic hexahydrate,C
 sodium sulfanylacetate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
 Sodium Sulfate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 sodium sulfate decahydrate,synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
+"sodium sulfate, anhydrous",synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
 sodium sulfate--water (1/10),synonym,CHEBI:32586,Na2SO4 x 10 H2O,CHEBI:32586,MAPPED,unique
 Sodium sulfide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
 sodium sulfide (anh.),synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
@@ -8143,6 +8800,7 @@ sodium sulfurothioate hydrate (2:1:5),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:
 sodium sulfurothioate--water (1/5),synonym,CHEBI:32150,Na2S2O3 x 5 H2O,CHEBI:32150,MAPPED,unique
 sodium sulfurothioate--water (1/5),synonym,CHEBI:32150,Sodium Thiosulfate Pentahydrate,CHEBI:32150,REJECTED,unique
 sodium sulphate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
+sodium sulphate decahydrate,synonym,CHEBI:32149,Na2SO4,CHEBI:32149,MAPPED,unique
 sodium sulphide,synonym,CHEBI:76208,Na2S,CHEBI:76208,MAPPED,unique
 Sodium sulphite,synonym,CHEBI:86477,Na2SO3,CHEBI:86477,MAPPED,unique
 Sodium tartrate,preferred_term,CHEBI:63017,Sodium tartrate,CHEBI:63017,MAPPED,unique
@@ -8150,6 +8808,7 @@ sodium tetraborate decahydrate,synonym,CHEBI:131366,Na2B4O7 x 10 H2O,CHEBI:13136
 sodium tetradecyl sulfate,ontology_label,CHEBI:75273,Niaproof,CHEBI:75273,MAPPED,unique
 sodium tetraoxidovanadate(3-),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
 sodium tetraoxidovanadate(V),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
+sodium tetraoxotungstate(VI),synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 Sodium thioglycolate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
 Sodium thioglycollate,synonym,CHEBI:86481,Na-thioglycolate,CHEBI:86481,MAPPED,unique
 Sodium thiophosphate tribasic hydrate,preferred_term,cas:10489-48-2,Sodium thiophosphate tribasic hydrate,CHEBI:46612,MAPPED,unique
@@ -8166,16 +8825,21 @@ Sodium trioxovanadate,synonym,CHEBI:75221,NaVO3,CHEBI:75221,MAPPED,unique
 sodium tripolyphosphate,ontology_label,cas:15091-98-2,Pentasodium tripolyphosphate hexahydrate,FOODON:03530244,MAPPED,unique
 sodium tungstate,ontology_label,CHEBI:63940,Na2WO4,CHEBI:63940,MAPPED,unique
 Sodium tungstate dihydrate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Sodium tungstate(VI),synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 sodium tungstate(VI) dihydrate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
+Sodium tungsten oxide,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 sodium vanadate (ortho),synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
 sodium vanadate hydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
 sodium vanadate monohydrate,synonym,CHEBI:132095,NaVO3 x H2O,CHEBI:132095,MAPPED,unique
 sodium vanillate,synonym,CHEBI:132748,Na-vanillate,CHEBI:132748,MAPPED,unique
+Sodium wolframate,synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 "sodium {2,2',2'',2'''-[ethane-1,2-diyldi(nitrilo-kappaN)]tetraacetato-kappaO(4-)}ferrate(1-)",synonym,CHEBI:78292,Sodium ferric EDTA,CHEBI:78292,MAPPED,unique
+Sodium β--glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
 Sodium(+),preferred_term,CHEBI:29101,Sodium(+),CHEBI:29101,MAPPED,unique
 sodium(1+),ontology_label,CHEBI:29101,Sodium(+),CHEBI:29101,MAPPED,unique
 Sodium(I) nitrate (1:1),synonym,CHEBI:63005,NaNO3,CHEBI:63005,MAPPED,unique
 Sodium-3-methyl-2-oxobutyrate,ontology_label,CHEBI:189431,3-Methyl-2-oxobutanoic acid sodium salt,CHEBI:189431,MAPPED,unique
+Sodium-β-glycerophosphate,synonym,CHEBI:132089,Sodium beta-glycerophosphate,CHEBI:132089,MAPPED,unique
 "sodium;(2R)-2-[(2R,3S,6R)-6-[[(2S,4R,5R,6R,7R,9R)-2-[(2R,5S)-5-[(2R,3S,5R)-5-[(2S,3S,5R,6R)-6-hydroxy-6-(hydroxymethyl)-3,5-dimethyloxan-2-yl]-3-methyloxolan-2-yl]-5-methyloxolan-2-yl]-7-methoxy-2,4,6-trimethyl-1,10-dioxaspiro[4.5]decan-9-yl]methyl]-3-methyloxan-2-yl]propanoate",synonym,cas:28643-80-3,Nigericin sodium salt,CHEBI:201444,MAPPED,unique
 sodium;(2S)-2-hydroxypropanoate,synonym,CHEBI:232798,Na-L-lactate,CHEBI:232798,MAPPED,unique
 "sodium;(2S,3S,4R,5R,6R)-3-[(2S,3R,5S,6R)-3-acetamido-5-hydroxy-6-(hydroxymethyl)oxan-2-yl]oxy-4,5,6-trihydroxyoxane-2-carboxylate",synonym,cas:9067-32-7,Hyaluronic acid sodium salt from Streptococcus equi,CHEBI:201433,MAPPED,unique
@@ -8187,6 +8851,7 @@ sodium;3-[ormyl(hydroxy)amino]propyl-hydroxyphosphinate,synonym,cas:66508-37-0,F
 sodium;3-methyl-2-oxobutanoate,synonym,CHEBI:189431,3-Methyl-2-oxobutanoic acid sodium salt,CHEBI:189431,MAPPED,unique
 sodium;hexadecanoate,synonym,CHEBI:234557,Sodium palmitate,CHEBI:234557,MAPPED,unique
 Sodiumbenzoate,synonym,CHEBI:113455,Na-benzoate,CHEBI:113455,MAPPED,unique
+Sodiumcitrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Sodiumcitrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
 Soil,preferred_term,ENVO:00001998,Soil,ENVO:00001998,MAPPED,resolved:owned
 soil,ontology_label,ENVO:00001998,CR1 Soil,ENVO:00001998,MAPPED,resolved:owned
@@ -8194,13 +8859,18 @@ soil,ontology_label,kgmicrobe.ingredient:green_house_soil,Green House Soil,ENVO:
 soil,ontology_label,kgmicrobe.ingredient:vermont_soil,Vermont Soil,ENVO:00001998,MAPPED,resolved:owned
 Soil Defined Carbon Mix,preferred_term,UNMAPPED_0303,Soil Defined Carbon Mix,,UNMAPPED,unique
 Soil extract,preferred_term,MICRO:0000457,Soil extract,MICRO:0000457,MAPPED,unique
+Soil extract (SE1),synonym,MICRO:0000457,Soil extract,MICRO:0000457,MAPPED,unique
+Soil extract (see below),synonym,MICRO:0000457,Soil extract,MICRO:0000457,MAPPED,unique
 Soil+Seawater Medium,preferred_term,UNMAPPED_0055,Soil+Seawater Medium,,UNMAPPED,unique
 Soilwater: GR+ Medium,preferred_term,UNMAPPED_0012,Soilwater: GR+ Medium,,UNMAPPED,unique
 Soilwater: GR- Medium,preferred_term,UNMAPPED_0078,Soilwater: GR- Medium,,UNMAPPED,unique
 Soilwater: Peat Medium,preferred_term,UNMAPPED_0103,Soilwater: Peat Medium,,UNMAPPED,unique
 Solanesol,preferred_term,CHEBI:26718,Solanesol,CHEBI:26718,MAPPED,unique
 Soluble starch,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Soluble starch (BD-Difco),synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Soluble starch (Sigma),synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Solvent blue 8,synonym,CHEBI:6872,Methylene blue,CHEBI:6872,MAPPED,unique
+Sorbitan Monooleate,preferred_term,NCIT:C75654,Sorbitan Monooleate,NCIT:C75654,MAPPED,unique
 Sorbitol,preferred_term,CHEBI:30911,Sorbitol,CHEBI:30911,MAPPED,unique
 Sorbose,preferred_term,CHEBI:27922,Sorbose,CHEBI:27922,MAPPED,unique
 Sorensen's potassium phosphate,synonym,CHEBI:63036,KH2PO4,CHEBI:63036,MAPPED,unique
@@ -8257,7 +8927,9 @@ Standard I Broth,preferred_term,UNMAPPED_0532,Standard I Broth,,UNMAPPED,unique
 stannous chloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
 Staphylomycin M1,preferred_term,NCIT:C1295,Staphylomycin M1,NCIT:C1295,MAPPED,unique
 Starch,preferred_term,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+Starch (soluble),synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Starch soluble,synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
+"Starch, soluble",synonym,CHEBI:28017,Starch,CHEBI:28017,MAPPED,unique
 Staurosporine,preferred_term,CHEBI:15738,Staurosporine,CHEBI:15738,MAPPED,unique
 Stearic acid,preferred_term,CHEBI:28842,Stearic acid,CHEBI:28842,MAPPED,unique
 "Stearic acid, sodium salt",synonym,CHEBI:132109,Na-stearate,CHEBI:132109,MAPPED,unique
@@ -8339,6 +9011,7 @@ Sulfur powder,synonym,kgmicrobe.compound:sulfur_powder,Sulfur (powder),CHEBI:334
 Sulfur-free DL minerals,preferred_term,kgmicrobe.ingredient:sulfur-free_dl_minerals,Sulfur-free DL minerals,kgmicrobe.ingredient:sulfur-free_dl_minerals,MAPPED,unique
 Sulfuric acid,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 sulfuric acid ammonium salt (1:2),synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+sulfuric acid magnesium salt,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 sulfuric acid magnesium salt heptahydrate,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 sulfuric acid magnesium salt heptahydrate,synonym,CHEBI:31795,MgSO4·H2O,CHEBI:31795,MAPPED,unique
 "sulfuric acid, calcium salt (1:1), dihydrate",synonym,CHEBI:32583,CaSO4 x 2 H2O,CHEBI:32583,MAPPED,unique
@@ -8350,6 +9023,7 @@ sulfurous acid sodium salt,synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 "sulfurous acid, monosodium salt",synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 "sulfurous acid, sodium salt (1:1)",synonym,CHEBI:26709,NaHSO3,CHEBI:26709,MAPPED,unique
 sulphate of ammonia,synonym,CHEBI:62946,(NH4)2SO4,CHEBI:62946,MAPPED,unique
+sulphate of magnesia,synonym,CHEBI:31795,MgSO4 x 7 H2O,CHEBI:31795,MAPPED,unique
 Sulphur,preferred_term,CHEBI:17909,Sulphur,CHEBI:17909,MAPPED,unique
 sulphuric acid,synonym,CHEBI:26836,H2SO4,CHEBI:26836,MAPPED,unique
 Sunfiber,preferred_term,UNMAPPED_0217,Sunfiber,,UNMAPPED,unique
@@ -8370,6 +9044,7 @@ syringaldehyde,preferred_term,CHEBI:67380,syringaldehyde,CHEBI:67380,MAPPED,uniq
 Syringic Acid,preferred_term,CHEBI:68329,Syringic Acid,CHEBI:68329,MAPPED,unique
 table salt,synonym,CHEBI:26710,NaCl,CHEBI:26710,MAPPED,unique
 table sugar,synonym,CHEBI:17992,Sucrose,CHEBI:17992,MAPPED,unique
+Table wine,preferred_term,FOODON:00004062,Table wine,FOODON:00004062,MAPPED,unique
 Tagatose,preferred_term,CHEBI:33954,Tagatose,CHEBI:33954,MAPPED,unique
 Takara_DO_Supp_MinusHisLeuTrp,preferred_term,kgmicrobe.ingredient:takara_do_supp_minushisleutrp,Takara_DO_Supp_MinusHisLeuTrp,kgmicrobe.ingredient:takara_do_supp_minushisleutrp,MAPPED,unique
 tangeretin,ontology_label,CHEBI:9400,Tangeritin,CHEBI:9400,MAPPED,unique
@@ -8387,6 +9062,8 @@ Taurocholate,preferred_term,CHEBI:36257,Taurocholate,CHEBI:36257,MAPPED,unique
 Taurocholic acid sodium salt hydrate,preferred_term,CHEBI:181226,Taurocholic acid sodium salt hydrate,CHEBI:181226,MAPPED,unique
 Tazobactam,preferred_term,CHEBI:9421,Tazobactam,CHEBI:9421,MAPPED,unique
 TCE,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Tea,preferred_term,FOODON:03315081,Tea,FOODON:03315081,MAPPED,unique
+tea food product,ontology_label,FOODON:03315081,Tea,FOODON:03315081,MAPPED,unique
 Teicoplanin,preferred_term,CHEBI:29687,Teicoplanin,CHEBI:29687,MAPPED,unique
 telluric acid,ontology_label,cas:314041-10-6,potassium tellurate hydrate,CHEBI:30463,MAPPED,unique
 Tellurite,preferred_term,CHEBI:30477,Tellurite,CHEBI:30477,MAPPED,unique
@@ -8397,8 +9074,10 @@ terpin,ontology_label,cas:2451-01-6,Terpene hydrate,CHEBI:134806,MAPPED,unique
 Tertiomycin A,preferred_term,kgmicrobe.compound:tertiomycin_a,Tertiomycin A,kgmicrobe.compound:tertiomycin_a,MAPPED,unique
 Tertiomycin B,preferred_term,kgmicrobe.compound:tertiomycin_b,Tertiomycin B,kgmicrobe.compound:tertiomycin_b,MAPPED,unique
 TES,preferred_term,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
+TES (Dry Buffer),synonym,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
 TES buffer,synonym,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
 TES buffer(Sigma T 1375),synonym,CHEBI:39035,TES,CHEBI:39035,MAPPED,unique
+testosterone,preferred_term,CHEBI:17347,testosterone,CHEBI:17347,MAPPED,unique
 Tetrabromopyrrole,preferred_term,kgmicrobe.compound:tetrabromopyrrole,Tetrabromopyrrole,kgmicrobe.compound:tetrabromopyrrole,MAPPED,unique
 tetrabutylammonium salt,ontology_label,cas:100683-54-3,Malondialdehyde tetrabutylammonium salt,CHEBI:51992,MAPPED,unique
 Tetrachloraethen,synonym,CHEBI:17300,Tetrachloroethene,CHEBI:17300,MAPPED,unique
@@ -8438,6 +9117,7 @@ Tetrazolium Blue,preferred_term,CHEBI:75198,Tetrazolium Blue,CHEBI:75198,MAPPED,
 Tetrazolium violet,preferred_term,CHEBI:75193,Tetrazolium violet,CHEBI:75193,MAPPED,unique
 Tetrodotoxin,preferred_term,CHEBI:9506,Tetrodotoxin,CHEBI:9506,MAPPED,unique
 Texazone,preferred_term,CHEBI:197442,Texazone,CHEBI:197442,MAPPED,unique
+Thallium acetate,synonym,CHEBI:75192,Thallium(I) acetate,CHEBI:75192,MAPPED,unique
 thallium(1+) acetate,synonym,CHEBI:75192,Thallium(I) acetate,CHEBI:75192,MAPPED,unique
 Thallium(I) acetate,preferred_term,CHEBI:75192,Thallium(I) acetate,CHEBI:75192,MAPPED,unique
 THAM,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
@@ -8456,7 +9136,9 @@ thiamin hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 Thiamin pyrophosphate,preferred_term,CHEBI:45931,Thiamin pyrophosphate,CHEBI:45931,MAPPED,unique
 Thiamin-HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 Thiamine,preferred_term,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Thiamine (0.05 μg/mL),synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
 Thiamine (B1),synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+Thiamine . HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 thiamine cation,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
 thiamine chloride hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 thiamine chloride hydrochloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
@@ -8472,6 +9154,7 @@ Thiamine HCl (Vitamin B1),synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,un
 Thiamine hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 thiamine hydrochloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
 thiamine ion,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine monophosphate,preferred_term,CHEBI:9533,thiamine monophosphate,CHEBI:9533,MAPPED,unique
 Thiamine pyrophosphate,preferred_term,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
 thiamine pyrophosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
 Thiamine solution see Medium No. 403,preferred_term,UNMAPPED_0538,Thiamine solution see Medium No. 403,,UNMAPPED,unique
@@ -8481,6 +9164,7 @@ thiamine(1+) diphosphate,ontology_label,CHEBI:9532,Thiamine pyrophosphate,CHEBI:
 thiamine(1+) diphosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
 thiamine(1+) diphosphate(1-),ontology_label,CHEBI:45931,Thiamin pyrophosphate,CHEBI:45931,MAPPED,unique
 thiamine(1+) ion,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
+thiamine(1+) monophosphate,ontology_label,CHEBI:9533,thiamine monophosphate,CHEBI:9533,MAPPED,unique
 thiamine(2+) dichloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 thiamine(2+) dichloride dihydrate,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
 Thiamine-HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
@@ -8490,7 +9174,10 @@ thiamine-pyrophosphate,synonym,kgmicrobe.ingredient:0_2_thiamine_pyrophosphate,0
 thiamines,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
 Thiamine HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 Thiamine·HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine·HCl·2H2O,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
 Thiamine・HCl,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine・HCl (see below),synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
+Thiamine・HCl・2H2O,synonym,CHEBI:132751,Thiamine-HCl x 2 H2O,CHEBI:132751,MAPPED,unique
 thiaminium,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
 thiaminium chloride hydrochloride,synonym,CHEBI:49105,Thiamine HCl,CHEBI:49105,MAPPED,unique
 thiaminium diphosphoric acid ester chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
@@ -8544,6 +9231,8 @@ Timentin,preferred_term,cas:86482-18-0,Timentin,cas:86482-18-0,MAPPED,unique
 tin dichloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
 tin dichloride.2H2O,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
 tin(II) chloride dihydrate,synonym,CHEBI:78074,SnCl2 x 2 H2O,CHEBI:78074,MAPPED,unique
+Titanium chloride,preferred_term,CHEBI:231499,Titanium chloride,CHEBI:231499,MAPPED,unique
+titanium tetrachloride,ontology_label,CHEBI:231499,Titanium chloride,CHEBI:231499,MAPPED,unique
 titanium trichloride,ontology_label,mesh:C039460,TiCl3,mesh:C039460,MAPPED,unique
 Titanium(III) citrate,preferred_term,UNMAPPED_0618,Titanium(III) citrate,,UNMAPPED,unique
 TitaniumIII chloride,preferred_term,cas:7705-07-9,TitaniumIII chloride,cas:7705-07-9,MAPPED,unique
@@ -8553,6 +9242,9 @@ TNT,synonym,CHEBI:27135,Trinitrotoluene,CHEBI:27135,MAPPED,unique
 Tobramycin,preferred_term,CHEBI:28864,Tobramycin,CHEBI:28864,MAPPED,unique
 Tobramycin sulfate salt,preferred_term,cas:79645-27-5,Tobramycin sulfate salt,CHEBI:35175,MAPPED,unique
 Todd Hewitt Broth,preferred_term,UNMAPPED_0544,Todd Hewitt Broth,,UNMAPPED,unique
+Todd Hewitt Broth (BD-Difco),synonym,UNMAPPED_0544,Todd Hewitt Broth,,UNMAPPED,unique
+Todd–Hewitt (TH) broth (Difco),synonym,UNMAPPED_0544,Todd Hewitt Broth,,UNMAPPED,unique
+Todd–Hewitt broth (Oxoid),synonym,UNMAPPED_0544,Todd Hewitt Broth,,UNMAPPED,unique
 Toluen,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
 Toluene,preferred_term,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
 Toluol,synonym,CHEBI:17578,Toluene,CHEBI:17578,MAPPED,unique
@@ -8560,6 +9252,7 @@ tomatidine,ontology_label,cas:69004-03-1,Tomatidine Hydrochloride,CHEBI:9629,MAP
 Tomatidine Hydrochloride,preferred_term,cas:69004-03-1,Tomatidine Hydrochloride,CHEBI:9629,MAPPED,unique
 Tomato extract,preferred_term,UNMAPPED_0545,Tomato extract,,UNMAPPED,unique
 Tomato juice,preferred_term,FOODON:03301454,Tomato juice,FOODON:03301454,MAPPED,unique
+Tomato juice (Del Monte),synonym,FOODON:03301454,Tomato juice,FOODON:03301454,MAPPED,unique
 Toray Silicone,ontology_label,mesh:C069668,Toray silicone SH 5535,mesh:C069668,MAPPED,unique
 Toray silicone SH 5535,preferred_term,mesh:C069668,Toray silicone SH 5535,mesh:C069668,MAPPED,unique
 Totarol,preferred_term,CHEBI:69241,Totarol,CHEBI:69241,MAPPED,unique
@@ -8571,18 +9264,34 @@ Trace Element,ontology_label,NCIT:C896,Trace element solution SL-10,NCIT:C896,MA
 Trace Element,ontology_label,NCIT:C896,Zeikus trace element solution,NCIT:C896,MAPPED,unresolved:no_chemistry
 Trace Element,ontology_label,kgmicrobe.ingredient:trace_element_solution_see_medium_no_187,Trace element solution see Medium No. 187,NCIT:C896,MAPPED,unresolved:no_chemistry
 Trace element solution,preferred_term,NCIT:C896,Trace element solution,NCIT:C896,MAPPED,unique
+Trace element solution (see Medium No. 187,synonym,kgmicrobe.ingredient:trace_element_solution_see_medium_no_187,Trace element solution see Medium No. 187,NCIT:C896,MAPPED,unique
 Trace element solution see Medium No. 187,preferred_term,kgmicrobe.ingredient:trace_element_solution_see_medium_no_187,Trace element solution see Medium No. 187,NCIT:C896,MAPPED,unique
 Trace element solution SL-10,preferred_term,NCIT:C896,Trace element solution SL-10,NCIT:C896,MAPPED,unique
 Trace Elements,ontology_label,mesh:D014131,Desulfovibrio trace elements,mesh:D014131,MAPPED,unique
+Trace elements (see below),synonym,mesh:D014131,Desulfovibrio trace elements,mesh:D014131,MAPPED,unique
 trace elements solution,ontology_label,MICRO:0000455,Algal Trace Elements Solution,MICRO:0000455,MAPPED,unique
 trace elements solution,ontology_label,MICRO:0000455,WC Trace Elements Solution,MICRO:0000455,MAPPED,unique
 Trace metal mix A5,preferred_term,MICRO:0001349,Trace metal mix A5,MICRO:0001349,MAPPED,unique
+Trace Metal Mix A5 (see below),synonym,MICRO:0001349,Trace metal mix A5,MICRO:0001349,MAPPED,unique
 Trace metal solution,preferred_term,kgmicrobe.ingredient:trace_metal_solution,Trace metal solution,kgmicrobe.ingredient:trace_metal_solution,MAPPED,unique
+Trace metal solution*,synonym,kgmicrobe.ingredient:trace_metal_solution,Trace metal solution,kgmicrobe.ingredient:trace_metal_solution,MAPPED,unique
+trace metals 44,ontology_label,MICRO:0000456,Metals ''44'' (see below),MICRO:0000456,MAPPED,unique
 Trace Metals Solution,preferred_term,kgmicrobe.ingredient:trace_metals_solution,Trace Metals Solution,kgmicrobe.ingredient:trace_metals_solution,MAPPED,unique
 Trace mineral solution,preferred_term,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace mineral solution (see below),synonym,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace mineral solution (see Medium No. 151 ),synonym,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace mineral solution (see Medium No. 852 ),synonym,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace mineral solution (see Medium No.852),synonym,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
+Trace mineral solution**,synonym,kgmicrobe.ingredient:trace_mineral_solution,Trace mineral solution,kgmicrobe.ingredient:trace_mineral_solution,MAPPED,unique
 Trace minerals,preferred_term,kgmicrobe.ingredient:trace_minerals,Trace minerals,kgmicrobe.ingredient:trace_minerals,MAPPED,unique
+Trace minerals (see below),synonym,kgmicrobe.ingredient:trace_minerals,Trace minerals,kgmicrobe.ingredient:trace_minerals,MAPPED,unique
+Trace minerals (see Medium No. 151,synonym,UNMAPPED_0553,Trace minerals see Medium No. 151,,UNMAPPED,unique
+Trace minerals (see Medium No. 197,synonym,UNMAPPED_0554,Trace minerals see Medium No. 197,,UNMAPPED,unique
+Trace minerals (see Medium No.151,synonym,CHEBI:1883,4-vinylphenol,CHEBI:1883,MAPPED,unique
 Trace minerals see Medium No. 151,preferred_term,UNMAPPED_0553,Trace minerals see Medium No. 151,,UNMAPPED,unique
 Trace minerals see Medium No. 197,preferred_term,UNMAPPED_0554,Trace minerals see Medium No. 197,,UNMAPPED,unique
+Trace minerals(see Medium No.151),synonym,CHEBI:1883,4-vinylphenol,CHEBI:1883,MAPPED,unique
+Trace minerals*,synonym,kgmicrobe.ingredient:trace_minerals,Trace minerals,kgmicrobe.ingredient:trace_minerals,MAPPED,unique
 Trace vitamins solution see Medium No. 284,preferred_term,UNMAPPED_0555,Trace vitamins solution see Medium No. 284,,UNMAPPED,unique
 Trans Styrylacetic Acid,preferred_term,kgmicrobe.compound:trans_styrylacetic_acid,Trans Styrylacetic Acid,kgmicrobe.compound:trans_styrylacetic_acid,MAPPED,unique
 "Trans,Trans-Farnesol",preferred_term,CHEBI:28600,"Trans,Trans-Farnesol",CHEBI:28600,MAPPED,unique
@@ -8595,6 +9304,7 @@ trans-3-phenylacrylic acid,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,M
 trans-4-coumaric acid,ontology_label,CHEBI:32374,p-Coumaric acid,CHEBI:32374,MAPPED,unique
 trans-4-Hydroxy-3-methoxycinnamic acid,synonym,CHEBI:193350,Ferulic Acid,CHEBI:193350,MAPPED,unique
 trans-4-Hydroxy-L-proline,synonym,CHEBI:18095,Hydroxy-L-Proline,CHEBI:18095,MAPPED,unique
+trans-8-Methyl-N-vanillyl-6-nonenamide,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 trans-aconitic acid,preferred_term,CHEBI:32806,trans-aconitic acid,CHEBI:32806,MAPPED,unique
 trans-beta-carboxystyrene,synonym,CHEBI:35697,trans-Cinnamic acid,CHEBI:35697,MAPPED,unique
 trans-but-2-enedioic acid,synonym,CHEBI:18012,Fumaric acid,CHEBI:18012,MAPPED,unique
@@ -8635,6 +9345,7 @@ trichloridocerium,synonym,kgmicrobe.compound:cecl3_x_7_h2o,CeCl3 x 7 H2O,CHEBI:3
 trichloroalumane,synonym,CHEBI:30114,AlCl3,CHEBI:30114,MAPPED,unique
 Trichloroethene,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
 Trichloroethylene,preferred_term,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
+Trichloroethylene (10 mg/ml in methanol),synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
 trichloroethylenum,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
 trichloroiron--water (1/6),synonym,CHEBI:86254,FeCl3 x 6 H2O,CHEBI:86254,MAPPED,unique
 triciene,synonym,CHEBI:16602,Trichloroethylene,CHEBI:16602,MAPPED,unique
@@ -8656,16 +9367,19 @@ triisocyanates,synonym,CHEBI:77775,Na2SeO4,CHEBI:77775,MAPPED,unique
 Trilon A,synonym,CHEBI:44557,Nitrilotriacetic acid,CHEBI:44557,MAPPED,unique
 trimagnesium dicitrate,ontology_label,CHEBI:131391,Mg-citrate,CHEBI:131391,MAPPED,unique
 Trimethoprim,preferred_term,CHEBI:45924,Trimethoprim,CHEBI:45924,MAPPED,unique
+trimethoprim (GlaxoSmithKline),synonym,CHEBI:45924,Trimethoprim,CHEBI:45924,MAPPED,unique
 Trimethoxybenzoate,synonym,CHEBI:58989,"3,4,5-trimethoxybenzoate",CHEBI:58989,MAPPED,unique
 Trimethyl(2-hydroxyethyl)ammonium chloride,synonym,CHEBI:133341,Choline chloride,CHEBI:133341,MAPPED,unique
 Trimethylamin,synonym,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
 Trimethylamine,preferred_term,CHEBI:18139,Trimethylamine,CHEBI:18139,MAPPED,unique
+Trimethylamine . HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 trimethylamine hydrochloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 trimethylamine monohydrochloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 trimethylamine N-oxide,ontology_label,CHEBI:15724,Trimethylamine-N-oxide,CHEBI:15724,MAPPED,unique
 Trimethylamine-HCl,preferred_term,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 Trimethylamine-N-oxide,preferred_term,CHEBI:15724,Trimethylamine-N-oxide,CHEBI:15724,MAPPED,unique
 Trimethylamine·HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
+Trimethylamine・HCl,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
 Trimethylaminoacetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
 Trimethylammonioacetate,synonym,kgmicrobe.compound:betaine_x_h2o,Betaine x H2O,CHEBI:17750,MAPPED,unique
 Trimethylammonium chloride,synonym,CHEBI:64700,Trimethylamine-HCl,CHEBI:64700,MAPPED,unique
@@ -8683,6 +9397,7 @@ triptohypol C,synonym,CHEBI:132340,Dihydrocelastrol,CHEBI:132340,MAPPED,unique
 Triptolide,preferred_term,CHEBI:9747,Triptolide,CHEBI:9747,MAPPED,unique
 Tris,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 Tris (hydroxymethyl aminomethane),synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris (hydroxymethyl) aminomethane,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 Tris [tris(hydroxymethyl)aminomethane],synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 tris acetate,ontology_label,CHEBI:66869,Tris Acetate Stock Solution,CHEBI:66869,MAPPED,unique
 Tris Acetate Stock Solution,preferred_term,CHEBI:66869,Tris Acetate Stock Solution,CHEBI:66869,MAPPED,unique
@@ -8709,12 +9424,16 @@ Tris-HCl buffer,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 Trisodium aminotriacetate,synonym,CHEBI:132766,"0.5 M Nitrilotriacetic acid, disodium salt",CHEBI:132766,MAPPED,unique
 Trisodium citrate,preferred_term,CHEBI:53258,Trisodium citrate,CHEBI:53258,MAPPED,resolved:owned
 trisodium citrate,ontology_label,mesh:C514290,Trisodium citrate x H2O,mesh:C514290,MAPPED,resolved:owned
+Trisodium citrate dehydrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Trisodium citrate dehydrate,synonym,CHEBI:32142,Sodium Citrate,CHEBI:32142,REJECTED,unique
 Trisodium Citrate Dihydrate,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Trisodium citrate x 2 H2O,preferred_term,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
 Trisodium citrate x 2 H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
+Trisodium citrate x 3 H2O,synonym,CHEBI:30769,Citric acid,CHEBI:30769,MAPPED,unique
 Trisodium citrate x H2O,preferred_term,mesh:C514290,Trisodium citrate x H2O,mesh:C514290,MAPPED,unique
+Trisodium citrate·2H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Trisodium citrate·2H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
+Trisodium citrate·3H2O,synonym,CHEBI:32142,Na3-citrate x 2 H2O,CHEBI:32142,MAPPED,unique
 Trisodium citrate·3H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
 Trisodium citrate・2H2O,synonym,CHEBI:32142,Trisodium citrate x 2 H2O,CHEBI:32142,REJECTED,unique
 trisodium ethylenediaminetetraacetate,synonym,CHEBI:63125,Na3-EDTA,CHEBI:63125,MAPPED,unique
@@ -8730,6 +9449,7 @@ trisodium trioxido(oxo)vanadium,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,un
 trisodium vanadate,synonym,CHEBI:35607,Na3VO4,CHEBI:35607,MAPPED,unique
 "trisodium;1-hydroxypropane-1,2,3-tricarboxylate",synonym,kgmicrobe.compound:dl-isocitric_acid_trisodium_salt_hydrate,DL-Isocitric acid trisodium salt hydrate,CHEBI:172950,MAPPED,unique
 Tris [tris(hydroxymethyl)aminomethane],synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Tris・HCl,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 Trithionate,preferred_term,CHEBI:15987,Trithionate,CHEBI:15987,MAPPED,unique
 trithionate(2-),ontology_label,CHEBI:15987,Trithionate,CHEBI:15987,MAPPED,unique
 Triton X-100,preferred_term,CHEBI:9750,Triton X-100,CHEBI:9750,MAPPED,unique
@@ -8740,6 +9460,9 @@ Trolamine,synonym,CHEBI:28621,Triethanolamine,CHEBI:28621,MAPPED,unique
 Troleandomycin,preferred_term,CHEBI:45735,Troleandomycin,CHEBI:45735,MAPPED,unique
 Trometamol,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
 Tromethamine,synonym,CHEBI:9754,Tris base,CHEBI:9754,MAPPED,unique
+Trypsin,preferred_term,CHEBI:9765,Trypsin,CHEBI:9765,MAPPED,unique
+Trypsin (Sigma--Aldrich),preferred_term,MICRO:0000673,Trypsin (Sigma--Aldrich),MICRO:0000673,MAPPED,unique
+trypsin assay,ontology_label,MICRO:0000673,Trypsin (Sigma--Aldrich),MICRO:0000673,MAPPED,unique
 Tryptamine,preferred_term,CHEBI:16765,Tryptamine,CHEBI:16765,MAPPED,unique
 tryptic soy agar,ontology_label,MICRO:0000114,Bacto Tryptic Soy Agar,MICRO:0000114,MAPPED,unique
 tryptic soy agar,ontology_label,MICRO:0000114,Bacto Tryptic Soy Agar (Difco),MICRO:0000114,REJECTED,unique
@@ -8784,6 +9507,8 @@ Tryptophan,preferred_term,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,resolved:own
 Tryptophan,synonym,CHEBI:16828,L-Tryptophan,CHEBI:16828,MAPPED,resolved:owned
 tryptophane,synonym,CHEBI:27897,Tryptophan,CHEBI:27897,MAPPED,unique
 Tryptose,preferred_term,MICRO:0000183,Tryptose,MICRO:0000183,MAPPED,unique
+Tryptose (BD-Difco),synonym,MICRO:0000183,Tryptose,MICRO:0000183,MAPPED,unique
+Tryptose phosphate broth (BD-Difco),synonym,UNMAPPED_0561,Tryptose-phosphate broth,,UNMAPPED,unique
 Tryptose-phosphate,preferred_term,UNMAPPED_0560,Tryptose-phosphate,,UNMAPPED,unique
 Tryptose-phosphate broth,preferred_term,UNMAPPED_0561,Tryptose-phosphate broth,,UNMAPPED,unique
 TSPP,synonym,CHEBI:71240,Sodium pyrophosphate,CHEBI:71240,MAPPED,unique
@@ -8794,6 +9519,7 @@ Tubercidin,preferred_term,CHEBI:48267,Tubercidin,CHEBI:48267,MAPPED,unique
 Tungstate,preferred_term,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
 TUNGSTATE(VI)ION,synonym,CHEBI:46502,Tungstate,CHEBI:46502,MAPPED,unique
 tungstic acid,ontology_label,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
+"Tungstic acid, disodium salt",synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 "Tungstic acid, sodium salt, dihydrate",synonym,CHEBI:63939,Na2WO4 x 2 H2O,CHEBI:63939,MAPPED,unique
 tungstic(VI) acid,synonym,CHEBI:36272,H2WO4,CHEBI:36272,MAPPED,unique
 Tunicamycin,preferred_term,CHEBI:29699,Tunicamycin,CHEBI:29699,MAPPED,unique
@@ -8803,11 +9529,14 @@ Tween 20,preferred_term,CHEBI:53424,Tween 20,CHEBI:53424,MAPPED,unique
 Tween 40,preferred_term,CHEBI:53423,Tween 40,CHEBI:53423,MAPPED,unique
 Tween 60,preferred_term,CHEBI:53425,Tween 60,CHEBI:53425,MAPPED,unique
 Tween 80,preferred_term,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Tween 80 (BD),synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
+Tween 80 (pH 8.0),synonym,CHEBI:53426,Tween 80,CHEBI:53426,MAPPED,unique
 TYG salts solution,preferred_term,kgmicrobe.ingredient:tyg_salts_solution,TYG salts solution,kgmicrobe.ingredient:tyg_salts_solution,MAPPED,unique
 TYGVS + Glucose,preferred_term,kgmicrobe.ingredient:tygvs_glucose,TYGVS + Glucose,kgmicrobe.ingredient:tygvs_glucose,MAPPED,unique
 Tyloxapol,preferred_term,CHEBI:141517,Tyloxapol,CHEBI:141517,MAPPED,unique
 TYROSINE,synonym,CHEBI:17895,L-Tyrosine,CHEBI:17895,MAPPED,unresolved:partial_chemistry
 tyrosine,ontology_label,CHEBI:18186,DL-Tyrosine,CHEBI:18186,MAPPED,unresolved:partial_chemistry
+Umbellatine,synonym,CHEBI:31271,Berberine,CHEBI:31271,MAPPED,unique
 undec-1-ene,synonym,CHEBI:77444,undecene,CHEBI:77444,MAPPED,unique
 undecan-2-ol,ontology_label,CHEBI:77930,2-undecanol,CHEBI:77930,MAPPED,unique
 undecene,preferred_term,CHEBI:77444,undecene,CHEBI:77444,MAPPED,unique
@@ -8823,6 +9552,7 @@ Uranyl Acetate Dihydrate,preferred_term,cas:6159-44-0,Uranyl Acetate Dihydrate,m
 Urazil,synonym,CHEBI:17568,Uracil,CHEBI:17568,MAPPED,unique
 Urd,synonym,CHEBI:16704,Uridine,CHEBI:16704,MAPPED,unique
 Urea,preferred_term,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
+Urea (Sigma U5218),synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
 uree,synonym,CHEBI:16199,Urea,CHEBI:16199,MAPPED,unique
 Uric acid,preferred_term,CHEBI:27226,Uric acid,CHEBI:27226,MAPPED,unique
 uric acids,synonym,CHEBI:27226,Uric acid,CHEBI:27226,MAPPED,unique
@@ -8837,6 +9567,7 @@ UW concentrated base no Mo,preferred_term,kgmicrobe.ingredient:uw_concentrated_b
 UW concentrated base no sulfur,preferred_term,kgmicrobe.ingredient:uw_concentrated_base_no_sulfur,UW concentrated base no sulfur,kgmicrobe.ingredient:uw_concentrated_base_no_sulfur,MAPPED,unique
 V-8 Juice,preferred_term,MICRO:0002250,V-8 Juice,MICRO:0002250,MAPPED,unique
 V8 canned vegetable juice,preferred_term,UNMAPPED_0564,V8 canned vegetable juice,,UNMAPPED,unique
+V8 canned vegetable juice (Campbell),synonym,UNMAPPED_0564,V8 canned vegetable juice,,UNMAPPED,unique
 Valerate,preferred_term,CHEBI:31011,Valerate,CHEBI:31011,MAPPED,unique
 Valerianic acid,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
 Valeriansaeure,synonym,CHEBI:17418,Valeric acid,CHEBI:17418,MAPPED,unique
@@ -8886,6 +9617,7 @@ Vermont Soil,preferred_term,kgmicrobe.ingredient:vermont_soil,Vermont Soil,ENVO:
 Vibriostat,preferred_term,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unique
 Vibriostatic Agent O/129,synonym,CHEBI:73908,Vibriostat,CHEBI:73908,MAPPED,unique
 victoria green B,synonym,CHEBI:72449,Malachite green,CHEBI:72449,MAPPED,unique
+Vino de Mesa,ontology_label,FOODON:00004062,Table wine,FOODON:00004062,MAPPED,unique
 Viomycin,preferred_term,CHEBI:15782,Viomycin,CHEBI:15782,MAPPED,unique
 Virginiamycin,preferred_term,CHEBI:87209,Virginiamycin,CHEBI:87209,MAPPED,unique
 Viridogrisein,synonym,mesh:C004910,Etamycin,mesh:C004910,MAPPED,unique
@@ -8893,7 +9625,10 @@ Visnagin,preferred_term,CHEBI:10002,Visnagin,CHEBI:10002,MAPPED,unique
 Vitafiber,preferred_term,UNMAPPED_0204,Vitafiber,,UNMAPPED,unique
 Vitagos 5650,preferred_term,UNMAPPED_0214,Vitagos 5650,,UNMAPPED,unique
 Vitamin,ontology_label,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
+vitamin (role),ontology_label,CHEBI:33229,Vitamins,CHEBI:33229,MAPPED,unique
 Vitamin B,preferred_term,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
+Vitamin B (Thiamine.HCl),synonym,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
+Vitamin B . (Cyanocobalamin),synonym,UNMAPPED_0005,Vitamin B,NCIT:C944,UNMAPPED,unique
 vitamin B-12,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresolved:partial_chemistry
 vitamin B-12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
 vitamin B1 pyrophosphate chloride,synonym,CHEBI:9532,Thiamine pyrophosphate,CHEBI:9532,MAPPED,unique
@@ -8915,8 +9650,11 @@ vitamin B7,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
 vitamin B9,synonym,CHEBI:27470,Folic acid,CHEBI:27470,MAPPED,unique
 vitamin C sodium,synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
 "vitamin C, sodium salt",synonym,CHEBI:113451,Na-ascorbate,CHEBI:113451,MAPPED,unique
+Vitamin D3,preferred_term,CHEBI:28940,Vitamin D3,CHEBI:28940,MAPPED,unique
 Vitamin H,synonym,CHEBI:15956,Biotin,CHEBI:15956,MAPPED,unique
+Vitamin K,preferred_term,CHEBI:28384,Vitamin K,CHEBI:28384,MAPPED,unique
 Vitamin K1,preferred_term,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
+Vitamin K1 (1 mg/ml),synonym,CHEBI:18067,Vitamin K1,CHEBI:18067,MAPPED,unique
 Vitamin K3,synonym,CHEBI:28869,Menadione,CHEBI:28869,MAPPED,unique
 Vitamin PP,synonym,CHEBI:17154,Nicotinamide,CHEBI:17154,MAPPED,unique
 Vitamin solution,preferred_term,MICRO:0000460,Vitamin solution,MICRO:0000460,MAPPED,resolved:owned
@@ -8929,6 +9667,8 @@ Vitamin solution (thermophilic formulation),preferred_term,kgmicrobe.ingredient:
 Vitamin solution see Medium No. 403,preferred_term,kgmicrobe.ingredient:vitamin_solution_see_medium_no_403,Vitamin solution see Medium No. 403,MICRO:0000460,MAPPED,unique
 VitaminB12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unique
 Vitamine B12,synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unique
+Vitamins,preferred_term,CHEBI:33229,Vitamins,CHEBI:33229,MAPPED,unique
+Vitamins (ATCC),synonym,CHEBI:33229,Vitamins,CHEBI:33229,MAPPED,unique
 vitamins B1,synonym,CHEBI:18385,Thiamine,CHEBI:18385,MAPPED,unique
 vitamins B12,synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unique
 Vitamins solution,preferred_term,kgmicrobe.ingredient:vitamins_solution,Vitamins solution,kgmicrobe.ingredient:vitamins_solution,MAPPED,unique
@@ -8943,6 +9683,7 @@ Vitamin B12  (9),synonym,CHEBI:17439,Cyanocobalamin,CHEBI:17439,MAPPED,unresol
 Vitamin B12  (9),synonym,CHEBI:176843,Vitamin B12,CHEBI:176843,MAPPED,unresolved:partial_chemistry
 Vitox,preferred_term,kgmicrobe.ingredient:vitox,Vitox,kgmicrobe.ingredient:vitox,MAPPED,unique
 Volvox Medium,preferred_term,UNMAPPED_0072,Volvox Medium,,UNMAPPED,unique
+VOSO4,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
 VOSO4 . 2H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
 VOSO4 . 5H2O,synonym,CHEBI:132758,VOSO4 x 5 H2O,CHEBI:132758,MAPPED,unique
 VOSO4 x 2 H2O,preferred_term,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
@@ -8959,15 +9700,19 @@ VOSO4.nH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
 VOSO4.xH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
 VOSO4·2 H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
 VOSO4·2H2O,synonym,CHEBI:87009,VOSO4 x 2 H2O,CHEBI:87009,MAPPED,unique
+VOSO4·nH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
 VOSO4·xH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
+VOSO4・xH2O,synonym,CHEBI:87020,VOSO4 x n H2O,CHEBI:87020,MAPPED,unique
 Vulgamycin,preferred_term,mesh:C012306,Vulgamycin,mesh:C012306,MAPPED,unique
 Vulpinic acid,preferred_term,CHEBI:144250,Vulpinic acid,CHEBI:144250,MAPPED,unique
 Wako Isomaltooligosaccharides,preferred_term,UNMAPPED_0222,Wako Isomaltooligosaccharides,,UNMAPPED,unique
 Warfarin,preferred_term,CHEBI:10033,Warfarin,CHEBI:10033,MAPPED,unique
 Waris Medium,preferred_term,UNMAPPED_0063,Waris Medium,,UNMAPPED,unique
+washed agar,preferred_term,MICRO:0001723,washed agar,MICRO:0001723,MAPPED,unique
 Wasser,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
 Wasserstoffchlorid,synonym,CHEBI:17883,HCl,CHEBI:17883,MAPPED,unique
 WATER,synonym,CHEBI:15377,Distilled water,CHEBI:15377,MAPPED,unique
+water (distilled or tapwater),synonym,UNMAPPED_0575,water distilled or tapwater,,UNMAPPED,unique
 water distilled or tapwater,preferred_term,UNMAPPED_0575,water distilled or tapwater,,UNMAPPED,unique
 WC Trace Elements Solution,preferred_term,MICRO:0000455,WC Trace Elements Solution,MICRO:0000455,MAPPED,unique
 Weinsteinsaeure,synonym,CHEBI:15671,L(+)-Tartaric acid,CHEBI:15671,MAPPED,unique
@@ -8978,6 +9723,7 @@ White wine,preferred_term,NCIT:C84877,White wine,NCIT:C84877,MAPPED,unique
 Whole egg,preferred_term,UNMAPPED_0577,Whole egg,,UNMAPPED,unique
 Whole eggs,synonym,UNMAPPED_0577,Whole egg,,UNMAPPED,unique
 Wilkins Chalgrene Anaerobe Broth,preferred_term,UNMAPPED_0578,Wilkins Chalgrene Anaerobe Broth,,UNMAPPED,unique
+Wilkins-Chalgren Anaerobe Broth (Oxoid CM0643),synonym,UNMAPPED_0579,Wilkins-Chalgren-Anaerobe-Broth,,UNMAPPED,unique
 Wilkins-Chalgren-Anaerobe-Broth,preferred_term,UNMAPPED_0579,Wilkins-Chalgren-Anaerobe-Broth,,UNMAPPED,unique
 Wolfe's mineral mix,preferred_term,kgmicrobe.ingredient:wolfes_mineral_mix,Wolfe's mineral mix,kgmicrobe.ingredient:wolfes_mineral_mix,MAPPED,unique
 Wolfe's mineral mix_minus_Nitrilotriacetic_acid,preferred_term,kgmicrobe.ingredient:wolfes_mineral_mix_minus_nitrilotriacetic_acid,Wolfe's mineral mix_minus_Nitrilotriacetic_acid,kgmicrobe.ingredient:wolfes_mineral_mix_minus_nitrilotriacetic_acid,MAPPED,unique
@@ -9003,6 +9749,7 @@ xi-5-Dodecanolide,ontology_label,CHEBI:171817,Delta-Dodecalactone,CHEBI:171817,M
 Xyl,synonym,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
 Xylan,preferred_term,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
 Xylan (hemicellulose substrate),synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
+Xylan (Tokyo Kasei or Sigma),synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
 Xylan from Beechwood,preferred_term,CHEBI:15447,Xylan from Beechwood,CHEBI:15447,MAPPED,unique
 xylans,synonym,CHEBI:37166,Xylan,CHEBI:37166,MAPPED,unique
 Xylit,synonym,CHEBI:17151,Xylitol,CHEBI:17151,MAPPED,unique
@@ -9017,8 +9764,10 @@ Xylose,preferred_term,CHEBI:18222,Xylose,CHEBI:18222,MAPPED,unique
 Xylotetraose,preferred_term,CHEBI:62972,Xylotetraose,CHEBI:62972,MAPPED,unique
 Xylotriose,preferred_term,CHEBI:149429,Xylotriose,CHEBI:149429,MAPPED,unique
 Yacontrol (Yacon root syrup),preferred_term,UNMAPPED_0208,Yacontrol (Yacon root syrup),,UNMAPPED,unique
+Yeast,preferred_term,FOODON:03411345,Yeast,FOODON:03411345,MAPPED,unique
 Yeast + Meat Extract + H2,preferred_term,kgmicrobe.ingredient:yeast_meat_extract_h2,Yeast + Meat Extract + H2,kgmicrobe.ingredient:yeast_meat_extract_h2,MAPPED,unique
 Yeast cell paste,preferred_term,UNMAPPED_0581,Yeast cell paste,,UNMAPPED,unique
+Yeast cell paste (see below),synonym,UNMAPPED_0581,Yeast cell paste,,UNMAPPED,unique
 Yeast extract,preferred_term,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 Yeast Extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 yeast extract,synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
@@ -9050,11 +9799,16 @@ Yeast extract(CAS: 8013-01-2),synonym,FOODON:03315426,Yeast extract,FOODON:03315
 Yeast Extract(Difco),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 Yeast extract(Oxoid),synonym,FOODON:03315426,Yeast extract,FOODON:03315426,MAPPED,unique
 Yeast extract-malt extract agar,preferred_term,kgmicrobe.ingredient:yeast_extract_malt_extract_agar,Yeast extract-malt extract agar,FOODON:03301056,MAPPED,unique
+Yeastolate,ontology_label,MICRO:0000522,"Yeastolate (BD; 2%, autoclaved)",MICRO:0000522,MAPPED,unique
+"Yeastolate (BD; 2%, autoclaved)",preferred_term,MICRO:0000522,"Yeastolate (BD; 2%, autoclaved)",MICRO:0000522,MAPPED,unique
+Yeastolate (Difco),synonym,MICRO:0000522,"Yeastolate (BD; 2%, autoclaved)",MICRO:0000522,MAPPED,unique
 YM broth,preferred_term,UNMAPPED_0583,YM broth,,UNMAPPED,unique
+YM broth (BD-Difco),synonym,UNMAPPED_0583,YM broth,,UNMAPPED,unique
 Zafirlukast,preferred_term,CHEBI:10100,Zafirlukast,CHEBI:10100,MAPPED,unique
 Zeikus trace element solution,preferred_term,NCIT:C896,Zeikus trace element solution,NCIT:C896,MAPPED,unique
 Zerenex,synonym,CHEBI:144421,Fe(III) citrate,CHEBI:144421,MAPPED,unique
 Zetan,synonym,CHEBI:45296,Hexadecane,CHEBI:45296,MAPPED,unique
+Zinc Acetate,preferred_term,CHEBI:62984,Zinc Acetate,CHEBI:62984,MAPPED,unique
 Zinc Chloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 zinc dichloride,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 Zinc Pyrithione,preferred_term,CHEBI:32076,Zinc Pyrithione,CHEBI:32076,MAPPED,unique
@@ -9078,6 +9832,7 @@ ZMB,preferred_term,UNMAPPED_0290,ZMB,,UNMAPPED,unique
 ZMB_ALS,preferred_term,UNMAPPED_0272,ZMB_ALS,,UNMAPPED,unique
 Zn2SO4·7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
 ZnCl,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
+ZnCl .6H O,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 ZnCl 2,synonym,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 ZnCl2,preferred_term,CHEBI:49976,ZnCl2,CHEBI:49976,MAPPED,unique
 ZnSO .7H O,synonym,CHEBI:86463,AlK(SO4)2,CHEBI:86463,MAPPED,unique
@@ -9100,6 +9855,7 @@ ZnSO4∙7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
 ZnSO4⋅7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
 ZnSO4・7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
 ZnSO4･7H2O,synonym,CHEBI:32312,ZnSO4 x 7 H2O,CHEBI:32312,MAPPED,unique
+Zostrix,synonym,CHEBI:31345,Calcium pantothenate,CHEBI:31345,MAPPED,unique
 Zykloheximid,synonym,CHEBI:27641,Cycloheximid,CHEBI:27641,MAPPED,unique
 Zymosan,preferred_term,cas:9010-72-4,Zymosan,NCIT:C183132,MAPPED,unique
 Zystein,synonym,CHEBI:15356,Cysteine,CHEBI:15356,MAPPED,unique
@@ -9111,6 +9867,11 @@ Zytosin,synonym,CHEBI:16040,Cytosine,CHEBI:16040,MAPPED,unique
 ß-nicotinamide adenine dinucleotide,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
 α-D-Glucose,synonym,CHEBI:17234,Glucose,CHEBI:17234,MAPPED,unique
 α-D-Glucose monohydrate,preferred_term,UNMAPPED_0587,α-D-Glucose monohydrate,,UNMAPPED,unique
+α-Ketoglutarate,synonym,CHEBI:16810,Na2 alpha-ketoglutarate,CHEBI:16810,MAPPED,unique
 α-lipoic acid,preferred_term,CHEBI:43796,α-lipoic acid,CHEBI:43796,MAPPED,unique
 α-Methylbutyric acid,synonym,CHEBI:37070,DL-2-Methylbutyric acid,CHEBI:37070,MAPPED,unique
 α1-Acid Glycoprotein from bovine plasma,preferred_term,cas:66455-27-4,α1-Acid Glycoprotein from bovine plasma,cas:66455-27-4,MAPPED,unique
+β--NAD,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+β-NAD,synonym,CHEBI:15846,beta-NAD,CHEBI:15846,MAPPED,unique
+‘Lab-Lemco’ powder,synonym,UNMAPPED_0419,Lab Lemco powder,,UNMAPPED,unique
+“Metals 44” (see below),synonym,MICRO:0000456,Metals ''44'' (see below),MICRO:0000456,MAPPED,unique

--- a/src/culturemech/data/mediaingredientmech/label_index.metadata.json
+++ b/src/culturemech/data/mediaingredientmech/label_index.metadata.json
@@ -1,7 +1,7 @@
 {
-  "byte_count": 854426,
+  "byte_count": 922191,
   "consumer_contract_version": 1,
-  "data_row_count": 9115,
+  "data_row_count": 9876,
   "header": [
     "label",
     "match_type",
@@ -12,7 +12,7 @@
     "ambiguity"
   ],
   "repository": "https://github.com/CultureBotAI/MediaIngredientMech",
-  "sha256": "7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac",
-  "source_commit": "82694054f5bbf74b5392bf8858c9962c2152a35a",
+  "sha256": "a36cd4683feb89e2fc2a1721dc15008d1e10c12044e89a36c27b6621a8aaf262",
+  "source_commit": "9f09e4fb97fb0e6cbbd6f25baca40b36512adb88",
   "source_path": "docs/data/label_index.csv"
 }

--- a/tests/test_mim_label_index.py
+++ b/tests/test_mim_label_index.py
@@ -9,7 +9,10 @@ import pytest
 
 from culturemech.export.kgx_export import transform
 from culturemech.ingredients.mim_label_index import (
+    AMBIGUITIES,
     INDEX_HEADER,
+    MAPPING_STATUSES,
+    MATCH_TYPES,
     LabelIndexError,
     MIMLabelIndex,
     ResolutionSource,
@@ -55,6 +58,21 @@ def test_packaged_artifact_is_verified_and_pinned():
     assert index.metadata["sha256"] == (
         "a36cd4683feb89e2fc2a1721dc15008d1e10c12044e89a36c27b6621a8aaf262"
     )
+
+
+def test_packaged_artifact_uses_only_known_enum_values():
+    """A pin bump must not introduce a column value the resolver cannot read.
+
+    `AMBIGUITIES`, `MATCH_TYPES` and `MAPPING_STATUSES` are closed sets here
+    while MIM grows them organically upstream, and an unsafe `ambiguity` fails
+    closed -- so a new value would silently stop labels resolving rather than
+    raise. The row count and hash both still match in that case (#417).
+    """
+
+    rows = get_default_mim_label_index().rows
+    assert {row.ambiguity for row in rows} <= AMBIGUITIES
+    assert {row.match_type for row in rows} <= MATCH_TYPES
+    assert {row.mapping_status for row in rows} <= MAPPING_STATUSES
 
 
 def test_mim_overrides_a_conflicting_local_grounding():

--- a/tests/test_mim_label_index.py
+++ b/tests/test_mim_label_index.py
@@ -50,10 +50,10 @@ def _row(
 
 def test_packaged_artifact_is_verified_and_pinned():
     index = get_default_mim_label_index()
-    assert len(index.rows) == 9115
-    assert index.metadata["source_commit"] == "82694054f5bbf74b5392bf8858c9962c2152a35a"
+    assert len(index.rows) == 9876
+    assert index.metadata["source_commit"] == "9f09e4fb97fb0e6cbbd6f25baca40b36512adb88"
     assert index.metadata["sha256"] == (
-        "7113b90cb82ea6d80c0abdb34b0620b71fe6b02e3000327b14dbf797062728ac"
+        "a36cd4683feb89e2fc2a1721dc15008d1e10c12044e89a36c27b6621a8aaf262"
     )
 
 


### PR DESCRIPTION
Step 2 of the downstream chain, after #411 settled the working tree. Advances the
vendored MediaIngredientMech label index 19 commits, `82694054f5` → `9f09e4fb97`,
making the recent MIM curation visible to CultureMech.

| | before | after | Δ |
|---|---:|---:|---:|
| distinct labels | 8,367 | 9,087 | **+720** |
| labels lost | — | — | **0** |
| data rows | 9,115 | 9,876 | +761 |
| bytes | 854,426 | 922,191 | +67,765 |

**587** of CultureMech's 1,862 unresolved distinct labels now resolve, covering
**2,669 of 6,105 unresolved mentions (44%)**.

Pinned to current MIM `main`. The four commits between `829994a9` (the ref
originally scoped) and `9f09e4fb` touch neither `label_index.csv` nor the SSSOM,
so the artifact is identical either way; pinning to the current ref just avoids
a stale-but-equivalent pointer.

## The 31 rows that change answer

**22 are unambiguous wins.** UNMAPPED records now grounded — `BG-11 Medium` →
`MICRO:0001348`, `Ox-bile` → `MICRO:0000610`, `Mycobactine J` →
`CHEBI:205364` (also fixing the spelling to "Mycobactin J"), `Homo-PIPES` →
`cas:202185-84-0`, `Na2Glycerophosphate•5H2O` → `cas:13408-09-8` — plus two
minted `kgmicrobe.compound:*` identifiers replaced by real ChEBI terms
(`CHEBI:91258`, `CHEBI:91259`, whose labels match exactly).

**9 change only `preferred_term`, and no identifier moves.** Verified
row-by-row: every one resolves to the same target before and after.

## Why those nine moved — and the one thing to know before KGX

They shift because **several MIM records share a single identifier**, so the
collapse to one row picks a different winner between builds:

| identifier | real ChEBI label | records claiming it |
|---|---|---|
| `CHEBI:75832` | iron(2+) sulfate (anhydrous) | `FeSO4`, `FeSO4 x 5 H2O`, `FeSO4 x 6 H2O` |
| `CHEBI:32599` | magnesium sulfate | `Magnesium sulfate`, `MgSO4 x 6 H2O` |
| `CHEBI:31795` | magnesium sulfate heptahydrate | `MgSO4 x 7 H2O` + 2 REJECTED |
| `CHEBI:86360` | manganese(II) sulfate | `MnSO4`, `MnSO4 x 7 H2O` |
| `CHEBI:29377` | sodium carbonate | `Na2CO3` (ingredient), `Sodium carbonate solution` (stock solution) |

This is **MIM #504**, which has grown from 25 identifier sets to 26 (60 records).
It predates this bump and this bump does not worsen it — but it does mean
`preferred_term` is **not stable across rebuilds**, and `kgx_export.py:340-346`
uses it as both a node `name` and, via `_create_solution_id`, a node **id**.
Filed separately. KGX export should not run on an unstable field.

## Adversarial review

Replayed **every** label through the real resolver under both pins — the test the
repo does not have:

```
labels tested : 9115
same answer   : 9092
LOST          : 0
gained        : 8
moved         : 15     (all kgmicrobe.compound:* -> real ChEBI terms)
```

Comprehensive identifier check: **12 moved, all gains** (8 unmapped→mapped, 4
minted→ontology), **zero regressions**.

Two failure modes specific to this artifact, both clear:

- **Unknown enum values** — `SAFE_AMBIGUITIES`, `MATCH_TYPES`, `MAPPING_STATUSES`
  are closed sets that MIM grows organically. None found; now asserted
  permanently by `ea244bd2d7`, mutation-checked.
- **Safe→unsafe ambiguity transitions** — these fail closed, so a label can stop
  resolving while staying in the file, invisible to a row-count or set-difference
  check. **0 found**; 2 went the other way. Safe fraction 97.3% → 97.6%,
  `conflict:different_substances` unchanged at 183.

Issues filed: **#416** (`kgx_export` derives node ids from `preferred_term`, an
unstable upstream field — blocker for the KGX step), **#417** (no test replays
resolutions across a pin bump; enum half fixed here), and re-measured evidence
added to **MIM#504**.

## Verification

- Dry run first (`refresh_mim_label_index.py` without `--apply`), which reported
  `+720 -0` and left the tree clean.
- Vendored file is **byte-identical** to MIM's `docs/data/label_index.csv` at
  `9f09e4fb` (`diff -q`).
- Recorded `sha256` matches the file on disk.
- Both pin assertion sites move with the artifact: row count, commit, and sha256
  in `tests/test_mim_label_index.py`, and the same three in
  `docs/mediaingredientmech_enrichment.md`. No stale `9115` / `82694054` /
  `7113b90c` reference remains anywhere in `tests/`, `docs/`, or `src/`.
- `tests/test_mim_label_index.py` + `tests/test_refresh_mim_label_index.py`:
  **25 passed**. The resolution assertions that were already there (EDTA →
  `CHEBI:4735`, Beef heart → `FOODON:00004410`, PABA → `CHEBI:30753`) still hold.
- Built in an isolated worktree; a concurrent session is live in the main
  checkout and its HEAD was not moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyveZVuXAT9bytKrGKUcY6
