### PR TITLE
Key KGX nodes on the record id, not its name (#438)

### DIFF
--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -17,17 +17,20 @@ MeSH, and curated local identities can be valid ingredient objects. See
 
 ### Nodes
 
-1. **Medium** (`culturemech:*`)
-   - Growth medium formulations
-   - Example: `culturemech:LB_Broth`
+1. **Medium** (`CultureMech:*`)
+   - Growth medium formulations, one node per record, keyed on the record's
+     permanent `id` (never its name: names repeat, #438)
+   - Example: `CultureMech:000001`
 
 2. **Organism/Taxon** (`NCBITaxon:*`)
    - Microorganisms that grow in media
    - Example: `NCBITaxon:562` (Escherichia coli)
 
-3. **Solution** (`culturemech:solution_*`)
-   - Pre-made stock solutions used in media preparation
-   - Example: `culturemech:solution_Trace_Metal_Solution`
+3. **Solution**
+   - A standalone stock-solution record is a `biolink:ChemicalMixture` node keyed
+     on its own `id`, like a medium: `CultureMech:013364`
+   - A solution nested inside a medium record has no id of its own and is minted
+     as `culturemech:solution_*`, e.g. `culturemech:solution_Trace_Metal_Solution`
 
 4. **Ingredient** (MIM-resolved external identity)
    - Chemicals, food products, mixtures, and registry-identified materials in media or solutions
@@ -44,7 +47,7 @@ MeSH, and curated local identities can be valid ingredient objects. See
 **Relationship**: Organism grows in a specific medium
 
 ```
-NCBITaxon:562 --[METPO:2000517 (grows in)]--> culturemech:LB_Broth
+NCBITaxon:562 --[METPO:2000517 (grows in)]--> CultureMech:000001
 ```
 
 **Structure**:
@@ -61,7 +64,7 @@ NCBITaxon:562 --[METPO:2000517 (grows in)]--> culturemech:LB_Broth
 {
   "subject": "NCBITaxon:562",
   "predicate": "METPO:2000517",
-  "object": "culturemech:LB_Broth",
+  "object": "CultureMech:000001",
   "qualifiers": [
     {
       "qualifier_type_id": "biolink:strain",
@@ -76,7 +79,7 @@ NCBITaxon:562 --[METPO:2000517 (grows in)]--> culturemech:LB_Broth
 **Relationship**: Medium contains a pre-made solution component
 
 ```
-culturemech:M9_Minimal --[biolink:has_part]--> culturemech:solution_Trace_Elements
+CultureMech:000002 --[biolink:has_part]--> culturemech:solution_Trace_Elements
 ```
 
 **Structure**:
@@ -90,7 +93,7 @@ culturemech:M9_Minimal --[biolink:has_part]--> culturemech:solution_Trace_Elemen
 **Example**:
 ```json
 {
-  "subject": "culturemech:M9_Minimal",
+  "subject": "CultureMech:000002",
   "predicate": "biolink:has_part",
   "object": "culturemech:solution_Trace_Elements",
   "qualifiers": [
@@ -143,7 +146,7 @@ culturemech:solution_Trace_Elements --[biolink:has_part]--> CHEBI:49976
 **Relationship**: Medium directly contains chemical ingredients
 
 ```
-culturemech:LB_Broth --[biolink:has_part]--> CHEBI:17234
+CultureMech:000001 --[biolink:has_part]--> CHEBI:17234
 ```
 
 **Structure**:
@@ -158,7 +161,7 @@ culturemech:LB_Broth --[biolink:has_part]--> CHEBI:17234
 **Example**:
 ```json
 {
-  "subject": "culturemech:LB_Broth",
+  "subject": "CultureMech:000001",
   "predicate": "biolink:has_part",
   "object": "CHEBI:17234",
   "qualifiers": [
@@ -179,7 +182,7 @@ culturemech:LB_Broth --[biolink:has_part]--> CHEBI:17234
 **Relationship**: Medium has a type classification (COMPLEX, DEFINED, etc.)
 
 ```
-culturemech:LB_Broth --[biolink:has_attribute]--> culturemech:medium_type_COMPLEX
+CultureMech:000001 --[biolink:has_attribute]--> culturemech:medium_type_COMPLEX
 ```
 
 **Structure**:
@@ -193,7 +196,7 @@ culturemech:LB_Broth --[biolink:has_attribute]--> culturemech:medium_type_COMPLE
 **Example**:
 ```json
 {
-  "subject": "culturemech:LB_Broth",
+  "subject": "CultureMech:000001",
   "predicate": "biolink:has_attribute",
   "object": "culturemech:medium_type_COMPLEX",
   "qualifiers": [

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -187,9 +187,10 @@ def transform(
         if edge:
             yield edge
 
-    # NEW: Edge Type 5: Medium → Type (as node attribute)
+    # NEW: Edge Type 5: Medium → Type (as node attribute). A medium's attribute,
+    # so a stock-solution record (202 carry a medium_type) does not get one (#442).
     medium_type = record.get("medium_type")
-    if medium_type:
+    if medium_type and not is_solution_record(record):
         edge = medium_to_type_edge(medium_id, medium_type)
         if edge:
             yield edge
@@ -369,12 +370,13 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     )
     # A stock-solution record is a mixture, not a growth medium, matching the
     # `mediadive.solution:*` nodes kg-microbe already carries (#374).
-    if is_solution_record(record):
+    solution = is_solution_record(record)
+    if solution:
         medium_category = [CHEMICAL_MIXTURE]
 
     yield asdict(Node(id=medium_id, category=medium_category, name=name))
 
-    if medium_type:
+    if medium_type and not solution:
         yield asdict(
             Node(
                 id=f"culturemech:medium_type_{medium_type}",

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -74,6 +74,54 @@ except ImportError:
 KNOWLEDGE_SOURCE = "infores:culturemech"
 NAMESPACE_UUID = uuid.uuid5(uuid.NAMESPACE_URL, "https://w3id.org/culturemech")
 
+# A standalone stock-solution record is recognised by the same two explicit
+# signals scripts/record_kinds.py uses: a curated `record_kind: SOLUTION`, or an
+# upstream solution id in `term.id`. Shape heuristics would also match malformed
+# media, so neither side uses them.
+_SOLUTION_TERM_PREFIXES = ("mediadive.solution:", "MediaIngredientMech:")
+
+
+def record_node_id(record: dict[str, Any]) -> str:
+    """The node id for a record: its own permanent CultureMech identifier.
+
+    Until #438 this was ``culturemech:{sanitized name}``, and node emission dedupes
+    on id, so records sharing a name collapsed into one node with merged edges:
+    3,181 media and 4,787 solutions on the 2026-09-09 corpus. The 4,784 MediaDive
+    solution records carry ``preferred_term`` and no ``name`` at all, so every one
+    of them sanitized to the empty string and none emitted a node.
+
+    ``id`` is required by the schema, immutable, never reused, and pinned by
+    ``just check-id-catalog``; it is the only identifier a node can safely carry.
+    A record without one is a data error, not a case to paper over with a name.
+    """
+    record_id = record.get("id")
+    if not isinstance(record_id, str) or not record_id.strip():
+        raise ValueError(
+            f"record has no id (name={record.get('name')!r}, "
+            f"preferred_term={record.get('preferred_term')!r}); every record must "
+            "carry its permanent CultureMech identifier"
+        )
+    return record_id.strip()
+
+
+def record_label(record: dict[str, Any]) -> str:
+    """Display label: ``name`` for media, ``preferred_term`` for solution records."""
+    for key in ("name", "preferred_term", "original_name"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return record_node_id(record)
+
+
+def is_solution_record(record: dict[str, Any]) -> bool:
+    """True for a standalone stock-solution record (see scripts/record_kinds.py)."""
+    if record.get("record_kind") == "SOLUTION":
+        return True
+    term = record.get("term")
+    tid = term.get("id") if isinstance(term, dict) else None
+    return isinstance(tid, str) and tid.startswith(_SOLUTION_TERM_PREFIXES)
+
+
 # Predicates following cmm-ai-automation schema
 GROWS_IN_MEDIUM = "METPO:2000517"  # grows in
 HAS_PART = "biolink:has_part"  # For medium→ingredient, solution→ingredient
@@ -107,10 +155,7 @@ def transform(
     9. Medium → has_database_reference → Database ID (legacy)
     10. Variant → variant_of → Base Medium (legacy)
     """
-    # Sanitized, not just space-replaced: a name carrying a quote would
-    # otherwise be spelled differently in the nodes and edges files (see
-    # `_sanitize_id`).
-    medium_id = f"culturemech:{_sanitize_id(str(record.get('name') or ''))}"
+    medium_id = record_node_id(record)
 
     # NEW: Edge Type 1: Organism → Medium (grows_in_medium)
     for organism in record.get("target_organisms", []):
@@ -314,16 +359,18 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     belongs to all 8,850 COMPLEX media. Deduplication is the writer's job (see
     ``koza_transform``), because it is a property of the run, not of the record.
     """
-    name = str(record.get("name") or "")
-    if not name:
-        return
-    medium_id = f"culturemech:{_sanitize_id(name)}"
+    medium_id = record_node_id(record)
+    name = record_label(record)
     medium_type = record.get("medium_type")
 
     medium_category, type_category = _MEDIUM_TYPE_CATEGORIES.get(
         str(medium_type or ""),
         (_DEFAULT_MEDIUM_CATEGORY, _DEFAULT_MEDIUM_TYPE_CATEGORY),
     )
+    # A stock-solution record is a mixture, not a growth medium, matching the
+    # `mediadive.solution:*` nodes kg-microbe already carries (#374).
+    if is_solution_record(record):
+        medium_category = [CHEMICAL_MIXTURE]
 
     yield asdict(Node(id=medium_id, category=medium_category, name=name))
 

--- a/tests/test_kg_microbe_integration.py
+++ b/tests/test_kg_microbe_integration.py
@@ -28,6 +28,7 @@ class TestOrganismMediaQueries:
         """Test finding all media for E. coli."""
         # Load a test recipe with E. coli
         recipe_yaml = """
+id: CultureMech:900001
 name: LB Medium
 category: bacterial
 medium_type: complex
@@ -52,9 +53,9 @@ ingredients:
 
         # Find organism edges
         organism_edges = [
-            e for e in edges
-            if e.get("predicate") == "METPO:2000517"
-            and e.get("subject") == "NCBITaxon:562"
+            e
+            for e in edges
+            if e.get("predicate") == "METPO:2000517" and e.get("subject") == "NCBITaxon:562"
         ]
 
         assert len(organism_edges) > 0, "Should find E. coli edge"
@@ -63,6 +64,7 @@ ingredients:
     def test_organism_with_strain_designation(self, tmpdir):
         """Test organism with strain designation is queryable."""
         recipe_yaml = """
+id: CultureMech:900002
 name: E. coli K-12 Medium
 category: bacterial
 medium_type: complex
@@ -84,10 +86,7 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         edges = list(transform(yaml.safe_load(recipe_yaml)))
-        organism_edges = [
-            e for e in edges
-            if e.get("predicate") == "METPO:2000517"
-        ]
+        organism_edges = [e for e in edges if e.get("predicate") == "METPO:2000517"]
 
         assert len(organism_edges) > 0
         # Check that strain info is preserved in qualifiers
@@ -101,6 +100,7 @@ class TestStrainMediaQueries:
     def test_dsm_strain_identification(self, tmpdir):
         """Test that DSM strain numbers are captured in media names."""
         recipe_yaml = """
+id: CultureMech:900003
 name: MODIFIED FOR DSM 11573
 category: bacterial
 medium_type: complex
@@ -119,10 +119,7 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         edges = list(transform(yaml.safe_load(recipe_yaml)))
-        organism_edges = [
-            e for e in edges
-            if e.get("predicate") == "METPO:2000517"
-        ]
+        organism_edges = [e for e in edges if e.get("predicate") == "METPO:2000517"]
 
         assert len(organism_edges) > 0
         # Verify strain info is accessible
@@ -179,6 +176,7 @@ class TestIngredientMediaQueries:
     def test_find_media_with_glucose(self, tmpdir):
         """Test finding all media containing glucose."""
         recipe_yaml = """
+id: CultureMech:900004
 name: Glucose Medium
 category: bacterial
 medium_type: defined
@@ -199,9 +197,9 @@ ingredients:
 
         # Find ingredient edges
         glucose_edges = [
-            e for e in edges
-            if e.get("object") == "CHEBI:17234"
-            and e.get("predicate") == "biolink:has_part"
+            e
+            for e in edges
+            if e.get("object") == "CHEBI:17234" and e.get("predicate") == "biolink:has_part"
         ]
 
         assert len(glucose_edges) > 0, "Should find glucose edge"
@@ -210,6 +208,7 @@ ingredients:
     def test_ingredient_with_concentration_qualifier(self, tmpdir):
         """Test that concentration is captured as qualifier."""
         recipe_yaml = """
+id: CultureMech:900005
 name: Test Medium
 category: bacterial
 medium_type: defined
@@ -227,10 +226,7 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         edges = list(transform(yaml.safe_load(recipe_yaml)))
-        nacl_edges = [
-            e for e in edges
-            if e.get("object") == "CHEBI:26710"
-        ]
+        nacl_edges = [e for e in edges if e.get("object") == "CHEBI:26710"]
 
         assert len(nacl_edges) > 0
         edge = nacl_edges[0]
@@ -247,6 +243,7 @@ class TestMediaProperties:
     def test_media_by_physical_state(self, tmpdir):
         """Test finding solid vs liquid media."""
         recipe_yaml = """
+id: CultureMech:900006
 name: Agar Plate
 category: bacterial
 medium_type: complex
@@ -263,16 +260,14 @@ ingredients:
         edges = list(transform(yaml.safe_load(recipe_yaml)))
 
         # Physical state should generate an edge
-        state_edges = [
-            e for e in edges
-            if e.get("predicate") == "biolink:has_attribute"
-        ]
+        state_edges = [e for e in edges if e.get("predicate") == "biolink:has_attribute"]
 
         assert len(state_edges) > 0, "Should have physical state edge"
 
     def test_media_with_ph_value(self, tmpdir):
         """Test that pH is captured in media metadata."""
         recipe_yaml = """
+id: CultureMech:900007
 name: pH 7.0 Medium
 category: bacterial
 medium_type: defined
@@ -296,6 +291,7 @@ class TestCommunityVsIsolateCultures:
     def test_isolate_culture_type(self, tmpdir):
         """Test organism_culture_type: isolate."""
         recipe_yaml = """
+id: CultureMech:900008
 name: Pure Culture Medium
 category: bacterial
 medium_type: complex
@@ -313,16 +309,14 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         edges = list(transform(yaml.safe_load(recipe_yaml)))
-        organism_edges = [
-            e for e in edges
-            if e.get("predicate") == "METPO:2000517"
-        ]
+        organism_edges = [e for e in edges if e.get("predicate") == "METPO:2000517"]
 
         assert len(organism_edges) > 0
 
     def test_community_culture_type(self, tmpdir):
         """Test organism_culture_type: community."""
         recipe_yaml = """
+id: CultureMech:900009
 name: Co-culture Medium
 category: bacterial
 medium_type: complex
@@ -344,10 +338,7 @@ ingredients:
         recipe_file.write(recipe_yaml)
 
         edges = list(transform(yaml.safe_load(recipe_yaml)))
-        organism_edges = [
-            e for e in edges
-            if e.get("predicate") == "METPO:2000517"
-        ]
+        organism_edges = [e for e in edges if e.get("predicate") == "METPO:2000517"]
 
         # Should have edges for both organisms
         assert len(organism_edges) >= 2
@@ -371,7 +362,7 @@ class TestRealDataIntegration:
         assert len(organisms) >= 2000, f"Expected ~2,104 organisms, got {len(organisms)}"
 
         # Check structure
-        for filepath, org_data in list(organisms.items())[:5]:
+        for _filepath, org_data in list(organisms.items())[:5]:
             assert "organism_name" in org_data
             assert "culture_type" in org_data
 

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -178,6 +178,7 @@ class TestTransform:
     def test_full_recipe_transform(self):
         """Test complete recipe with multiple edge types."""
         record = {
+            "id": "CultureMech:900010",
             "name": "LB Broth",
             "medium_type": "COMPLEX",
             "physical_state": "LIQUID",
@@ -202,11 +203,12 @@ class TestTransform:
         # Should have: ingredient + organism + application + physical_state
         assert len(edges) >= 3
         subjects = [e["subject"] for e in edges]
-        assert "culturemech:LB_Broth" in subjects
+        assert "CultureMech:900010" in subjects
 
     def test_minimal_recipe(self):
         """Test recipe with minimal required fields."""
         record = {
+            "id": "CultureMech:900011",
             "name": "Minimal Medium",
             "medium_type": "DEFINED",
             "physical_state": "LIQUID",

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -103,3 +103,13 @@ def test_edges_from_a_solution_record_use_its_id_not_the_empty_local_id():
     subjects = {e["subject"] for e in transform(CURATED_SOLUTION)}
     assert subjects == {"CultureMech:900105"}
     assert _record_node(CURATED_SOLUTION)["category"] == ["biolink:ChemicalMixture"]
+
+
+def test_a_solution_record_gets_no_medium_type_node_or_edge():
+    """202 solution records carry a medium_type; it is a medium's attribute (#442)."""
+    typed = {**CURATED_SOLUTION, "medium_type": "DEFINED"}
+    assert not any(n["id"].startswith("culturemech:medium_type_") for n in nodes(typed))
+    assert not any(e["predicate"] == "biolink:has_attribute" for e in transform(typed))
+    # and a medium with the same field still gets both
+    assert any(n["id"] == "culturemech:medium_type_DEFINED" for n in nodes(MEDIUM))
+    assert any(e["predicate"] == "biolink:has_attribute" for e in transform(MEDIUM))

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -1,0 +1,105 @@
+"""A KGX node is keyed on the record's permanent id, never on its name (#438).
+
+Node emission dedupes on id, so the name-keyed ids the export used until #438
+collapsed every record sharing a name into one node with merged edges — 3,181
+media and 4,787 solution records on the 2026-09-09 corpus. The 4,784 MediaDive
+solution records carry ``preferred_term`` and no ``name`` at all, so they
+sanitized to the empty string and emitted no node while their ``has_part``
+edges still pointed at ``culturemech:``.
+
+Kept free of corpus paths on purpose: conftest tiers a module by substring, and
+these cases need no records.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from culturemech.export.kgx_export import (
+    is_solution_record,
+    nodes,
+    record_label,
+    record_node_id,
+    transform,
+)
+
+MEDIUM = {
+    "id": "CultureMech:900101",
+    "name": "Defined freshwater medium (CoSO4)",
+    "medium_type": "DEFINED",
+    "ingredients": [{"preferred_term": "Glucose", "term": {"id": "CHEBI:17234"}}],
+}
+# The #392 shape: a second record whose name sanitizes to the same string.
+TWIN = {**MEDIUM, "id": "CultureMech:900102"}
+
+# The MediaDive solution-record shape: preferred_term, no name, upstream term id.
+SOLUTION = {
+    "id": "CultureMech:900103",
+    "preferred_term": "SL10 elements",
+    "term": {"id": "mediadive.solution:4367"},
+    "composition": [{"preferred_term": "ZnSO4", "term": {"id": "CHEBI:32312"}}],
+}
+
+
+def _record_node(record):
+    by_id = {n["id"]: n for n in nodes(record)}
+    return by_id[record_node_id(record)]
+
+
+def test_the_node_id_is_the_record_id():
+    assert record_node_id(MEDIUM) == "CultureMech:900101"
+    assert _record_node(MEDIUM)["id"] == "CultureMech:900101"
+
+
+def test_records_sharing_a_name_keep_distinct_nodes_and_edges():
+    """The collapse: same name, different records, one node before #438."""
+    assert record_node_id(MEDIUM) != record_node_id(TWIN)
+    subjects = {e["subject"] for e in transform(MEDIUM)} | {e["subject"] for e in transform(TWIN)}
+    assert subjects == {"CultureMech:900101", "CultureMech:900102"}
+
+
+def test_a_solution_record_with_no_name_gets_a_node_labelled_by_preferred_term():
+    node = _record_node(SOLUTION)
+    assert node["name"] == "SL10 elements"
+    assert node["category"] == ["biolink:ChemicalMixture"]
+
+
+def test_a_solution_record_is_recognised_by_either_explicit_signal():
+    assert is_solution_record(SOLUTION)
+    assert is_solution_record({"id": "CultureMech:900104", "name": "x", "record_kind": "SOLUTION"})
+    assert not is_solution_record(MEDIUM)
+
+
+def test_a_medium_is_a_growth_medium_not_a_bare_mixture():
+    assert "biolink:GrowthMedium" in _record_node(MEDIUM)["category"]
+
+
+def test_label_falls_back_from_name_to_preferred_term():
+    assert record_label(MEDIUM) == "Defined freshwater medium (CoSO4)"
+    assert record_label(SOLUTION) == "SL10 elements"
+
+
+@pytest.mark.parametrize("bad", [{}, {"id": ""}, {"id": "   "}, {"name": "LB"}])
+def test_a_record_without_an_id_is_an_error_not_a_name_keyed_node(bad):
+    """Falling back to the name would quietly reinstate the collapse."""
+    with pytest.raises(ValueError, match="no id"):
+        record_node_id(bad)
+    with pytest.raises(ValueError):
+        list(nodes(bad))
+    with pytest.raises(ValueError):
+        list(transform(bad))
+
+
+# The curated `record_kind: SOLUTION` shape (#175): MediaRecipe fields, no name.
+CURATED_SOLUTION = {
+    "id": "CultureMech:900105",
+    "preferred_term": "Trace salt solution",
+    "record_kind": "SOLUTION",
+    "ingredients": [{"preferred_term": "ZnSO4", "term": {"id": "CHEBI:32312"}}],
+}
+
+
+def test_edges_from_a_solution_record_use_its_id_not_the_empty_local_id():
+    subjects = {e["subject"] for e in transform(CURATED_SOLUTION)}
+    assert subjects == {"CultureMech:900105"}
+    assert _record_node(CURATED_SOLUTION)["category"] == ["biolink:ChemicalMixture"]

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -40,6 +40,7 @@ from culturemech.export.kgx_export import (  # noqa: E402
 )
 
 RECORD = {
+    "id": "CultureMech:900001",
     "name": "Canary Medium",
     "medium_type": "COMPLEX",
     "physical_state": "LIQUID",
@@ -68,7 +69,17 @@ RECORD = {
     "variants": [{"name": "Canary Medium agar"}],
 }
 
-DEFINED_RECORD = {"name": "Defined Canary", "medium_type": "DEFINED", "physical_state": "LIQUID"}
+DEFINED_RECORD = {
+    "id": "CultureMech:900002",
+    "name": "Defined Canary",
+    "medium_type": "DEFINED",
+    "physical_state": "LIQUID",
+}
+
+
+def _minted(curie: str) -> bool:
+    """An id this export declares: a record id, or an auxiliary node it mints."""
+    return curie.startswith(("CultureMech:", "culturemech:"))
 
 
 # --- qualifier flattening -------------------------------------------------
@@ -147,7 +158,7 @@ def test_medium_and_type_categories_follow_the_consumer():
     """kg-microbe fixes these in transform_utils/constants.py; a medium node the
     loader does not recognise is worse than no node."""
     by_id = {n["id"]: n for n in nodes(RECORD)}
-    assert by_id["culturemech:Canary_Medium"]["category"] == [
+    assert by_id["CultureMech:900001"]["category"] == [
         "biolink:GrowthMedium",
         "biolink:ComplexMolecularMixture",
     ]
@@ -156,7 +167,7 @@ def test_medium_and_type_categories_follow_the_consumer():
     ]
 
     defined = {n["id"]: n for n in nodes(DEFINED_RECORD)}
-    assert defined["culturemech:Defined_Canary"]["category"] == [
+    assert defined["CultureMech:900002"]["category"] == [
         "biolink:GrowthMedium",
         "biolink:ChemicalMixture",
     ]
@@ -165,8 +176,11 @@ def test_medium_and_type_categories_follow_the_consumer():
 
 def test_a_medium_type_outside_the_table_falls_back_rather_than_guessing():
     """BUFFER and NEGATIVE_CONTROL assert nothing about composition."""
-    buffer_nodes = {n["id"]: n for n in nodes({"name": "B", "medium_type": "BUFFER"})}
-    assert buffer_nodes["culturemech:B"]["category"] == ["biolink:GrowthMedium"]
+    buffer_nodes = {
+        n["id"]: n
+        for n in nodes({"id": "CultureMech:900003", "name": "B", "medium_type": "BUFFER"})
+    }
+    assert buffer_nodes["CultureMech:900003"]["category"] == ["biolink:GrowthMedium"]
     assert buffer_nodes["culturemech:medium_type_BUFFER"]["category"] == ["biolink:ChemicalMixture"]
 
 
@@ -175,7 +189,8 @@ def test_only_minted_ids_get_nodes():
     authoritative labels. Minting name-less rows for them here would put a
     competing node into the merge."""
     ids = {n["id"] for n in nodes(RECORD)}
-    assert all(i.startswith("culturemech:") for i in ids)
+    # Record nodes carry the record id (#438); everything else is minted here.
+    assert all(i.startswith(("culturemech:", "CultureMech:")) for i in ids)
     assert not any(i.startswith(("CHEBI:", "NCBITaxon:")) for i in ids)
 
 
@@ -217,16 +232,22 @@ def test_ids_survive_kozas_asymmetric_sanitization():
     # And the medium id goes through the same sanitizer as the solution id --
     # before the fix it only replaced spaces, so a quoted medium name would drift
     # exactly the same way.
-    quoted = {n["id"] for n in nodes({"name": r"Foo \"Bar\"", "medium_type": "COMPLEX"})}
-    edge_subjects = {
-        e["subject"] for e in transform({"name": r"Foo \"Bar\"", "medium_type": "COMPLEX"})
-    }
+    quoted_record = {"id": "CultureMech:900004", "name": r"Foo \"Bar\"", "medium_type": "COMPLEX"}
+    quoted = {n["id"] for n in nodes(quoted_record)}
+    edge_subjects = {e["subject"] for e in transform(quoted_record)}
     assert edge_subjects <= quoted
 
 
-def test_a_record_with_no_name_mints_nothing():
-    """`culturemech:` alone would be a garbage node bound to every unnamed record."""
-    assert list(nodes({"medium_type": "COMPLEX"})) == []
+def test_a_record_with_no_name_still_mints_its_node_under_its_id():
+    """Before #438 an unnamed record minted nothing while its edges pointed at the
+    empty `culturemech:` -- the shape of all 4,784 MediaDive solution records."""
+    by_id = {n["id"]: n for n in nodes({"id": "CultureMech:900005", "medium_type": "COMPLEX"})}
+    assert by_id["CultureMech:900005"]["name"] == "CultureMech:900005"
+
+
+def test_a_record_with_no_id_is_refused_rather_than_name_keyed():
+    with pytest.raises(ValueError, match="no id"):
+        list(nodes({"name": "Anonymous", "medium_type": "COMPLEX"}))
 
 
 # --- the koza path, end to end -------------------------------------------
@@ -277,6 +298,7 @@ def exported_shared(tmp_path: Path) -> tuple[list[dict], list[dict]]:
         (records_dir / f"record_{i}.yaml").write_text(
             yaml.safe_dump(
                 {
+                    "id": f"CultureMech:90001{i}",
                     "name": name,
                     "medium_type": "COMPLEX",
                     "solutions": [SHARED_SOLUTION],
@@ -305,12 +327,7 @@ def test_no_culturemech_id_in_the_edges_dangles(exported):
     and 0 unused."""
     node_rows, edge_rows = exported
     declared = {n["id"] for n in node_rows}
-    referenced = {
-        end
-        for e in edge_rows
-        for end in (e["subject"], e["object"])
-        if end.startswith("culturemech:")
-    }
+    referenced = {end for e in edge_rows for end in (e["subject"], e["object"]) if _minted(end)}
     assert referenced - declared == set()
 
 
@@ -318,7 +335,7 @@ def test_ontology_ids_are_referenced_but_not_declared(exported):
     node_rows, edge_rows = exported
     declared = {n["id"] for n in node_rows}
     referenced = {end for e in edge_rows for end in (e["subject"], e["object"])}
-    external = {r for r in referenced if not r.startswith("culturemech:")}
+    external = {r for r in referenced if not _minted(r)}
     assert external, "fixture must reference ontology terms"
     assert external & declared == set()
 

--- a/tests/test_mim_label_index.py
+++ b/tests/test_mim_label_index.py
@@ -269,6 +269,7 @@ def test_invalid_header_and_noncontiguous_groups_are_rejected():
 
 def test_kgx_uses_mim_for_override_non_chebi_and_authoritative_unmapped():
     record = {
+        "id": "CultureMech:900020",
         "name": "Resolver Canary",
         "ingredients": [
             {"preferred_term": "EDTA", "term": {"id": "CHEBI:64755"}},
@@ -284,6 +285,7 @@ def test_kgx_uses_mim_for_override_non_chebi_and_authoritative_unmapped():
 
 def test_kgx_labels_ambiguous_and_source_anchored_local_fallbacks():
     record = {
+        "id": "CultureMech:900021",
         "name": "Fallback Canary",
         "ingredients": [
             {


### PR DESCRIPTION
Closes #438.

`kgx_export.py` minted node ids from the record **name** and never read the record's `id`. Emission dedupes on id, so same-name records collapsed into one node with merged edges, and the 4,784 MediaDive solution records (`preferred_term`, no `name`) minted nothing while their edges pointed at the empty `culturemech:`.

| | before | after |
|---|--:|--:|
| media records → nodes | 10,891 → 7,710 | 10,891 → 10,891 |
| solution records → nodes | 4,986 → 199 | 4,986 → 4,986 |
| record nodes, full export | 7,909 | **15,877, all distinct** |
| nodes / edges | 9,375 / 163,864 | 17,344 / 211,172 |
| edges from the empty id | present | 0 |
| dangling minted references | — | 0 |

Record nodes now carry `CultureMech:NNNNNN` verbatim, the id `just check-id-catalog` pins. Label falls back `name` → `preferred_term`. No id is a `ValueError`, not a name-keyed node. A standalone solution record is `biolink:ChemicalMixture`, matching kg-microbe's `mediadive.solution:*` nodes (#374). Auxiliary nodes (`culturemech:medium_type_*`, `application_*`, `state_*`, nested `solution_*`) are unchanged.

## Verified

| check | result |
|---|---|
| probe on `main`: two same-name records | one subject, `culturemech:Defined_freshwater_medium_CoSO4` |
| probe on `main`: preferred_term-only solution record | no node; edge subject `culturemech:` |
| `tests/test_kgx_node_ids.py` here | 11 passed, fast tier |
| five touched test modules | 95 passed |
| `just kgx-export-sample algae` (canary) | 249 records → 249 record nodes, 0 empty, 0 dangling |
| `just kgx-export` (full corpus) | 15,877 record nodes, all distinct, 0 empty, 0 dangling |
| ruff + black on all six changed files | clean |

Not in scope, noted for the review: `transform()` walks `ingredients` and `solutions[].composition` but not a solution record's top-level `composition`, so the 4,784 MediaDive solution records now have nodes but still emit no composition edges. `docs/KGX_SEMANTIC_MODEL.md` examples updated.

## Review (adversarial pass, read-only) — #440, #441, #442

| # | finding | disposition |
|---|---|---|
| #440 | the export now spans two prefixes for one namespace: `CultureMech:` records, `culturemech:` auxiliary nodes; the schema declares only `culturemech` | open: a prefix decision with #374 consequences, not taken here |
| #441 | nested solutions are still name-keyed: 51 names carry several compositions (`Vitamin solution`: 15) and merge into one node each | open: pre-existing, needs an id-shape decision (parent-scoped vs composition-keyed vs link to the solution record) |
| #442 | solution records mint a node but no composition: `transform()` never walks top-level `composition[]`, 35,009 rows; 0 of 4,986 solution records emit a `has_part` | open for the composition walk; the medium-type half **addressed in `7204270f54`** |

Also measured for the review: 0 records fall back to the id as label; the exporter's `is_solution_record` agrees with `scripts/record_kinds.py` on all 15,877 records.

After `7204270f54` the full export is 17,344 nodes / 210,970 edges: `has_attribute` 34,246 → 34,044 (the 202 solution records), everything else unchanged, still 0 empty ids and 0 dangling minted references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYhSJTpSd39D97GPjoemDR

