### PR TITLE
Resolve a medium's nested solution to its record, or key it on composition (#441)

### DIFF
--- a/docs/KGX_SEMANTIC_MODEL.md
+++ b/docs/KGX_SEMANTIC_MODEL.md
@@ -30,8 +30,12 @@ MeSH, and curated local identities can be valid ingredient objects. See
    - A standalone stock-solution record is a `biolink:ChemicalMixture` node keyed
      on its own `id`, like a medium: `CultureMech:013364`. Its reagents live in
      top-level `composition` and are exported as `has_part` edges from that id (#442)
-   - A solution nested inside a medium record has no id of its own and is minted
-     as `CultureMech:solution_*`, e.g. `CultureMech:solution_Trace_Metal_Solution`
+   - A solution nested inside a medium record links to the standalone solution
+     record that carries the same upstream id (`term.id`, 1,228 today) or that its
+     `culturemech_term` names, and mints nothing. Otherwise it is minted as
+     `CultureMech:solution_{name}_{fingerprint}`, the fingerprint taken over the
+     name and composition as written, so one stock shared by many media is one
+     node and two stocks that share a name are two (#441).
 
 4. **Ingredient** (MIM-resolved external identity)
    - Chemicals, food products, mixtures, and registry-identified materials in media or solutions

--- a/scripts/export_kgx.py
+++ b/scripts/export_kgx.py
@@ -19,6 +19,7 @@ about.
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -66,6 +67,11 @@ def run(records_dir: Path, output_dir: Path, limit: int = 0) -> tuple[int, int]:
     files = find_records(records_dir)
     if not files:
         raise SystemExit(f"No record YAMLs found under {records_dir}")
+    # The transform resolves a medium's nested solution to the standalone
+    # solution record that carries the same upstream id (#441). koza loads the
+    # transform as a fresh module copy, so the records directory travels in the
+    # environment rather than a module global.
+    os.environ["CULTUREMECH_RECORDS_DIR"] = str(records_dir)
 
     # No dedup reset here, and deliberately so. Koza loads the transform with
     # `importlib.util.spec_from_file_location` and, in its own words, "without

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -918,17 +918,24 @@ _RECORD_ID_LINE = re.compile(r"^id: (CultureMech:\d{6})\n", re.M)
 _SOLUTION_TERM_LINES = re.compile(r"^term:\n  id: (\S+)", re.M)
 
 
-@lru_cache(maxsize=1)
 def _solution_record_index() -> dict[str, str]:
-    """Upstream solution id -> the standalone solution record that carries it.
+    """Upstream solution id -> the standalone solution record that carries it,
+    for the records directory named in the environment; empty when unset."""
+    root = os.environ.get(RECORDS_DIR_ENV)
+    return _index_records_under(root) if root else {}
+
+
+@lru_cache(maxsize=4)
+def _index_records_under(root: str) -> dict[str, str]:
+    """Build the index for one directory. Cached per directory, not per process:
+    the first cut cached the result of the first call regardless of which
+    directory the environment named, so a second run in the same process with a
+    different records directory reused a stale index (#448 review).
 
     `term.id` sits within the first four lines of all 4,784 solution records and
     `id:` is line one, so a regex over the file text is enough; a second YAML
     parse of the corpus would double the export's cost for nothing.
     """
-    root = os.environ.get(RECORDS_DIR_ENV)
-    if not root:
-        return {}
     index: dict[str, str] = {}
     for path in Path(root).glob("*/*.yaml"):
         head = path.read_text(errors="replace")[:600]

--- a/src/culturemech/export/kgx_export.py
+++ b/src/culturemech/export/kgx_export.py
@@ -48,9 +48,14 @@ Legacy Edges (for backward compatibility):
 10. Variant → variant_of → Base Medium
 """
 
+import hashlib
+import os
+import re
 import uuid
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from culturemech.ingredients.mim_label_index import GroundingDecision, resolve_ingredient
@@ -171,16 +176,21 @@ def transform(
 
     # NEW: Edge Type 2: Medium → Solution (has_solution_component)
     for solution in record.get("solutions", []):
-        edge = medium_to_solution_edge(medium_id, solution)
+        target, minted = nested_solution_target(solution)
+        if not target:
+            continue
+        edge = medium_to_solution_edge(medium_id, solution, target)
         if edge:
             yield edge
 
-        # NEW: Edge Type 3: Solution → Ingredient (has_part)
-        # Extract ingredients from solution composition
-        solution_id = _create_solution_id(solution.get("preferred_term", ""))
+        # NEW: Edge Type 3: Solution → Ingredient (has_part). Only for a node we
+        # mint here: a solution record exports its own composition (#442), and
+        # the nested references that resolve to one carry none anyway (#441).
+        if not minted:
+            continue
         for ingredient in solution.get("composition", []):
             edge = solution_to_ingredient_edge(
-                solution_id, ingredient, ingredient_resolver=ingredient_resolver
+                target, ingredient, ingredient_resolver=ingredient_resolver
             )
             if edge:
                 yield edge
@@ -412,13 +422,13 @@ def nodes(record: dict[str, Any]) -> Iterator[dict[str, Any]]:
         )
 
     for solution in record.get("solutions", []) or []:
-        preferred_term = solution.get("preferred_term")
-        if preferred_term:
+        target, minted = nested_solution_target(solution)
+        if target and minted:
             yield asdict(
                 Node(
-                    id=_create_solution_id(preferred_term),
+                    id=target,
                     category=[CHEMICAL_MIXTURE],
-                    name=str(preferred_term),
+                    name=str(solution.get("preferred_term")),
                 )
             )
 
@@ -501,7 +511,9 @@ def organism_grows_in_medium_edge(organism: dict, medium_id: str) -> dict | None
     )
 
 
-def medium_to_solution_edge(medium_id: str, solution: dict) -> dict | None:
+def medium_to_solution_edge(
+    medium_id: str, solution: dict, solution_id: str | None = None
+) -> dict | None:
     """
     Medium → has_solution_component (biolink:has_part) → Solution
 
@@ -515,11 +527,10 @@ def medium_to_solution_edge(medium_id: str, solution: dict) -> dict | None:
 
     Data preserved: Solution reference, concentration
     """
-    solution_name = solution.get("preferred_term")
-    if not solution_name:
+    if solution_id is None:
+        solution_id, _minted = nested_solution_target(solution)
+    if not solution_id:
         return None
-
-    solution_id = _create_solution_id(solution_name)
 
     qualifiers, value, unit = _quantity(solution.get("concentration"))
 
@@ -895,6 +906,91 @@ def _sanitize_id(text: str) -> str:
     while "__" in text:
         text = text.replace("__", "_")
     return text.strip("_")
+
+
+# Where a run's records live, for the solution-record index below. Set by
+# scripts/export_kgx.py before koza starts; koza loads this module as a fresh
+# copy, so a module global set from the runner would not reach it, and the
+# environment is the one channel both copies share. Unset in unit tests, where
+# the index is empty and every nested solution is minted.
+RECORDS_DIR_ENV = "CULTUREMECH_RECORDS_DIR"
+_RECORD_ID_LINE = re.compile(r"^id: (CultureMech:\d{6})\n", re.M)
+_SOLUTION_TERM_LINES = re.compile(r"^term:\n  id: (\S+)", re.M)
+
+
+@lru_cache(maxsize=1)
+def _solution_record_index() -> dict[str, str]:
+    """Upstream solution id -> the standalone solution record that carries it.
+
+    `term.id` sits within the first four lines of all 4,784 solution records and
+    `id:` is line one, so a regex over the file text is enough; a second YAML
+    parse of the corpus would double the export's cost for nothing.
+    """
+    root = os.environ.get(RECORDS_DIR_ENV)
+    if not root:
+        return {}
+    index: dict[str, str] = {}
+    for path in Path(root).glob("*/*.yaml"):
+        head = path.read_text(errors="replace")[:600]
+        record = _RECORD_ID_LINE.match(head)
+        term = _SOLUTION_TERM_LINES.search(head)
+        if record and term and term.group(1).startswith(_SOLUTION_TERM_PREFIXES):
+            index[term.group(1)] = record.group(1)
+    return index
+
+
+def _solution_fingerprint(solution: dict) -> str:
+    """Eight hex digits over the name and the composition as written.
+
+    Two nested solutions with one name and different reagents are different
+    stocks (`Vitamin solution` carries 15 compositions corpus-wide, #441); two
+    with the same name and reagents are one stock shared by many media. Keyed on
+    the record's own ids and values, not the resolver's, so the id is stable
+    across MIM pins; it does move when a grounding in the record is repaired,
+    which is acceptable for a node that has no permanent identifier.
+    """
+    rows = sorted(
+        (
+            str(
+                (row.get("term") or {}).get("id")
+                or (row.get("chebi_term") or {}).get("id")
+                or row.get("preferred_term")
+            ),
+            str((row.get("concentration") or {}).get("value")),
+            str((row.get("concentration") or {}).get("unit")),
+        )
+        for row in (solution.get("composition") or [])
+        if isinstance(row, dict)
+    )
+    payload = repr((str(solution.get("preferred_term") or ""), rows)).encode()
+    return hashlib.sha1(payload).hexdigest()[:8]
+
+
+def nested_solution_target(solution: dict) -> tuple[str | None, bool]:
+    """The node a medium's nested solution points at, and whether we mint it.
+
+    In order:
+    1. `culturemech_term.id` naming a record: that record (15 today).
+    2. `term.id` matching a standalone solution record: that record (1,228 today,
+       none of which carries a composition of its own, so nothing is lost).
+    3. Otherwise a minted `CultureMech:solution_{name}_{fingerprint}` node.
+
+    Until #441 every nested solution was `CultureMech:solution_{name}`, and
+    emission dedupes on id, so 51 names holding several different compositions
+    collapsed into union nodes and the sanitizer merged MediaDive's footnote-marked
+    names (`Vitamin solution*`, `**`) on top.
+    """
+    name = solution.get("preferred_term")
+    if not name:
+        return None, False
+    local = solution.get("culturemech_term")
+    if isinstance(local, dict) and str(local.get("id", "")).startswith(f"{PREFIX}:"):
+        return str(local["id"]), False
+    term = solution.get("term")
+    tid = term.get("id") if isinstance(term, dict) else None
+    if isinstance(tid, str) and tid in _solution_record_index():
+        return _solution_record_index()[tid], False
+    return f"{_create_solution_id(str(name))}_{_solution_fingerprint(solution)}", True
 
 
 def _create_solution_id(solution_name: str) -> str:

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -17,7 +17,6 @@ import pytest
 
 from culturemech.export.kgx_export import (
     RECORDS_DIR_ENV,
-    _solution_record_index,
     is_solution_record,
     nested_solution_target,
     nodes,
@@ -260,30 +259,37 @@ def test_an_upstream_solution_id_resolves_to_the_record_that_carries_it(tmp_path
         "  label: SL10 elements\ncomposition:\n- preferred_term: ZnSO4\n  term:\n    id: CHEBI:32312\n"
     )
     monkeypatch.setenv(RECORDS_DIR_ENV, str(tmp_path))
-    _solution_record_index.cache_clear()
-    try:
-        ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
-        assert nested_solution_target(ref) == ("CultureMech:900301", False)
-        record = _with_solutions("CultureMech:900302", ref)
-        assert not any(n["id"].startswith("CultureMech:solution_") for n in nodes(record))
-        objects = [e["object"] for e in transform(record) if e["subject"] == "CultureMech:900302"]
-        assert "CultureMech:900301" in objects
-        # and an id the index does not know is minted as before
-        unknown = {"preferred_term": "Other", "term": {"id": "mediadive.solution:1"}}
-        assert nested_solution_target(unknown)[1] is True
-    finally:
-        _solution_record_index.cache_clear()
+    ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
+    assert nested_solution_target(ref) == ("CultureMech:900301", False)
+    record = _with_solutions("CultureMech:900302", ref)
+    assert not any(n["id"].startswith("CultureMech:solution_") for n in nodes(record))
+    objects = [e["object"] for e in transform(record) if e["subject"] == "CultureMech:900302"]
+    assert "CultureMech:900301" in objects
+    # and an id the index does not know is minted as before
+    unknown = {"preferred_term": "Other", "term": {"id": "mediadive.solution:1"}}
+    assert nested_solution_target(unknown)[1] is True
+
+
+def test_the_index_follows_the_records_directory_not_the_first_call(tmp_path, monkeypatch):
+    """Two runs in one process with different directories must not share an index:
+    the koza-path tests do exactly that with their per-test tmp dirs."""
+    ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
+    for n, rid in enumerate(("CultureMech:900311", "CultureMech:900312")):
+        d = tmp_path / f"run{n}" / "bacterial"
+        d.mkdir(parents=True)
+        (d / "sol.yaml").write_text(
+            f"id: {rid}\npreferred_term: SL10 elements\nterm:\n  id: mediadive.solution:4367\n"
+        )
+    monkeypatch.setenv(RECORDS_DIR_ENV, str(tmp_path / "run0"))
+    assert nested_solution_target(ref)[0] == "CultureMech:900311"
+    monkeypatch.setenv(RECORDS_DIR_ENV, str(tmp_path / "run1"))
+    assert nested_solution_target(ref)[0] == "CultureMech:900312"
 
 
 def test_without_a_records_dir_the_index_is_empty_and_everything_is_minted(monkeypatch):
     monkeypatch.delenv(RECORDS_DIR_ENV, raising=False)
-    _solution_record_index.cache_clear()
-    try:
-        assert _solution_record_index() == {}
-        ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
-        assert nested_solution_target(ref)[1] is True
-    finally:
-        _solution_record_index.cache_clear()
+    ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
+    assert nested_solution_target(ref)[1] is True
 
 
 def test_a_minted_nested_solution_still_exports_its_composition():

--- a/tests/test_kgx_node_ids.py
+++ b/tests/test_kgx_node_ids.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import pytest
 
 from culturemech.export.kgx_export import (
+    RECORDS_DIR_ENV,
+    _solution_record_index,
     is_solution_record,
+    nested_solution_target,
     nodes,
     record_label,
     record_node_id,
@@ -185,3 +188,109 @@ def test_a_value_that_is_not_a_number_keeps_the_qualifier_but_no_typed_pair(raw)
     edge = next(e for e in transform(record) if e["predicate"] == "biolink:has_part")
     assert edge["value"] is None and edge["unit"] is None
     assert edge["qualifiers"][0]["qualifier_value"] == f"{raw} G_PER_L"
+
+
+# --- nested solutions (#441) -------------------------------------------------
+
+VITAMINS_A = {
+    "preferred_term": "Vitamin solution",
+    "concentration": {"value": "1", "unit": "ML_PER_L"},
+    "composition": [{"preferred_term": "Biotin", "term": {"id": "CHEBI:15956"}}],
+}
+VITAMINS_B = {
+    "preferred_term": "Vitamin solution",
+    "concentration": {"value": "1", "unit": "ML_PER_L"},
+    "composition": [{"preferred_term": "Thiamine", "term": {"id": "CHEBI:18385"}}],
+}
+
+
+def _with_solutions(record_id, *solutions):
+    return {
+        "id": record_id,
+        "name": "Canary",
+        "medium_type": "DEFINED",
+        "solutions": list(solutions),
+    }
+
+
+def test_two_nested_solutions_with_one_name_and_different_reagents_are_different_nodes():
+    """The union node: `Vitamin solution` carried 15 compositions under one id."""
+    a, _ = nested_solution_target(VITAMINS_A)
+    b, _ = nested_solution_target(VITAMINS_B)
+    assert a != b
+    assert a.startswith("CultureMech:solution_Vitamin_solution_") and b.startswith(
+        "CultureMech:solution_Vitamin_solution_"
+    )
+
+
+def test_one_stock_shared_by_two_media_is_one_node():
+    """Same name, same reagents: one stock, one node, one composition (#312)."""
+    a, _ = nested_solution_target(VITAMINS_A)
+    b, _ = nested_solution_target(dict(VITAMINS_A))
+    assert a == b
+
+
+def test_footnote_marked_names_are_kept_apart_when_their_reagents_differ():
+    """MediaDive's `Vitamin solution*` and `**` are two stocks; the sanitizer drops
+    the asterisks, so the composition has to keep them apart."""
+    star = {**VITAMINS_A, "preferred_term": "Vitamin solution*"}
+    star2 = {**VITAMINS_B, "preferred_term": "Vitamin solution**"}
+    assert nested_solution_target(star)[0] != nested_solution_target(star2)[0]
+
+
+def test_a_nested_solution_naming_a_record_links_to_it_and_mints_nothing():
+    ref = {
+        "preferred_term": "SES",
+        "culturemech_term": {"id": "CultureMech:000130", "label": "SES"},
+    }
+    record = _with_solutions("CultureMech:900201", ref)
+    assert nested_solution_target(ref) == ("CultureMech:000130", False)
+    assert not any(n["id"].startswith("CultureMech:solution_") for n in nodes(record))
+    link = [e for e in transform(record) if e["object"] == "CultureMech:000130"]
+    assert len(link) == 1 and link[0]["subject"] == "CultureMech:900201"
+
+
+def test_an_upstream_solution_id_resolves_to_the_record_that_carries_it(tmp_path, monkeypatch):
+    """The 1,228 `mediadive.solution:` references; none carries a composition of
+    its own, so the record's exported composition (#442) is the depth."""
+    records = tmp_path / "bacterial"
+    records.mkdir()
+    (records / "sol.yaml").write_text(
+        "id: CultureMech:900301\npreferred_term: SL10 elements\nterm:\n  id: mediadive.solution:4367\n"
+        "  label: SL10 elements\ncomposition:\n- preferred_term: ZnSO4\n  term:\n    id: CHEBI:32312\n"
+    )
+    monkeypatch.setenv(RECORDS_DIR_ENV, str(tmp_path))
+    _solution_record_index.cache_clear()
+    try:
+        ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
+        assert nested_solution_target(ref) == ("CultureMech:900301", False)
+        record = _with_solutions("CultureMech:900302", ref)
+        assert not any(n["id"].startswith("CultureMech:solution_") for n in nodes(record))
+        objects = [e["object"] for e in transform(record) if e["subject"] == "CultureMech:900302"]
+        assert "CultureMech:900301" in objects
+        # and an id the index does not know is minted as before
+        unknown = {"preferred_term": "Other", "term": {"id": "mediadive.solution:1"}}
+        assert nested_solution_target(unknown)[1] is True
+    finally:
+        _solution_record_index.cache_clear()
+
+
+def test_without_a_records_dir_the_index_is_empty_and_everything_is_minted(monkeypatch):
+    monkeypatch.delenv(RECORDS_DIR_ENV, raising=False)
+    _solution_record_index.cache_clear()
+    try:
+        assert _solution_record_index() == {}
+        ref = {"preferred_term": "SL10 elements", "term": {"id": "mediadive.solution:4367"}}
+        assert nested_solution_target(ref)[1] is True
+    finally:
+        _solution_record_index.cache_clear()
+
+
+def test_a_minted_nested_solution_still_exports_its_composition():
+    record = _with_solutions("CultureMech:900401", VITAMINS_A)
+    target, minted = nested_solution_target(VITAMINS_A)
+    assert minted
+    assert any(n["id"] == target for n in nodes(record))
+    assert any(
+        e["subject"] == target and e["predicate"] == "biolink:has_part" for e in transform(record)
+    )


### PR DESCRIPTION
Closes #441.

Nested solutions were the last name-keyed nodes: `CultureMech:solution_Vitamin_solution` was the union of fifteen different stocks, and the sanitizer folded MediaDive's footnote-marked names (`Vitamin solution*`, `**`) into it as well.

A nested solution now resolves, in order:

| case | today | target | minted node |
|---|--:|---|---|
| `culturemech_term` names a record | 15 | that record | no |
| `term.id` matches a standalone solution record | 1,228 | that record (its #442 composition is the depth; none of these carries its own) | no |
| otherwise | rest | `CultureMech:solution_{name}_{fingerprint}` over name + composition as written | yes |

The term index is a regex head-scan of the records directory (`term:` sits within four lines of every solution record; `id:` is line one), passed to koza's fresh module copy through `CULTUREMECH_RECORDS_DIR`, which `scripts/export_kgx.py` sets. Unset, the index is empty and everything is minted, which is what the unit tests exercise.

| full corpus | before | after |
|---|--:|--:|
| medium → solution-record edges | 0 | **1,243** (1,228 + 15, exactly) |
| minted nested-solution nodes | 1,402, name-keyed | 1,484, all fingerprinted |
| `Vitamin solution` nodes, exact name | 1 (union of 15 stocks) | 15 (one per composition); 21 across its footnote spellings |
| nodes / edges | 17,344 / 245,431 | 17,426 / 245,697 |
| dangling | 0 | 0 |

## Verified

| check | result |
|---|---|
| probe on `main` | two different `Vitamin solution` stocks → one node; a `culturemech_term` reference → a minted name node |
| seven new cases in `tests/test_kgx_node_ids.py` | green here; the union case is red on `main` |
| canary through `scripts/export_kgx.py` (25 media with upstream ids + their 20 records + 10 media with minted stocks) | 48 medium → record edges, 44 minted nodes all fingerprinted, 0 dangling |
| full corpus | table above |
| KGX test modules | 110 passed; ruff + black clean |

## Review (adversarial pass, read-only)

| finding | disposition |
|---|---|
| the index cache was keyed on nothing, so a second run in one process with a different records dir reused a stale index; the koza-path tests do exactly that with per-test tmp dirs | **addressed in `380de8f4ba`**: cached per directory; a test switches directories without clearing anything |
| the PR body said `Vitamin solution` became 58 nodes; that was a prefix over-count (it also matched `Vitamin solution B12`, `… (10x)`, …) | corrected above: 15 for the exact name, one per composition, 21 across its footnote spellings |
| the fingerprint keeps same-reagent stocks apart when their value, unit, or footnote spelling differs: 114 (name, reagent-set) groups become 175 extra nodes | by design: a stock at a different strength is a different stock, and MediaDive's `*`/`**` mark different stocks within one medium; noted in `_solution_fingerprint` |
| one nested `mediadive.solution:` id (5059, in `CultureMech:002236`) has no record behind it; it is minted with its own composition so nothing dangles | filed #449, a corpus gap |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

