### PR TITLE
Document native merge queue operation

### DIFF
--- a/docs/MERGE_QUEUE.md
+++ b/docs/MERGE_QUEUE.md
@@ -1,0 +1,25 @@
+# Merging through the queue
+
+When `main` requires GitHub's native merge queue, a reviewed PR enters the queue
+and its required checks run again against the candidate containing current
+`main` and preceding queued changes. A green PR check run alone does not show
+that this combined candidate passed.
+
+After required PR checks pass, enqueue the reviewed revision with:
+
+```sh
+gh pr merge PR_NUMBER --repo CultureBotAI/CultureMech --match-head-commit HEAD_SHA
+```
+
+The queue selects the configured merge method. Avoid `--admin`, which bypasses
+the queue. On failure, inspect the PR timeline and the `merge_group` Actions
+run, fix the cause, and enqueue the updated revision after its PR checks pass.
+
+The changed-Python check compares against the queue group base so changes earlier in the candidate are included. The nightly merge-YAML freshness report and Pages deployment have separate triggers.
+
+Required workflow triggers and stable job names are checked by
+`tests/test_merge_queue_workflows.py`. Coordinate job renames with the `main`
+ruleset so the queue continues receiving every expected result.
+
+References: [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+and [`gh pr merge`](https://cli.github.com/manual/gh_pr_merge).

--- a/docs/MERGE_QUEUE.md
+++ b/docs/MERGE_QUEUE.md
@@ -11,6 +11,14 @@ After required PR checks pass, enqueue the reviewed revision with:
 gh pr merge PR_NUMBER --repo CultureBotAI/CultureMech --match-head-commit HEAD_SHA
 ```
 
+Enqueueing is asynchronous. Before deleting the branch or cleaning its worktree,
+confirm `state` is `MERGED`, `headRefOid` equals the reviewed `HEAD_SHA`, and
+`mergeCommit.oid` is present:
+
+```sh
+gh pr view PR_NUMBER --repo CultureBotAI/CultureMech --json state,headRefOid,mergeCommit
+```
+
 The queue selects the configured merge method. Avoid `--admin`, which bypasses
 the queue. On failure, inspect the PR timeline and the `merge_group` Actions
 run, fix the cause, and enqueue the updated revision after its PR checks pass.


### PR DESCRIPTION
Documents how to enqueue the reviewed PR revision when `main` requires the native merge queue, how candidate checks differ from PR checks, and how to handle queue failures. Includes repository-specific validation behavior and links to GitHub documentation.

This draft is the documentation-only verification candidate for the merge queue rollout. After https://github.com/CultureBotAI/CultureMech/pull/462 merges and the queue is enabled, refresh this branch on `main` and verify it through the real queue.

Validation: documentation diff and `git diff --check`; queue behavior has not yet been exercised.
