### PR TITLE
Derive script paths from the checkout instead of one laptop (#430)

### DIFF
--- a/scripts/export_mediadive_composition.py
+++ b/scripts/export_mediadive_composition.py
@@ -9,6 +9,7 @@ This script connects to the local MongoDB database and exports:
 
 import json
 from pathlib import Path
+
 from pymongo import MongoClient
 
 # MongoDB connection
@@ -29,11 +30,11 @@ def export_collection(db, collection_name: str, output_file: Path):
 
     # Convert ObjectId to string
     for doc in documents:
-        if '_id' in doc:
-            doc['_id'] = str(doc['_id'])
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
 
     # Write to file
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         json.dump(documents, f, indent=2)
 
     print(f"✓ Exported {len(documents)} documents from {collection_name} to {output_file}")
@@ -64,17 +65,13 @@ def main():
         # Export medium_composition
         print("\n1. Exporting medium_composition...")
         comp_count = export_collection(
-            db,
-            "medium_composition",
-            OUTPUT_DIR / "medium_composition_data.json"
+            db, "medium_composition", OUTPUT_DIR / "medium_composition_data.json"
         )
 
         # Export medium_strains
         print("\n2. Exporting medium_strains...")
         strain_count = export_collection(
-            db,
-            "medium_strains",
-            OUTPUT_DIR / "medium_strains_data.json"
+            db, "medium_strains", OUTPUT_DIR / "medium_strains_data.json"
         )
 
         # Create summary
@@ -83,10 +80,10 @@ def main():
             "composition_records": comp_count,
             "strain_records": strain_count,
             "database": DATABASE_NAME,
-            "collections": ["medium_composition", "medium_strains"]
+            "collections": ["medium_composition", "medium_strains"],
         }
 
-        with open(OUTPUT_DIR / "composition_export_stats.json", 'w') as f:
+        with open(OUTPUT_DIR / "composition_export_stats.json", "w") as f:
             json.dump(summary, f, indent=2)
 
         print("\n" + "=" * 60)

--- a/scripts/export_mediadive_composition.py
+++ b/scripts/export_mediadive_composition.py
@@ -15,8 +15,9 @@ from pymongo import MongoClient
 MONGODB_URI = "mongodb://localhost:27017"
 DATABASE_NAME = "mediadive"
 
-# Output directory
-OUTPUT_DIR = Path("/Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CultureMech/data/raw/mediadive")
+# Output directory, inside this checkout
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = REPO_ROOT / "data" / "raw" / "mediadive"
 
 
 def export_collection(db, collection_name: str, output_file: Path):

--- a/scripts/generate_ingredient_umap.py
+++ b/scripts/generate_ingredient_umap.py
@@ -17,6 +17,7 @@ Example:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -28,11 +29,14 @@ from culturemech.visualization.ingredient_umap_generator import IngredientUMAPGe
 _REPO_ROOT = Path(__file__).parent.parent
 
 _EMBEDDINGS_FILENAME = "DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_v2_2026-05-26_00_56_15.tsv.gz"
-# Prefer local data/embeddings/; fall back to sibling CommunityMech location
+# Prefer local data/embeddings/; fall back to the CommunityMech checkout,
+# COMMUNITYMECH_ROOT or the sibling directory (CultureMech#430)
 _LOCAL_EMBEDDINGS = _REPO_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME
-_COMMUNITYMECH_EMBEDDINGS = (
-    "/Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CommunityMech"
-    "/CommunityMech/data/embeddings/" + _EMBEDDINGS_FILENAME
+_COMMUNITYMECH_ROOT = Path(
+    os.environ.get("COMMUNITYMECH_ROOT", _REPO_ROOT.parent / "CommunityMech")
+)
+_COMMUNITYMECH_EMBEDDINGS = str(
+    _COMMUNITYMECH_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME
 )
 KG_MICROBE_EMBEDDINGS = str(_LOCAL_EMBEDDINGS) if _LOCAL_EMBEDDINGS.exists() else _COMMUNITYMECH_EMBEDDINGS
 

--- a/scripts/generate_ingredient_umap.py
+++ b/scripts/generate_ingredient_umap.py
@@ -26,7 +26,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from culturemech.visualization.ingredient_umap_generator import IngredientUMAPGenerator
 
-_REPO_ROOT = Path(__file__).parent.parent
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _EMBEDDINGS_FILENAME = (
     "DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_v2_2026-05-26_00_56_15.tsv.gz"
@@ -34,8 +34,10 @@ _EMBEDDINGS_FILENAME = (
 # Prefer local data/embeddings/; fall back to the CommunityMech checkout,
 # COMMUNITYMECH_ROOT or the sibling directory (CultureMech#430)
 _LOCAL_EMBEDDINGS = _REPO_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME
+# `or`, not a get() default: an exported-but-empty variable is Path("") is
+# Path("."), which would resolve against the working directory (#434).
 _COMMUNITYMECH_ROOT = Path(
-    os.environ.get("COMMUNITYMECH_ROOT", _REPO_ROOT.parent / "CommunityMech")
+    os.environ.get("COMMUNITYMECH_ROOT") or _REPO_ROOT.parent / "CommunityMech"
 )
 _COMMUNITYMECH_EMBEDDINGS = str(_COMMUNITYMECH_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME)
 KG_MICROBE_EMBEDDINGS = (

--- a/scripts/generate_ingredient_umap.py
+++ b/scripts/generate_ingredient_umap.py
@@ -28,17 +28,19 @@ from culturemech.visualization.ingredient_umap_generator import IngredientUMAPGe
 
 _REPO_ROOT = Path(__file__).parent.parent
 
-_EMBEDDINGS_FILENAME = "DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_v2_2026-05-26_00_56_15.tsv.gz"
+_EMBEDDINGS_FILENAME = (
+    "DeepWalkSkipGramEnsmallen_degreenorm_embedding_512_v2_2026-05-26_00_56_15.tsv.gz"
+)
 # Prefer local data/embeddings/; fall back to the CommunityMech checkout,
 # COMMUNITYMECH_ROOT or the sibling directory (CultureMech#430)
 _LOCAL_EMBEDDINGS = _REPO_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME
 _COMMUNITYMECH_ROOT = Path(
     os.environ.get("COMMUNITYMECH_ROOT", _REPO_ROOT.parent / "CommunityMech")
 )
-_COMMUNITYMECH_EMBEDDINGS = str(
-    _COMMUNITYMECH_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME
+_COMMUNITYMECH_EMBEDDINGS = str(_COMMUNITYMECH_ROOT / "data" / "embeddings" / _EMBEDDINGS_FILENAME)
+KG_MICROBE_EMBEDDINGS = (
+    str(_LOCAL_EMBEDDINGS) if _LOCAL_EMBEDDINGS.exists() else _COMMUNITYMECH_EMBEDDINGS
 )
-KG_MICROBE_EMBEDDINGS = str(_LOCAL_EMBEDDINGS) if _LOCAL_EMBEDDINGS.exists() else _COMMUNITYMECH_EMBEDDINGS
 
 NAME_TO_CHEBI_PATH = Path("data/chemical_name_to_chebi_mapping_enhanced.json")
 # Sibling repo path: CultureMech/../culturebotai-claw/workspace/
@@ -129,7 +131,9 @@ def main():
     if unified_mapping:
         print(f"  Unified mapping: {unified_mapping}")
     else:
-        print(f"  Unified mapping: not found at {args.unified_mapping} (CAS-RN/KG annotations will be empty)")
+        print(
+            f"  Unified mapping: not found at {args.unified_mapping} (CAS-RN/KG annotations will be empty)"
+        )
 
     generator = IngredientUMAPGenerator(
         name_to_chebi_path=name_to_chebi,

--- a/scripts/import_from_culturebotht.py
+++ b/scripts/import_from_culturebotht.py
@@ -31,9 +31,15 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-# CULTUREBOTHT_ROOT names the outer CultureBotHT checkout; the repository
-# itself is nested one level down (CultureMech#430).
-CULTUREBOTHT_ROOT = Path(os.environ.get("CULTUREBOTHT_ROOT", REPO_ROOT.parent / "CultureBotHT"))
+# CULTUREBOTHT_ROOT names the CultureBotHT repository itself, matching
+# COMMUNITYMECH_ROOT in generate_ingredient_umap.py (#435). The sibling
+# fallback carries the doubled directory because the checkout nests
+# (CultureBotHT/CultureBotHT); the variable does not (#430).
+# `or`, not a get() default: an exported-but-empty variable is Path("") is
+# Path("."), which would resolve against the working directory (#434).
+CULTUREBOTHT_ROOT = Path(
+    os.environ.get("CULTUREBOTHT_ROOT") or REPO_ROOT.parent / "CultureBotHT" / "CultureBotHT"
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -270,8 +276,8 @@ def main():
     parser.add_argument(
         "--culturebotht-dir",
         type=Path,
-        default=CULTUREBOTHT_ROOT / "CultureBotHT",
-        help="Path to CultureBotHT repository (default: $CULTUREBOTHT_ROOT/CultureBotHT)",
+        default=CULTUREBOTHT_ROOT,
+        help="Path to the CultureBotHT repository (default: $CULTUREBOTHT_ROOT)",
     )
 
     parser.add_argument(

--- a/scripts/import_from_culturebotht.py
+++ b/scripts/import_from_culturebotht.py
@@ -19,6 +19,7 @@ This script:
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -27,6 +28,13 @@ import yaml
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# CULTUREBOTHT_ROOT names the outer CultureBotHT checkout; the repository
+# itself is nested one level down (CultureMech#430).
+CULTUREBOTHT_ROOT = Path(
+    os.environ.get('CULTUREBOTHT_ROOT', REPO_ROOT.parent / 'CultureBotHT')
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -249,8 +257,8 @@ def main():
     parser.add_argument(
         '--culturebotht-dir',
         type=Path,
-        default=Path('/Users/marcin/Documents/VIMSS/ontology/KG-Hub/KG-Microbe/CultureBotHT/CultureBotHT'),
-        help='Path to CultureBotHT repository'
+        default=CULTUREBOTHT_ROOT / 'CultureBotHT',
+        help='Path to CultureBotHT repository (default: $CULTUREBOTHT_ROOT/CultureBotHT)'
     )
 
     parser.add_argument(

--- a/scripts/import_from_culturebotht.py
+++ b/scripts/import_from_culturebotht.py
@@ -21,25 +21,21 @@ import argparse
 import logging
 import os
 import sys
-from pathlib import Path
-from typing import Dict, Any, Optional
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
 import yaml
 
 # Add src to path
-sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 # CULTUREBOTHT_ROOT names the outer CultureBotHT checkout; the repository
 # itself is nested one level down (CultureMech#430).
-CULTUREBOTHT_ROOT = Path(
-    os.environ.get('CULTUREBOTHT_ROOT', REPO_ROOT.parent / 'CultureBotHT')
-)
+CULTUREBOTHT_ROOT = Path(os.environ.get("CULTUREBOTHT_ROOT", REPO_ROOT.parent / "CultureBotHT"))
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(levelname)s: %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -48,25 +44,35 @@ class CultureBotHTImporter:
 
     # Medium type mapping: CultureBotHT → CultureMech
     MEDIUM_TYPE_MAP = {
-        'MINIMAL': 'DEFINED',
-        'DEFINED': 'DEFINED',
-        'RICH': 'COMPLEX',
-        'COMPLEX': 'COMPLEX',
+        "MINIMAL": "DEFINED",
+        "DEFINED": "DEFINED",
+        "RICH": "COMPLEX",
+        "COMPLEX": "COMPLEX",
     }
 
     # Category inference from media name patterns
     CATEGORY_PATTERNS = {
-        'bacterial': [
-            'LB', 'TSB', 'nutrient', 'brain_heart', 'mueller_hinton',
-            'pseudomonas', 'bacillus', 'escherichia', 'salmonella'
+        "bacterial": [
+            "LB",
+            "TSB",
+            "nutrient",
+            "brain_heart",
+            "mueller_hinton",
+            "pseudomonas",
+            "bacillus",
+            "escherichia",
+            "salmonella",
         ],
-        'algae': [
-            'BG11', 'BG12', 'cyanobacteria', 'synechococcus', 'prochlorococcus',
-            'photosynthetic', 'blue_green'
+        "algae": [
+            "BG11",
+            "BG12",
+            "cyanobacteria",
+            "synechococcus",
+            "prochlorococcus",
+            "photosynthetic",
+            "blue_green",
         ],
-        'fungal': [
-            'PDA', 'sabouraud', 'malt', 'czapek', 'yeast_mold', 'fungal'
-        ],
+        "fungal": ["PDA", "sabouraud", "malt", "czapek", "yeast_mold", "fungal"],
     }
 
     def __init__(self, culturebotht_dir: Path, output_dir: Path, dry_run: bool = False):
@@ -76,16 +82,16 @@ class CultureBotHTImporter:
         self.dry_run = dry_run
 
         self.stats = {
-            'files_read': 0,
-            'files_imported': 0,
-            'files_skipped': 0,
-            'errors': 0,
-            'categories': {
-                'bacterial': 0,
-                'algae': 0,
-                'fungal': 0,
-                'specialized': 0,
-            }
+            "files_read": 0,
+            "files_imported": 0,
+            "files_skipped": 0,
+            "errors": 0,
+            "categories": {
+                "bacterial": 0,
+                "algae": 0,
+                "fungal": 0,
+                "specialized": 0,
+            },
         }
 
     def infer_category(self, medium_name: str) -> str:
@@ -98,93 +104,98 @@ class CultureBotHTImporter:
                 return category.upper()
 
         # Default to specialized
-        return 'SPECIALIZED'
+        return "SPECIALIZED"
 
-    def transform_medium(self, source_data: Dict[str, Any], source_file: str) -> Dict[str, Any]:
+    def transform_medium(self, source_data: dict[str, Any], source_file: str) -> dict[str, Any]:
         """Transform CultureBotHT medium to CultureMech schema."""
 
         # Start with source data (already mostly compatible)
         medium = source_data.copy()
 
         # Map medium type
-        if 'medium_type' in medium:
-            original_type = medium['medium_type']
-            medium['medium_type'] = self.MEDIUM_TYPE_MAP.get(original_type, original_type)
+        if "medium_type" in medium:
+            original_type = medium["medium_type"]
+            medium["medium_type"] = self.MEDIUM_TYPE_MAP.get(original_type, original_type)
 
         # Infer and add category
-        if 'category' not in medium:
-            medium['category'] = self.infer_category(medium.get('name', ''))
+        if "category" not in medium:
+            medium["category"] = self.infer_category(medium.get("name", ""))
 
         # Add source tracking
-        if 'sources' not in medium:
-            medium['sources'] = []
+        if "sources" not in medium:
+            medium["sources"] = []
 
-        medium['sources'].append({
-            'database': 'CultureBotHT',
-            'database_id': medium.get('name', ''),
-            'url': f'https://github.com/CultureBotAI/CultureBotHT'
-        })
+        medium["sources"].append(
+            {
+                "database": "CultureBotHT",
+                "database_id": medium.get("name", ""),
+                "url": "https://github.com/CultureBotAI/CultureBotHT",
+            }
+        )
 
         # Add import metadata
-        if 'curation_history' not in medium:
-            medium['curation_history'] = []
+        if "curation_history" not in medium:
+            medium["curation_history"] = []
 
-        medium['curation_history'].append({
-            'timestamp': datetime.now(timezone.utc).isoformat(),
-            'curator': 'import_from_culturebotht.py',
-            'action': 'IMPORTED',
-            'notes': f'Imported from CultureBotHT repository: {source_file}'
-        })
+        medium["curation_history"].append(
+            {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "curator": "import_from_culturebotht.py",
+                "action": "IMPORTED",
+                "notes": f"Imported from CultureBotHT repository: {source_file}",
+            }
+        )
 
         # Add data quality flags if needed
-        if 'data_quality_flags' not in medium:
-            medium['data_quality_flags'] = []
+        if "data_quality_flags" not in medium:
+            medium["data_quality_flags"] = []
 
         # Check for unmapped ingredients
         unmapped_count = 0
-        for ingredient in medium.get('ingredients', []):
-            if 'term' not in ingredient or not ingredient.get('term', {}).get('id'):
+        for ingredient in medium.get("ingredients", []):
+            if "term" not in ingredient or not ingredient.get("term", {}).get("id"):
                 unmapped_count += 1
 
         if unmapped_count > 0:
-            medium['data_quality_flags'].append('has_unmapped_ingredients')
+            medium["data_quality_flags"].append("has_unmapped_ingredients")
 
         return medium
 
     def sanitize_filename(self, name: str) -> str:
         """Convert name to safe filename (snake_case)."""
         import re
+
         # Convert to lowercase
         name = name.lower()
         # Replace spaces and special chars with underscore
-        name = re.sub(r'[^a-z0-9]+', '_', name)
+        name = re.sub(r"[^a-z0-9]+", "_", name)
         # Remove leading/trailing underscores
-        name = name.strip('_')
+        name = name.strip("_")
         # Collapse multiple underscores
-        name = re.sub(r'_+', '_', name)
+        name = re.sub(r"_+", "_", name)
         return name
 
     def import_file(self, yaml_file: Path) -> bool:
         """Import a single media YAML file."""
         try:
             # Read source file
-            with open(yaml_file, 'r', encoding='utf-8') as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 source_data = yaml.safe_load(f)
 
-            if not source_data or 'name' not in source_data:
+            if not source_data or "name" not in source_data:
                 logger.warning(f"Skipping {yaml_file.name}: No name field")
-                self.stats['files_skipped'] += 1
+                self.stats["files_skipped"] += 1
                 return False
 
             # Transform to CultureMech schema
             medium = self.transform_medium(source_data, yaml_file.name)
 
             # Determine output category and filename
-            category = medium['category'].lower()
-            self.stats['categories'][category] = self.stats['categories'].get(category, 0) + 1
+            category = medium["category"].lower()
+            self.stats["categories"][category] = self.stats["categories"].get(category, 0) + 1
 
             # Create safe filename from name field
-            safe_name = self.sanitize_filename(medium['name'])
+            safe_name = self.sanitize_filename(medium["name"])
             output_filename = f"{safe_name}.yaml"
 
             # Determine output path
@@ -196,16 +207,18 @@ class CultureBotHTImporter:
                 output_category_dir.mkdir(parents=True, exist_ok=True)
 
                 # Write output file
-                with open(output_path, 'w', encoding='utf-8') as f:
-                    yaml.dump(medium, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+                with open(output_path, "w", encoding="utf-8") as f:
+                    yaml.dump(
+                        medium, f, default_flow_style=False, allow_unicode=True, sort_keys=False
+                    )
 
             logger.info(f"✓ Imported {yaml_file.name} → {category}/{output_filename}")
-            self.stats['files_imported'] += 1
+            self.stats["files_imported"] += 1
             return True
 
         except Exception as e:
             logger.error(f"✗ Error importing {yaml_file}: {e}")
-            self.stats['errors'] += 1
+            self.stats["errors"] += 1
             return False
 
     def import_all(self) -> None:
@@ -230,7 +243,7 @@ class CultureBotHTImporter:
 
         # Import each file
         for yaml_file in yaml_files:
-            self.stats['files_read'] += 1
+            self.stats["files_read"] += 1
             self.import_file(yaml_file)
 
         # Print summary
@@ -242,7 +255,7 @@ class CultureBotHTImporter:
         logger.info(f"Files skipped: {self.stats['files_skipped']}")
         logger.info(f"Errors: {self.stats['errors']}")
         logger.info("\nBy category:")
-        for category, count in sorted(self.stats['categories'].items()):
+        for category, count in sorted(self.stats["categories"].items()):
             if count > 0:
                 logger.info(f"  {category}: {count}")
         logger.info("=" * 60)
@@ -255,23 +268,21 @@ def main():
     )
 
     parser.add_argument(
-        '--culturebotht-dir',
+        "--culturebotht-dir",
         type=Path,
-        default=CULTUREBOTHT_ROOT / 'CultureBotHT',
-        help='Path to CultureBotHT repository (default: $CULTUREBOTHT_ROOT/CultureBotHT)'
+        default=CULTUREBOTHT_ROOT / "CultureBotHT",
+        help="Path to CultureBotHT repository (default: $CULTUREBOTHT_ROOT/CultureBotHT)",
     )
 
     parser.add_argument(
-        '--output-dir',
+        "--output-dir",
         type=Path,
-        default=Path('data/normalized_yaml'),
-        help='Output directory for normalized YAML files'
+        default=Path("data/normalized_yaml"),
+        help="Output directory for normalized YAML files",
     )
 
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show what would be imported without writing files'
+        "--dry-run", action="store_true", help="Show what would be imported without writing files"
     )
 
     args = parser.parse_args()
@@ -283,15 +294,13 @@ def main():
 
     # Run import
     importer = CultureBotHTImporter(
-        culturebotht_dir=args.culturebotht_dir,
-        output_dir=args.output_dir,
-        dry_run=args.dry_run
+        culturebotht_dir=args.culturebotht_dir, output_dir=args.output_dir, dry_run=args.dry_run
     )
 
     importer.import_all()
 
-    return 0 if importer.stats['errors'] == 0 else 1
+    return 0 if importer.stats["errors"] == 0 else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/src/culturemech/import/import_cofactors.py
+++ b/src/culturemech/import/import_cofactors.py
@@ -3,11 +3,19 @@ Import cofactor hierarchy from PFASCommunityAgents.
 Creates cofactor reference data and ingredient mappings.
 """
 
-import yaml
-from pathlib import Path
+import os
 import sys
+from pathlib import Path
 
-PFAS_REPO = Path("/Users/marcin/Documents/VIMSS/ontology/PFAS/PFASCommunityAgents")
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+# PFASCOMMUNITYAGENTS_ROOT names the PFASCommunityAgents checkout; the
+# fallback is the sibling directory. `or`, not a get() default, so an
+# exported-but-empty variable does not become Path(".") (#432, #434).
+PFAS_REPO = Path(
+    os.environ.get("PFASCOMMUNITYAGENTS_ROOT") or REPO_ROOT.parent / "PFASCommunityAgents"
+)
 COFACTOR_FILE = PFAS_REPO / "data/reference/cofactor_hierarchy.yaml"
 MAPPING_FILE = PFAS_REPO / "data/reference/ingredient_cofactor_mapping.csv"
 
@@ -31,54 +39,54 @@ def import_cofactor_hierarchy():
 
     cofactors = []
 
-    for cat_key, cat_data in pfas_data.get('cofactor_hierarchy', {}).items():
+    for cat_key, cat_data in pfas_data.get("cofactor_hierarchy", {}).items():
         category_enum = CATEGORY_MAPPING.get(cat_key, "OTHER_SPECIALIZED")
 
-        for cofactor_key, cofactor_data in cat_data.get('cofactors', {}).items():
+        for cofactor_key, cofactor_data in cat_data.get("cofactors", {}).items():
             cofactor = {
-                'preferred_term': cofactor_data.get('names', [cofactor_key])[0],
-                'category': category_enum,
+                "preferred_term": cofactor_data.get("names", [cofactor_key])[0],
+                "category": category_enum,
             }
 
             # Add CHEBI term
-            if 'id' in cofactor_data:
-                cofactor['term'] = {
-                    'id': cofactor_data['id'],
-                    'label': cofactor['preferred_term'],
+            if "id" in cofactor_data:
+                cofactor["term"] = {
+                    "id": cofactor_data["id"],
+                    "label": cofactor["preferred_term"],
                 }
 
             # Add precursor
-            if 'precursor' in cofactor_data:
-                cofactor['precursor'] = cofactor_data['precursor']
-                if 'precursor_id' in cofactor_data:
-                    cofactor['precursor_term'] = {
-                        'id': cofactor_data['precursor_id'],
-                        'label': cofactor_data['precursor'],
+            if "precursor" in cofactor_data:
+                cofactor["precursor"] = cofactor_data["precursor"]
+                if "precursor_id" in cofactor_data:
+                    cofactor["precursor_term"] = {
+                        "id": cofactor_data["precursor_id"],
+                        "label": cofactor_data["precursor"],
                     }
 
             # Add EC associations
-            if 'ec_associations' in cofactor_data:
-                cofactor['ec_associations'] = cofactor_data['ec_associations']
+            if "ec_associations" in cofactor_data:
+                cofactor["ec_associations"] = cofactor_data["ec_associations"]
 
             # Add KEGG pathways
-            if 'kegg_pathways' in cofactor_data:
-                cofactor['kegg_pathways'] = cofactor_data['kegg_pathways']
+            if "kegg_pathways" in cofactor_data:
+                cofactor["kegg_pathways"] = cofactor_data["kegg_pathways"]
 
             # Add enzyme examples
-            if 'enzyme_examples' in cofactor_data:
-                cofactor['enzyme_examples'] = cofactor_data['enzyme_examples']
+            if "enzyme_examples" in cofactor_data:
+                cofactor["enzyme_examples"] = cofactor_data["enzyme_examples"]
 
             # Add biosynthesis genes
-            if 'biosynthesis_genes' in cofactor_data:
-                cofactor['biosynthesis_genes'] = cofactor_data['biosynthesis_genes']
+            if "biosynthesis_genes" in cofactor_data:
+                cofactor["biosynthesis_genes"] = cofactor_data["biosynthesis_genes"]
 
             # Add bioavailability
-            if 'bioavailability' in cofactor_data:
-                cofactor['bioavailability'] = cofactor_data['bioavailability']
+            if "bioavailability" in cofactor_data:
+                cofactor["bioavailability"] = cofactor_data["bioavailability"]
 
             # Add notes
-            if 'notes' in cofactor_data:
-                cofactor['notes'] = cofactor_data['notes']
+            if "notes" in cofactor_data:
+                cofactor["notes"] = cofactor_data["notes"]
 
             cofactors.append(cofactor)
 
@@ -91,8 +99,14 @@ def write_cofactor_reference(cofactors: list, output_dir: Path):
     output_dir.mkdir(parents=True, exist_ok=True)
     output_file = output_dir / "cofactors.yaml"
 
-    with open(output_file, 'w') as f:
-        yaml.dump({'cofactors': cofactors}, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    with open(output_file, "w") as f:
+        yaml.dump(
+            {"cofactors": cofactors},
+            f,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
 
     print(f"✓ Wrote {len(cofactors)} cofactors to {output_file}")
 
@@ -102,8 +116,12 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Import cofactor hierarchy from PFAS data")
-    parser.add_argument("--output-dir", type=Path, default=Path("data/reference"),
-                        help="Output directory for cofactor reference (default: data/reference)")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/reference"),
+        help="Output directory for cofactor reference (default: data/reference)",
+    )
 
     args = parser.parse_args()
 
@@ -118,7 +136,7 @@ def main():
     print("\nCofactors by category:")
     by_category = {}
     for cofactor in cofactors:
-        cat = cofactor.get('category', 'UNKNOWN')
+        cat = cofactor.get("category", "UNKNOWN")
         by_category[cat] = by_category.get(cat, 0) + 1
 
     for cat, count in sorted(by_category.items()):

--- a/src/culturemech/import/import_ingredient_roles.py
+++ b/src/culturemech/import/import_ingredient_roles.py
@@ -4,13 +4,21 @@ Enriches existing media recipes with role annotations.
 """
 
 import csv
-from pathlib import Path
-import yaml
+import os
 import sys
+from pathlib import Path
+
+import yaml
 
 from culturemech.curate.curation_event import record_curation_event
 
-PFAS_REPO = Path("/Users/marcin/Documents/VIMSS/ontology/PFAS/PFASCommunityAgents")
+REPO_ROOT = Path(__file__).resolve().parents[3]
+# PFASCOMMUNITYAGENTS_ROOT names the PFASCommunityAgents checkout; the
+# fallback is the sibling directory. `or`, not a get() default, so an
+# exported-but-empty variable does not become Path(".") (#432, #434).
+PFAS_REPO = Path(
+    os.environ.get("PFASCOMMUNITYAGENTS_ROOT") or REPO_ROOT.parent / "PFASCommunityAgents"
+)
 INGREDIENT_FILE = PFAS_REPO / "data/sheets_pfas/PFAS_Data_for_AI_media_ingredients_extended.tsv"
 
 # Map PFAS role tokens (lowercase source values) to CultureMech faceted role
@@ -28,16 +36,16 @@ INGREDIENT_FILE = PFAS_REPO / "data/sheets_pfas/PFAS_Data_for_AI_media_ingredien
 #   strength / osmotic pressure, not elemental supply); mapped to
 #   PhysicochemicalRoleEnum.OSMOTIC_AGENT.
 ROLE_MAPPING = {
-    "carbon source":      ("nutritional_roles",     "CARBON_SOURCE"),
-    "nitrogen source":    ("nutritional_roles",     "NITROGEN_SOURCE"),
-    "mineral":            ("nutritional_roles",     "TRACE_ELEMENT"),
-    "trace element":      ("nutritional_roles",     "TRACE_ELEMENT"),
-    "vitamin source":     ("nutritional_roles",     "VITAMIN_SOURCE"),
-    "protein source":     ("nutritional_roles",     "PROTEIN_SOURCE"),
-    "amino acid source":  ("nutritional_roles",     "AMINO_ACID_SOURCE"),
-    "buffer":             ("physicochemical_roles", "BUFFER"),
-    "salt":               ("physicochemical_roles", "OSMOTIC_AGENT"),
-    "solidifying agent":  ("physicochemical_roles", "SOLIDIFYING_AGENT"),
+    "carbon source": ("nutritional_roles", "CARBON_SOURCE"),
+    "nitrogen source": ("nutritional_roles", "NITROGEN_SOURCE"),
+    "mineral": ("nutritional_roles", "TRACE_ELEMENT"),
+    "trace element": ("nutritional_roles", "TRACE_ELEMENT"),
+    "vitamin source": ("nutritional_roles", "VITAMIN_SOURCE"),
+    "protein source": ("nutritional_roles", "PROTEIN_SOURCE"),
+    "amino acid source": ("nutritional_roles", "AMINO_ACID_SOURCE"),
+    "buffer": ("physicochemical_roles", "BUFFER"),
+    "salt": ("physicochemical_roles", "OSMOTIC_AGENT"),
+    "solidifying agent": ("physicochemical_roles", "SOLIDIFYING_AGENT"),
 }
 
 
@@ -55,10 +63,10 @@ def load_ingredient_roles():
     roles_db: dict[str, dict[str, list[str]]] = {}
 
     with open(INGREDIENT_FILE) as f:
-        reader = csv.DictReader(f, delimiter='\t')
+        reader = csv.DictReader(f, delimiter="\t")
         for row in reader:
-            chebi_id = row.get('ontology_id', '').strip()
-            role_raw = row.get('role', '').strip()
+            chebi_id = row.get("ontology_id", "").strip()
+            role_raw = row.get("role", "").strip()
             mapping = ROLE_MAPPING.get(role_raw)
 
             if chebi_id and mapping:
@@ -85,9 +93,9 @@ def enrich_recipe_with_roles(recipe_path: Path, roles_db: dict, dry_run: bool = 
     modified = False
     changes = []
 
-    for ingredient in recipe.get('ingredients', []):
-        term = ingredient.get('term', {})
-        chebi_id = term.get('id')
+    for ingredient in recipe.get("ingredients", []):
+        term = ingredient.get("term", {})
+        chebi_id = term.get("id")
 
         if chebi_id in roles_db:
             for slot, enum_values in roles_db[chebi_id].items():
@@ -109,7 +117,7 @@ def enrich_recipe_with_roles(recipe_path: Path, roles_db: dict, dry_run: bool = 
                 source="PFAS_Data_for_AI_media_ingredients_extended.tsv",
                 skip_if_recent=True,
             )
-            with open(recipe_path, 'w') as f:
+            with open(recipe_path, "w") as f:
                 yaml.dump(recipe, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
             print(f"✓ Updated {recipe_path.name}")
         else:
@@ -134,7 +142,9 @@ def enrich_all_recipes(kb_dir: Path, roles_db: dict, dry_run: bool = False):
         except Exception as e:
             print(f"Error processing {recipe_path}: {e}")
 
-    print(f"\n✓ {'Would update' if dry_run else 'Updated'} {updated_count} recipes with ingredient roles")
+    print(
+        f"\n✓ {'Would update' if dry_run else 'Updated'} {updated_count} recipes with ingredient roles"
+    )
 
 
 def main():
@@ -142,10 +152,15 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Import ingredient roles from PFAS data")
-    parser.add_argument("--kb-dir", type=Path, default=Path("data/normalized_yaml"),
-                        help="Knowledge base directory (default: data/normalized_yaml)")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Show what would be changed without modifying files")
+    parser.add_argument(
+        "--kb-dir",
+        type=Path,
+        default=Path("data/normalized_yaml"),
+        help="Knowledge base directory (default: data/normalized_yaml)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be changed without modifying files"
+    )
 
     args = parser.parse_args()
 

--- a/tests/test_scripts_are_machine_independent.py
+++ b/tests/test_scripts_are_machine_independent.py
@@ -1,0 +1,82 @@
+"""No script may hardcode a path that only exists on one machine (#430).
+
+A literal `/Users/<name>/...` runs on one laptop and, when that checkout
+moves, nowhere. The same is true of `Path.home() / "Documents/..."` and
+`expanduser("~/Documents/...")`, which are the same path with the prefix cut
+off; claw's guard missed that shape for a month (culturebotai-claw#365), so
+this one refuses it from the start. Derive paths from the file's own location
+(`Path(__file__).resolve().parent.parent`) and take another checkout's root
+from its fleet environment variable.
+
+A dot-directory under home (`~/.data/oaklib`, `/Users/x/.cache`) is a tool
+cache, not a checkout, and stays allowed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+_MACHINE_PATH = re.compile(
+    r"""(
+        /(?:Users|home)/[^/\s'"]+/(?!\.)          # /Users/name/x, not /Users/name/.cache
+      | Documents/
+      | Path\.home\(\)\s*/\s*['"](?!\.)          # Path.home() / "x", not / ".cache"
+      | expanduser\(\s*['"]~/(?!\.)              # expanduser("~/x"), not "~/.cache"
+    )""",
+    re.VERBOSE,
+)
+
+
+def has_machine_path(source: str) -> bool:
+    return _MACHINE_PATH.search(source) is not None
+
+
+def _scripts() -> list[Path]:
+    return sorted(SCRIPTS.glob("*.py"))
+
+
+def test_there_are_scripts_to_check():
+    """Guards the parametrization: an empty glob would pass everything."""
+    assert len(_scripts()) >= 10, f"only {len(_scripts())} scripts found"
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        'OUTPUT_DIR = Path("/Users/someone/Documents/VIMSS/ontology/X/data")',
+        "root = Path.home() / 'Documents/VIMSS/ontology/X'",
+        'root = os.path.expanduser("~/Documents/X")',
+        'p = "/home/someone/checkouts/X/kb"',
+    ],
+)
+def test_the_guard_recognises_each_shape(snippet):
+    """Driven by an input the guard must refuse, so a loosened regex goes red."""
+    assert has_machine_path(snippet), snippet
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        'CACHE = Path.home() / ".data" / "oaklib" / "chebi.db"',
+        'db = os.path.expanduser("~/.cache/x.db")',
+        "# see /Users/someone/.claude/plans/notes.md",
+        "ROOT = Path(__file__).resolve().parent.parent",
+    ],
+)
+def test_the_guard_allows_caches_and_derived_paths(snippet):
+    assert not has_machine_path(snippet), snippet
+
+
+@pytest.mark.parametrize("path", _scripts(), ids=lambda p: p.name)
+def test_no_script_hardcodes_a_machine_path(path):
+    assert not has_machine_path(path.read_text(encoding="utf-8")), (
+        f"{path.name} embeds a path that exists on one machine; derive it from "
+        f"the file's own location or take the other checkout's root from its "
+        f"environment variable"
+    )

--- a/tests/test_scripts_are_machine_independent.py
+++ b/tests/test_scripts_are_machine_independent.py
@@ -10,6 +10,12 @@ from its fleet environment variable.
 
 A dot-directory under home (`~/.data/oaklib`, `/Users/x/.cache`) is a tool
 cache, not a checkout, and stays allowed.
+
+Scope is every Python source we ship, `scripts/*.py` and `src/**/*.py`, not
+one directory: the first cut globbed `scripts/*.py` and so could not see the
+same hardcode sitting in two importable modules that `just import-pfas-roles`
+and `just import-pfas-cofactors` run (#432). Python sources only — the
+`Documents/` branch is deliberately broad and would fire on prose.
 """
 
 from __future__ import annotations
@@ -21,6 +27,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "scripts"
+SRC = ROOT / "src"
 
 _MACHINE_PATH = re.compile(
     r"""(
@@ -37,13 +44,18 @@ def has_machine_path(source: str) -> bool:
     return _MACHINE_PATH.search(source) is not None
 
 
-def _scripts() -> list[Path]:
-    return sorted(SCRIPTS.glob("*.py"))
+def _python_sources() -> list[Path]:
+    """Every Python source in the repository, both trees."""
+    return sorted(SCRIPTS.glob("*.py")) + sorted(SRC.rglob("*.py"))
 
 
-def test_there_are_scripts_to_check():
-    """Guards the parametrization: an empty glob would pass everything."""
-    assert len(_scripts()) >= 10, f"only {len(_scripts())} scripts found"
+def test_both_trees_are_covered():
+    """Guards the parametrization: an empty glob would pass everything, and a
+    glob that reaches only one tree is how #432 stayed invisible."""
+    found = _python_sources()
+    assert len(found) >= 10, f"only {len(found)} Python sources found"
+    for tree in (SCRIPTS, SRC):
+        assert any(tree in p.parents for p in found), f"nothing found under {tree.name}/"
 
 
 @pytest.mark.parametrize(
@@ -73,10 +85,10 @@ def test_the_guard_allows_caches_and_derived_paths(snippet):
     assert not has_machine_path(snippet), snippet
 
 
-@pytest.mark.parametrize("path", _scripts(), ids=lambda p: p.name)
-def test_no_script_hardcodes_a_machine_path(path):
+@pytest.mark.parametrize("path", _python_sources(), ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_python_source_hardcodes_a_machine_path(path):
     assert not has_machine_path(path.read_text(encoding="utf-8")), (
-        f"{path.name} embeds a path that exists on one machine; derive it from "
+        f"{path.relative_to(ROOT)} embeds a path that exists on one machine; derive it from "
         f"the file's own location or take the other checkout's root from its "
         f"environment variable"
     )


### PR DESCRIPTION
Closes #430.

Three scripts named an absolute path under one developer's home directory. Since the Mech checkouts moved on 2026-09-07 all three point at nothing.

| script | was | now |
|---|---|---|
| `export_mediadive_composition.py` | `OUTPUT_DIR` an absolute path into this repo | `REPO_ROOT / "data" / "raw" / "mediadive"` |
| `generate_ingredient_umap.py` | absolute CommunityMech embeddings fallback | `COMMUNITYMECH_ROOT`, else the sibling directory |
| `import_from_culturebotht.py` | `--culturebotht-dir` default absolute | `CULTUREBOTHT_ROOT`, else the sibling directory |

`tests/test_scripts_are_machine_independent.py` is new: it refuses `/Users`, `/home`, a `Documents/` segment, and `Path.home()`/`expanduser("~/")` joined to a non-dot literal. A dot-directory under home is a tool cache and stays allowed. It carries its own positive and negative cases so a loosened pattern goes red on its own.

## Verified

| check | result |
|---|---|
| guard predicate on `origin/main` scripts | 3 flagged |
| guard predicate on this branch | 0 flagged |
| new test file | 196 passed |
| `just test-fast` (CI's fast tier) | 1486 passed, 23 skipped |
| `--help` for both CLI scripts with an empty environment | both work |
| ruff on the changed files | 8 findings, same as `origin/main` |

Found by claw's fleet-wide search for the same class (culturebotai-claw#365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhuGBogKrsE76ejRJJ2292


---

## Review follow-up (#432, #433, #434, #435)

Adversarial review of this branch filed four issues; all four are addressed in `8402c024bd`.

**#432 — the guard covered a directory, not the bug class.** `scripts/*.py` is
non-recursive and excludes `src/`, where two importable modules carried the same
hardcode, both reachable from `just import-pfas-roles` and `just import-pfas-cofactors`:

| file | was |
|---|---|
| `src/culturemech/import/import_cofactors.py:10` | `PFAS_REPO = Path("/Users/…/PFAS/PFASCommunityAgents")` |
| `src/culturemech/import/import_ingredient_roles.py:13` | same literal |

Both now read `PFASCOMMUNITYAGENTS_ROOT` with a sibling fallback. The guard scans
`scripts/*.py` and `src/**/*.py`, and its non-vacuity test asserts both trees are
reached so a one-tree glob fails on its own.

**#433** `generate_ingredient_umap.py` resolves `__file__` before deriving a sibling from it.
**#434** Both overrides use `or`, so an exported-but-empty variable is not `Path(".")`.
**#435** `CULTUREBOTHT_ROOT` names the repository; the doubled directory stays in the fallback.

### Verified

| check | result |
|---|---|
| widened guard on `origin/main` `src/` files | 2 red |
| widened guard on `origin/main` scripts | 3 red |
| widened guard on this branch | 295 passed |
| fast tier | 1581 passed, 23 skipped |
| ruff + black, all six changed files | clean |
| both modules import with no environment set | yes |
| with `PFASCOMMUNITYAGENTS_ROOT` set, source file found | yes |
| two `src/` files == `origin/main` + this edit + formatters | byte identical |

Reformatting in the two `src/` files is what the changed-Python gate requires once they are touched.
