### PR TITLE
One CURIE prefix for everything the KGX export mints (#440)

### DIFF
--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -37,7 +37,8 @@ MeSH, and curated local identities can be valid ingredient objects. See
    - Chemicals, food products, mixtures, and registry-identified materials in media or solutions
    - Examples: `CHEBI:17234` (glucose), `FOODON:00004410` (beef heart food product)
 
-5. **Medium Type** (`CultureMech:medium_type_*`)
+5. **Medium Type** (`CultureMech:medium_type_*`), **Application** (`CultureMech:application_*`),
+   **Physical State** (`CultureMech:state_*`), **Variant** (`CultureMech:variant_*`)
    - Every id this export mints uses the one prefix `CultureMech`, which expands to
      `https://w3id.org/culturemech/`, the same base as the schema's LinkML prefix
      `culturemech` (#440). Register `CultureMech` in a consumer's prefix map.

--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -31,15 +31,18 @@ MeSH, and curated local identities can be valid ingredient objects. See
      on its own `id`, like a medium: `CultureMech:013364`. Its reagents live in
      top-level `composition` and are exported as `has_part` edges from that id (#442)
    - A solution nested inside a medium record has no id of its own and is minted
-     as `culturemech:solution_*`, e.g. `culturemech:solution_Trace_Metal_Solution`
+     as `CultureMech:solution_*`, e.g. `CultureMech:solution_Trace_Metal_Solution`
 
 4. **Ingredient** (MIM-resolved external identity)
    - Chemicals, food products, mixtures, and registry-identified materials in media or solutions
    - Examples: `CHEBI:17234` (glucose), `FOODON:00004410` (beef heart food product)
 
-5. **Medium Type** (`culturemech:medium_type_*`)
+5. **Medium Type** (`CultureMech:medium_type_*`)
+   - Every id this export mints uses the one prefix `CultureMech`, which expands to
+     `https://w3id.org/culturemech/`, the same base as the schema's LinkML prefix
+     `culturemech` (#440). Register `CultureMech` in a consumer's prefix map.
    - Type classification nodes
-   - Example: `culturemech:medium_type_COMPLEX`
+   - Example: `CultureMech:medium_type_COMPLEX`
 
 ## Primary Edges (cmm-ai-automation semantic model)
 
@@ -80,7 +83,7 @@ NCBITaxon:562 --[METPO:2000517 (grows in)]--> CultureMech:000001
 **Relationship**: Medium contains a pre-made solution component
 
 ```
-CultureMech:000002 --[biolink:has_part]--> culturemech:solution_Trace_Elements
+CultureMech:000002 --[biolink:has_part]--> CultureMech:solution_Trace_Elements
 ```
 
 **Structure**:
@@ -96,7 +99,7 @@ CultureMech:000002 --[biolink:has_part]--> culturemech:solution_Trace_Elements
 {
   "subject": "CultureMech:000002",
   "predicate": "biolink:has_part",
-  "object": "culturemech:solution_Trace_Elements",
+  "object": "CultureMech:solution_Trace_Elements",
   "qualifiers": [
     {
       "qualifier_type_id": "biolink:concentration",
@@ -111,7 +114,7 @@ CultureMech:000002 --[biolink:has_part]--> culturemech:solution_Trace_Elements
 **Relationship**: Solution contains chemical ingredients
 
 ```
-culturemech:solution_Trace_Elements --[biolink:has_part]--> CHEBI:49976
+CultureMech:solution_Trace_Elements --[biolink:has_part]--> CHEBI:49976
 ```
 
 **Structure**:
@@ -126,7 +129,7 @@ culturemech:solution_Trace_Elements --[biolink:has_part]--> CHEBI:49976
 **Example**:
 ```json
 {
-  "subject": "culturemech:solution_Trace_Elements",
+  "subject": "CultureMech:solution_Trace_Elements",
   "predicate": "biolink:has_part",
   "object": "CHEBI:49976",
   "qualifiers": [
@@ -183,7 +186,7 @@ CultureMech:000001 --[biolink:has_part]--> CHEBI:17234
 **Relationship**: Medium has a type classification (COMPLEX, DEFINED, etc.)
 
 ```
-CultureMech:000001 --[biolink:has_attribute]--> culturemech:medium_type_COMPLEX
+CultureMech:000001 --[biolink:has_attribute]--> CultureMech:medium_type_COMPLEX
 ```
 
 **Structure**:
@@ -199,7 +202,7 @@ CultureMech:000001 --[biolink:has_attribute]--> culturemech:medium_type_COMPLEX
 {
   "subject": "CultureMech:000001",
   "predicate": "biolink:has_attribute",
-  "object": "culturemech:medium_type_COMPLEX",
+  "object": "CultureMech:medium_type_COMPLEX",
   "qualifiers": [
     {
       "qualifier_type_id": "biolink:attribute_type",

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -36,7 +36,7 @@ Primary Edges:
 5. Medium → has_attribute (biolink:has_attribute) → Medium Type
    - Subject: Medium
    - Predicate: biolink:has_attribute
-   - Object: Type node (e.g., culturemech:medium_type_COMPLEX)
+   - Object: Type node (e.g., CultureMech:medium_type_COMPLEX)
    - Qualifiers: attribute_type = "medium_type"
 
 Legacy Edges (for backward compatibility):
@@ -72,6 +72,12 @@ except ImportError:
 # and the module no longer needs the package at import time.
 
 KNOWLEDGE_SOURCE = "infores:culturemech"
+# The one CURIE prefix for every id this export mints. Record nodes carry the
+# record's own `CultureMech:NNNNNN`, so the auxiliary nodes use the same prefix
+# rather than a lower-cased twin of it (#440). The schema's `culturemech:` is the
+# LinkML class-URI prefix, a different artifact; both expand to
+# https://w3id.org/culturemech/, which is the mapping kg-microbe should register.
+PREFIX = "CultureMech"
 NAMESPACE_UUID = uuid.uuid5(uuid.NAMESPACE_URL, "https://w3id.org/culturemech")
 
 # A standalone stock-solution record is recognised by the same two explicit
@@ -369,7 +375,7 @@ def to_edge(edge_dict: dict[str, Any]) -> Edge:
 def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """Every node this record mints, as dicts. Companion to ``transform``.
 
-    Yields duplicates across records by design — ``culturemech:medium_type_COMPLEX``
+    Yields duplicates across records by design — ``CultureMech:medium_type_COMPLEX``
     belongs to all 8,850 COMPLEX media. Deduplication is the writer's job (see
     ``koza_transform``), because it is a property of the run, not of the record.
     """
@@ -392,7 +398,7 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     if medium_type and not solution:
         yield asdict(
             Node(
-                id=f"culturemech:medium_type_{medium_type}",
+                id=f"{PREFIX}:medium_type_{medium_type}",
                 category=type_category,
                 name=str(medium_type),
             )
@@ -413,7 +419,7 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
         if application:
             yield asdict(
                 Node(
-                    id=f"culturemech:application_{_sanitize_id(str(application))}",
+                    id=f"{PREFIX}:application_{_sanitize_id(str(application))}",
                     category=[ATTRIBUTE],
                     name=str(application),
                 )
@@ -423,7 +429,7 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
     if physical_state:
         yield asdict(
             Node(
-                id=f"culturemech:state_{str(physical_state).lower()}",
+                id=f"{PREFIX}:state_{str(physical_state).lower()}",
                 category=[ATTRIBUTE],
                 name=str(physical_state),
             )
@@ -436,7 +442,7 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
         if variant_name:
             yield asdict(
                 Node(
-                    id=f"culturemech:{_sanitize_id(str(variant_name))}",
+                    id=f"{PREFIX}:variant_{_sanitize_id(str(variant_name))}",
                     category=_DEFAULT_MEDIUM_CATEGORY,
                     name=str(variant_name),
                 )
@@ -649,11 +655,11 @@ def medium_to_type_edge(medium_id: str, medium_type: str) -> dict | None:
     Creates a type attribute node:
     - subject: medium
     - predicate: biolink:has_attribute
-    - object: type node (e.g., culturemech:medium_type_COMPLEX)
+    - object: type node (e.g., CultureMech:medium_type_COMPLEX)
 
     Data preserved: Medium type classification (COMPLEX, DEFINED, etc.)
     """
-    type_id = f"culturemech:medium_type_{medium_type}"
+    type_id = f"{PREFIX}:medium_type_{medium_type}"
 
     return _make_association(
         subject=medium_id,
@@ -671,7 +677,7 @@ def ingredient_to_edge(
     ingredient_resolver: IngredientResolver = resolve_ingredient,
 ) -> dict | None:
     """
-    Medium (culturemech:LB_Broth) → has_part → Glucose (CHEBI:17234)
+    Medium (CultureMech:000001) → has_part → Glucose (CHEBI:17234)
 
     Qualifiers:
     - concentration: 10 g/L
@@ -736,7 +742,7 @@ def application_to_edge(medium_id: str, application: str) -> dict | None:
     Data preserved: Application description
     """
     # Create a synthetic ID for the application
-    app_id = f"culturemech:application_{_sanitize_id(application)}"
+    app_id = f"{PREFIX}:application_{_sanitize_id(application)}"
 
     return _make_association(
         subject=medium_id,
@@ -754,7 +760,7 @@ def physical_state_to_edge(medium_id: str, physical_state: str) -> dict | None:
 
     Data preserved: Physical state
     """
-    state_id = f"culturemech:state_{physical_state.lower()}"
+    state_id = f"{PREFIX}:state_{physical_state.lower()}"
 
     return _make_association(
         subject=medium_id,
@@ -813,7 +819,7 @@ def variant_to_edge(medium_id: str, variant: dict) -> dict | None:
     if not variant_name:
         return None
 
-    variant_id = f"culturemech:{_sanitize_id(variant_name)}"
+    variant_id = f"{PREFIX}:variant_{_sanitize_id(variant_name)}"
 
     return _make_association(
         subject=variant_id,
@@ -873,8 +879,8 @@ def _format_evidence(evidence_items: list[dict] | None) -> tuple:
 # out spelled one way in the nodes file and another in the edges file, which is
 # how the full-corpus run produced 2 dangling references and 2 orphan nodes:
 #
-#   node: culturemech:solution_Mineral_salt_solution*_\"Hutner_Cohen-Bazire\"
-#   edge: culturemech:solution_Mineral_salt_solution*_Hutner_Cohen-Bazire
+#   node: CultureMech:solution_Mineral_salt_solution*_\"Hutner_Cohen-Bazire\"
+#   edge: CultureMech:solution_Mineral_salt_solution*_Hutner_Cohen-Bazire
 #
 # Stripping them here makes both sides agree regardless of koza's asymmetry, and
 # a CURIE has no business carrying a quote or an asterisk in the first place.
@@ -883,7 +889,7 @@ _ID_SEPARATOR_CHARS = " /"
 
 # The colon is separate because it is the one character that is not merely ugly:
 # it is the CURIE delimiter. Names like `Solution A:` produced
-# `culturemech:solution_Solution_A:`, a two-colon id that any consumer splitting
+# `CultureMech:solution_Solution_A:`, a two-colon id that any consumer splitting
 # on `:` reads wrongly — and this export exists to be consumed. 19 ids in the
 # corpus were affected. Mapped to an underscore rather than dropped so
 # `Autotrophic growth on ferrous sulfate:Add 13.9 g/l` does not weld two words
@@ -911,7 +917,7 @@ def _sanitize_id(text: str) -> str:
 def _create_solution_id(solution_name: str) -> str:
     """Create a CURIE for a solution."""
     sanitized = _sanitize_id(solution_name)
-    return f"culturemech:solution_{sanitized}"
+    return f"{PREFIX}:solution_{sanitized}"
 
 
 def _make_association(
@@ -941,7 +947,7 @@ def _make_association(
 
 # Node ids already written in this run. A medium-type or solution node is shared
 # by thousands of records, so without this the nodes file would carry ~8,850 rows
-# for `culturemech:medium_type_COMPLEX` alone. Run-scoped rather than per-record,
+# for `CultureMech:medium_type_COMPLEX` alone. Run-scoped rather than per-record,
 # which is why it cannot live in `nodes()`.
 _EMITTED_NODE_IDS: set = set()
 

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -128,7 +128,7 @@ class TestPhysicalStateToEdge:
 
         assert edge is not None
         assert edge["subject"] == "culturemech:LB"
-        assert edge["object"] == "culturemech:state_liquid"
+        assert edge["object"] == "CultureMech:state_liquid"
         assert edge["predicate"] == "biolink:has_attribute"
 
 

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -108,10 +108,10 @@ def test_edges_from_a_solution_record_use_its_id_not_the_empty_local_id():
 def test_a_solution_record_gets_no_medium_type_node_or_edge():
     """202 solution records carry a medium_type; it is a medium's attribute (#442)."""
     typed = {**CURATED_SOLUTION, "medium_type": "DEFINED"}
-    assert not any(n["id"].startswith("culturemech:medium_type_") for n in nodes(typed))
+    assert not any(n["id"].startswith("CultureMech:medium_type_") for n in nodes(typed))
     assert not any(e["predicate"] == "biolink:has_attribute" for e in transform(typed))
     # and a medium with the same field still gets both
-    assert any(n["id"] == "culturemech:medium_type_DEFINED" for n in nodes(MEDIUM))
+    assert any(n["id"] == "CultureMech:medium_type_DEFINED" for n in nodes(MEDIUM))
     assert any(e["predicate"] == "biolink:has_attribute" for e in transform(MEDIUM))
 
 
@@ -123,3 +123,24 @@ def test_a_solution_record_emits_its_top_level_composition():
     objects = [e["object"] for e in transform(SOLUTION) if e["predicate"] == "biolink:has_part"]
     assert len(objects) == 1 and objects[0].startswith("CHEBI:")
     assert all(e["subject"] == "CultureMech:900103" for e in transform(SOLUTION))
+
+
+def test_everything_the_export_mints_shares_one_prefix():
+    """Records carry CultureMech:NNNNNN; auxiliary nodes used a lower-cased twin of
+    that prefix until #440, which no consumer treats as the same namespace."""
+    full = {
+        **MEDIUM,
+        "physical_state": "LIQUID",
+        "applications": ["Canary use"],
+        "solutions": [{"preferred_term": "Trace Elements", "composition": []}],
+        "variants": [{"name": "Canary agar"}],
+    }
+    minted = {n["id"] for n in nodes(full)}
+    minted |= {
+        end
+        for e in transform(full)
+        for end in (e["subject"], e["object"])
+        if ":" in end and end.split(":", 1)[0].lower() == "culturemech"
+    }
+    assert len(minted) >= 6, minted
+    assert all(i.startswith("CultureMech:") for i in minted), sorted(minted)

--- a/tests/test_kgx_tsv_export.py
+++ b/tests/test_kgx_tsv_export.py
@@ -79,7 +79,7 @@ DEFINED_RECORD = {
 
 def _minted(curie: str) -> bool:
     """An id this export declares: a record id, or an auxiliary node it mints."""
-    return curie.startswith(("CultureMech:", "culturemech:"))
+    return curie.startswith("CultureMech:")
 
 
 # --- qualifier flattening -------------------------------------------------
@@ -162,7 +162,7 @@ def test_medium_and_type_categories_follow_the_consumer():
         "biolink:GrowthMedium",
         "biolink:ComplexMolecularMixture",
     ]
-    assert by_id["culturemech:medium_type_COMPLEX"]["category"] == [
+    assert by_id["CultureMech:medium_type_COMPLEX"]["category"] == [
         "biolink:ComplexMolecularMixture"
     ]
 
@@ -171,7 +171,7 @@ def test_medium_and_type_categories_follow_the_consumer():
         "biolink:GrowthMedium",
         "biolink:ChemicalMixture",
     ]
-    assert defined["culturemech:medium_type_DEFINED"]["category"] == ["biolink:ChemicalMixture"]
+    assert defined["CultureMech:medium_type_DEFINED"]["category"] == ["biolink:ChemicalMixture"]
 
 
 def test_a_medium_type_outside_the_table_falls_back_rather_than_guessing():
@@ -181,7 +181,7 @@ def test_a_medium_type_outside_the_table_falls_back_rather_than_guessing():
         for n in nodes({"id": "CultureMech:900003", "name": "B", "medium_type": "BUFFER"})
     }
     assert buffer_nodes["CultureMech:900003"]["category"] == ["biolink:GrowthMedium"]
-    assert buffer_nodes["culturemech:medium_type_BUFFER"]["category"] == ["biolink:ChemicalMixture"]
+    assert buffer_nodes["CultureMech:medium_type_BUFFER"]["category"] == ["biolink:ChemicalMixture"]
 
 
 def test_only_minted_ids_get_nodes():
@@ -189,8 +189,8 @@ def test_only_minted_ids_get_nodes():
     authoritative labels. Minting name-less rows for them here would put a
     competing node into the merge."""
     ids = {n["id"] for n in nodes(RECORD)}
-    # Record nodes carry the record id (#438); everything else is minted here.
-    assert all(i.startswith(("culturemech:", "CultureMech:")) for i in ids)
+    # One prefix for records (#438) and for everything minted here (#440).
+    assert all(i.startswith("CultureMech:") for i in ids)
     assert not any(i.startswith(("CHEBI:", "NCBITaxon:")) for i in ids)
 
 
@@ -203,8 +203,8 @@ def test_ids_survive_kozas_asymmetric_sanitization():
     from every edge column, but `TSVWriter.write_row` restores a node's `id` from
     the raw record and bypasses that, so the same solution was spelled two ways:
 
-        node: culturemech:solution_Mineral_salt_solution*_\"Hutner_Cohen-Bazire\"
-        edge: culturemech:solution_Mineral_salt_solution*_Hutner_Cohen-Bazire
+        node: CultureMech:solution_Mineral_salt_solution*_\"Hutner_Cohen-Bazire\"
+        edge: CultureMech:solution_Mineral_salt_solution*_Hutner_Cohen-Bazire
 
     Stripping the characters at the source makes both sides agree no matter what
     koza does downstream.
@@ -223,8 +223,8 @@ def test_ids_survive_kozas_asymmetric_sanitization():
 
     # The colon is the CURIE delimiter, so a name carrying one produced a
     # two-colon id that any consumer splitting on `:` reads wrongly. 19 in the
-    # corpus, e.g. `Solution A:` -> `culturemech:solution_Solution_A:`.
-    assert _create_solution_id("Solution A:") == "culturemech:solution_Solution_A"
+    # corpus, e.g. `Solution A:` -> `CultureMech:solution_Solution_A:`.
+    assert _create_solution_id("Solution A:") == "CultureMech:solution_Solution_A"
     assert _create_solution_id("Solution A:").count(":") == 1
     # Mapped to `_`, not dropped, so two words are not welded together.
     assert _sanitize_id("growth on sulfate:Add 13.9 g") == "growth_on_sulfate_Add_13.9_g"
@@ -394,7 +394,7 @@ def test_a_solution_shared_by_two_media_emits_its_composition_once(exported_shar
     composition = [
         e
         for e in edge_rows
-        if e["subject"].startswith("culturemech:solution_") and e["predicate"] == "biolink:has_part"
+        if e["subject"].startswith("CultureMech:solution_") and e["predicate"] == "biolink:has_part"
     ]
     assert composition, "fixture must reference a shared solution"
     assert len(composition) == len({e["id"] for e in composition})
@@ -403,7 +403,7 @@ def test_a_solution_shared_by_two_media_emits_its_composition_once(exported_shar
     to_solution = [
         e
         for e in edge_rows
-        if e["object"].startswith("culturemech:solution_") and e["predicate"] == "biolink:has_part"
+        if e["object"].startswith("CultureMech:solution_") and e["predicate"] == "biolink:has_part"
     ]
     assert len(to_solution) == 2, to_solution
 
@@ -414,7 +414,7 @@ def test_shared_nodes_are_written_once(exported):
     node_rows, _edge_rows = exported
     ids = [n["id"] for n in node_rows]
     assert len(ids) == len(set(ids))
-    assert "culturemech:state_liquid" in ids
+    assert "CultureMech:state_liquid" in ids
 
 
 def test_a_second_run_in_the_same_process_repeats_the_output(tmp_path):


### PR DESCRIPTION
Closes #440.

After #438 record nodes carried `CultureMech:NNNNNN` while every auxiliary node stayed under `culturemech:`, a lower-cased twin that no consumer treats as the same namespace. Everything the export mints now uses `CultureMech`; the schema's `culturemech:` remains the LinkML class-URI prefix, and both expand to `https://w3id.org/culturemech/`, the single mapping a consumer registers (#374).

| id kind | before | after |
|---|---|---|
| record | `CultureMech:000001` | unchanged |
| medium type | `culturemech:medium_type_COMPLEX` | `CultureMech:medium_type_COMPLEX` |
| nested solution | `culturemech:solution_Trace_Elements` | `CultureMech:solution_Trace_Elements` |
| application / state | `culturemech:application_*`, `culturemech:state_*` | `CultureMech:application_*`, `CultureMech:state_*` |
| variant | `culturemech:LB_Agar` | `CultureMech:variant_LB_Agar` (gains the kind marker the others have) |

The SSSOM pipeline's `culturemech:<ingredient>` subject CURIEs are a separate product and are untouched.

## Verified

| check | result |
|---|---|
| probe on `main` | a fixture record mints five `culturemech:` ids beside its `CultureMech:` record id |
| `test_everything_the_export_mints_shares_one_prefix` | green here, red on `main` |
| algae canary | 349 nodes, all `CultureMech`, 0 lower-cased endpoints, 0 dangling |
| full corpus | 17,344 nodes / 245,431 edges, totals identical to before; 17,344 of 17,344 ids under one prefix; 0 dangling |
| other consumers of the old shape (ignore-independent search) | none outside tests that hand-pass ids and the SSSOM CURIEs |
| KGX test modules | 98 passed; ruff + black clean |

## Review (adversarial pass, read-only)

| finding | disposition |
|---|---|
| nested-solution ids: `_sanitize_id` drops `*` and parentheses, so MediaDive's footnote-marked names (`Vitamin solution*`, `**`, `***`, distinct stocks within one medium) merge; 104 of 1,402 ids absorb more than one distinct name | recorded on #441 with the measurement; the id shape is that issue's decision and this PR changes only the prefix |
| the doc listed medium type but not the other three auxiliary shapes, including the new `variant_` marker | **addressed in `7270e0129b`** |
| the `variant_` kind marker is a shape change beyond the prefix | kept: it matches `solution_` / `state_` / `application_`, variant ids are not permanent, and `test_creates_variant_edge` asserts on the name fragment only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

