### PR TITLE
Export a solution record's own composition (#442)

### DIFF
--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -28,7 +28,8 @@ MeSH, and curated local identities can be valid ingredient objects. See
 
 3. **Solution**
    - A standalone stock-solution record is a `biolink:ChemicalMixture` node keyed
-     on its own `id`, like a medium: `CultureMech:013364`
+     on its own `id`, like a medium: `CultureMech:013364`. Its reagents live in
+     top-level `composition` and are exported as `has_part` edges from that id (#442)
    - A solution nested inside a medium record has no id of its own and is minted
      as `culturemech:solution_*`, e.g. `culturemech:solution_Trace_Metal_Solution`
 

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -147,7 +147,7 @@ def transform(
     1. organism → medium (grows_in_medium: METPO:2000517)
     2. medium → solution (has_part)
     3. solution → ingredient (has_part)
-    4. medium → ingredient (has_part)
+    4. medium → ingredient (has_part); a solution record's own composition too
     5. medium → type (as node attribute via has_attribute)
     6. Medium → has_application → Use case (legacy)
     7. Medium → has_physical_state → State (legacy)
@@ -181,6 +181,19 @@ def transform(
 
     # Edge Type 4: Medium → Ingredient (has_part)
     for ingredient in record.get("ingredients", []):
+        edge = medium_to_ingredient_edge(
+            medium_id, ingredient, ingredient_resolver=ingredient_resolver
+        )
+        if edge:
+            yield edge
+
+    # Edge Type 4b: a stock-solution record's own composition (has_part). A
+    # SolutionRecipe-shaped record keeps its reagents in top-level `composition`,
+    # not `ingredients`; the 4,784 MediaDive solution records carry 35,009 such
+    # rows, all grounded, and until #442 none reached the graph. Their
+    # `ingredients` list is a single ungrounded placeholder, so walking both
+    # emits nothing twice.
+    for ingredient in record.get("composition", []) or []:
         edge = medium_to_ingredient_edge(
             medium_id, ingredient, ingredient_resolver=ingredient_resolver
         )

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -113,3 +113,13 @@ def test_a_solution_record_gets_no_medium_type_node_or_edge():
     # and a medium with the same field still gets both
     assert any(n["id"] == "culturemech:medium_type_DEFINED" for n in nodes(MEDIUM))
     assert any(e["predicate"] == "biolink:has_attribute" for e in transform(MEDIUM))
+
+
+def test_a_solution_record_emits_its_top_level_composition():
+    """The SolutionRecipe shape keeps reagents in `composition`, not `ingredients`;
+    until #442 transform() never walked it and 4,784 records emitted no has_part."""
+    # The object goes through the MIM resolver (ZnSO4 publishes as CHEBI:35176), so
+    # assert the edge and its identity class rather than the record's own id.
+    objects = [e["object"] for e in transform(SOLUTION) if e["predicate"] == "biolink:has_part"]
+    assert len(objects) == 1 and objects[0].startswith("CHEBI:")
+    assert all(e["subject"] == "CultureMech:900103" for e in transform(SOLUTION))

--- a/tests/test_kgx_solution_composition.py
+++ b/tests/test_kgx_solution_composition.py
@@ -1,0 +1,68 @@
+"""Every solution record with a grounded composition reaches the graph (#442).
+
+Corpus tier by construction (it reads data/normalized_yaml). The unit case lives
+in tests/test_kgx_node_ids.py; this is the gate that the 0-of-4,986 figure
+cannot come back: a solution record whose `composition` carries at least one
+resolvable id must be the subject of at least one has_part edge.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from record_kinds import is_solution_record  # noqa: E402
+
+from culturemech.export.kgx_export import resolve_ingredient, transform  # noqa: E402
+
+NORMALIZED = REPO / "data" / "normalized_yaml"
+
+
+def _solution_records_with_composition():
+    for path in sorted(NORMALIZED.glob("*/*.yaml")):
+        record = yaml.safe_load(path.read_text())
+        if isinstance(record, dict) and is_solution_record(record) and record.get("composition"):
+            yield path, record
+
+
+def test_the_population_is_not_empty():
+    """Guards the gate below against passing vacuously."""
+    assert sum(1 for _ in _solution_records_with_composition()) > 1000
+
+
+def _resolvable(record) -> bool:
+    """At least one composition row the MIM resolver gives an identity to.
+
+    A record whose only row MIM explicitly leaves unmapped (10 today, e.g. the
+    single-row `OXOID Legionella CYE-Agar base` solutions) correctly emits
+    nothing; that is the resolver's decision, not a missing walk.
+    """
+    return any(
+        getattr(resolve_ingredient(row), "identifier", None)
+        for row in record["composition"]
+        if isinstance(row, dict)
+    )
+
+
+@pytest.mark.corpus
+def test_every_solution_record_with_a_resolvable_composition_emits_a_has_part():
+    silent, suppressed = [], 0
+    for path, record in _solution_records_with_composition():
+        emits = any(e["predicate"] == "biolink:has_part" for e in transform(record))
+        if emits:
+            continue
+        if _resolvable(record):
+            silent.append(path.name)
+        else:
+            suppressed += 1
+    assert suppressed < 50, f"{suppressed} solution records have no resolvable row; expected ~10"
+    assert not silent, (
+        f"{len(silent)} solution record(s) carry a resolvable composition but emit no "
+        f"has_part (#442): " + ", ".join(silent[:10])
+    )

--- a/tests/test_kgx_solution_composition.py
+++ b/tests/test_kgx_solution_composition.py
@@ -61,7 +61,12 @@ def test_every_solution_record_with_a_resolvable_composition_emits_a_has_part():
             silent.append(path.name)
         else:
             suppressed += 1
-    assert suppressed < 50, f"{suppressed} solution records have no resolvable row; expected ~10"
+    # Pinned, not bounded: the count is a property of the MIM pin, so a bump that
+    # changes it should show up here rather than slide under a loose ceiling (#417).
+    assert suppressed == 10, (
+        f"{suppressed} solution records have no resolvable composition row (baseline 10, "
+        "all single-row solutions MIM leaves unmapped); re-measure after a MIM pin bump"
+    )
     assert not silent, (
         f"{len(silent)} solution record(s) carry a resolvable composition but emit no "
         f"has_part (#442): " + ", ".join(silent[:10])

--- a/tests/test_kgx_solution_composition.py
+++ b/tests/test_kgx_solution_composition.py
@@ -1,9 +1,14 @@
-"""Every solution record with a grounded composition reaches the graph (#442).
+"""Every solution record with a resolvable composition reaches the graph (#442).
 
 Corpus tier by construction (it reads data/normalized_yaml). The unit case lives
 in tests/test_kgx_node_ids.py; this is the gate that the 0-of-4,986 figure
 cannot come back: a solution record whose `composition` carries at least one
-resolvable id must be the subject of at least one has_part edge.
+row the MIM resolver gives an identity to must be the subject of a has_part.
+
+It reads the session-parsed `corpus` fixture rather than walking the tree: the
+first version parsed all 15,877 files itself, twice, and cost the CI corpus job
+nine minutes under coverage (run 34445132327), enough to hit its 40-minute
+timeout on a slow runner.
 """
 
 from __future__ import annotations
@@ -12,7 +17,6 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
 
 REPO = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO / "scripts"))
@@ -21,27 +25,14 @@ from record_kinds import is_solution_record  # noqa: E402
 
 from culturemech.export.kgx_export import resolve_ingredient, transform  # noqa: E402
 
-NORMALIZED = REPO / "data" / "normalized_yaml"
 
-
-def _solution_records_with_composition():
-    for path in sorted(NORMALIZED.glob("*/*.yaml")):
-        record = yaml.safe_load(path.read_text())
-        if isinstance(record, dict) and is_solution_record(record) and record.get("composition"):
-            yield path, record
-
-
-def test_the_population_is_not_empty():
-    """Guards the gate below against passing vacuously."""
-    assert sum(1 for _ in _solution_records_with_composition()) > 1000
-
-
-def _resolvable(record) -> bool:
+def _resolvable(record: dict) -> bool:
     """At least one composition row the MIM resolver gives an identity to.
 
     A record whose only row MIM explicitly leaves unmapped (10 today, e.g. the
     single-row `OXOID Legionella CYE-Agar base` solutions) correctly emits
-    nothing; that is the resolver's decision, not a missing walk.
+    nothing; that is the resolver's decision, not a missing walk. The same
+    `identifier` the edge builder reads (`_resolved_ingredient_id`).
     """
     return any(
         getattr(resolve_ingredient(row), "identifier", None)
@@ -51,11 +42,18 @@ def _resolvable(record) -> bool:
 
 
 @pytest.mark.corpus
-def test_every_solution_record_with_a_resolvable_composition_emits_a_has_part():
+def test_every_solution_record_with_a_resolvable_composition_emits_a_has_part(corpus):
+    population = [
+        (path, record)
+        for path, record in corpus
+        if is_solution_record(record) and record.get("composition")
+    ]
+    # Guards against passing vacuously: the corpus holds 4,784 of these today.
+    assert len(population) > 1000, f"only {len(population)} solution records with a composition"
+
     silent, suppressed = [], 0
-    for path, record in _solution_records_with_composition():
-        emits = any(e["predicate"] == "biolink:has_part" for e in transform(record))
-        if emits:
+    for path, record in population:
+        if any(e["predicate"] == "biolink:has_part" for e in transform(record)):
             continue
         if _resolvable(record):
             silent.append(path.name)


### PR DESCRIPTION
Closes #442.

`transform()` walked `ingredients[]` and `solutions[].composition[]`, never a record's top-level `composition[]`, where a `SolutionRecipe`-shaped record keeps its reagents. The 4,784 MediaDive solution records hold 35,009 grounded rows there and none reached the graph. Each record's `ingredients` is one ungrounded `See source for composition` placeholder, so walking both lists is safe.

| | before | after |
|---|--:|--:|
| solution records that are a `has_part` subject | 0 of 4,986 | **4,774 of 4,986** |
| `has_part` edges from solution records | 0 | 34,461 |
| edges, full export | 210,970 | 245,431 |
| record nodes / empty ids / dangling | 15,877 / 0 / 0 | 15,877 / 0 / 0 |

The 10 silent records are single-row solutions whose only reagent MIM explicitly leaves unmapped (`AUTHORITATIVE_UNMAPPED`, e.g. `OXOID Legionella CYE-Agar base`); the resolver suppresses those by design.

## Verified

| check | result |
|---|---|
| probe on `main` (the new corpus gate) | 4,774 resolvable solution records emit no `has_part` |
| canary, 50 MediaDive solution records through `scripts/export_kgx.py` | 272 rows → 275 `has_part`, 51/51 subjects, 0 dangling |
| `just kgx-export`, full corpus | table above |
| `tests/test_kgx_solution_composition.py` (corpus tier, resolver-aware) | 2 passed |
| touched unit modules | 84 passed |
| ruff + black | clean |

The algae `kgx-export-sample` canary was run first and proved nothing here: algae holds no solution record with a `composition`, so the 50-record canary above was built to take the same launcher path.

## Review (adversarial pass, read-only)

| finding | disposition |
|---|---|
| the corpus gate's "resolvable" test must mean what the edge means | checked: both use `GroundingDecision.identifier` (`_resolved_ingredient_id`), so the gate cannot pass vacuously against the edge |
| `suppressed < 50` was a guessed ceiling, not a baseline | **addressed in `92581c9c2e`**: pinned at the measured 10, with the reason, so a MIM pin bump that changes it is visible (#417) |
| the walk runs for every record, not only solution records | acceptable: `composition` exists only on the 4,784 solution records today, and a medium carrying one would be reagents either way |
| the first corpus gate re-parsed all 15,877 files itself, twice; 541 s in CI under coverage, and the corpus job hit its 40-minute timeout (run 34445132327, on a runner already 1.7× slower than usual) | **addressed in `4135663729`**: reads the session `corpus` fixture, one test, 0.12 s of its own work; corpus job back to 16m32s (run 34448738542) |
| quantities travel as one qualifier string where the MediaDive transform has `value`/`unit` columns | filed #445; a #374 structural item, deliberately not folded in here |
| each MediaDive solution record's `ingredients` is a placeholder beside a full `composition`, flagged `incomplete_composition` | filed #444, a corpus defect found while fixing this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


