### PR TITLE
Make the single-file validation recipes fail loudly and validate the right class (#450)

### DIFF
--- a/project.justfile
+++ b/project.justfile
@@ -1251,40 +1251,51 @@ install-koza:
 [group('QC')]
 validate file:
     #!/usr/bin/env bash
-    set -e
-    echo "=== Schema validation ==="
-    uv run linkml-validate --schema {{schema_path}} --target-class MediaRecipe {{file}}
+    # Strict shell, and the class comes from the record's shape: a solution
+    # record validated as MediaRecipe fails on its own slots (#450).
+    set -euo pipefail
+    cls=$(uv run python scripts/record_target_class.py "{{file}}")
+    echo "=== Schema validation ($cls) ==="
+    uv run linkml-validate --schema {{schema_path}} --target-class "$cls" "{{file}}"
     echo "✓ Schema validation passed"
 
     echo ""
     echo "=== Term validation ==="
-    uv run linkml-term-validator validate-data {{file}} -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}}
+    uv run linkml-term-validator validate-data "{{file}}" -s {{schema_path}} -t "$cls" --labels -c {{oak_config}}
     echo "✓ Term validation passed"
 
     echo ""
     echo "=== Reference validation ==="
-    uv run linkml-reference-validator validate data {{file}} --schema {{schema_path}} --target-class MediaRecipe
+    uv run linkml-reference-validator validate data "{{file}}" --schema {{schema_path}} --target-class "$cls"
     echo "✓ Reference validation passed"
 
 [group('QC')]
 validate-schema file:
     #!/usr/bin/env bash
-    echo "Validating schema structure..."
-    uv run linkml-validate --schema {{schema_path}} --target-class MediaRecipe "{{file}}"
+    set -euo pipefail
+    cls=$(uv run python scripts/record_target_class.py "{{file}}")
+    echo "Validating schema structure ($cls)..."
+    uv run linkml-validate --schema {{schema_path}} --target-class "$cls" "{{file}}"
     echo "✓ Schema validation passed"
 
 [group('QC')]
 validate-terms file:
     #!/usr/bin/env bash
-    echo "Validating ontology terms..."
-    uv run linkml-term-validator validate-data {{file}} -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}}
+    # `set -e` is the fix for #450: without it a validator that failed to spawn
+    # still ended in "✓ Term validation passed" and exit 0.
+    set -euo pipefail
+    cls=$(uv run python scripts/record_target_class.py "{{file}}")
+    echo "Validating ontology terms ($cls)..."
+    uv run linkml-term-validator validate-data "{{file}}" -s {{schema_path}} -t "$cls" --labels -c {{oak_config}}
     echo "✓ Term validation passed"
 
 [group('QC')]
 validate-references file:
     #!/usr/bin/env bash
-    echo "Validating evidence references..."
-    uv run linkml-reference-validator validate data {{file}} --schema {{schema_path}} --target-class MediaRecipe
+    set -euo pipefail
+    cls=$(uv run python scripts/record_target_class.py "{{file}}")
+    echo "Validating evidence references ($cls)..."
+    uv run linkml-reference-validator validate data "{{file}}" --schema {{schema_path}} --target-class "$cls"
     echo "✓ Reference validation passed"
 
 # id↔label gate (Engine A): the schema binds the organism/environment/precursor/
@@ -1302,7 +1313,8 @@ validate-terms-all:
     # `**/*.yaml` (recursive, matching Engine B) instead of one-level `*/*.yaml`.
     for file in data/normalized_yaml/**/*.yaml; do
         [ -e "$file" ] || continue
-        uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t MediaRecipe --labels -c {{oak_config}} || rc=1
+        cls=$(uv run python scripts/record_target_class.py "$file")
+        uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t "$cls" --labels -c {{oak_config}} || rc=1
     done
     exit $rc
 

--- a/project.justfile
+++ b/project.justfile
@@ -1311,11 +1311,12 @@ validate-terms-all:
     shopt -s globstar nullglob
     rc=0
     # `**/*.yaml` (recursive, matching Engine B) instead of one-level `*/*.yaml`.
-    for file in data/normalized_yaml/**/*.yaml; do
+    # One helper process for the whole corpus (#450); per file it would be
+    # 15,878 spawns. The class is the record's shape, as in the single-file recipes.
+    while IFS=$'\t' read -r file cls; do
         [ -e "$file" ] || continue
-        cls=$(uv run python scripts/record_target_class.py "$file")
         uv run linkml-term-validator validate-data "$file" -s {{schema_path}} -t "$cls" --labels -c {{oak_config}} || rc=1
-    done
+    done < <(uv run python scripts/record_target_class.py --all data/normalized_yaml)
     exit $rc
 
 # id↔label gate (Engine B): runs the shared OAK validator over the full

--- a/scripts/record_target_class.py
+++ b/scripts/record_target_class.py
@@ -9,6 +9,10 @@ swallowed. The decision is `record_kinds.has_solution_shape`, the same one
 `validate_strict` routes on, so the recipes cannot disagree with the gate.
 
 Usage: record_target_class.py <record.yaml>   ->   SolutionRecipe | MediaRecipe
+       record_target_class.py --all <dir>     ->   one "<path>\t<class>" line per
+                                                  **/*.yaml under <dir>, so a whole-
+                                                  corpus recipe spawns one process,
+                                                  not one per record
 """
 
 from __future__ import annotations
@@ -28,6 +32,17 @@ def target_class(record: object) -> str:
 
 
 def main(argv: list[str]) -> int:
+    if len(argv) == 3 and argv[1] == "--all":
+        failed = 0
+        for path in sorted(Path(argv[2]).glob("**/*.yaml")):
+            try:
+                record = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except (OSError, yaml.YAMLError) as exc:
+                print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+                failed += 1
+                continue
+            print(f"{path}\t{target_class(record)}")
+        return 1 if failed else 0
     if len(argv) != 2:
         print(__doc__.strip(), file=sys.stderr)
         return 2

--- a/scripts/record_target_class.py
+++ b/scripts/record_target_class.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Print the LinkML class a record file validates against (#450).
+
+A stock-solution record has the `SolutionRecipe` shape (`preferred_term`,
+`composition`, an upstream `term`); everything else is a `MediaRecipe`. The
+`just validate*` recipes hardcoded `MediaRecipe`, so a solution record was
+checked against the wrong class and, with no `set -e`, the failure was
+swallowed. The decision is `record_kinds.has_solution_shape`, the same one
+`validate_strict` routes on, so the recipes cannot disagree with the gate.
+
+Usage: record_target_class.py <record.yaml>   ->   SolutionRecipe | MediaRecipe
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from record_kinds import has_solution_shape  # noqa: E402
+
+
+def target_class(record: object) -> str:
+    return "SolutionRecipe" if has_solution_shape(record) else "MediaRecipe"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    try:
+        record = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+    print(target_class(record))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_record_target_class.py
+++ b/tests/test_record_target_class.py
@@ -64,3 +64,18 @@ def test_an_unreadable_file_is_an_error_not_a_default_class(tmp_path):
         text=True,
     )
     assert out.returncode == 1 and out.stdout == ""
+
+
+def test_batch_mode_prints_one_line_per_record(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "sol.yaml").write_text(
+        "id: CultureMech:900001\npreferred_term: SL10\nterm:\n  id: mediadive.solution:1\n"
+    )
+    (tmp_path / "a" / "med.yaml").write_text("id: CultureMech:900003\nname: LB\n")
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--all", str(tmp_path)], capture_output=True, text=True
+    )
+    assert out.returncode == 0, out.stderr
+    lines = dict(line.split("\t") for line in out.stdout.splitlines())
+    assert lines[str(tmp_path / "a" / "med.yaml")] == "MediaRecipe"
+    assert lines[str(tmp_path / "a" / "sol.yaml")] == "SolutionRecipe"

--- a/tests/test_record_target_class.py
+++ b/tests/test_record_target_class.py
@@ -1,0 +1,66 @@
+"""The validation recipes pick a record's LinkML class from its shape (#450).
+
+Kept free of corpus paths: these are fixtures, and conftest tiers a module by
+substring.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "record_target_class.py"
+sys.path.insert(0, str(REPO / "scripts"))
+
+from record_target_class import target_class  # noqa: E402
+
+SOLUTION = {
+    "id": "CultureMech:900001",
+    "preferred_term": "SL10",
+    "term": {"id": "mediadive.solution:1"},
+}
+CURATED_SOLUTION = {
+    "id": "CultureMech:900002",
+    "name": "Trace salts",
+    "record_kind": "SOLUTION",
+    "ingredients": [],
+}
+MEDIUM = {"id": "CultureMech:900003", "name": "LB", "medium_type": "COMPLEX"}
+
+
+def test_shape_decides_the_class():
+    assert target_class(SOLUTION) == "SolutionRecipe"
+    # a curated SOLUTION with MediaRecipe fields keeps the MediaRecipe shape (#175)
+    assert target_class(CURATED_SOLUTION) == "MediaRecipe"
+    assert target_class(MEDIUM) == "MediaRecipe"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (
+            "id: CultureMech:900001\npreferred_term: SL10\nterm:\n  id: mediadive.solution:1\n",
+            "SolutionRecipe",
+        ),
+        ("id: CultureMech:900003\nname: LB\n", "MediaRecipe"),
+    ],
+)
+def test_the_script_prints_the_class_for_a_file(tmp_path, body, expected):
+    path = tmp_path / "r.yaml"
+    path.write_text(body)
+    out = subprocess.run([sys.executable, str(SCRIPT), str(path)], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == expected
+
+
+def test_an_unreadable_file_is_an_error_not_a_default_class(tmp_path):
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), str(tmp_path / "missing.yaml")],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 1 and out.stdout == ""


### PR DESCRIPTION
Closes #450.

`just validate-terms`, `validate-schema` and `validate-references` ran in a bash block with no `set -e`, so a validator that failed to spawn, or a record that failed, still printed "✓ … passed" and exited 0. They also hardcoded `-t MediaRecipe`, so a solution record was checked against the wrong class.

| recipe, on a solution record | `main` | here |
|---|---|---|
| `validate-schema` | exit 0 with four errors printed (class `MediaRecipe`) | exit 0, "No issues found" (`SolutionRecipe`) |
| `validate-terms`, validator not installed | exit 0, "✓ Term validation passed" | exit 2 |
| `validate-references`, validator not installed | exit 0, "✓ Reference validation passed" | exit 2 |

The class comes from `scripts/record_target_class.py`, which decides by `record_kinds.has_solution_shape`, the routing `validate_strict` already uses. `validate-terms-all` routes per file the same way. A medium still validates as `MediaRecipe` (`lb_broth.yaml`: exit 0).

Four cases pin the helper in `tests/test_record_target_class.py` (fast tier), including that an unreadable file is an error rather than a default class.

## Review (adversarial pass, read-only)

| finding | disposition |
|---|---|
| `validate-terms-all` called the class helper once per file: one `uv` spawn is 0.07 s, so 15,878 of them add ~19 minutes to a recipe that already validates every record | **addressed in `6015452ab7`**: a `--all` mode classifies the corpus in one process (88 s, 4,785 `SolutionRecipe` / 11,093 `MediaRecipe`) and the recipe reads the lines from a process substitution |
| the composite `just validate` now stops at the term step on a machine without `linkml-term-validator` | intended: that is the false green this PR removes; `pyproject.toml` lists the validator as a dependency, so a synced environment has it |
| callers of the recipes | only the README recipe-name test and skill prose; nothing asserts on the old "MediaRecipe" output text |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

