### PR TITLE
Stock solutions live in the category directories, not solutions/ (#422)

### DIFF
--- a/.claude/skills/create-recipe/SKILL.md
+++ b/.claude/skills/create-recipe/SKILL.md
@@ -166,7 +166,9 @@ just assign-ids
 There is no `solutions/` category. A stock solution is a record with
 `record_kind: SOLUTION`, saved in the category directory of the media it
 serves; most sit in `bacterial/`, as
-`data/normalized_yaml/bacterial/DAS_Vitamin_Cocktail.yaml` does.
+`data/normalized_yaml/bacterial/DAS_Vitamin_Cocktail.yaml` does. When the
+choice is not obvious, follow an existing solution record from the same source
+rather than guessing (see `docs/CONTRIBUTING.md`).
 `data/normalized_yaml/solutions/` holds one legacy index and no records
 (#422).
 

--- a/.claude/skills/create-recipe/SKILL.md
+++ b/.claude/skills/create-recipe/SKILL.md
@@ -162,7 +162,13 @@ just assign-ids
 - `archaea/` - Archaeal media
 - `fungal/` - Fungal/yeast media
 - `specialized/` - Cross-kingdom or specialized
-- `solutions/` - Stock solutions (not complete media)
+
+There is no `solutions/` category. A stock solution is a record with
+`record_kind: SOLUTION`, saved in the category directory of the media it
+serves; most sit in `bacterial/`, as
+`data/normalized_yaml/bacterial/DAS_Vitamin_Cocktail.yaml` does.
+`data/normalized_yaml/solutions/` holds one legacy index and no records
+(#422).
 
 **Filename Format**:
 ```
@@ -314,10 +320,10 @@ target_organisms:
 
 **Process**:
 1. Identify as solution (not complete medium)
-2. Save to `solutions/` directory
-3. Mark as stock solution
+2. Save to the category directory of the media it serves (`bacterial/` here)
+3. Set `record_kind: SOLUTION`
 
-**Output Location**: `data/normalized_yaml/solutions/<slug>.yaml` (here `10x_pbs.yaml`)
+**Output Location**: `data/normalized_yaml/<category>/<slug>.yaml` (here `bacterial/10x_pbs.yaml`)
 
 ### Pattern 4: Batch Import
 
@@ -421,7 +427,7 @@ pH 7.3, autoclave 121°C for 15 min
 
 **Input**: "Create 1 M Tris-HCl pH 8.0 stock solution"
 
-**Output**: `data/normalized_yaml/solutions/<slug>.yaml` (here `1m_tris_hcl_ph8.yaml`)
+**Output**: `data/normalized_yaml/<category>/<slug>.yaml` with `record_kind: SOLUTION` (here `bacterial/1m_tris_hcl_ph8.yaml`)
 
 ## Tips for Best Results
 

--- a/.claude/skills/review-recipes/reference/operations.md
+++ b/.claude/skills/review-recipes/reference/operations.md
@@ -18,7 +18,7 @@
 **Solution:** Run `python -c "from culturemech.utils.id_utils import rebuild_culturemech_registry; rebuild_culturemech_registry()"`
 
 **Issue:** Solution reference broken
-**Solution:** Check solution exists in `data/normalized_yaml/solutions/`
+**Solution:** Check the solution record exists. Solutions are `record_kind: SOLUTION` records in the category directories, not a directory of their own (#422): `grep -rl 'preferred_term: <solution name>' data/normalized_yaml/`
 
 **Issue:** Concentration units invalid
 **Solution:** Convert to enum value from schema (e.g., "g/L" → "G_PER_L")

--- a/.claude/skills/review-recipes/reference/operations.md
+++ b/.claude/skills/review-recipes/reference/operations.md
@@ -18,7 +18,7 @@
 **Solution:** Run `python -c "from culturemech.utils.id_utils import rebuild_culturemech_registry; rebuild_culturemech_registry()"`
 
 **Issue:** Solution reference broken
-**Solution:** Check the solution record exists. Solutions are `record_kind: SOLUTION` records in the category directories, not a directory of their own (#422): `grep -rl 'preferred_term: <solution name>' data/normalized_yaml/`
+**Solution:** Check the solution record exists. Solutions are `record_kind: SOLUTION` records in the category directories, not a directory of their own (#422): `grep -rl '^preferred_term: <solution name>' data/normalized_yaml/` (anchored: an unanchored match also finds every medium that uses it)
 
 **Issue:** Concentration units invalid
 **Solution:** Convert to enum value from schema (e.g., "g/L" → "G_PER_L")

--- a/.claude/skills/review-recipes/reference/pipeline-and-patterns.md
+++ b/.claude/skills/review-recipes/reference/pipeline-and-patterns.md
@@ -69,7 +69,7 @@ PYTHONPATH=src python scripts/generate_coverage_report.py \
 
 # 2. Check ingredient linkages
 PYTHONPATH=src python scripts/validate_ingredients.py \
-  data/normalized_yaml/solutions/DAS_Vitamin_Cocktail.yaml
+  data/normalized_yaml/bacterial/DAS_Vitamin_Cocktail.yaml
 
 # 3. Find usage in media
 grep -r "DAS_Vitamin_Cocktail" data/normalized_yaml/algae/

--- a/docs/DATA_LAYERS.md
+++ b/docs/DATA_LAYERS.md
@@ -303,7 +303,19 @@ normalized_yaml/
     Anaerobic_Medium.yaml
     Marine_Broth.yaml
     ...
+  solutions/
+    mediadive_solution_index.json   # legacy index only; no records live here
 ```
+
+Stock solutions are **not a category**. A solution record carries
+`record_kind: SOLUTION` (or an upstream `mediadive.solution:` /
+`MediaIngredientMech:` term id; see `scripts/record_kinds.py`) and lives in the
+category directory of the media it serves -- 4,772 of them in `bacterial/`.
+`solutions/` held them until `fe5b2f016d` (2026-04-04) moved them, and now
+holds one legacy index. The schema's `CategoryEnum` lists the five directories
+above plus a transitional `imported` value that no record or directory uses;
+`tests/test_record_directories.py` pins that every directory holding records
+is a `CategoryEnum` value (#422).
 
 ### Importing from Raw to Normalized
 

--- a/docs/media_growth_review_goal_prompt.md
+++ b/docs/media_growth_review_goal_prompt.md
@@ -13,7 +13,7 @@ Use the repo's media YAML records themselves as the target media list. Research 
 Targets:
 - Primary target corpus: every media recipe YAML record under `data/normalized_yaml/**/*.yaml`; this list of YAML records is the target media list.
 - Include these directories: `data/normalized_yaml/algae`, `data/normalized_yaml/archaea`, `data/normalized_yaml/bacterial`, `data/normalized_yaml/fungal`, and `data/normalized_yaml/specialized`.
-- Treat `data/normalized_yaml/solutions` as supporting stock-solution records, not primary growth-media targets, unless a solution record is clearly used as a growable medium or is needed to model a parent medium or variant.
+- Treat records with `record_kind: SOLUTION` (or a `mediadive.solution:` term id) inside those directories as supporting stock-solution records, not primary growth-media targets, unless a solution record is clearly used as a growable medium or is needed to model a parent medium or variant.
 - Process the corpus in explicit batches when needed. Each batch report must state the exact YAML paths reviewed.
 
 Search strategy:

--- a/docs/media_growth_review_goal_prompt.md
+++ b/docs/media_growth_review_goal_prompt.md
@@ -13,7 +13,7 @@ Use the repo's media YAML records themselves as the target media list. Research 
 Targets:
 - Primary target corpus: every media recipe YAML record under `data/normalized_yaml/**/*.yaml`; this list of YAML records is the target media list.
 - Include these directories: `data/normalized_yaml/algae`, `data/normalized_yaml/archaea`, `data/normalized_yaml/bacterial`, `data/normalized_yaml/fungal`, and `data/normalized_yaml/specialized`.
-- Treat records with `record_kind: SOLUTION` (or a `mediadive.solution:` term id) inside those directories as supporting stock-solution records, not primary growth-media targets, unless a solution record is clearly used as a growable medium or is needed to model a parent medium or variant.
+- Treat records with `record_kind: SOLUTION` (or a `mediadive.solution:` / `MediaIngredientMech:` term id) inside those directories as supporting stock-solution records, not primary growth-media targets, unless a solution record is clearly used as a growable medium or is needed to model a parent medium or variant.
 - Process the corpus in explicit batches when needed. Each batch report must state the exact YAML paths reviewed.
 
 Search strategy:

--- a/tests/test_record_directories.py
+++ b/tests/test_record_directories.py
@@ -47,6 +47,26 @@ def _directories_holding_records() -> set[str]:
     return holding
 
 
+def _records_at_the_top_level() -> list[str]:
+    """Tracked YAML directly under the corpus root. `validate-strict` would see
+    it (it uses `rglob`), but the audits, the index generator and the repair
+    scripts walk `*/*.yaml` and would not; the first version of this guard
+    skipped it too (review of #424). Depth is filtered here, not in the
+    pathspec: a git pathspec `*` matches across `/`."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "--", "data/normalized_yaml"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return sorted(
+        entry
+        for entry in listing.split("\0")
+        if entry.endswith(".yaml") and len(Path(entry).parts) == 3
+    )
+
+
 def test_every_directory_holding_records_is_a_schema_category() -> None:
     categories = _category_values()
     holding = _directories_holding_records()
@@ -65,6 +85,14 @@ def test_the_guard_is_not_vacuous() -> None:
     populated = {"bacterial", "fungal", "archaea", "specialized", "algae"}
     assert _directories_holding_records() == populated
     assert _category_values() == populated | {"imported"}
+
+
+def test_no_record_sits_at_the_top_level_of_the_corpus() -> None:
+    stray = _records_at_the_top_level()
+    assert not stray, (
+        f"{len(stray)} record(s) directly under data/normalized_yaml/, where the "
+        f"`*/*.yaml` audits do not look: {stray[:5]}. Records go in a category directory."
+    )
 
 
 def test_the_legacy_solutions_directory_holds_no_records() -> None:

--- a/tests/test_record_directories.py
+++ b/tests/test_record_directories.py
@@ -1,0 +1,74 @@
+"""Records live only in the schema's category directories (#422).
+
+The create-recipe skill told curators to save stock solutions under
+`data/normalized_yaml/solutions/`. That directory held the MediaDive solution
+records until `fe5b2f016d` (2026-04-04) moved them into `bacterial/`; since
+then it has held one legacy index and nothing scans it. A record written there
+would validate, be assigned an id, and be invisible to every corpus gate.
+
+This pins the layout the rest of the tooling assumes: every directory under
+the normalized corpus that holds a record is a `CategoryEnum` value.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+NORMALIZED = ROOT / "data" / "normalized_yaml"
+SCHEMA = ROOT / "src" / "culturemech" / "schema" / "culturemech.yaml"
+
+
+def _category_values() -> set[str]:
+    schema = yaml.safe_load(SCHEMA.read_text())
+    return set(schema["enums"]["CategoryEnum"]["permissible_values"])
+
+
+def _directories_holding_records() -> set[str]:
+    """Directories with a TRACKED record. Git, not the filesystem, is the oracle:
+    a local import run can leave an untracked directory of YAML beside the
+    corpus (an `imported/` tree was sitting here when this test was written),
+    and that is a workstation state, not the repository's layout (#419)."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "--", "data/normalized_yaml"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    holding: set[str] = set()
+    for entry in listing.split("\0"):
+        parts = Path(entry).parts
+        if len(parts) >= 4 and entry.endswith(".yaml"):
+            holding.add(parts[2])
+    return holding
+
+
+def test_every_directory_holding_records_is_a_schema_category() -> None:
+    categories = _category_values()
+    holding = _directories_holding_records()
+    assert holding, "no record directories found; is this the right checkout?"
+    assert holding <= categories, (
+        f"records found outside the schema's categories: {sorted(holding - categories)}. "
+        f"Stock solutions carry `record_kind: SOLUTION` and live in the category "
+        f"directory of the media they serve, not in a directory of their own (#422)."
+    )
+
+
+def test_the_guard_is_not_vacuous() -> None:
+    """Five populated category directories is what the corpus looks like today.
+    The enum also carries `imported`, a transitional value ("to be
+    recategorized") that no record and no directory uses."""
+    populated = {"bacterial", "fungal", "archaea", "specialized", "algae"}
+    assert _directories_holding_records() == populated
+    assert _category_values() == populated | {"imported"}
+
+
+def test_the_legacy_solutions_directory_holds_no_records() -> None:
+    assert "solutions" not in _directories_holding_records()
+    assert (
+        NORMALIZED / "solutions" / "mediadive_solution_index.json"
+    ).is_file(), "the legacy index is gone; update DATA_LAYERS.md, which says it is still there"


### PR DESCRIPTION
Closes #422.
Closes #426.
Closes #427.

(#425 stays open: legacy tooling that still assumes the old layout.)

## The decision, and what settles it

The issue asked whether `data/normalized_yaml/solutions/` should become a real category or the skill should stop naming it. The repository already decided:

- `fe5b2f016d` (2026-04-04) moved the 4,784 MediaDive solution records out of `solutions/mediadive/` into `bacterial/`; 4,772 are there today and 2 in `archaea/`.
- The schema's `CategoryEnum` is `bacterial, fungal, archaea, specialized, algae` plus a transitional `imported` value. No `solutions`.
- `scripts/record_kinds.py` identifies a solution by `record_kind: SOLUTION` or an upstream `mediadive.solution:` / `MediaIngredientMech:` term id, never by directory. `docs/CONTRIBUTING.md` already documents the marker.
- `solutions/` holds one file, a 2026-03-09 index whose filenames no longer resolve there.

So the skill was describing a layout that had been gone for five months. This PR makes the skill and the docs say what the repository does.

## Changes

- `create-recipe/SKILL.md`: the category list no longer offers `solutions/`; Pattern 3 and Example 3 say "the category directory of the media it serves" and "set `record_kind: SOLUTION`", with a real record (`bacterial/DAS_Vitamin_Cocktail.yaml`) as the model.
- `review-recipes/reference/`: one code-fence path and one troubleshooting line still pointed at `solutions/`. Both corrected. (The validator from #420 could not see either: one is inside a code fence, the other names the directory itself, which is tracked because of the index.)
- `docs/DATA_LAYERS.md`: states the rule, the move, and that `solutions/` is a legacy index directory.
- `docs/media_growth_review_goal_prompt.md`: "treat `data/normalized_yaml/solutions` as supporting records" became "treat `record_kind: SOLUTION` records inside the category directories as supporting records".

## Guard

`tests/test_record_directories.py`: every directory under the normalized corpus that holds a **tracked** record is a `CategoryEnum` value, and `solutions/` holds none. It asks `git ls-files`, not the filesystem: an untracked `imported/` tree of YAML appeared beside the corpus while this was being written (a concurrent import run), and a filesystem walk reported it as a layout violation. That is the #419 lesson again, applied to a second test.

Mutation-checked:

```
$ printf 'name: probe\n' > data/normalized_yaml/solutions/probe.yaml && git add -N $_
AssertionError: records found outside the schema's categories: ['solutions']. ...
```

## Review

Adversarial review of the first commit, filed as #425 (tools that still assume the retired layout, including an importer default that would recreate it), #426 (the guard skipped a record dropped at the top level of the corpus, where the `*/*.yaml` audits do not look) and #427 (an unanchored existence grep and one missing id prefix). #426 and #427 are fixed in the second commit; #426's assertion is mutation-checked with an intent-to-add probe.

## Not in this PR

Legacy remnants of the old layout, filed as #425 rather than swept here: two scripts still default to `data/normalized_yaml/solutions/mediadive` and would silently find nothing, the stale `mediadive_solution_index.json`, and `solutions_index.json` (category `solutions`, count 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01By2ZEQZ3kHPeSAzacQNUCN
