### PR TITLE
Decide skill path existence by git, not the filesystem (#419)

### DIFF
--- a/.claude/skills/create-recipe/SKILL.md
+++ b/.claude/skills/create-recipe/SKILL.md
@@ -317,7 +317,7 @@ target_organisms:
 2. Save to `solutions/` directory
 3. Mark as stock solution
 
-**Output Location**: `data/normalized_yaml/solutions/10x_PBS.yaml`
+**Output Location**: `data/normalized_yaml/solutions/<slug>.yaml` (here `10x_pbs.yaml`)
 
 ### Pattern 4: Batch Import
 
@@ -397,7 +397,7 @@ Create a recipe for TSB (Tryptic Soy Broth):
 pH 7.3, autoclave 121°C for 15 min
 ```
 
-**Output**: `data/normalized_yaml/bacterial/TSB.yaml` with CultureMech ID
+**Output**: `data/normalized_yaml/bacterial/tsb.yaml` with CultureMech ID
 
 ### Example 2: From JSON
 
@@ -421,7 +421,7 @@ pH 7.3, autoclave 121°C for 15 min
 
 **Input**: "Create 1 M Tris-HCl pH 8.0 stock solution"
 
-**Output**: `data/normalized_yaml/solutions/1M_Tris_HCl_pH8.yaml`
+**Output**: `data/normalized_yaml/solutions/<slug>.yaml` (here `1m_tris_hcl_ph8.yaml`)
 
 ## Tips for Best Results
 

--- a/.claude/skills/manage-identifiers/SKILL.md
+++ b/.claude/skills/manage-identifiers/SKILL.md
@@ -91,7 +91,7 @@ ingredients:  # <-- Collection key
 - ✗ Git merge conflicts more likely
 
 **Files**:
-- Data: `data/curated/unmapped_ingredients.yaml`
+- Data, in the MediaIngredientMech checkout: `MediaIngredientMech/data/curated/unmapped_ingredients.yaml`
 - ID script in the MediaIngredientMech checkout:
   `MediaIngredientMech/scripts/add_mediaingredientmech_ids.py`
 

--- a/.claude/skills/match-kg-microbe/SKILL.md
+++ b/.claude/skills/match-kg-microbe/SKILL.md
@@ -154,7 +154,7 @@ The value is always a `mediadive.medium:XXX` node ID. When multiple KG-Microbe m
 
 **No matches found**: Check that `term.id` fields are populated in the media's ingredients. Unmapped ingredients cannot contribute to matching.
 
-**KG-Microbe path not found**: Verify the `--kg-microbe` path points to the repo root containing `data/transformed_last9/mediadive/edges.tsv`.
+**KG-Microbe path not found**: Verify the `--kg-microbe` path points to the repo root containing `<kg-microbe>/data/transformed_last9/mediadive/edges.tsv`.
 
 **Match seems wrong**: Use Option C to inspect the specific recipe. The match is purely by CHEBI set equality — verify both the CultureMech and KG-Microbe recipes actually represent the same medium.
 

--- a/.claude/skills/match-kg-microbe/SKILL.md
+++ b/.claude/skills/match-kg-microbe/SKILL.md
@@ -154,7 +154,7 @@ The value is always a `mediadive.medium:XXX` node ID. When multiple KG-Microbe m
 
 **No matches found**: Check that `term.id` fields are populated in the media's ingredients. Unmapped ingredients cannot contribute to matching.
 
-**KG-Microbe path not found**: Verify the `--kg-microbe` path points to the repo root containing `<kg-microbe>/data/transformed_last9/mediadive/edges.tsv`.
+**KG-Microbe path not found**: `--kg-microbe` must be the kg-microbe checkout itself; `<kg-microbe>/data/transformed_last9/mediadive/edges.tsv` must exist under it.
 
 **Match seems wrong**: Use Option C to inspect the specific recipe. The match is purely by CHEBI set equality — verify both the CultureMech and KG-Microbe recipes actually represent the same medium.
 

--- a/.claude/skills/research-ingredient-roles/SKILL.md
+++ b/.claude/skills/research-ingredient-roles/SKILL.md
@@ -69,7 +69,7 @@ just research-ingredient-roles-edison-batch \
 ```
 
 Uses the role-research template
-(`templates/ingredient_role_research.md`) that asks Edison for the three
+(`MediaIngredientMech/templates/ingredient_role_research.md`) that asks Edison for the three
 facets, cited primary evidence per role, organism-conditional caveats, and
 a machine-readable fenced YAML block.
 

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,9 @@ cache/
 # behind the corpus while the gate stayed green, because the gate compares against
 # --max-allowed rather than against the file.
 reports/chebi_consistency.tsv
+# Written by `just report-label-drift`; the CI workflow uploads it as an
+# artifact and never commits it (#419).
+reports/label_drift.tsv
 
 # Regenerable content-review outputs with no reader; only the .tsv is consumed (#168).
 # Regenerate with `just review-media-content`.

--- a/scripts/validate_claude_skills.py
+++ b/scripts/validate_claude_skills.py
@@ -80,12 +80,23 @@ def normalize_reference(raw: str) -> str | None:
     return value
 
 
+class NotAGitCheckout(RuntimeError):
+    """The validator needs git to answer "is this path tracked or generated"."""
+
+
 @cache
 def _tracked_paths(root: Path) -> frozenset[str]:
     """Every tracked file, plus every directory that contains one."""
-    listing = subprocess.run(
-        ["git", "ls-files", "-z"], cwd=root, capture_output=True, text=True, check=True
-    ).stdout
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z"], cwd=root, capture_output=True, text=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise NotAGitCheckout(
+            f"{root} is not a git checkout (or git is not installed); local path "
+            f"references can only be validated against git"
+        ) from error
+    listing = completed.stdout
     paths: set[str] = set()
     for entry in listing.split("\0"):
         if not entry:
@@ -145,31 +156,29 @@ def validate_skills() -> list[str]:
     errors: list[str] = []
     loose_markdown = sorted(SKILLS_DIR.glob("*.md"))
     for path in loose_markdown:
-        errors.append(f"{path.relative_to(ROOT)}: use <skill>/SKILL.md layout")
+        errors.append(f"{_display(path)}: use <skill>/SKILL.md layout")
 
     for directory in sorted(path for path in SKILLS_DIR.iterdir() if path.is_dir()):
         skill_file = directory / "SKILL.md"
         if not skill_file.is_file():
-            errors.append(f"{directory.relative_to(ROOT)}: missing SKILL.md")
+            errors.append(f"{_display(directory)}: missing SKILL.md")
             continue
         try:
             metadata = frontmatter(skill_file)
         except ValueError as error:
-            errors.append(f"{skill_file.relative_to(ROOT)}: {error}")
+            errors.append(f"{_display(skill_file)}: {error}")
             continue
         missing = sorted(REQUIRED_FRONTMATTER - metadata.keys())
         if missing:
-            errors.append(f"{skill_file.relative_to(ROOT)}: missing {', '.join(missing)}")
+            errors.append(f"{_display(skill_file)}: missing {', '.join(missing)}")
         nested_metadata = metadata.get("metadata")
         nested_version = (
             nested_metadata.get("version") if isinstance(nested_metadata, dict) else None
         )
         if not metadata.get("version") and not nested_version:
-            errors.append(f"{skill_file.relative_to(ROOT)}: missing version")
+            errors.append(f"{_display(skill_file)}: missing version")
         if metadata.get("name") != directory.name:
-            errors.append(
-                f"{skill_file.relative_to(ROOT)}: name must match directory {directory.name!r}"
-            )
+            errors.append(f"{_display(skill_file)}: name must match directory {directory.name!r}")
 
         for document in sorted(directory.rglob("*.md")):
             seen: set[str] = set()
@@ -187,7 +196,11 @@ def validate_skills() -> list[str]:
 
 
 def main() -> int:
-    errors = validate_skills()
+    try:
+        errors = validate_skills()
+    except NotAGitCheckout as error:
+        print(f"error: {error}")
+        return 1
     if errors:
         for error in errors:
             print(f"error: {error}")

--- a/scripts/validate_claude_skills.py
+++ b/scripts/validate_claude_skills.py
@@ -1,9 +1,26 @@
 #!/usr/bin/env python3
-"""Validate repository Claude skill layout, metadata, and local references."""
+"""Validate repository Claude skill layout, metadata, and local references.
+
+A local path named in a skill is checked against **git**, not the filesystem
+(#419). The filesystem is the wrong oracle in both directions: a generated
+artifact such as `app/data.js` exists on a machine that has built the pages
+and is absent on a fresh clone, and macOS resolves `TSB.yaml` to the tracked
+`tsb.yaml` while Linux CI does not. So a reference passes when it is either
+
+* **tracked** -- a file or directory `git ls-files` knows about, or
+* **generated** -- ignored by `.gitignore`, or a directory whose contents an
+  ignore pattern declares (`data/raw_yaml/**/*.yaml` declares `data/raw_yaml/`).
+
+Anything else is reported as missing. Paths in a sibling checkout are written
+with the repository name first (`MediaIngredientMech/templates/...`) or with a
+placeholder root (`<kg-microbe>/data/...`), and are not checked here.
+"""
 
 from __future__ import annotations
 
 import re
+import subprocess
+from functools import cache
 from pathlib import Path
 
 import yaml
@@ -11,8 +28,33 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS_DIR = ROOT / ".claude" / "skills"
 REQUIRED_FRONTMATTER = {"name", "description"}
+
+# Top-level directories a skill may name as a local path. Anything outside this
+# list is treated as prose, so keep it to directories the repository actually
+# has; a new top-level directory should be added here when a skill first cites it.
+LOCAL_PREFIXES = (
+    "scripts",
+    "src",
+    "docs",
+    "conf",
+    "data",
+    "app",
+    "pages",
+    "tests",
+    "templates",
+    "history",
+    "output",
+    "reports",
+    "curation",
+    "research",
+    ".claude",
+    ".github",
+)
+LOCAL_FILES = ("README", "NEXT_TASKS", "CLAUDE", "project.justfile", "pyproject.toml")
+_PREFIX_ALTERNATION = "|".join(re.escape(prefix) for prefix in LOCAL_PREFIXES)
+_FILE_ALTERNATION = "|".join(re.escape(name) for name in LOCAL_FILES)
 LOCAL_REFERENCE = re.compile(
-    r"`((?:scripts|src|docs|conf|\.claude)/[^`\s]+|(?:README|NEXT_TASKS|project\.justfile)[^`\s]*)`"
+    rf"`((?:{_PREFIX_ALTERNATION})/[^`\s]+|(?:{_FILE_ALTERNATION})[^`\s]*)`"
 )
 
 
@@ -36,6 +78,67 @@ def normalize_reference(raw: str) -> str | None:
     if any(token in value for token in ("*", "{", "}", "<", ">", "[", "]", "$")):
         return None
     return value
+
+
+@cache
+def _tracked_paths(root: Path) -> frozenset[str]:
+    """Every tracked file, plus every directory that contains one."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=root, capture_output=True, text=True, check=True
+    ).stdout
+    paths: set[str] = set()
+    for entry in listing.split("\0"):
+        if not entry:
+            continue
+        paths.add(entry)
+        paths.update(str(parent) for parent in Path(entry).parents if str(parent) != ".")
+    return frozenset(paths)
+
+
+@cache
+def _ignore_patterns(root: Path) -> tuple[str, ...]:
+    """Positive patterns from the repository `.gitignore`, without a leading slash."""
+    ignore_file = root / ".gitignore"
+    if not ignore_file.is_file():
+        return ()
+    patterns = []
+    for line in ignore_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        patterns.append(line.lstrip("/"))
+    return tuple(patterns)
+
+
+def _is_ignored(root: Path, reference: str) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--no-index", reference], cwd=root, capture_output=True
+    )
+    return result.returncode == 0
+
+
+def classify_reference(reference: str, root: Path | None = None) -> str:
+    """`tracked`, `generated`, or `missing` -- decided by git, never by the filesystem."""
+    root = root or ROOT
+    path = reference.rstrip("/")
+    if path in _tracked_paths(root):
+        return "tracked"
+    if _is_ignored(root, reference):
+        return "generated"
+    # A directory is declared generated when an ignore pattern reaches into it,
+    # e.g. `data/raw_yaml/**/*.yaml` for `data/raw_yaml/`.
+    if any(pattern.startswith(path + "/") for pattern in _ignore_patterns(root)):
+        return "generated"
+    return "missing"
+
+
+def _display(path: Path) -> str:
+    """Repository-relative when the file is inside ROOT; a test may point
+    SKILLS_DIR elsewhere while still checking references against ROOT's git."""
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
 
 
 def validate_skills() -> list[str]:
@@ -68,11 +171,18 @@ def validate_skills() -> list[str]:
                 f"{skill_file.relative_to(ROOT)}: name must match directory {directory.name!r}"
             )
 
-        for document in directory.rglob("*.md"):
+        for document in sorted(directory.rglob("*.md")):
+            seen: set[str] = set()
             for match in LOCAL_REFERENCE.finditer(document.read_text()):
                 reference = normalize_reference(match.group(1))
-                if reference and not (ROOT / reference).exists():
-                    errors.append(f"{document.relative_to(ROOT)}: missing local path {reference}")
+                if not reference or reference in seen:
+                    continue
+                seen.add(reference)
+                if classify_reference(reference, ROOT) == "missing":
+                    errors.append(
+                        f"{_display(document)}: missing local path {reference} "
+                        f"(not tracked by git and not declared generated in .gitignore)"
+                    )
     return errors
 
 

--- a/tests/test_claude_skills.py
+++ b/tests/test_claude_skills.py
@@ -38,3 +38,79 @@ def test_validator_accepts_standard_nested_skill_metadata(tmp_path, monkeypatch)
     monkeypatch.setattr(validate_claude_skills, "SKILLS_DIR", tmp_path / ".claude" / "skills")
 
     assert validate_claude_skills.validate_skills() == []
+
+
+# --- existence is decided by git, not the filesystem (#419) -------------------
+
+
+def _skill_referencing(tmp_path: Path, monkeypatch, body: str) -> list[str]:
+    """Validate one throwaway skill against the REAL repository's git state."""
+    skill_dir = tmp_path / ".claude" / "skills" / "throwaway"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: throwaway\ndescription: x\nversion: 1.0.0\n---\n\n" + body,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(validate_claude_skills, "SKILLS_DIR", tmp_path / ".claude" / "skills")
+    return validate_claude_skills.validate_skills()
+
+
+def test_a_tracked_path_is_present() -> None:
+    assert validate_claude_skills.classify_reference("scripts/validate_claude_skills.py") == (
+        "tracked"
+    )
+    assert validate_claude_skills.classify_reference("src/culturemech/schema/") == "tracked"
+
+
+def test_a_generated_artifact_counts_as_present_whether_or_not_it_is_on_disk() -> None:
+    """`app/data.js` exists only on a machine that has built the pages, and
+    `data/raw_yaml/` only where a conversion has run. Both are declared
+    generated in `.gitignore`, which is the fact the skill boundary rests on."""
+    assert validate_claude_skills.classify_reference("app/data.js") == "generated"
+    assert validate_claude_skills.classify_reference("data/raw_yaml/") == "generated"
+
+
+def test_a_directory_is_generated_when_an_ignore_pattern_reaches_into_it() -> None:
+    """`.gitignore` says `data/raw_yaml/**/*.yaml`, not `data/raw_yaml/`, so
+    `git check-ignore` on the bare directory says no. The layer is still
+    declared, and the validator has to read the declaration, not the answer."""
+    assert validate_claude_skills._is_ignored(validate_claude_skills.ROOT, "data/raw_yaml/") is (
+        False
+    )
+    assert validate_claude_skills.classify_reference("data/raw_yaml/") == "generated"
+
+
+def test_case_is_decided_by_git_not_by_the_filesystem() -> None:
+    """On macOS `Path('docs/data_layers.md').exists()` is True because the
+    tracked file is `DATA_LAYERS.md`; on Linux CI it is False. Git gives one
+    answer on both, which is how `TSB.yaml` was caught standing in for the
+    tracked `tsb.yaml` in the create-recipe skill (#419)."""
+    assert validate_claude_skills.classify_reference("docs/DATA_LAYERS.md") == "tracked"
+    assert validate_claude_skills.classify_reference("docs/data_layers.md") == "missing"
+
+
+def test_an_unknown_path_under_a_data_prefix_is_reported(tmp_path, monkeypatch) -> None:
+    """The regression guard for #419: `data/` was outside the old prefix list,
+    so a wrong data-layer path in prose was never looked at."""
+    errors = _skill_referencing(tmp_path, monkeypatch, "Never edit `data/raw_yamlx/`.\n")
+    assert len(errors) == 1
+    assert "data/raw_yamlx/" in errors[0]
+
+
+def test_a_declared_generated_path_is_accepted(tmp_path, monkeypatch) -> None:
+    errors = _skill_referencing(
+        tmp_path, monkeypatch, "Never edit `data/raw_yaml/` or `app/data.js`.\n"
+    )
+    assert errors == []
+
+
+def test_sibling_repository_paths_are_not_checked_here(tmp_path, monkeypatch) -> None:
+    """A path in another checkout is written with the repository name first or
+    a placeholder root; neither matches a local prefix, so neither is checked."""
+    errors = _skill_referencing(
+        tmp_path,
+        monkeypatch,
+        "See `MediaIngredientMech/templates/ingredient_role_research.md` and "
+        "`<kg-microbe>/data/transformed_last9/mediadive/edges.tsv`.\n",
+    )
+    assert errors == []

--- a/tests/test_claude_skills.py
+++ b/tests/test_claude_skills.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).parents[1]
 SCRIPT = ROOT / "scripts" / "validate_claude_skills.py"
 SPEC = importlib.util.spec_from_file_location("validate_claude_skills", SCRIPT)
@@ -114,3 +116,38 @@ def test_sibling_repository_paths_are_not_checked_here(tmp_path, monkeypatch) ->
         "`<kg-microbe>/data/transformed_last9/mediadive/edges.tsv`.\n",
     )
     assert errors == []
+
+
+def test_a_tree_that_is_not_a_git_checkout_is_a_plain_error(tmp_path, monkeypatch) -> None:
+    """Outside a checkout the answer is "cannot validate", not a traceback."""
+    skill_dir = tmp_path / ".claude" / "skills" / "throwaway"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: throwaway\ndescription: x\nversion: 1.0.0\n---\n\nSee `docs/x.md`.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(validate_claude_skills, "ROOT", tmp_path)
+    monkeypatch.setattr(validate_claude_skills, "SKILLS_DIR", tmp_path / ".claude" / "skills")
+    validate_claude_skills._tracked_paths.cache_clear()
+    try:
+        with pytest.raises(validate_claude_skills.NotAGitCheckout):
+            validate_claude_skills.validate_skills()
+    finally:
+        validate_claude_skills._tracked_paths.cache_clear()
+
+
+def test_every_layout_error_survives_a_skills_dir_outside_root(tmp_path, monkeypatch) -> None:
+    """The crash #420 fixed for the missing-path message applied to all of them."""
+    skills = tmp_path / ".claude" / "skills"
+    (skills / "renamed").mkdir(parents=True)
+    (skills / "renamed" / "SKILL.md").write_text(
+        "---\nname: other\ndescription: x\n---\n", encoding="utf-8"
+    )
+    (skills / "empty").mkdir()
+    (skills / "loose.md").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(validate_claude_skills, "SKILLS_DIR", skills)
+    errors = validate_claude_skills.validate_skills()
+    assert any("use <skill>/SKILL.md layout" in e for e in errors)
+    assert any("missing SKILL.md" in e for e in errors)
+    assert any("missing version" in e for e in errors)
+    assert any("name must match directory" in e for e in errors)


### PR DESCRIPTION
Closes #419. Closes #421 and #423 (review findings fixed in the second commit; #422 stays open as a curation-policy decision).

## What was wrong

`scripts/validate_claude_skills.py` decided whether a skill's local path existed with `Path.exists()`, and only for paths under `scripts/`, `src/`, `docs/`, `conf/` and `.claude/`. Two consequences:

- **Wrong oracle.** `app/data.js` exists on a machine that has built the pages and not on a fresh clone. macOS reports `data/normalized_yaml/bacterial/TSB.yaml` as existing because the tracked file is `tsb.yaml`; Linux CI does not.
- **Blind spot.** Every `data/`, `app/`, `pages/`, `templates/` and `reports/` path in a skill was outside the prefix list and never looked at. That is why the boundary line #419 reviewed was never checked, in either direction.

## What changes

Existence is decided by git. A reference passes when it is **tracked** (`git ls-files`, file or containing directory) or **generated** (`git check-ignore`, or a `.gitignore` pattern that reaches into the directory, so `data/raw_yaml/**/*.yaml` declares `data/raw_yaml/`). The prefix list now covers every top-level directory a skill cites. Sibling-checkout paths keep their existing spellings (`MediaIngredientMech/...`, `<kg-microbe>/...`) and are not checked here.

## Mutation test

The new validator run against `main`'s skills at `c85c37080b`:

```
6 errors on main's skills
   data/normalized_yaml/solutions/10x_PBS.yaml
   data/normalized_yaml/bacterial/TSB.yaml
   data/normalized_yaml/solutions/1M_Tris_HCl_pH8.yaml
   data/curated/unmapped_ingredients.yaml
   data/transformed_last9/mediadive/edges.tsv
   templates/ingredient_role_research.md
```

All six are fixed in this PR: one case mismatch, two hypothetical outputs rewritten as placeholders, two MediaIngredientMech paths and one kg-microbe path now named as such. `reports/label_drift.tsv` (written by `just report-label-drift`, uploaded by CI) is gitignored so it classifies as generated.

## A correction to the issue

`data/raw_yaml/` was already declared generated: `.gitignore:130` carries `data/raw_yaml/**/*.yaml`. `git check-ignore data/raw_yaml/` answers no because the pattern names the files inside the directory, not the directory. The skill's boundary line was correct as written. The validator's inability to see it was the real defect, and that is what this fixes.

## Review

Adversarial review of the first commit found three things, filed as #421 (traceback outside a git checkout; other error paths still crash when `SKILLS_DIR` is outside `ROOT`), #422 (the `solutions/` convention the create-recipe skill describes does not match the repository) and #423 (the placeholder wording). #421 and #423 are fixed in the second commit with a test each; #422 is a policy decision and is left open.

## Not in this PR

- Replacing the local validator with claw's `kg-microbe-skills check`: claw is not a test dependency of this repository, and `tests.yaml` runs this script directly. Left as the open question the issue raises.
- The create-recipe skill tells curators to save stock solutions to `data/normalized_yaml/solutions/`, but that directory tracks only an index file and solution records live in the category directories. Filed separately from the review.

## Verification

- `uv run python scripts/validate_claude_skills.py` -> `validated 17 Claude skills`
- `tests/test_claude_skills.py`: 10 tests, all in the `fast` tier (checked with `-m fast --collect-only`; the module deliberately avoids spelling the corpus path, #386)
- `just test-fast`: 1537 passed
- black and ruff clean on both changed Python files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By2ZEQZ3kHPeSAzacQNUCN
