### PR TITLE
Run required validation on merge queue candidates

### DIFF
--- a/.github/workflows/chebi-consistency.yaml
+++ b/.github/workflows/chebi-consistency.yaml
@@ -1,35 +1,18 @@
 name: chebi-consistency
 
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
-    # NOTE: the probe (audit_chebi_consistency.py) and these path filters cover
-    # only data/normalized_yaml/**. The derived data/merge_yaml/** files are NOT
-    # validated here, on the assumption that merge_yaml is always regenerated
-    # from normalized_yaml — an inconsistency introduced *only* in merge_yaml
-    # would not be caught by this gate. If merge_yaml ever becomes hand-edited,
-    # add 'data/merge_yaml/**' here and extend the probe to scan it.
-      # data/merge_yaml/** is listed too, NOT because this gate reads it, but
-      # because GitHub evaluates these path filters against only the FIRST 300
-      # changed files. A corpus-wide PR changes ~20k files, merge_yaml sorts
-      # first, and a filter naming only normalized_yaml never matches — the
-      # workflow is then silently ABSENT from the checks rather than reported
-      # as skipped, and the PR reads as green. See #277.
-    paths:
-      - 'data/normalized_yaml/**'
-      - 'data/merge_yaml/**'
-      - 'scripts/audit_chebi_consistency.py'
-      - 'project.justfile'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/chebi-consistency.yaml'
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: chebi-consistency-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   consistency:

--- a/.github/workflows/concentration-plausibility.yaml
+++ b/.github/workflows/concentration-plausibility.yaml
@@ -13,34 +13,19 @@ name: concentration-plausibility
 # with corpus size; a new flattened cocktail is a specific defect shape that an
 # import has reintroduced.
 
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
-    # Scoped to normalized_yaml: the detectors read only that tree. merge_yaml is
-    # derived from it, so a defect introduced *only* in merge_yaml would not be
-    # caught here — same caveat as chebi-consistency.
-      # data/merge_yaml/** is listed too, NOT because this gate reads it, but
-      # because GitHub evaluates these path filters against only the FIRST 300
-      # changed files. A corpus-wide PR changes ~20k files, merge_yaml sorts
-      # first, and a filter naming only normalized_yaml never matches — the
-      # workflow is then silently ABSENT from the checks rather than reported
-      # as skipped, and the PR reads as green. See #277.
-    paths:
-      - 'data/normalized_yaml/**'
-      - 'data/merge_yaml/**'
-      - 'scripts/audit_concentration_plausibility.py'
-      - 'scripts/audit_merged_duplicates.py'
-      - 'project.justfile'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/concentration-plausibility.yaml'
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: concentration-plausibility-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   plausibility:
@@ -63,8 +48,7 @@ jobs:
       - name: Check concentration plausibility
         run: just audit-concentration-plausibility
 
-      # Runs here rather than in its own workflow because it shares this one's
-      # path filter exactly and guards the same thing — a concentration that is
+      # Runs here because it guards the same thing — a concentration that is
       # not a real measurement. Its baselines are per-detector, so it cannot
       # trade a repair in one class against a regression in another (#302).
       - name: Check for summed duplicate-merge artifacts

--- a/.github/workflows/curation-history.yaml
+++ b/.github/workflows/curation-history.yaml
@@ -13,40 +13,30 @@ name: Curation history
 # this job has no dependency on the private culturebotai-claw repo. Only the
 # `just new-history` scaffolder needs claw, and that is a dev-time tool.
 
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
-      # data/merge_yaml/** is listed too, NOT because this gate reads it, but
-      # because GitHub evaluates these path filters against only the FIRST 300
-      # changed files. A corpus-wide PR changes ~20k files, merge_yaml sorts
-      # first, and a filter naming only normalized_yaml never matches — the
-      # workflow is then silently ABSENT from the checks rather than reported
-      # as skipped, and the PR reads as green. See #277.
-    paths:
-      - "data/normalized_yaml/**"
-      - "data/merge_yaml/**"
-      - "history/**"
-      - "src/culturemech/schema/history.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/curation-history.yaml"
+  merge_group:
+    types: [checks_requested]
   push:
-    branches: [main]
+    branches:
+    - main
     paths:
-      - "data/normalized_yaml/**"
-      - "data/merge_yaml/**"
-      - "history/**"
-      - "src/culturemech/schema/history.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/curation-history.yaml"
+    - data/normalized_yaml/**
+    - data/merge_yaml/**
+    - history/**
+    - src/culturemech/schema/history.yaml
+    - pyproject.toml
+    - uv.lock
+    - .github/workflows/curation-history.yaml
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: curation-history-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   history:

--- a/.github/workflows/label-correspondence.yaml
+++ b/.github/workflows/label-correspondence.yaml
@@ -16,21 +16,24 @@ name: label-correspondence
 # reloads the schema+OAK per file (~hours over the full corpus) and covers the
 # same canonical-label surface Engine B already enforces in one pass.
 
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
-    paths: &trigger_paths
-      - "data/normalized_yaml/**"
-      - "data/merge_yaml/**"
-      - "output/**.sssom.tsv"
-      - "src/culturemech/schema/**"
-      - "scripts/validate_id_label_correspondence.py"
-      - "conf/id_label_targets.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/label-correspondence.yaml"
+  merge_group:
+    types: [checks_requested]
   push:
-    branches: [main]
-    paths: *trigger_paths
+    branches:
+    - main
+    paths:
+    - data/normalized_yaml/**
+    - data/merge_yaml/**
+    - output/**.sssom.tsv
+    - src/culturemech/schema/**
+    - scripts/validate_id_label_correspondence.py
+    - conf/id_label_targets.yaml
+    - pyproject.toml
+    - uv.lock
+    - .github/workflows/label-correspondence.yaml
   workflow_dispatch:
 
 permissions:
@@ -40,8 +43,7 @@ permissions:
 # fleet (culturebotai-claw#180, Phase 5). TraitMech was the canary and
 # MediaIngredientMech the second adopter; both passed on main before this.
 #
-# What stays here is what is CultureMech's: the trigger filter above, scoped to
-# this corpus, and the inputs below.
+# What stays here is what is CultureMech's: the trigger events and the inputs below.
 jobs:
   label-drift-report:
     # Pinned to a claw commit, not a branch: a moving ref would change this

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 name: tests
 
-# Deliberately NO `paths:` filter, unlike the data-integrity workflows.
+# Every pull request runs these tests, as does every merge queue candidate.
 #
 # Two reasons. First, this repo's tests span scripts/, src/, AND the corpus —
 # tests/test_record_kinds.py asserts against the real data/normalized_yaml/
@@ -8,18 +8,22 @@ name: tests
 # gates are how the repo ended up here: validate-strict and chebi-consistency
 # are both scoped to data/normalized_yaml/**, so a pure scripts/ + tests/ PR
 # could land with no checks at all (#129).
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
-    branches: [main]
+    branches:
+    - main
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changed-python-quality:
@@ -40,7 +44,7 @@ jobs:
         run: uv sync --frozen --extra dev
       - name: Ruff and Black on changed Python
         env:
-          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.merge_group.base_sha || github.event.before }}
         run: uv run python scripts/check_changed_python.py
       - name: Validate Claude skills
         run: uv run python scripts/validate_claude_skills.py

--- a/.github/workflows/validate-strict.yaml
+++ b/.github/workflows/validate-strict.yaml
@@ -1,30 +1,18 @@
 name: validate-strict
 
+# Required checks must report for every PR and merge queue candidate.
 on:
   pull_request:
-      # data/merge_yaml/** is listed too, NOT because this gate reads it, but
-      # because GitHub evaluates these path filters against only the FIRST 300
-      # changed files. A corpus-wide PR changes ~20k files, merge_yaml sorts
-      # first, and a filter naming only normalized_yaml never matches — the
-      # workflow is then silently ABSENT from the checks rather than reported
-      # as skipped, and the PR reads as green. See #277.
-    paths:
-      - 'data/normalized_yaml/**'
-      - 'data/merge_yaml/**'
-      - 'src/culturemech/schema/**'
-      - 'scripts/validate_strict.py'
-      - 'project.justfile'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/validate-strict.yaml'
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: validate-strict-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:

--- a/.github/workflows/vendored-sync.yaml
+++ b/.github/workflows/vendored-sync.yaml
@@ -14,8 +14,11 @@ name: vendored-sync
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
-    branches: [main]
+    branches:
+    - main
   workflow_dispatch:
 
 permissions:

--- a/tests/test_check_changed_python.py
+++ b/tests/test_check_changed_python.py
@@ -91,3 +91,30 @@ def test_the_vendored_exclusion_does_not_swallow_hand_written_scripts() -> None:
     hand_written = "scripts/export_kgx.py"
     assert (ROOT / hand_written).is_file()
     assert check_changed_python.select_python_files([hand_written]) == [hand_written]
+
+
+def test_merge_group_base_covers_changes_before_the_last_commit(tmp_path, monkeypatch):
+    """A queue candidate can include several PR commits; HEAD^ misses earlier ones."""
+
+    def git(*args):
+        return subprocess.check_output(
+            ["git", "-c", "user.name=Queue test", "-c", "user.email=queue@example.invalid", *args],
+            cwd=tmp_path,
+            text=True,
+        ).strip()
+
+    git("init", "--quiet")
+    git("commit", "--quiet", "--allow-empty", "-m", "base")
+    base = git("rev-parse", "HEAD")
+    for name in ("first.py", "second.py"):
+        (tmp_path / name).write_text("VALUE = 1\n")
+        git("add", name)
+        git("commit", "--quiet", "-m", name)
+    monkeypatch.setattr(check_changed_python, "ROOT", tmp_path)
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    monkeypatch.setenv("GITHUB_EVENT_BEFORE", base)
+    assert check_changed_python.changed_paths(check_changed_python.default_base()) == [
+        "first.py",
+        "second.py",
+    ]
+    assert check_changed_python.changed_paths("HEAD^") == ["second.py"]

--- a/tests/test_concentration_plausibility.py
+++ b/tests/test_concentration_plausibility.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
@@ -374,6 +375,17 @@ def test_the_gate_is_wired_into_ci():
     15 issues without ever being invoked."""
     wf = REPO_ROOT / ".github" / "workflows" / "concentration-plausibility.yaml"
     assert wf.is_file(), "no workflow runs the plausibility gate"
-    text = wf.read_text()
-    assert "just audit-concentration-plausibility" in text
-    assert "data/normalized_yaml/**" in text, "gate not triggered by corpus edits"
+    document = yaml.safe_load(wf.read_text())
+    events = document.get("on", document.get(True, {}))
+    # Unfiltered events cover corpus edits too; requiring a literal path would
+    # reject that stronger coverage. Missing events must still fail (#464).
+    assert "pull_request" in events, "corpus PRs do not trigger the gate"
+    assert events["pull_request"] in (None, {}), "required PR gate must be unfiltered"
+    assert events.get("merge_group") == {"types": ["checks_requested"]}
+    audit_steps = [
+        step
+        for step in document["jobs"]["plausibility"]["steps"]
+        if step.get("run") == "just audit-concentration-plausibility"
+    ]
+    assert audit_steps, "no executable step runs the plausibility gate"
+    assert all("if" not in step for step in audit_steps), "plausibility gate can be skipped"

--- a/tests/test_merge_queue_workflows.py
+++ b/tests/test_merge_queue_workflows.py
@@ -1,0 +1,91 @@
+"""Required checks must report on every PR and its actual merge queue candidate."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+# Job/check names are an external ruleset contract. Renames require coordinated
+# settings changes; deriving this list from the workflows would hide a deletion.
+REQUIRED_JOBS = {
+    "chebi-consistency.yaml": {"consistency": "consistency"},
+    "concentration-plausibility.yaml": {"plausibility": "plausibility"},
+    "curation-history.yaml": {"history": "history"},
+    "label-correspondence.yaml": {"label-drift-report": "label-drift-report"},
+    "tests.yaml": {
+        "changed-python-quality": "Changed Python quality + wheel smoke",
+        "fast": "Fast tests (Python ${{ matrix.python-version }})",
+        "corpus-and-integration": "Full corpus and integration suite",
+    },
+    "validate-strict.yaml": {"validate": "validate"},
+    "vendored-sync.yaml": {"vendored-sync": "vendored-sync"},
+}
+
+
+def _load(name):
+    return yaml.safe_load((ROOT / ".github" / "workflows" / name).read_text())
+
+
+def _assert_required_workflow(document, expected_jobs):
+    events = document.get("on", document.get(True, {}))
+    assert "pull_request" in events, "missing PR trigger"
+    assert events["pull_request"] in (None, {}), "required PR checks cannot be filtered"
+    assert events.get("merge_group") == {"types": ["checks_requested"]}, "missing queue trigger"
+    for job_id, check_name in expected_jobs.items():
+        job = document["jobs"][job_id]
+        assert job.get("name", job_id) == check_name, "required check renamed"
+        assert "if" not in job, "required job cannot skip the candidate"
+        assert not job.get("continue-on-error"), "required job must fail on errors"
+        for step in job.get("steps", []):
+            if step.get("uses", "").startswith("actions/checkout@"):
+                assert "ref" not in step.get("with", {}), "must check out the event's candidate"
+    concurrency = document.get("concurrency")
+    if concurrency:
+        assert "github.run_id" in concurrency["group"], "queue runs need distinct groups"
+        assert concurrency["cancel-in-progress"] == "${{ github.event_name == 'pull_request' }}"
+
+
+@pytest.mark.parametrize("workflow", REQUIRED_JOBS)
+def test_required_workflow_runs_for_pr_and_merge_group(workflow):
+    _assert_required_workflow(_load(workflow), REQUIRED_JOBS[workflow])
+
+
+@pytest.mark.parametrize("defect", ["queue", "paths", "skip", "cancel", "checkout"])
+def test_the_guard_rejects_a_broken_workflow(defect):
+    name = "vendored-sync.yaml"
+    document = _load(name)
+    _assert_required_workflow(document, REQUIRED_JOBS[name])  # unmutated control
+    broken = deepcopy(document)
+    events = broken.get("on", broken.get(True))
+    job = broken["jobs"]["vendored-sync"]
+    if defect == "queue":
+        del events["merge_group"]
+    elif defect == "paths":
+        events["pull_request"] = {"paths": ["src/**"]}
+    elif defect == "skip":
+        job["if"] = "github.event_name == 'pull_request'"
+    elif defect == "cancel":
+        broken["concurrency"]["cancel-in-progress"] = True
+    else:
+        job["steps"][0]["with"] = {"ref": "main"}
+    with pytest.raises(AssertionError):
+        _assert_required_workflow(broken, REQUIRED_JOBS[name])
+
+
+def test_required_job_names_are_unambiguous():
+    names = [
+        _load(workflow)["jobs"][job_id].get("name", job_id)
+        for workflow, jobs in REQUIRED_JOBS.items()
+        for job_id in jobs
+    ]
+    assert len(names) == len(set(names)), "different required workflows report the same check"
+
+
+def test_changed_python_uses_the_complete_merge_group_base():
+    steps = _load("tests.yaml")["jobs"]["changed-python-quality"]["steps"]
+    quality = next(step for step in steps if step.get("name") == "Ruff and Black on changed Python")
+    assert quality["env"]["GITHUB_EVENT_BEFORE"] == (
+        "${{ github.event.merge_group.base_sha || github.event.before }}"
+    )

--- a/tests/test_workflow_dependency_paths.py
+++ b/tests/test_workflow_dependency_paths.py
@@ -85,12 +85,18 @@ def test_the_guard_is_not_vacuous():
     the likely way — every case above vanishes and the suite still passes.
     """
     blocks = _blocks()
-    assert len(blocks) >= 8, f"expected the known path-filtered blocks, found {len(blocks)}"
     assert len(_workflow_files()) >= 10, "workflow discovery found almost nothing"
-    assert {w for w, _, _ in blocks} >= {
-        "chebi-consistency.yaml",
-        "concentration-plausibility.yaml",
-        "curation-history.yaml",
-        "label-correspondence.yaml",
-        "validate-strict.yaml",
+    # PR checks are now unconditional for merge queues. These push scopes remain
+    # filtered, so discovering none is still a parser/discovery failure.
+    assert {(workflow, trigger) for workflow, trigger, _ in blocks} >= {
+        ("curation-history.yaml", "push"),
+        ("label-correspondence.yaml", "push"),
+        ("generate-pages.yaml", "push"),
     }
+
+
+@pytest.mark.parametrize("on_key", ["on", True])
+def test_path_discovery_handles_yaml_boolean_keys_and_unfiltered_events(on_key):
+    paths = ["data/**", "pyproject.toml", "uv.lock"]
+    document = {on_key: {"pull_request": None, "push": {"paths": paths}}}
+    assert _paths_blocks(document) == [("push", paths)]


### PR DESCRIPTION
Required validation now runs on every pull request and on `merge_group: checks_requested`, so native merge queues receive every required result for the candidate SHA. Existing push scopes and pinned reusable workflows are preserved.

The changed-Python job uses the merge group base SHA, covering changes before the last commit in a candidate. PR runs alone may cancel older runs; queue runs retain distinct concurrency groups.

Validation: `just test-fast`: 1,663 passed, 15 skipped; 33 focused workflow/diff tests passed. Changed-file Ruff and Black checks passed. Actionlint 1.7.12 passed. The queue guard passed on current files, failed after restoring the old workflow without its queue event, and passed immediately after restoring the change.

This PR prepares CI; enabling the queue and required checks is a separate repository-settings step.

The concentration-plausibility wiring test parses PR and merge-group coverage and verifies an executable, unconditional audit step. Local validation includes 1,663 passing fast tests, 20 queue/changed-Python tests, the formerly failing guard, and six negative-control trigger/step mutations.

Fixes #464.
